### PR TITLE
Add update entity to Synology DSM

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1178,6 +1178,7 @@ omit =
     homeassistant/components/synology_dsm/sensor.py
     homeassistant/components/synology_dsm/service.py
     homeassistant/components/synology_dsm/switch.py
+    homeassistant/components/synology_dsm/update.py
     homeassistant/components/synology_srm/device_tracker.py
     homeassistant/components/syslog/notify.py
     homeassistant/components/system_bridge/__init__.py

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -21,7 +21,6 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.components.switch import SwitchEntityDescription
-from homeassistant.components.update import UpdateEntityDescription
 from homeassistant.const import (
     DATA_MEGABYTES,
     DATA_RATE_KILOBYTES_PER_SECOND,
@@ -95,13 +94,6 @@ class SynologyDSMBinarySensorEntityDescription(
     BinarySensorEntityDescription, SynologyDSMEntityDescription
 ):
     """Describes Synology DSM binary sensor entity."""
-
-
-@dataclass
-class SynologyDSMUpdateEntityEntityDescription(
-    UpdateEntityDescription, SynologyDSMEntityDescription
-):
-    """Describes Synology DSM update entity."""
 
 
 @dataclass

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -21,6 +21,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.components.update import UpdateEntityDescription
 from homeassistant.const import (
     DATA_MEGABYTES,
     DATA_RATE_KILOBYTES_PER_SECOND,
@@ -38,6 +39,7 @@ PLATFORMS = [
     Platform.CAMERA,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.UPDATE,
 ]
 COORDINATOR_CAMERAS = "coordinator_cameras"
 COORDINATOR_CENTRAL = "coordinator_central"
@@ -93,6 +95,13 @@ class SynologyDSMBinarySensorEntityDescription(
     BinarySensorEntityDescription, SynologyDSMEntityDescription
 ):
     """Describes Synology DSM binary sensor entity."""
+
+
+@dataclass
+class SynologyDSMUpdateEntityEntityDescription(
+    UpdateEntityDescription, SynologyDSMEntityDescription
+):
+    """Describes Synology DSM update entity."""
 
 
 @dataclass

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -121,9 +121,11 @@ class SynologyDSMSwitchEntityDescription(
 # Binary sensors
 UPGRADE_BINARY_SENSORS: tuple[SynologyDSMBinarySensorEntityDescription, ...] = (
     SynologyDSMBinarySensorEntityDescription(
+        # Deprecated, scheduled to be removed in 2022.6 (#68664)
         api_key=SynoCoreUpgrade.API_KEY,
         key="update_available",
         name="Update Available",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.UPDATE,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),

--- a/homeassistant/components/synology_dsm/manifest.json
+++ b/homeassistant/components/synology_dsm/manifest.json
@@ -2,7 +2,7 @@
   "domain": "synology_dsm",
   "name": "Synology DSM",
   "documentation": "https://www.home-assistant.io/integrations/synology_dsm",
-  "requirements": ["py-synologydsm-api==1.0.7"],
+  "requirements": ["py-synologydsm-api==1.0.8"],
   "codeowners": ["@hacf-fr", "@Quentame", "@mib1185"],
   "config_flow": true,
   "ssdp": [

--- a/homeassistant/components/synology_dsm/update.py
+++ b/homeassistant/components/synology_dsm/update.py
@@ -1,0 +1,84 @@
+"""Support for Synology DSM update platform."""
+from __future__ import annotations
+
+from typing import Any, Final
+
+from synology_dsm.api.core.upgrade import SynoCoreUpgrade
+
+from homeassistant.components.update import UpdateEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import SynoApi, SynologyDSMBaseEntity
+from .const import (
+    COORDINATOR_CENTRAL,
+    DOMAIN,
+    SYNO_API,
+    SynologyDSMUpdateEntityEntityDescription,
+)
+
+UPDATE_ENTITIES: Final = [
+    SynologyDSMUpdateEntityEntityDescription(
+        api_key=SynoCoreUpgrade.API_KEY,
+        key="update",
+        name="DSM Update",
+        entity_category=EntityCategory.CONFIG,
+    )
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up demo update entities."""
+    data = hass.data[DOMAIN][entry.unique_id]
+    api: SynoApi = data[SYNO_API]
+    coordinator = data[COORDINATOR_CENTRAL]
+
+    async_add_entities(
+        [
+            SynoDSMUpdateEntity(api, coordinator, description)
+            for description in UPDATE_ENTITIES
+        ]
+    )
+
+
+class SynoDSMUpdateEntity(SynologyDSMBaseEntity, UpdateEntity):
+    """Mixin for update entity specific attributes."""
+
+    entity_description: SynologyDSMUpdateEntityEntityDescription
+
+    def __init__(
+        self,
+        api: SynoApi,
+        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        description: SynologyDSMUpdateEntityEntityDescription,
+    ) -> None:
+        """Initialize the Synology DSM binary_sensor entity."""
+        super().__init__(api, coordinator, description)
+
+    @property
+    def current_version(self) -> str | None:
+        """Version currently in use."""
+        return self._api.information.version_string  # type: ignore[no-any-return]
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        if not self._api.upgrade.update_available:
+            return self.current_version
+        return self._api.upgrade.available_version  # type: ignore[no-any-return]
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the full release notes of the latest version available."""
+        base_url = "http://update.synology.com/autoupdate/whatsnew.php?"
+        if (details := self._api.upgrade.available_version_details) is not None:
+            url = f"{base_url}model={self._api.information.model}&update_version={details['buildnumber']}"
+            if details.get("nano") > 0:
+                return f"{url}-{details['nano']}"
+            return url
+        return None

--- a/homeassistant/components/synology_dsm/update.py
+++ b/homeassistant/components/synology_dsm/update.py
@@ -1,7 +1,7 @@
 """Support for Synology DSM update platform."""
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Final
 
 from synology_dsm.api.core.upgrade import SynoCoreUpgrade
 
@@ -10,7 +10,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import SynoApi, SynologyDSMBaseEntity
 from .const import (
@@ -50,15 +49,6 @@ class SynoDSMUpdateEntity(SynologyDSMBaseEntity, UpdateEntity):
     """Mixin for update entity specific attributes."""
 
     entity_description: SynologyDSMUpdateEntityEntityDescription
-
-    def __init__(
-        self,
-        api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
-        description: SynologyDSMUpdateEntityEntityDescription,
-    ) -> None:
-        """Initialize the Synology DSM binary_sensor entity."""
-        super().__init__(api, coordinator, description)
 
     @property
     def current_version(self) -> str | None:

--- a/homeassistant/components/synology_dsm/update.py
+++ b/homeassistant/components/synology_dsm/update.py
@@ -1,31 +1,35 @@
 """Support for Synology DSM update platform."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Final
 
 from synology_dsm.api.core.upgrade import SynoCoreUpgrade
 from yarl import URL
 
-from homeassistant.components.update import UpdateEntity
+from homeassistant.components.update import UpdateEntity, UpdateEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import SynoApi, SynologyDSMBaseEntity
-from .const import (
-    COORDINATOR_CENTRAL,
-    DOMAIN,
-    SYNO_API,
-    SynologyDSMUpdateEntityEntityDescription,
-)
+from .const import COORDINATOR_CENTRAL, DOMAIN, SYNO_API, SynologyDSMEntityDescription
+
+
+@dataclass
+class SynologyDSMUpdateEntityEntityDescription(
+    UpdateEntityDescription, SynologyDSMEntityDescription
+):
+    """Describes Synology DSM update entity."""
+
 
 UPDATE_ENTITIES: Final = [
     SynologyDSMUpdateEntityEntityDescription(
         api_key=SynoCoreUpgrade.API_KEY,
         key="update",
         name="DSM Update",
-        entity_category=EntityCategory.CONFIG,
+        entity_category=EntityCategory.DIAGNOSTIC,
     )
 ]
 
@@ -33,16 +37,14 @@ UPDATE_ENTITIES: Final = [
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up demo update entities."""
+    """Set up Synology DSM update entities."""
     data = hass.data[DOMAIN][entry.unique_id]
     api: SynoApi = data[SYNO_API]
     coordinator = data[COORDINATOR_CENTRAL]
 
     async_add_entities(
-        [
-            SynoDSMUpdateEntity(api, coordinator, description)
-            for description in UPDATE_ENTITIES
-        ]
+        SynoDSMUpdateEntity(api, coordinator, description)
+        for description in UPDATE_ENTITIES
     )
 
 

--- a/homeassistant/components/synology_dsm/update.py
+++ b/homeassistant/components/synology_dsm/update.py
@@ -52,6 +52,7 @@ class SynoDSMUpdateEntity(SynologyDSMBaseEntity, UpdateEntity):
     """Mixin for update entity specific attributes."""
 
     entity_description: SynologyDSMUpdateEntityEntityDescription
+    _attr_title = "Synology DSM"
 
     @property
     def current_version(self) -> str | None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1283,7 +1283,7 @@ py-nightscout==1.2.2
 py-schluter==0.1.7
 
 # homeassistant.components.synology_dsm
-py-synologydsm-api==1.0.7
+py-synologydsm-api==1.0.8
 
 # homeassistant.components.zabbix
 py-zabbix==1.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -853,7 +853,7 @@ py-melissa-climate==2.1.4
 py-nightscout==1.2.2
 
 # homeassistant.components.synology_dsm
-py-synologydsm-api==1.0.7
+py-synologydsm-api==1.0.8
 
 # homeassistant.components.seventeentrack
 py17track==2021.12.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The binary sensor entity that would show if there was an update available for the Synology DSM firmware has been deprecated and will be removed in Home Assistant 2022.6.
The Synology DSM integration now provides an update entity as a replacement for the deprecated entity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Adds the `update` platform to the Synology DSM integration and deprecates the binary sensors with "Update" device class
- for this a bump of `py-synologydsm-api` is needed
release-notes: https://github.com/mib1185/py-synologydsm-api/releases/tag/v1.0.8
changes: https://github.com/mib1185/py-synologydsm-api/compare/v1.0.7...v1.0.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/22170

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
