### PR TITLE
Don't create two zwave_js.lock entities for a single device

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -209,6 +209,12 @@ def get_config_parameter_discovery_schema(
     )
 
 
+DOOR_LOCK_CURRENT_MODE_SCHEMA = ZWaveValueDiscoverySchema(
+    command_class={CommandClass.DOOR_LOCK},
+    property={CURRENT_MODE_PROPERTY},
+    type={"number"},
+)
+
 SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA = ZWaveValueDiscoverySchema(
     command_class={CommandClass.SWITCH_MULTILEVEL},
     property={CURRENT_VALUE_PROPERTY},
@@ -501,16 +507,17 @@ DISCOVERY_SCHEMAS = [
     ),
     # ====== START OF GENERIC MAPPING SCHEMAS =======
     # locks
+    # Door Lock CC
+    ZWaveDiscoverySchema(platform="lock", primary_value=DOOR_LOCK_CURRENT_MODE_SCHEMA),
+    # Only discover the Lock CC if the Door Lock CC isn't also present on the node
     ZWaveDiscoverySchema(
         platform="lock",
         primary_value=ZWaveValueDiscoverySchema(
-            command_class={
-                CommandClass.LOCK,
-                CommandClass.DOOR_LOCK,
-            },
-            property={CURRENT_MODE_PROPERTY, LOCKED_PROPERTY},
-            type={"number", "boolean"},
+            command_class={CommandClass.LOCK},
+            property={LOCKED_PROPERTY},
+            type={"boolean"},
         ),
+        absent_values=[DOOR_LOCK_CURRENT_MODE_SCHEMA],
     ),
     # door lock door status
     ZWaveDiscoverySchema(

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -515,6 +515,12 @@ def light_express_controls_ezmultipli_state_fixture():
     return json.loads(load_fixture("zwave_js/express_controls_ezmultipli_state.json"))
 
 
+@pytest.fixture(name="lock_home_connect_620_state", scope="session")
+def lock_home_connect_620_state_fixture():
+    """Load the Home Connect 620 lock node state fixture data."""
+    return json.loads(load_fixture("zwave_js/lock_home_connect_620_state.json"))
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state, log_config_state):
     """Mock a client."""
@@ -1029,5 +1035,13 @@ def zp3111_fixture(client, zp3111_state):
 def express_controls_ezmultipli_fixture(client, express_controls_ezmultipli_state):
     """Mock a Express Controls EZMultiPli node."""
     node = Node(client, copy.deepcopy(express_controls_ezmultipli_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="lock_home_connect_620")
+def lock_home_connect_620_fixture(client, lock_home_connect_620_state):
+    """Mock a Home Connect 620 lock node."""
+    node = Node(client, copy.deepcopy(lock_home_connect_620_state))
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/lock_home_connect_620_state.json
+++ b/tests/components/zwave_js/fixtures/lock_home_connect_620_state.json
@@ -1,0 +1,11476 @@
+{
+  "nodeId": 14,
+  "index": 0,
+  "installerIcon": 768,
+  "userIcon": 768,
+  "status": 4,
+  "ready": true,
+  "isListening": false,
+  "isRouting": true,
+  "isSecure": true,
+  "manufacturerId": 144,
+  "productId": 9128,
+  "productType": 2065,
+  "firmwareVersion": "7.20",
+  "zwavePlusVersion": 2,
+  "name": "Shed Door Lock",
+  "deviceConfig": {
+    "filename": "/usr/src/app/store/.config-db/devices/0x0090/hc620.json",
+    "isEmbedded": true,
+    "manufacturer": "Kwikset",
+    "manufacturerId": 144,
+    "label": "HC620",
+    "description": "Home Connect 620 Connected Smart Lock",
+    "devices": [
+      {
+        "productType": 2065,
+        "productId": 936
+      },
+      {
+        "productType": 2065,
+        "productId": 5032
+      },
+      {
+        "productType": 2065,
+        "productId": 9128
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "paramInformation": {
+      "_map": {}
+    },
+    "metadata": {
+      "inclusion": "Press button \"A\" on the lock interior one time",
+      "exclusion": "Press button \"A\" one time",
+      "reset": "1. Remove battery pack.\n2. Press and HOLD \"Program\" button while reinserting the battery pack. Keep holding the button for 30 seconds until the lock beeps and the status LED flashes red",
+      "manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4279/5069372%20Weiser%20GED1800ss.pdf"
+    }
+  },
+  "label": "HC620",
+  "interviewAttempts": 0,
+  "endpoints": [
+    {
+      "nodeId": 14,
+      "index": 0,
+      "installerIcon": 768,
+      "userIcon": 768,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 64,
+          "label": "Entry Control"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Door Lock"
+        },
+        "mandatorySupportedCCs": [32, 118],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 76,
+          "name": "Door Lock Logging",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 85,
+          "name": "Transport Service",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 98,
+          "name": "Door Lock",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 99,
+          "name": "User Code",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 108,
+          "name": "Supervision",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 113,
+          "name": "Notification",
+          "version": 8,
+          "isSecure": true
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 118,
+          "name": "Lock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 5,
+          "isSecure": true
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 139,
+          "name": "Time Parameters",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 152,
+          "name": "Security",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 159,
+          "name": "Security 2",
+          "version": 1,
+          "isSecure": true
+        }
+      ]
+    }
+  ],
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "currentMode",
+      "propertyName": "currentMode",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Current lock mode",
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "Unsecured",
+          "1": "UnsecuredWithTimeout",
+          "16": "InsideUnsecured",
+          "17": "InsideUnsecuredWithTimeout",
+          "32": "OutsideUnsecured",
+          "33": "OutsideUnsecuredWithTimeout",
+          "254": "Unknown",
+          "255": "Secured"
+        }
+      },
+      "value": 255
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "targetMode",
+      "propertyName": "targetMode",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Target lock mode",
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "Unsecured",
+          "1": "UnsecuredWithTimeout",
+          "255": "Secured"
+        }
+      },
+      "value": 255
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "duration",
+      "propertyName": "duration",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Remaining duration until target lock mode"
+      },
+      "value": {
+        "value": 0,
+        "unit": "seconds"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "outsideHandlesCanOpenDoor",
+      "propertyName": "outsideHandlesCanOpenDoor",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Which outside handles can open the door (actual status)"
+      },
+      "value": [false, false, false, false]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "insideHandlesCanOpenDoor",
+      "propertyName": "insideHandlesCanOpenDoor",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Which inside handles can open the door (actual status)"
+      },
+      "value": [true, false, false, false]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "latchStatus",
+      "propertyName": "latchStatus",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "The current status of the latch"
+      },
+      "value": "open"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "boltStatus",
+      "propertyName": "boltStatus",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "The current status of the bolt"
+      },
+      "value": "locked"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "doorStatus",
+      "propertyName": "doorStatus",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "The current status of the door"
+      },
+      "value": "open"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "lockTimeout",
+      "propertyName": "lockTimeout",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Seconds until lock mode times out"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "operationType",
+      "propertyName": "operationType",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Lock operation type",
+        "min": 0,
+        "max": 255,
+        "states": {
+          "2": "Timed",
+          "3": "unknown (0x03)"
+        }
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "outsideHandlesCanOpenDoorConfiguration",
+      "propertyName": "outsideHandlesCanOpenDoorConfiguration",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true,
+        "label": "Which outside handles can open the door (configuration)"
+      },
+      "value": [false, false, false, false]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "insideHandlesCanOpenDoorConfiguration",
+      "propertyName": "insideHandlesCanOpenDoorConfiguration",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true,
+        "label": "Which inside handles can open the door (configuration)"
+      },
+      "value": [false, false, false, false]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "lockTimeoutConfiguration",
+      "propertyName": "lockTimeoutConfiguration",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Duration of timed mode in seconds",
+        "min": 0,
+        "max": 65535
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "autoRelockTime",
+      "propertyName": "autoRelockTime",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Duration in seconds until lock returns to secure state",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "holdAndReleaseTime",
+      "propertyName": "holdAndReleaseTime",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Duration in seconds the latch stays retracted",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "twistAssist",
+      "propertyName": "twistAssist",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Twist Assist enabled"
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 98,
+      "commandClassName": "Door Lock",
+      "property": "blockToBlock",
+      "propertyName": "blockToBlock",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Block-to-block functionality enabled"
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "keypadMode",
+      "propertyName": "keypadMode",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "masterCode",
+      "propertyName": "masterCode",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "Master Code",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 1,
+      "propertyName": "userCode",
+      "propertyKeyName": "1",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (1)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 1,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "1",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (1)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 2,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "2",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (2)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 2,
+      "propertyName": "userCode",
+      "propertyKeyName": "2",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (2)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 3,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "3",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (3)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 3,
+      "propertyName": "userCode",
+      "propertyKeyName": "3",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (3)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 4,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "4",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (4)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 4,
+      "propertyName": "userCode",
+      "propertyKeyName": "4",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (4)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 5,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "5",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (5)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 5,
+      "propertyName": "userCode",
+      "propertyKeyName": "5",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (5)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 6,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "6",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (6)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 6,
+      "propertyName": "userCode",
+      "propertyKeyName": "6",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (6)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 7,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "7",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (7)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 7,
+      "propertyName": "userCode",
+      "propertyKeyName": "7",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (7)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 8,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "8",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (8)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 8,
+      "propertyName": "userCode",
+      "propertyKeyName": "8",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (8)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 9,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "9",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (9)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 9,
+      "propertyName": "userCode",
+      "propertyKeyName": "9",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (9)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 10,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "10",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (10)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 10,
+      "propertyName": "userCode",
+      "propertyKeyName": "10",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (10)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 11,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "11",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (11)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 11,
+      "propertyName": "userCode",
+      "propertyKeyName": "11",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (11)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 12,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "12",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (12)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 12,
+      "propertyName": "userCode",
+      "propertyKeyName": "12",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (12)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 13,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "13",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (13)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 13,
+      "propertyName": "userCode",
+      "propertyKeyName": "13",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (13)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 14,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "14",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (14)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 14,
+      "propertyName": "userCode",
+      "propertyKeyName": "14",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (14)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 15,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "15",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (15)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 15,
+      "propertyName": "userCode",
+      "propertyKeyName": "15",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (15)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 16,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "16",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (16)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 16,
+      "propertyName": "userCode",
+      "propertyKeyName": "16",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (16)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 17,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "17",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (17)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 17,
+      "propertyName": "userCode",
+      "propertyKeyName": "17",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (17)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 18,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "18",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (18)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 18,
+      "propertyName": "userCode",
+      "propertyKeyName": "18",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (18)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 19,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "19",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (19)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 19,
+      "propertyName": "userCode",
+      "propertyKeyName": "19",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (19)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 20,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "20",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (20)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 20,
+      "propertyName": "userCode",
+      "propertyKeyName": "20",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (20)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 21,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "21",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (21)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 21,
+      "propertyName": "userCode",
+      "propertyKeyName": "21",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (21)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 22,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "22",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (22)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 22,
+      "propertyName": "userCode",
+      "propertyKeyName": "22",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (22)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 23,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "23",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (23)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 23,
+      "propertyName": "userCode",
+      "propertyKeyName": "23",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (23)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 24,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "24",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (24)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 24,
+      "propertyName": "userCode",
+      "propertyKeyName": "24",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (24)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 25,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "25",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (25)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 25,
+      "propertyName": "userCode",
+      "propertyKeyName": "25",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (25)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 26,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "26",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (26)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 26,
+      "propertyName": "userCode",
+      "propertyKeyName": "26",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (26)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 27,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "27",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (27)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 27,
+      "propertyName": "userCode",
+      "propertyKeyName": "27",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (27)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 28,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "28",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (28)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 28,
+      "propertyName": "userCode",
+      "propertyKeyName": "28",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (28)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 29,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "29",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (29)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 29,
+      "propertyName": "userCode",
+      "propertyKeyName": "29",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (29)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 30,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "30",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (30)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 30,
+      "propertyName": "userCode",
+      "propertyKeyName": "30",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (30)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 31,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "31",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (31)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 31,
+      "propertyName": "userCode",
+      "propertyKeyName": "31",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (31)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 32,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "32",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (32)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 32,
+      "propertyName": "userCode",
+      "propertyKeyName": "32",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (32)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 33,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "33",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (33)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 33,
+      "propertyName": "userCode",
+      "propertyKeyName": "33",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (33)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 34,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "34",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (34)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 34,
+      "propertyName": "userCode",
+      "propertyKeyName": "34",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (34)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 35,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "35",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (35)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 35,
+      "propertyName": "userCode",
+      "propertyKeyName": "35",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (35)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 36,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "36",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (36)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 36,
+      "propertyName": "userCode",
+      "propertyKeyName": "36",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (36)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 37,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "37",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (37)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 37,
+      "propertyName": "userCode",
+      "propertyKeyName": "37",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (37)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 38,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "38",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (38)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 38,
+      "propertyName": "userCode",
+      "propertyKeyName": "38",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (38)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 39,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "39",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (39)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 39,
+      "propertyName": "userCode",
+      "propertyKeyName": "39",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (39)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 40,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "40",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (40)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 40,
+      "propertyName": "userCode",
+      "propertyKeyName": "40",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (40)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 41,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "41",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (41)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 41,
+      "propertyName": "userCode",
+      "propertyKeyName": "41",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (41)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 42,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "42",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (42)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 42,
+      "propertyName": "userCode",
+      "propertyKeyName": "42",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (42)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 43,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "43",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (43)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 43,
+      "propertyName": "userCode",
+      "propertyKeyName": "43",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (43)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 44,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "44",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (44)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 44,
+      "propertyName": "userCode",
+      "propertyKeyName": "44",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (44)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 45,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "45",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (45)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 45,
+      "propertyName": "userCode",
+      "propertyKeyName": "45",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (45)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 46,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "46",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (46)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 46,
+      "propertyName": "userCode",
+      "propertyKeyName": "46",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (46)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 47,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "47",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (47)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 47,
+      "propertyName": "userCode",
+      "propertyKeyName": "47",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (47)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 48,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "48",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (48)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 48,
+      "propertyName": "userCode",
+      "propertyKeyName": "48",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (48)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 49,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "49",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (49)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 49,
+      "propertyName": "userCode",
+      "propertyKeyName": "49",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (49)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 50,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "50",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (50)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 50,
+      "propertyName": "userCode",
+      "propertyKeyName": "50",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (50)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 51,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "51",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (51)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 51,
+      "propertyName": "userCode",
+      "propertyKeyName": "51",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (51)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 52,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "52",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (52)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 52,
+      "propertyName": "userCode",
+      "propertyKeyName": "52",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (52)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 53,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "53",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (53)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 53,
+      "propertyName": "userCode",
+      "propertyKeyName": "53",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (53)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 54,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "54",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (54)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 54,
+      "propertyName": "userCode",
+      "propertyKeyName": "54",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (54)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 55,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "55",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (55)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 55,
+      "propertyName": "userCode",
+      "propertyKeyName": "55",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (55)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 56,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "56",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (56)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 56,
+      "propertyName": "userCode",
+      "propertyKeyName": "56",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (56)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 57,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "57",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (57)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 57,
+      "propertyName": "userCode",
+      "propertyKeyName": "57",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (57)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 58,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "58",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (58)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 58,
+      "propertyName": "userCode",
+      "propertyKeyName": "58",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (58)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 59,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "59",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (59)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 59,
+      "propertyName": "userCode",
+      "propertyKeyName": "59",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (59)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 60,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "60",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (60)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 60,
+      "propertyName": "userCode",
+      "propertyKeyName": "60",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (60)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 61,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "61",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (61)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 61,
+      "propertyName": "userCode",
+      "propertyKeyName": "61",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (61)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 62,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "62",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (62)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 62,
+      "propertyName": "userCode",
+      "propertyKeyName": "62",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (62)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 63,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "63",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (63)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 63,
+      "propertyName": "userCode",
+      "propertyKeyName": "63",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (63)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 64,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "64",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (64)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 64,
+      "propertyName": "userCode",
+      "propertyKeyName": "64",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (64)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 65,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "65",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (65)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 65,
+      "propertyName": "userCode",
+      "propertyKeyName": "65",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (65)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 66,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "66",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (66)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 66,
+      "propertyName": "userCode",
+      "propertyKeyName": "66",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (66)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 67,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "67",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (67)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 67,
+      "propertyName": "userCode",
+      "propertyKeyName": "67",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (67)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 68,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "68",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (68)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 68,
+      "propertyName": "userCode",
+      "propertyKeyName": "68",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (68)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 69,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "69",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (69)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 69,
+      "propertyName": "userCode",
+      "propertyKeyName": "69",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (69)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 70,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "70",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (70)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 70,
+      "propertyName": "userCode",
+      "propertyKeyName": "70",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (70)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 71,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "71",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (71)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 71,
+      "propertyName": "userCode",
+      "propertyKeyName": "71",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (71)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 72,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "72",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (72)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 72,
+      "propertyName": "userCode",
+      "propertyKeyName": "72",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (72)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 73,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "73",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (73)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 73,
+      "propertyName": "userCode",
+      "propertyKeyName": "73",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (73)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 74,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "74",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (74)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 74,
+      "propertyName": "userCode",
+      "propertyKeyName": "74",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (74)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 75,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "75",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (75)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 75,
+      "propertyName": "userCode",
+      "propertyKeyName": "75",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (75)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 76,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "76",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (76)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 76,
+      "propertyName": "userCode",
+      "propertyKeyName": "76",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (76)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 77,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "77",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (77)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 77,
+      "propertyName": "userCode",
+      "propertyKeyName": "77",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (77)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 78,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "78",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (78)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 78,
+      "propertyName": "userCode",
+      "propertyKeyName": "78",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (78)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 79,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "79",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (79)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 79,
+      "propertyName": "userCode",
+      "propertyKeyName": "79",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (79)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 80,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "80",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (80)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 80,
+      "propertyName": "userCode",
+      "propertyKeyName": "80",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (80)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 81,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "81",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (81)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 81,
+      "propertyName": "userCode",
+      "propertyKeyName": "81",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (81)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 82,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "82",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (82)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 82,
+      "propertyName": "userCode",
+      "propertyKeyName": "82",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (82)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 83,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "83",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (83)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 83,
+      "propertyName": "userCode",
+      "propertyKeyName": "83",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (83)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 84,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "84",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (84)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 84,
+      "propertyName": "userCode",
+      "propertyKeyName": "84",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (84)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 85,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "85",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (85)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 85,
+      "propertyName": "userCode",
+      "propertyKeyName": "85",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (85)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 86,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "86",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (86)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 86,
+      "propertyName": "userCode",
+      "propertyKeyName": "86",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (86)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 87,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "87",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (87)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 87,
+      "propertyName": "userCode",
+      "propertyKeyName": "87",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (87)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 88,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "88",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (88)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 88,
+      "propertyName": "userCode",
+      "propertyKeyName": "88",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (88)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 89,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "89",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (89)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 89,
+      "propertyName": "userCode",
+      "propertyKeyName": "89",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (89)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 90,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "90",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (90)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 90,
+      "propertyName": "userCode",
+      "propertyKeyName": "90",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (90)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 91,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "91",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (91)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 91,
+      "propertyName": "userCode",
+      "propertyKeyName": "91",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (91)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 92,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "92",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (92)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 92,
+      "propertyName": "userCode",
+      "propertyKeyName": "92",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (92)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 93,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "93",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (93)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 93,
+      "propertyName": "userCode",
+      "propertyKeyName": "93",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (93)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 94,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "94",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (94)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 94,
+      "propertyName": "userCode",
+      "propertyKeyName": "94",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (94)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 95,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "95",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (95)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 95,
+      "propertyName": "userCode",
+      "propertyKeyName": "95",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (95)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 96,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "96",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (96)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 96,
+      "propertyName": "userCode",
+      "propertyKeyName": "96",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (96)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 97,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "97",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (97)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 97,
+      "propertyName": "userCode",
+      "propertyKeyName": "97",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (97)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 98,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "98",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (98)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 98,
+      "propertyName": "userCode",
+      "propertyKeyName": "98",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (98)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 99,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "99",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (99)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 99,
+      "propertyName": "userCode",
+      "propertyKeyName": "99",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (99)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 100,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "100",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (100)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 100,
+      "propertyName": "userCode",
+      "propertyKeyName": "100",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (100)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 101,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "101",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (101)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 101,
+      "propertyName": "userCode",
+      "propertyKeyName": "101",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (101)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 102,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "102",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (102)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 102,
+      "propertyName": "userCode",
+      "propertyKeyName": "102",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (102)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 103,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "103",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (103)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 103,
+      "propertyName": "userCode",
+      "propertyKeyName": "103",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (103)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 104,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "104",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (104)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 104,
+      "propertyName": "userCode",
+      "propertyKeyName": "104",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (104)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 105,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "105",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (105)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 105,
+      "propertyName": "userCode",
+      "propertyKeyName": "105",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (105)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 106,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "106",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (106)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 106,
+      "propertyName": "userCode",
+      "propertyKeyName": "106",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (106)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 107,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "107",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (107)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 107,
+      "propertyName": "userCode",
+      "propertyKeyName": "107",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (107)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 108,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "108",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (108)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 108,
+      "propertyName": "userCode",
+      "propertyKeyName": "108",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (108)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 109,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "109",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (109)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 109,
+      "propertyName": "userCode",
+      "propertyKeyName": "109",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (109)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 110,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "110",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (110)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 110,
+      "propertyName": "userCode",
+      "propertyKeyName": "110",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (110)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 111,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "111",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (111)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 111,
+      "propertyName": "userCode",
+      "propertyKeyName": "111",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (111)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 112,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "112",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (112)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 112,
+      "propertyName": "userCode",
+      "propertyKeyName": "112",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (112)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 113,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "113",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (113)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 113,
+      "propertyName": "userCode",
+      "propertyKeyName": "113",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (113)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 114,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "114",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (114)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 114,
+      "propertyName": "userCode",
+      "propertyKeyName": "114",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (114)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 115,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "115",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (115)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 115,
+      "propertyName": "userCode",
+      "propertyKeyName": "115",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (115)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 116,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "116",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (116)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 116,
+      "propertyName": "userCode",
+      "propertyKeyName": "116",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (116)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 117,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "117",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (117)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 117,
+      "propertyName": "userCode",
+      "propertyKeyName": "117",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (117)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 118,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "118",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (118)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 118,
+      "propertyName": "userCode",
+      "propertyKeyName": "118",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (118)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 119,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "119",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (119)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 119,
+      "propertyName": "userCode",
+      "propertyKeyName": "119",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (119)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 120,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "120",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (120)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 120,
+      "propertyName": "userCode",
+      "propertyKeyName": "120",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (120)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 121,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "121",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (121)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 121,
+      "propertyName": "userCode",
+      "propertyKeyName": "121",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (121)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 122,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "122",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (122)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 122,
+      "propertyName": "userCode",
+      "propertyKeyName": "122",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (122)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 123,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "123",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (123)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 123,
+      "propertyName": "userCode",
+      "propertyKeyName": "123",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (123)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 124,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "124",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (124)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 124,
+      "propertyName": "userCode",
+      "propertyKeyName": "124",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (124)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 125,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "125",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (125)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 125,
+      "propertyName": "userCode",
+      "propertyKeyName": "125",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (125)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 126,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "126",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (126)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 126,
+      "propertyName": "userCode",
+      "propertyKeyName": "126",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (126)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 127,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "127",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (127)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 127,
+      "propertyName": "userCode",
+      "propertyKeyName": "127",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (127)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 128,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "128",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (128)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 128,
+      "propertyName": "userCode",
+      "propertyKeyName": "128",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (128)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 129,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "129",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (129)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 129,
+      "propertyName": "userCode",
+      "propertyKeyName": "129",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (129)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 130,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "130",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (130)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 130,
+      "propertyName": "userCode",
+      "propertyKeyName": "130",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (130)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 131,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "131",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (131)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 131,
+      "propertyName": "userCode",
+      "propertyKeyName": "131",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (131)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 132,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "132",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (132)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 132,
+      "propertyName": "userCode",
+      "propertyKeyName": "132",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (132)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 133,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "133",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (133)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 133,
+      "propertyName": "userCode",
+      "propertyKeyName": "133",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (133)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 134,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "134",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (134)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 134,
+      "propertyName": "userCode",
+      "propertyKeyName": "134",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (134)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 135,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "135",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (135)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 135,
+      "propertyName": "userCode",
+      "propertyKeyName": "135",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (135)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 136,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "136",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (136)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 136,
+      "propertyName": "userCode",
+      "propertyKeyName": "136",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (136)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 137,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "137",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (137)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 137,
+      "propertyName": "userCode",
+      "propertyKeyName": "137",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (137)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 138,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "138",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (138)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 138,
+      "propertyName": "userCode",
+      "propertyKeyName": "138",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (138)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 139,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "139",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (139)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 139,
+      "propertyName": "userCode",
+      "propertyKeyName": "139",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (139)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 140,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "140",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (140)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 140,
+      "propertyName": "userCode",
+      "propertyKeyName": "140",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (140)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 141,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "141",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (141)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 141,
+      "propertyName": "userCode",
+      "propertyKeyName": "141",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (141)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 142,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "142",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (142)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 142,
+      "propertyName": "userCode",
+      "propertyKeyName": "142",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (142)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 143,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "143",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (143)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 143,
+      "propertyName": "userCode",
+      "propertyKeyName": "143",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (143)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 144,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "144",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (144)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 144,
+      "propertyName": "userCode",
+      "propertyKeyName": "144",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (144)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 145,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "145",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (145)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 145,
+      "propertyName": "userCode",
+      "propertyKeyName": "145",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (145)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 146,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "146",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (146)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 146,
+      "propertyName": "userCode",
+      "propertyKeyName": "146",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (146)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 147,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "147",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (147)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 147,
+      "propertyName": "userCode",
+      "propertyKeyName": "147",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (147)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 148,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "148",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (148)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 148,
+      "propertyName": "userCode",
+      "propertyKeyName": "148",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (148)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 149,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "149",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (149)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 149,
+      "propertyName": "userCode",
+      "propertyKeyName": "149",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (149)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 150,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "150",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (150)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 150,
+      "propertyName": "userCode",
+      "propertyKeyName": "150",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (150)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 151,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "151",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (151)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 151,
+      "propertyName": "userCode",
+      "propertyKeyName": "151",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (151)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 152,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "152",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (152)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 152,
+      "propertyName": "userCode",
+      "propertyKeyName": "152",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (152)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 153,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "153",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (153)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 153,
+      "propertyName": "userCode",
+      "propertyKeyName": "153",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (153)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 154,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "154",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (154)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 154,
+      "propertyName": "userCode",
+      "propertyKeyName": "154",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (154)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 155,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "155",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (155)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 155,
+      "propertyName": "userCode",
+      "propertyKeyName": "155",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (155)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 156,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "156",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (156)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 156,
+      "propertyName": "userCode",
+      "propertyKeyName": "156",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (156)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 157,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "157",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (157)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 157,
+      "propertyName": "userCode",
+      "propertyKeyName": "157",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (157)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 158,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "158",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (158)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 158,
+      "propertyName": "userCode",
+      "propertyKeyName": "158",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (158)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 159,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "159",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (159)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 159,
+      "propertyName": "userCode",
+      "propertyKeyName": "159",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (159)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 160,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "160",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (160)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 160,
+      "propertyName": "userCode",
+      "propertyKeyName": "160",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (160)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 161,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "161",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (161)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 161,
+      "propertyName": "userCode",
+      "propertyKeyName": "161",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (161)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 162,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "162",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (162)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 162,
+      "propertyName": "userCode",
+      "propertyKeyName": "162",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (162)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 163,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "163",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (163)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 163,
+      "propertyName": "userCode",
+      "propertyKeyName": "163",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (163)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 164,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "164",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (164)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 164,
+      "propertyName": "userCode",
+      "propertyKeyName": "164",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (164)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 165,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "165",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (165)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 165,
+      "propertyName": "userCode",
+      "propertyKeyName": "165",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (165)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 166,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "166",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (166)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 166,
+      "propertyName": "userCode",
+      "propertyKeyName": "166",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (166)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 167,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "167",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (167)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 167,
+      "propertyName": "userCode",
+      "propertyKeyName": "167",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (167)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 168,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "168",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (168)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 168,
+      "propertyName": "userCode",
+      "propertyKeyName": "168",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (168)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 169,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "169",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (169)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 169,
+      "propertyName": "userCode",
+      "propertyKeyName": "169",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (169)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 170,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "170",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (170)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 170,
+      "propertyName": "userCode",
+      "propertyKeyName": "170",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (170)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 171,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "171",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (171)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 171,
+      "propertyName": "userCode",
+      "propertyKeyName": "171",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (171)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 172,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "172",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (172)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 172,
+      "propertyName": "userCode",
+      "propertyKeyName": "172",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (172)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 173,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "173",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (173)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 173,
+      "propertyName": "userCode",
+      "propertyKeyName": "173",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (173)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 174,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "174",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (174)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 174,
+      "propertyName": "userCode",
+      "propertyKeyName": "174",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (174)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 175,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "175",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (175)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 175,
+      "propertyName": "userCode",
+      "propertyKeyName": "175",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (175)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 176,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "176",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (176)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 176,
+      "propertyName": "userCode",
+      "propertyKeyName": "176",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (176)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 177,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "177",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (177)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 177,
+      "propertyName": "userCode",
+      "propertyKeyName": "177",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (177)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 178,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "178",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (178)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 178,
+      "propertyName": "userCode",
+      "propertyKeyName": "178",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (178)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 179,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "179",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (179)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 179,
+      "propertyName": "userCode",
+      "propertyKeyName": "179",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (179)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 180,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "180",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (180)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 180,
+      "propertyName": "userCode",
+      "propertyKeyName": "180",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (180)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 181,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "181",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (181)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 181,
+      "propertyName": "userCode",
+      "propertyKeyName": "181",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (181)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 182,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "182",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (182)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 182,
+      "propertyName": "userCode",
+      "propertyKeyName": "182",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (182)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 183,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "183",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (183)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 183,
+      "propertyName": "userCode",
+      "propertyKeyName": "183",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (183)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 184,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "184",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (184)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 184,
+      "propertyName": "userCode",
+      "propertyKeyName": "184",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (184)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 185,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "185",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (185)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 185,
+      "propertyName": "userCode",
+      "propertyKeyName": "185",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (185)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 186,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "186",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (186)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 186,
+      "propertyName": "userCode",
+      "propertyKeyName": "186",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (186)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 187,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "187",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (187)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 187,
+      "propertyName": "userCode",
+      "propertyKeyName": "187",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (187)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 188,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "188",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (188)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 188,
+      "propertyName": "userCode",
+      "propertyKeyName": "188",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (188)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 189,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "189",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (189)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 189,
+      "propertyName": "userCode",
+      "propertyKeyName": "189",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (189)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 190,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "190",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (190)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 190,
+      "propertyName": "userCode",
+      "propertyKeyName": "190",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (190)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 191,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "191",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (191)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 191,
+      "propertyName": "userCode",
+      "propertyKeyName": "191",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (191)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 192,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "192",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (192)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 192,
+      "propertyName": "userCode",
+      "propertyKeyName": "192",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (192)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 193,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "193",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (193)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 193,
+      "propertyName": "userCode",
+      "propertyKeyName": "193",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (193)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 194,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "194",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (194)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 194,
+      "propertyName": "userCode",
+      "propertyKeyName": "194",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (194)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 195,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "195",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (195)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 195,
+      "propertyName": "userCode",
+      "propertyKeyName": "195",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (195)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 196,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "196",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (196)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 196,
+      "propertyName": "userCode",
+      "propertyKeyName": "196",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (196)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 197,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "197",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (197)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 197,
+      "propertyName": "userCode",
+      "propertyKeyName": "197",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (197)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 198,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "198",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (198)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 198,
+      "propertyName": "userCode",
+      "propertyKeyName": "198",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (198)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 199,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "199",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (199)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 199,
+      "propertyName": "userCode",
+      "propertyKeyName": "199",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (199)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 200,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "200",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (200)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 200,
+      "propertyName": "userCode",
+      "propertyKeyName": "200",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (200)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 201,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "201",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (201)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 201,
+      "propertyName": "userCode",
+      "propertyKeyName": "201",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (201)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 202,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "202",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (202)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 202,
+      "propertyName": "userCode",
+      "propertyKeyName": "202",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (202)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 203,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "203",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (203)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 203,
+      "propertyName": "userCode",
+      "propertyKeyName": "203",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (203)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 204,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "204",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (204)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 204,
+      "propertyName": "userCode",
+      "propertyKeyName": "204",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (204)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 205,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "205",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (205)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 205,
+      "propertyName": "userCode",
+      "propertyKeyName": "205",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (205)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 206,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "206",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (206)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 206,
+      "propertyName": "userCode",
+      "propertyKeyName": "206",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (206)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 207,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "207",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (207)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 207,
+      "propertyName": "userCode",
+      "propertyKeyName": "207",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (207)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 208,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "208",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (208)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 208,
+      "propertyName": "userCode",
+      "propertyKeyName": "208",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (208)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 209,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "209",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (209)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 209,
+      "propertyName": "userCode",
+      "propertyKeyName": "209",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (209)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 210,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "210",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (210)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 210,
+      "propertyName": "userCode",
+      "propertyKeyName": "210",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (210)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 211,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "211",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (211)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 211,
+      "propertyName": "userCode",
+      "propertyKeyName": "211",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (211)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 212,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "212",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (212)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 212,
+      "propertyName": "userCode",
+      "propertyKeyName": "212",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (212)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 213,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "213",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (213)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 213,
+      "propertyName": "userCode",
+      "propertyKeyName": "213",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (213)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 214,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "214",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (214)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 214,
+      "propertyName": "userCode",
+      "propertyKeyName": "214",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (214)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 215,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "215",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (215)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 215,
+      "propertyName": "userCode",
+      "propertyKeyName": "215",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (215)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 216,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "216",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (216)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 216,
+      "propertyName": "userCode",
+      "propertyKeyName": "216",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (216)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 217,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "217",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (217)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 217,
+      "propertyName": "userCode",
+      "propertyKeyName": "217",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (217)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 218,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "218",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (218)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 218,
+      "propertyName": "userCode",
+      "propertyKeyName": "218",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (218)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 219,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "219",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (219)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 219,
+      "propertyName": "userCode",
+      "propertyKeyName": "219",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (219)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 220,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "220",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (220)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 220,
+      "propertyName": "userCode",
+      "propertyKeyName": "220",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (220)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 221,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "221",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (221)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 221,
+      "propertyName": "userCode",
+      "propertyKeyName": "221",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (221)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 222,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "222",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (222)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 222,
+      "propertyName": "userCode",
+      "propertyKeyName": "222",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (222)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 223,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "223",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (223)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 223,
+      "propertyName": "userCode",
+      "propertyKeyName": "223",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (223)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 224,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "224",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (224)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 224,
+      "propertyName": "userCode",
+      "propertyKeyName": "224",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (224)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 225,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "225",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (225)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 225,
+      "propertyName": "userCode",
+      "propertyKeyName": "225",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (225)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 226,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "226",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (226)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 226,
+      "propertyName": "userCode",
+      "propertyKeyName": "226",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (226)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 227,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "227",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (227)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 227,
+      "propertyName": "userCode",
+      "propertyKeyName": "227",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (227)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 228,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "228",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (228)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 228,
+      "propertyName": "userCode",
+      "propertyKeyName": "228",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (228)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 229,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "229",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (229)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 229,
+      "propertyName": "userCode",
+      "propertyKeyName": "229",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (229)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 230,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "230",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (230)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 230,
+      "propertyName": "userCode",
+      "propertyKeyName": "230",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (230)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 231,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "231",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (231)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 231,
+      "propertyName": "userCode",
+      "propertyKeyName": "231",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (231)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 232,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "232",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (232)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 232,
+      "propertyName": "userCode",
+      "propertyKeyName": "232",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (232)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 233,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "233",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (233)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 233,
+      "propertyName": "userCode",
+      "propertyKeyName": "233",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (233)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 234,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "234",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (234)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 234,
+      "propertyName": "userCode",
+      "propertyKeyName": "234",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (234)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 235,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "235",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (235)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 235,
+      "propertyName": "userCode",
+      "propertyKeyName": "235",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (235)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 236,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "236",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (236)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 236,
+      "propertyName": "userCode",
+      "propertyKeyName": "236",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (236)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 237,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "237",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (237)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 237,
+      "propertyName": "userCode",
+      "propertyKeyName": "237",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (237)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 238,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "238",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (238)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 238,
+      "propertyName": "userCode",
+      "propertyKeyName": "238",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (238)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 239,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "239",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (239)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 239,
+      "propertyName": "userCode",
+      "propertyKeyName": "239",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (239)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 240,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "240",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (240)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 240,
+      "propertyName": "userCode",
+      "propertyKeyName": "240",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (240)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 241,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "241",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (241)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 241,
+      "propertyName": "userCode",
+      "propertyKeyName": "241",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (241)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 242,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "242",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (242)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 242,
+      "propertyName": "userCode",
+      "propertyKeyName": "242",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (242)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 243,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "243",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (243)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 243,
+      "propertyName": "userCode",
+      "propertyKeyName": "243",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (243)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 244,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "244",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (244)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 244,
+      "propertyName": "userCode",
+      "propertyKeyName": "244",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (244)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 245,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "245",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (245)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 245,
+      "propertyName": "userCode",
+      "propertyKeyName": "245",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (245)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 246,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "246",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (246)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 246,
+      "propertyName": "userCode",
+      "propertyKeyName": "246",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (246)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 247,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "247",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (247)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 247,
+      "propertyName": "userCode",
+      "propertyKeyName": "247",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (247)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 248,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "248",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (248)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 248,
+      "propertyName": "userCode",
+      "propertyKeyName": "248",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (248)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 249,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "249",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (249)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 249,
+      "propertyName": "userCode",
+      "propertyKeyName": "249",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (249)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userIdStatus",
+      "propertyKey": 250,
+      "propertyName": "userIdStatus",
+      "propertyKeyName": "250",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "User ID status (250)",
+        "states": {
+          "0": "Available",
+          "1": "Enabled",
+          "2": "Disabled",
+          "3": "Messaging",
+          "4": "PassageMode"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 99,
+      "commandClassName": "User Code",
+      "property": "userCode",
+      "propertyKey": 250,
+      "propertyName": "userCode",
+      "propertyKeyName": "250",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "User Code (250)",
+        "minLength": 4,
+        "maxLength": 10
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 10,
+      "propertyName": "Lock Direction",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Indicates the direction of the lock. Set to 1 (Right handed lock) to initiate direction detection.",
+        "label": "Lock Direction",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "states": {
+          "0": "Unknown latch position",
+          "1": "Right handed lock",
+          "2": "Left handed lock"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 46,
+      "propertyName": "Motor Resistance",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Motor Resistance",
+        "default": 0,
+        "min": 0,
+        "max": 255,
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      },
+      "value": 750900
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 1,
+      "propertyName": "Status LED",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "label": "Status LED",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 2,
+      "propertyName": "Buzzer",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "label": "Buzzer",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 3,
+      "propertyName": "User Program Button",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "label": "User Program Button",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 4,
+      "propertyName": "Secure Screen",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "description": "Control the secure screen functionality (on touch locks only)",
+        "label": "Secure Screen",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 40,
+      "propertyName": "Reset to Factory Default Settings",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "label": "Reset to Factory Default Settings",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "states": {
+          "0": "Normal Operation",
+          "1": "Reset to Factory Defaults",
+          "2": "Perform a modified factory reset"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Power Management",
+      "propertyKey": "Power status",
+      "propertyName": "Power Management",
+      "propertyKeyName": "Power status",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Power status",
+        "ccSpecific": {
+          "notificationType": 8
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "1": "Power has been applied"
+        }
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Lock state",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Lock state",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Lock state",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "11": "Lock jammed"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Keypad state",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Keypad state",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Keypad state",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "16": "Keypad temporary disabled"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Home Security",
+      "propertyKey": "Cover status",
+      "propertyName": "Home Security",
+      "propertyKeyName": "Cover status",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Cover status",
+        "ccSpecific": {
+          "notificationType": 7
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "3": "Tampering, product cover removed"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Power Management",
+      "propertyKey": "Battery maintenance status",
+      "propertyName": "Power Management",
+      "propertyKeyName": "Battery maintenance status",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Battery maintenance status",
+        "ccSpecific": {
+          "notificationType": 8
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "10": "Replace battery soon",
+          "11": "Replace battery now"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "alarmType",
+      "propertyName": "alarmType",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Alarm Type",
+        "min": 0,
+        "max": 255
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "alarmLevel",
+      "propertyName": "alarmLevel",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Alarm Level",
+        "min": 0,
+        "max": 255
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 144
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 2065
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 9128
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 118,
+      "commandClassName": "Lock",
+      "property": "locked",
+      "propertyName": "locked",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "description": "Whether the lock is locked",
+        "label": "Locked"
+      },
+      "value": true
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 128,
+      "commandClassName": "Battery",
+      "property": "level",
+      "propertyName": "level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Battery level",
+        "min": 0,
+        "max": 100,
+        "unit": "%"
+      },
+      "value": 100
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 128,
+      "commandClassName": "Battery",
+      "property": "isLow",
+      "propertyName": "isLow",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Low battery level"
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type",
+        "states": {
+          "0": "Unknown",
+          "1": "Static Controller",
+          "2": "Controller",
+          "3": "Enhanced Slave",
+          "4": "Slave",
+          "5": "Installer",
+          "6": "Routing Slave",
+          "7": "Bridge Controller",
+          "8": "Device under Test",
+          "9": "N/A",
+          "10": "AV Remote",
+          "11": "AV Device"
+        }
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version"
+      },
+      "value": "7.13"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions"
+      },
+      "value": ["7.20", "69.32"]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hardwareVersion",
+      "propertyName": "hardwareVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip hardware version"
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "sdkVersion",
+      "propertyName": "sdkVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "SDK version"
+      },
+      "value": "7.13.8"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationFrameworkAPIVersion",
+      "propertyName": "applicationFrameworkAPIVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave application framework API version"
+      },
+      "value": "10.13.8"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationFrameworkBuildNumber",
+      "propertyName": "applicationFrameworkBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave application framework API build number"
+      },
+      "value": 373
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hostInterfaceVersion",
+      "propertyName": "hostInterfaceVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Serial API version"
+      },
+      "value": "unused"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hostInterfaceBuildNumber",
+      "propertyName": "hostInterfaceBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Serial API build number"
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "zWaveProtocolVersion",
+      "propertyName": "zWaveProtocolVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version"
+      },
+      "value": "7.13.8"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "zWaveProtocolBuildNumber",
+      "propertyName": "zWaveProtocolBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol build number"
+      },
+      "value": 373
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationVersion",
+      "propertyName": "applicationVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Application version"
+      },
+      "value": "7.20.0"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationBuildNumber",
+      "propertyName": "applicationBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Application build number"
+      },
+      "value": 43707
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 139,
+      "commandClassName": "Time Parameters",
+      "property": "dateAndTime",
+      "propertyName": "dateAndTime",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      }
+    }
+  ],
+  "isFrequentListening": "1000ms",
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 7,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing Slave"
+    },
+    "generic": {
+      "key": 64,
+      "label": "Entry Control"
+    },
+    "specific": {
+      "key": 1,
+      "label": "Door Lock"
+    },
+    "mandatorySupportedCCs": [32, 118],
+    "mandatoryControlledCCs": []
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0090:0x0811:0x23a8:7.20",
+  "statistics": {
+    "commandsTX": 1,
+    "commandsRX": 0,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0
+  },
+  "highestSecurityClass": 2,
+  "isControllerNode": false,
+  "keepAwake": false
+}

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -222,3 +222,8 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
 
     assert node.status == NodeStatus.DEAD
     assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY).state == STATE_UNAVAILABLE
+
+
+async def test_only_one_lock(hass, client, lock_home_connect_620, integration):
+    """Test node with both Door Lock and Lock CC values only gets one lock entity."""
+    assert len(hass.states.async_entity_ids("lock")) == 1


### PR DESCRIPTION
## Proposed change
The Home Connect 620 supports both the Door Lock and Lock CC's which results in two lock entities being created. This PR makes it so that when both CCs are included, only one lock entity gets created


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
