### PR TITLE
Update pylint to 2.13.0

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -75,6 +75,8 @@ class AlexaCapability:
     https://developer.amazon.com/docs/device-apis/message-guide.html
     """
 
+    # pylint: disable=no-self-use
+
     supported_locales = {"en-US"}
 
     def __init__(self, entity: State, instance: str | None = None) -> None:
@@ -86,28 +88,23 @@ class AlexaCapability:
         """Return the Alexa API name of this interface."""
         raise NotImplementedError
 
-    @staticmethod
-    def properties_supported() -> list[dict]:
+    def properties_supported(self) -> list[dict]:
         """Return what properties this entity supports."""
         return []
 
-    @staticmethod
-    def properties_proactively_reported() -> bool:
+    def properties_proactively_reported(self) -> bool:
         """Return True if properties asynchronously reported."""
         return False
 
-    @staticmethod
-    def properties_retrievable() -> bool:
+    def properties_retrievable(self) -> bool:
         """Return True if properties can be retrieved."""
         return False
 
-    @staticmethod
-    def properties_non_controllable() -> bool | None:
+    def properties_non_controllable(self) -> bool | None:
         """Return True if non controllable."""
         return None
 
-    @staticmethod
-    def get_property(name):
+    def get_property(self, name):
         """Read and return a property.
 
         Return value should be a dict, or raise UnsupportedProperty.
@@ -117,13 +114,11 @@ class AlexaCapability:
         """
         raise UnsupportedProperty(name)
 
-    @staticmethod
-    def supports_deactivation():
+    def supports_deactivation(self):
         """Applicable only to scenes."""
         return None
 
-    @staticmethod
-    def capability_proactively_reported():
+    def capability_proactively_reported(self):
         """Return True if the capability is proactively reported.
 
         Set properties_proactively_reported() for proactively reported properties.
@@ -131,16 +126,14 @@ class AlexaCapability:
         """
         return None
 
-    @staticmethod
-    def capability_resources():
+    def capability_resources(self):
         """Return the capability object.
 
         Applicable to ToggleController, RangeController, and ModeController interfaces.
         """
         return []
 
-    @staticmethod
-    def configuration():
+    def configuration(self):
         """Return the configuration object.
 
         Applicable to the ThermostatController, SecurityControlPanel, ModeController, RangeController,
@@ -148,8 +141,7 @@ class AlexaCapability:
         """
         return []
 
-    @staticmethod
-    def configurations():
+    def configurations(self):
         """Return the configurations object.
 
         The plural configurations object is different that the singular configuration object.
@@ -157,31 +149,29 @@ class AlexaCapability:
         """
         return []
 
-    @staticmethod
-    def inputs():
+    def inputs(self):
         """Applicable only to media players."""
         return []
 
-    @staticmethod
-    def semantics():
+    def semantics(self):
         """Return the semantics object.
 
         Applicable to ToggleController, RangeController, and ModeController interfaces.
         """
         return []
 
-    @staticmethod
-    def supported_operations():
+    def supported_operations(self):
         """Return the supportedOperations object."""
         return []
 
-    @staticmethod
-    def camera_stream_configurations():
+    def camera_stream_configurations(self):
         """Applicable only to CameraStreamController."""
         return None
 
     def serialize_discovery(self):
         """Serialize according to the Discovery API."""
+        # pylint: disable=assignment-from-none
+        # Methods may be overridden and return a value.
         result = {"type": "AlexaInterface", "interface": self.name(), "version": "3"}
 
         if (instance := self.instance) is not None:

--- a/homeassistant/components/alexa/resources.py
+++ b/homeassistant/components/alexa/resources.py
@@ -200,6 +200,8 @@ class AlexaCapabilityResource:
     https://developer.amazon.com/docs/device-apis/resources-and-assets.html#capability-resources
     """
 
+    # pylint: disable=no-self-use
+
     def __init__(self, labels):
         """Initialize an Alexa resource."""
         self._resource_labels = []
@@ -210,13 +212,11 @@ class AlexaCapabilityResource:
         """Return capabilityResources object serialized for an API response."""
         return self.serialize_labels(self._resource_labels)
 
-    @staticmethod
-    def serialize_configuration():
+    def serialize_configuration(self):
         """Return ModeResources, PresetResources friendlyNames serialized for an API response."""
         return []
 
-    @staticmethod
-    def serialize_labels(resources):
+    def serialize_labels(self, resources):
         """Return resource label objects for friendlyNames serialized for an API response."""
         labels = []
         for label in resources:

