### PR TITLE
Simplify zha IEEE validation schema

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -104,12 +104,14 @@ SERVICE_WARNING_DEVICE_WARN = "warning_device_warn"
 SERVICE_ZIGBEE_BIND = "service_zigbee_bind"
 IEEE_SERVICE = "ieee_based_service"
 
+IEEE_SCHEMA = vol.All(cv.string, EUI64.convert)
+
 SERVICE_PERMIT_PARAMS = {
-    vol.Optional(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+    vol.Optional(ATTR_IEEE): IEEE_SCHEMA,
     vol.Optional(ATTR_DURATION, default=60): vol.All(
         vol.Coerce(int), vol.Range(0, 254)
     ),
-    vol.Inclusive(ATTR_SOURCE_IEEE, "install_code"): vol.All(cv.string, EUI64.convert),
+    vol.Inclusive(ATTR_SOURCE_IEEE, "install_code"): IEEE_SCHEMA,
     vol.Inclusive(ATTR_INSTALL_CODE, "install_code"): vol.All(
         cv.string, convert_install_code
     ),
@@ -126,12 +128,12 @@ SERVICE_SCHEMAS = {
     IEEE_SERVICE: vol.Schema(
         vol.All(
             cv.deprecated(ATTR_IEEE_ADDRESS, replacement_key=ATTR_IEEE),
-            {vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert)},
+            {vol.Required(ATTR_IEEE): IEEE_SCHEMA},
         )
     ),
     SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE: vol.Schema(
         {
-            vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+            vol.Required(ATTR_IEEE): IEEE_SCHEMA,
             vol.Required(ATTR_ENDPOINT_ID): cv.positive_int,
             vol.Required(ATTR_CLUSTER_ID): cv.positive_int,
             vol.Optional(ATTR_CLUSTER_TYPE, default=CLUSTER_TYPE_IN): cv.string,
@@ -142,7 +144,7 @@ SERVICE_SCHEMAS = {
     ),
     SERVICE_WARNING_DEVICE_SQUAWK: vol.Schema(
         {
-            vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+            vol.Required(ATTR_IEEE): IEEE_SCHEMA,
             vol.Optional(
                 ATTR_WARNING_DEVICE_MODE, default=WARNING_DEVICE_SQUAWK_MODE_ARMED
             ): cv.positive_int,
@@ -156,7 +158,7 @@ SERVICE_SCHEMAS = {
     ),
     SERVICE_WARNING_DEVICE_WARN: vol.Schema(
         {
-            vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+            vol.Required(ATTR_IEEE): IEEE_SCHEMA,
             vol.Optional(
                 ATTR_WARNING_DEVICE_MODE, default=WARNING_DEVICE_MODE_EMERGENCY
             ): cv.positive_int,
@@ -177,7 +179,7 @@ SERVICE_SCHEMAS = {
     ),
     SERVICE_ISSUE_ZIGBEE_CLUSTER_COMMAND: vol.Schema(
         {
-            vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+            vol.Required(ATTR_IEEE): IEEE_SCHEMA,
             vol.Required(ATTR_ENDPOINT_ID): cv.positive_int,
             vol.Required(ATTR_CLUSTER_ID): cv.positive_int,
             vol.Optional(ATTR_CLUSTER_TYPE, default=CLUSTER_TYPE_IN): cv.string,
@@ -322,7 +324,7 @@ async def websocket_get_groups(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/device",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -503,7 +505,7 @@ async def websocket_remove_group_members(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/reconfigure",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -553,7 +555,7 @@ async def websocket_update_topology(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/clusters",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -594,7 +596,7 @@ async def websocket_device_clusters(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/clusters/attributes",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
         vol.Required(ATTR_ENDPOINT_ID): int,
         vol.Required(ATTR_CLUSTER_ID): int,
         vol.Required(ATTR_CLUSTER_TYPE): str,
@@ -641,7 +643,7 @@ async def websocket_device_cluster_attributes(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/clusters/commands",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
         vol.Required(ATTR_ENDPOINT_ID): int,
         vol.Required(ATTR_CLUSTER_ID): int,
         vol.Required(ATTR_CLUSTER_TYPE): str,
@@ -701,7 +703,7 @@ async def websocket_device_cluster_commands(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/clusters/attributes/value",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
         vol.Required(ATTR_ENDPOINT_ID): int,
         vol.Required(ATTR_CLUSTER_ID): int,
         vol.Required(ATTR_CLUSTER_TYPE): str,
@@ -756,7 +758,7 @@ async def websocket_read_zigbee_cluster_attributes(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/bindable",
-        vol.Required(ATTR_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_IEEE): IEEE_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -789,8 +791,8 @@ async def websocket_get_bindable_devices(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/bind",
-        vol.Required(ATTR_SOURCE_IEEE): vol.All(cv.string, EUI64.convert),
-        vol.Required(ATTR_TARGET_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_SOURCE_IEEE): IEEE_SCHEMA,
+        vol.Required(ATTR_TARGET_IEEE): IEEE_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -817,8 +819,8 @@ async def websocket_bind_devices(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/devices/unbind",
-        vol.Required(ATTR_SOURCE_IEEE): vol.All(cv.string, EUI64.convert),
-        vol.Required(ATTR_TARGET_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_SOURCE_IEEE): IEEE_SCHEMA,
+        vol.Required(ATTR_TARGET_IEEE): IEEE_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -862,7 +864,7 @@ def is_cluster_binding(value: Any) -> ClusterBinding:
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/groups/bind",
-        vol.Required(ATTR_SOURCE_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_SOURCE_IEEE): IEEE_SCHEMA,
         vol.Required(GROUP_ID): cv.positive_int,
         vol.Required(BINDINGS): vol.All(cv.ensure_list, [is_cluster_binding]),
     }
@@ -884,7 +886,7 @@ async def websocket_bind_group(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/groups/unbind",
-        vol.Required(ATTR_SOURCE_IEEE): vol.All(cv.string, EUI64.convert),
+        vol.Required(ATTR_SOURCE_IEEE): IEEE_SCHEMA,
         vol.Required(GROUP_ID): cv.positive_int,
         vol.Required(BINDINGS): vol.All(cv.ensure_list, [is_cluster_binding]),
     }


### PR DESCRIPTION
## Proposed change
Small change to add a dedicated variable for `vol.All(cv.string, EUI64.convert)`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