--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -188,7 +188,9 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(device.mac.hex())
         _LOGGER.error(
-            "Failed to authenticate to the device at %s: %s", device.host[0], err_msg
+            "Failed to authenticate to the device at %s: %s",
+            device.host[0],
+            err_msg,  # pylint: disable=used-before-assignment
         )
         return self.async_show_form(step_id="auth", errors=errors)
 
@@ -251,7 +253,9 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_finish()
 
             _LOGGER.error(
-                "Failed to unlock the device at %s: %s", device.host[0], err_msg
+                "Failed to unlock the device at %s: %s",
+                device.host[0],
+                err_msg,  # pylint: disable=used-before-assignment
             )
 
         else:

--- a/homeassistant/components/color_extractor/__init__.py
+++ b/homeassistant/components/color_extractor/__init__.py
@@ -80,7 +80,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
         except UnidentifiedImageError as ex:
             _LOGGER.error(
                 "Bad image from %s '%s' provided, are you sure it's an image? %s",
-                image_type,
+                image_type,  # pylint: disable=used-before-assignment
                 image_reference,
                 ex,
             )

--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 
-# pylint: disable-next=deprecated-typing-alias
 # Issue with Python 3.9.0 and 3.9.1 with collections.abc.Callable
 # https://bugs.python.org/issue42965
 from typing import Any, Callable, NamedTuple, Optional

--- a/homeassistant/components/horizon/media_player.py
+++ b/homeassistant/components/horizon/media_player.py
@@ -202,12 +202,12 @@ class HorizonDevice(MediaPlayerEntity):
             try:
                 self._client.connect()
                 self._client.authorize()
-            except AuthenticationError as msg:
-                _LOGGER.error("Authentication to %s failed: %s", self._name, msg)
+            except AuthenticationError as msg2:
+                _LOGGER.error("Authentication to %s failed: %s", self._name, msg2)
                 return
-            except OSError as msg:
+            except OSError as msg2:
                 # occurs if horizon box is offline
-                _LOGGER.error("Reconnect to %s failed: %s", self._name, msg)
+                _LOGGER.error("Reconnect to %s failed: %s", self._name, msg2)
                 return
 
             self._send(key=key, channel=channel)

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -365,10 +365,10 @@ class HomeAssistantHTTP:
             )
             try:
                 context = self._create_emergency_ssl_context()
-            except OSError as error:
+            except OSError as error2:
                 _LOGGER.error(
                     "Could not create an emergency self signed ssl certificate: %s",
-                    error,
+                    error2,
                 )
                 context = None
             else:

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -288,8 +288,8 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         self._with_family,
                     )
                     return await self.async_step_verification_code(None, errors)
-                except PyiCloudFailedLoginException as error:
-                    _LOGGER.error("Error logging into iCloud service: %s", error)
+                except PyiCloudFailedLoginException as error_login:
+                    _LOGGER.error("Error logging into iCloud service: %s", error_login)
                     self.api = None
                     errors = {CONF_PASSWORD: "invalid_auth"}
                     return self._show_setup_form(user_input, errors, "user")

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -527,8 +527,6 @@ class LazyState(State):
 
     __slots__ = [
         "_row",
-        "entity_id",
-        "state",
         "_attributes",
         "_last_changed",
         "_last_updated",

--- a/homeassistant/components/solaredge_local/sensor.py
+++ b/homeassistant/components/solaredge_local/sensor.py
@@ -209,7 +209,6 @@ def setup_platform(
         _LOGGER.debug("Credentials correct and site is active")
     except AttributeError:
         _LOGGER.error("Missing details data in solaredge status")
-        _LOGGER.debug("Status is: %s", status)
         return
     except (ConnectTimeout, HTTPError):
         _LOGGER.error("Could not retrieve details from SolarEdge API")

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -188,6 +188,7 @@ class SonosDiscoveryManager:
             _ = soco.volume
             return soco
         except NotSupportedException as exc:
+            # pylint: disable-next=used-before-assignment
             _LOGGER.debug("Device %s is not supported, ignoring: %s", uid, exc)
             self.data.discovery_ignored.add(ip_address)
         except (OSError, SoCoException) as ex:

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -234,6 +234,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class DeviceListener(TuyaDeviceListener):
     """Device Update Listener."""
 
+    # pylint: disable=arguments-differ
+    # Library incorrectly defines methods as 'classmethod'
+    # https://github.com/tuya/tuya-iot-python-sdk/pull/48
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -94,6 +94,8 @@ if TYPE_CHECKING:
 
     from ..entity import ZhaEntity
 
+    # pylint: disable-next=broken-collections-callable
+    # Safe inside TYPE_CHECKING block
     _LogFilterType = Union[Filter, Callable[[LogRecord], int]]
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -231,7 +231,7 @@ class Battery(Sensor):
         return cls(unique_id, zha_device, channels, **kwargs)
 
     @staticmethod
-    def formatter(value: int) -> int:
+    def formatter(value: int) -> int:  # pylint: disable=arguments-differ
         """Return the state of the entity."""
         # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
         if not isinstance(value, numbers.Number) or value == -1:
@@ -391,8 +391,7 @@ class Illuminance(Sensor):
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _unit = LIGHT_LUX
 
-    @staticmethod
-    def formatter(value: int) -> float:
+    def formatter(self, value: int) -> float:
         """Convert illumination data."""
         return round(pow(10, ((value - 1) / 10000)), 1)
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1187,7 +1187,7 @@ async def _old_conf_migrator(old_config: dict[str, Any]) -> dict[str, Any]:
 class ConfigFlow(data_entry_flow.FlowHandler):
     """Base class for config flows with some helpers."""
 
-    def __init_subclass__(cls, domain: str | None = None, **kwargs: Any) -> None:
+    def __init_subclass__(cls, *, domain: str | None = None, **kwargs: Any) -> None:
         """Initialize a subclass, register if possible."""
         super().__init_subclass__(**kwargs)
         if domain is not None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -101,7 +101,7 @@ block_async_io.enable()
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")
-_R_co = TypeVar("_R_co", covariant=True)  # pylint: disable=invalid-name
+_R_co = TypeVar("_R_co", covariant=True)
 # Internal; not helpers.typing.UNDEFINED due to circular dependency
 _UNDEF: dict[Any, Any] = {}
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])

--- a/homeassistant/helpers/helper_config_entry_flow.py
+++ b/homeassistant/helpers/helper_config_entry_flow.py
@@ -181,7 +181,6 @@ class HelperConfigFlowHandler(config_entries.ConfigFlow):
 
     VERSION = 1
 
-    # pylint: disable-next=arguments-differ
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Initialize a subclass."""
         super().__init_subclass__(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ good-names = [
     "j",
     "k",
     "Run",
-    "T",
     "ip",
 ]
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.2.1
 mock-open==1.4.0
 mypy==0.941
 pre-commit==2.17.0
-pylint==2.12.2
+pylint==2.13.0
 pipdeptree==2.2.1
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -137,6 +137,10 @@ def test_invalid_discovery_info(
             msg_id="hass-argument-type",
             node=discovery_info_node,
             args=(4, "DiscoveryInfoType | None"),
+            line=6,
+            col_offset=4,
+            end_line=6,
+            end_col_offset=41,
         ),
     ):
         type_hint_checker.visit_asyncfunctiondef(func_node)


### PR DESCRIPTION
## Proposed change
Update pylint to `2.13.0`.
This is a bigger feature update, see below for some notable changes. I'll open a followup to remove `pylint: disable` messages which now have become obsolete. Those are not included here to keep the diff a bit smaller.
* #68657

Release post: https://pylint.pycqa.org/en/latest/whatsnew/2.13.html
Compare view: https://github.com/PyCQA/pylint/compare/v2.12.2...v2.13.0

### Notable changes
* Improved error ranges for class and function issues. Especially useful with the VS Code Python extension.
* Several new checkers for unicode security issues, including [Trojan Sources](https://trojansource.codes/).
* Improved `invalid-name` checker for TypeVars. See #68205
  * Some good name: `T`, `_U`, `AnyStr`, `_CallableT`, `_EntityT`, `T_co`, `T_contra`
  * Some bad names: `T_CALLABLE`, `SomeType` (or anything ending in `Type`)
  * Private names are recommended, although not a requirement by pylint. https://github.com/home-assistant/core/pull/68205#issuecomment-1072548688
* Several changes / improvements to the `used-before-assignment` logic, especially with `try` / `except` blocks.
* Detect if a `staticmethod` is overwritten with an instance method (or the other way round). Usually, `staticmethod` can be removed in these cases as the methods are called from the instance anyway.
* New `redefined-slots-in-subclass` checker. `__slots__` in subclasses should **not** contain items from the parent class `__slots__`. Python [docs](https://docs.python.org/3.10/reference/datamodel.html#notes-on-using-slots).
```
However, child subclasses will get a __dict__ and __weakref__ unless they also define __slots__
(which should only contain names of any additional slots).
```
* Relaxed `arguments-differ` check to allow redefinitions with extra parameters if those have default values.
```py
class LightEntity:
    async def async_turn_on(self, **kwargs: Any) -> None:
        ...

class SomeLight(LightEntity):
    async def async_turn_on(
        self,
        *,
        brightness: int | None = None,
        effect: str | None = None,
        **kwargs: Any,
    ) -> None:
        ...
``` 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
