### PR TITLE
Add initial implementation of a calendar trigger

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -99,6 +99,20 @@ class CalendarEvent:
         """Return true if the event is an all day event."""
         return not isinstance(self.start, datetime.datetime)
 
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the event."""
+        data = {
+            "start": self.start.isoformat(),
+            "end": self.end.isoformat(),
+            "summary": self.summary,
+            "all_day": self.all_day,
+        }
+        if self.description:
+            data["description"] = self.description
+        if self.location:
+            data["location"] = self.location
+        return data
+
 
 def _get_datetime_local(
     dt_or_d: datetime.datetime | datetime.date,

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -135,7 +135,6 @@ class CalendarEventListener:
         self._unsub_event = None
         self._listen_next_calendar_event()
 
-    @callback
     async def _handle_refresh(self, now: datetime.datetime) -> None:
         """Handle core config update."""
         _LOGGER.debug("Refresh events @ %s", now)

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -1,0 +1,171 @@
+"""Offer calendar automation rules."""
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.automation import (
+    AutomationActionType,
+    AutomationTriggerInfo,
+)
+from homeassistant.const import CONF_ENTITY_ID, CONF_EVENT, CONF_PLATFORM
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time,
+    async_track_time_interval,
+)
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
+
+from . import DOMAIN, CalendarEventDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_START = "start"
+UPDATE_INTERVAL = datetime.timedelta(minutes=15)
+
+TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_PLATFORM): DOMAIN,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_EVENT, default=EVENT_START): vol.In({EVENT_START}),
+    }
+)
+
+
+class CalendarEventListener:
+    """Helper class to listen to calendar events."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        job: HassJob,
+        trigger_data: dict[str, Any],
+        entity: CalendarEventDevice,
+    ) -> None:
+        """Initialize CalendarEventListener."""
+        self._hass = hass
+        self._job = job
+        self._trigger_data = trigger_data
+        self._entity = entity
+        self._unsub_event: CALLBACK_TYPE | None = None
+        self._unsub_refresh: CALLBACK_TYPE | None = None
+        # Upcoming set of events with their trigger time
+        self._events: list[tuple[datetime.datetime, dict[str, Any]]] = []
+
+    async def async_attach(self) -> None:
+        """Attach a calendar event listener."""
+        now = dt_util.utcnow()
+        await self._fetch_events(now)
+        self._unsub_refresh = async_track_time_interval(
+            self._hass, self._handle_refresh, UPDATE_INTERVAL
+        )
+        self._listen_next_calendar_event()
+
+    @callback
+    def async_detach(self) -> None:
+        """Detach the calendar event listener."""
+        assert self._unsub_event is not None
+        assert self._unsub_refresh is not None
+
+        self._unsub_event()
+        self._unsub_event = None
+        self._unsub_refresh()
+        self._unsub_refresh = None
+
+    async def _fetch_events(self, now: datetime.datetime) -> None:
+        """Update the set of eligible events."""
+        start_date = now
+        end_date = now + UPDATE_INTERVAL * 2
+        events = await self._entity.async_get_events(self._hass, start_date, end_date)  # type: ignore[no-untyped-call]
+
+        def trigger_time_func(event: dict[str, Any]) -> datetime.datetime:
+            value = dt_util.parse_datetime(event["dt_start"])
+            assert value
+            return value
+
+        # Build list of events and the appropriate time to trigger an alarm. The
+        # returned events may have already started but matched the start/end time
+        # filtering above, so exclude any events that have already passed the
+        # trigger time.
+        event_list = [(trigger_time_func(event), event) for event in events]
+        event_list.sort(key=lambda x: x[0])
+
+        def filter_upcoming(pair: tuple[datetime.datetime, dict[str, Any]]) -> bool:
+            return pair[0] >= now
+
+        self._events = list(filter(filter_upcoming, event_list))
+        _LOGGER.debug("Populated event list %s", self._events)
+
+    @callback
+    def _listen_next_calendar_event(self) -> None:
+        """Set up the calendar event listener."""
+        assert self._unsub_event is None
+
+        if not self._events:
+            return
+
+        (event_datetime, _data) = self._events[0]
+        _LOGGER.debug("Scheduling next event trigger @ %s", event_datetime)
+        self._unsub_event = async_track_point_in_utc_time(
+            self._hass,
+            self._handle_calendar_event,
+            event_datetime,
+        )
+
+    async def _handle_calendar_event(self, now: Any) -> None:
+        """Handle calendar event."""
+        _LOGGER.debug("Calendar event @ %s", now)
+
+        # Consume all events that are eligible to fire
+        while len(self._events) > 0 and self._events[0][0] <= now:
+            (_fire_time, event) = self._events.pop(0)
+            _LOGGER.debug("Event: %s", event)
+            self._hass.async_run_hass_job(
+                self._job,
+                {"trigger": {**self._trigger_data, "calendar_event": event}},
+            )
+        self._unsub_event = None
+        self._listen_next_calendar_event()
+
+    @callback
+    async def _handle_refresh(self, now: datetime.datetime) -> None:
+        """Handle core config update."""
+        _LOGGER.debug("Refresh events @ %s", now)
+        if self._unsub_event:
+            self._unsub_event()
+            self._unsub_event = None
+        await self._fetch_events(now)
+        self._listen_next_calendar_event()
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: AutomationTriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach trigger for the specified calendar."""
+    entity_id = config[CONF_ENTITY_ID]
+    event_type = config[CONF_EVENT]
+
+    component: EntityComponent = hass.data[DOMAIN]
+    if not (entity := component.get_entity(entity_id)):
+        raise HomeAssistantError(f"Entity does not exist {entity_id}")
+    assert isinstance(entity, CalendarEventDevice)
+
+    trigger_data = {
+        **automation_info["trigger_data"],
+        "platform": DOMAIN,
+        "event": event_type,
+    }
+
+    listener = CalendarEventListener(hass, HassJob(action), trigger_data, entity)
+    await listener.async_attach()
+    return listener.async_detach

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -84,7 +84,7 @@ class CalendarEventListener:
         start_date = now
         end_date = now + UPDATE_INTERVAL * 2
         _LOGGER.debug("Fetching events between %s, %s", start_date, end_date)
-        events = await self._entity.async_get_events(self._hass, start_date, end_date)  # type: ignore[no-untyped-call]
+        events = await self._entity.async_get_events(self._hass, start_date, end_date)
 
         def trigger_time_func(event: dict[str, Any]) -> datetime.datetime:
             value = dt_util.parse_datetime(event["dt_start"])

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -125,7 +125,7 @@ class CalendarEventListener:
         _LOGGER.debug("Calendar event @ %s", now)
 
         # Consume all events that are eligible to fire
-        while len(self._events) > 0 and self._events[0][0] <= now:
+        while self._events and self._events[0][0] <= now:
             (_fire_time, event) = self._events.pop(0)
             _LOGGER.debug("Event: %s", event)
             self._hass.async_run_hass_job(

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -97,10 +97,11 @@ class CalendarEventListener:
         event_list = [(trigger_time_func(event), event) for event in events]
         event_list.sort(key=lambda x: x[0])
 
-        def filter_upcoming(pair: tuple[datetime.datetime, dict[str, Any]]) -> bool:
-            return pair[0] >= now
-
-        self._events = list(filter(filter_upcoming, event_list))
+        self._events = [
+            (trigger_time, event)
+            for (trigger_time, event) in event_list
+            if trigger_time > now
+        ]
         _LOGGER.debug("Populated event list %s", self._events)
 
     @callback
@@ -119,7 +120,7 @@ class CalendarEventListener:
             event_datetime,
         )
 
-    async def _handle_calendar_event(self, now: Any) -> None:
+    async def _handle_calendar_event(self, now: datetime.datetime) -> None:
         """Handle calendar event."""
         _LOGGER.debug("Calendar event @ %s", now)
 

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -83,6 +83,7 @@ class CalendarEventListener:
         """Update the set of eligible events."""
         start_date = now
         end_date = now + UPDATE_INTERVAL * 2
+        _LOGGER.debug("Fetching events between %s, %s", start_date, end_date)
         events = await self._entity.async_get_events(self._hass, start_date, end_date)  # type: ignore[no-untyped-call]
 
         def trigger_time_func(event: dict[str, Any]) -> datetime.datetime:

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -34,7 +34,7 @@ TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): DOMAIN,
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
-        vol.Required(CONF_EVENT, default=EVENT_START): vol.In({EVENT_START}),
+        vol.Optional(CONF_EVENT, default=EVENT_START): vol.In({EVENT_START}),
     }
 )
 

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -57,7 +57,7 @@ async def now() -> datetime.datetime:
 class FakeSchedule:
     """Test fixture class for return events in a specific date range."""
 
-    def __init__(self, now: datetime.datetime):
+    def __init__(self, now: datetime.datetime) -> None:
         """Initiailize FakeSchedule."""
         # Map of event start time to event
         self.events: list[dict[str, Any]] = []

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -82,7 +82,6 @@ class FakeSchedule:
         end_date: datetime.datetime,
     ) -> list[dict[str, Any]]:
         """Get all events in a specific time frame, used by the demo calendar."""
-        _LOGGER.debug(f"Fetching events between {start_date}, {end_date}")
         assert start_date < end_date
         values = []
         for event in self.events:

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -68,7 +68,7 @@ class FakeSchedule:
     ) -> dict[str, Any]:
         """Create a new fake event, used by tests."""
         event_data = {
-            "title": "Event %s" % secrets.token_hex(16),  # Arbitrary unique data
+            "title": f"Event {secrets.token_hex(16)}",  # Arbitrary unique data
             "dt_start": (self.now + start_timedelta).isoformat(),
             "dt_end": (self.now + end_timedelta).isoformat(),
         }
@@ -82,7 +82,7 @@ class FakeSchedule:
         end_date: datetime.datetime,
     ) -> list[dict[str, Any]]:
         """Get all events in a specific time frame, used by the demo calendar."""
-        _LOGGER.debug("Fetching events between %s, %s", start_date, end_date)
+        _LOGGER.debug(f"Fetching events between {start_date}, {end_date}")
         assert start_date < end_date
         values = []
         for event in self.events:
@@ -160,7 +160,7 @@ def mock_update_interval() -> Generator[None, None, None]:
 
 async def fire_time(hass: HomeAssistant, trigger_time: datetime.datetime) -> None:
     """Fire an alarm and wait."""
-    _LOGGER.debug("Firing alarm @ %s", trigger_time)
+    _LOGGER.debug("Firing alarm @ {trigger_time}")
     with patch("homeassistant.util.dt.utcnow", return_value=trigger_time):
         async_fire_time_changed(hass, trigger_time)
         await hass.async_block_till_done()

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -105,7 +105,7 @@ def fake_schedule(now: datetime.datetime) -> Generator[FakeSchedule, None, None]
 
 
 @pytest.fixture(autouse=True)
-async def setup_calendar(hass: HomeAssistant, fake_schedule: FakeSchedule):
+async def setup_calendar(hass: HomeAssistant, fake_schedule: FakeSchedule) -> None:
     """Initialize the demo calendar."""
     assert await async_setup_component(hass, calendar.DOMAIN, CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -1,0 +1,374 @@
+"""Tests for the calendar automation.
+
+The tests create calendar based automations, set up a fake set of calendar
+events, then advance time to exercise that the automation is called. The
+tests use a fixture that mocks out events returned by the calendar entity,
+and create events using a relative time offset and then advance the clock
+forward exercising the triggers.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+import datetime
+import logging
+import secrets
+from typing import Any, Generator
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import calendar
+import homeassistant.components.automation as automation
+from homeassistant.components.calendar.trigger import EVENT_START
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed, async_mock_service
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CALENDAR_ENTITY_ID = "calendar.calendar_2"
+CONFIG = {calendar.DOMAIN: {"platform": "demo"}}
+
+TEST_AUTOMATION_ACTION = {
+    "service": "test.automation",
+    "data_template": {
+        "platform": "{{ trigger.platform }}",
+        "event": "{{ trigger.event }}",
+        "calendar_event": "{{ trigger.calendar_event }}",
+    },
+}
+
+# The trigger sets two alarms: One based on the next event and one
+# to refresh the schedule. The test advances the time an arbitrary
+# amount to trigger either type of event with a small jitter.
+TEST_TIME_ADVANCE_INTERVAL = datetime.timedelta(minutes=1)
+TEST_UPDATE_INTERVAL = datetime.timedelta(minutes=15)
+
+
+@pytest.fixture
+async def now() -> datetime.datetime:
+    """Fixture to provide a base time for tests."""
+    return dt_util.utcnow()
+
+
+class FakeSchedule:
+    """Test fixture class for return events in a specific date range."""
+
+    def __init__(self, now: datetime.datetime):
+        """Initiailize FakeSchedule."""
+        # Map of event start time to event
+        self.events: list[dict[str, Any]] = []
+        self.now = now
+
+    def create_event(
+        self, start_timedelta: datetime.timedelta, end_timedelta: datetime.timedelta
+    ) -> dict[str, Any]:
+        """Create a new fake event, used by tests."""
+        event_data = {
+            "title": "Event %s" % secrets.token_hex(16),  # Arbitrary unique data
+            "dt_start": (self.now + start_timedelta).isoformat(),
+            "dt_end": (self.now + end_timedelta).isoformat(),
+        }
+        self.events.append(event_data)
+        return event_data
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[dict[str, Any]]:
+        """Get all events in a specific time frame, used by the demo calendar."""
+        _LOGGER.debug("Fetching events between %s, %s", start_date, end_date)
+        assert start_date < end_date
+        values = []
+        for event in self.events:
+            if (
+                start_date < dt_util.parse_datetime(event["dt_start"]) < end_date
+                or start_date < dt_util.parse_datetime(event["dt_end"]) < end_date
+            ):
+                values.append(event)
+        return values
+
+
+@pytest.fixture
+def fake_schedule(now: datetime.datetime) -> Generator[FakeSchedule, None, None]:
+    """Fixture that tests can use to make fake events."""
+    schedule = FakeSchedule(now)
+    with patch(
+        "homeassistant.components.demo.calendar.DemoGoogleCalendar.async_get_events",
+        new=schedule.async_get_events,
+    ):
+        yield schedule
+
+
+@pytest.fixture(autouse=True)
+async def setup_calendar(hass: HomeAssistant, fake_schedule: FakeSchedule):
+    """Initialize the demo calendar."""
+    assert await async_setup_component(hass, calendar.DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+
+async def create_automation(
+    hass: HomeAssistant, event_type: str, offset: str | None = None
+) -> None:
+    """Register an automation."""
+    trigger_data = {
+        "platform": calendar.DOMAIN,
+        "entity_id": CALENDAR_ENTITY_ID,
+        "event": event_type,
+    }
+    if offset:
+        trigger_data["offset"] = offset
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": trigger_data,
+                "action": TEST_AUTOMATION_ACTION,
+                "mode": "queued",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+def calls(hass: HomeAssistant) -> Callable[[], list]:
+    """Fixture to return payload data for automation calls."""
+    service_calls = async_mock_service(hass, "test", "automation")
+
+    def get_trigger_data() -> list:
+        return [c.data for c in service_calls]
+
+    return get_trigger_data
+
+
+@pytest.fixture(autouse=True)
+def mock_update_interval() -> Generator[None, None, None]:
+    """Fixture to override the update interval for refreshing events."""
+    with patch(
+        "homeassistant.components.calendar.trigger.UPDATE_INTERVAL",
+        new=TEST_UPDATE_INTERVAL,
+    ):
+        yield
+
+
+async def fire_time(hass: HomeAssistant, trigger_time: datetime.datetime) -> None:
+    """Fire an alarm and wait."""
+    _LOGGER.debug("Firing alarm @ %s", trigger_time)
+    with patch("homeassistant.util.dt.utcnow", return_value=trigger_time):
+        async_fire_time_changed(hass, trigger_time)
+        await hass.async_block_till_done()
+
+
+async def fire_between(
+    hass: HomeAssistant, now: datetime.datetime, end_time: datetime.datetime
+) -> datetime.datetime:
+    """Simulate the passage of time by firing alarms until the time is reached."""
+    trigger_time = now
+    while trigger_time < (now + end_time):
+        trigger_time = trigger_time + TEST_TIME_ADVANCE_INTERVAL
+        await fire_time(hass, trigger_time)
+    return trigger_time
+
+
+async def test_event_start_trigger(hass, calls, fake_schedule, now):
+    """Test the a calendar trigger based on start time."""
+    event_data = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=30),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    await create_automation(hass, EVENT_START)
+    assert len(calls()) == 0
+
+    await fire_between(hass, now, datetime.timedelta(hours=1, minutes=5))
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data,
+        }
+    ]
+
+
+async def test_calendar_trigger_with_no_events(hass, calls, fake_schedule, now):
+    """Test a calendar trigger setup  with no events."""
+
+    await create_automation(hass, EVENT_START)
+
+    # No calls, at arbitrary times
+    await fire_between(hass, now, datetime.timedelta(minutes=30))
+    assert len(calls()) == 0
+
+
+async def test_multiple_events(hass, calls, fake_schedule, now):
+    """Test that a trigger fires for multiple events."""
+
+    event_data1 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=15),
+        end_timedelta=datetime.timedelta(minutes=30),
+    )
+    event_data2 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=45),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    await create_automation(hass, EVENT_START)
+
+    await fire_between(hass, now, datetime.timedelta(minutes=75))
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data1,
+        },
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data2,
+        },
+    ]
+
+
+async def test_multiple_events_sharing_start_time(hass, calls, fake_schedule, now):
+    """Test that a trigger fires for every event sharing a start time."""
+
+    event_data1 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=30),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    event_data2 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=30),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    await create_automation(hass, EVENT_START)
+
+    await fire_between(hass, now, datetime.timedelta(minutes=75))
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data1,
+        },
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data2,
+        },
+    ]
+
+
+async def test_overlap_events(hass, calls, fake_schedule, now):
+    """Test that a trigger fires for events that overlap."""
+
+    event_data1 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=15),
+        end_timedelta=datetime.timedelta(minutes=45),
+    )
+    event_data2 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=30),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    await create_automation(hass, EVENT_START)
+
+    await fire_between(hass, now, datetime.timedelta(minutes=75))
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data1,
+        },
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data2,
+        },
+    ]
+
+
+async def test_invalid_calendar_id(hass, caplog):
+    """Test creating a trigger with an invalid calendar id."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "action": TEST_AUTOMATION_ACTION,
+                "trigger": {
+                    "platform": calendar.DOMAIN,
+                    "entity_id": "invalid-calendar-id",
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert "Invalid config for [automation]" in caplog.text
+
+
+async def test_update_next_event(hass, calls, fake_schedule, now):
+    """Test detection of a new event after initial trigger is setup."""
+
+    event_data1 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=45),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    await create_automation(hass, EVENT_START)
+
+    # No calls before event start
+    current_time = await fire_between(hass, now, datetime.timedelta(minutes=10))
+    assert len(calls()) == 0
+
+    # Create a new event between now and when the event fires
+    event_data2 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=30),
+        end_timedelta=datetime.timedelta(minutes=40),
+    )
+
+    # Advance past the end of the events
+    await fire_between(hass, current_time, datetime.timedelta(minutes=60))
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data2,
+        },
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data1,
+        },
+    ]
+
+
+async def test_update_missed(hass, calls, fake_schedule, now):
+    """Test that new events are missed if they arrive outside the update interval."""
+
+    event_data1 = fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=45),
+        end_timedelta=datetime.timedelta(minutes=60),
+    )
+    await create_automation(hass, EVENT_START)
+
+    # Events are refreshed at t+15 minutes. A new event is added, but the next
+    # update happens after the event is already over.
+    current_time = await fire_between(hass, now, datetime.timedelta(minutes=20))
+    assert len(calls()) == 0
+
+    fake_schedule.create_event(
+        start_timedelta=datetime.timedelta(minutes=30),
+        end_timedelta=datetime.timedelta(minutes=40),
+    )
+
+    # Only the first event is returned
+    await fire_between(hass, current_time, datetime.timedelta(minutes=60))
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_START,
+            "calendar_event": event_data1,
+        },
+    ]

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -34,7 +34,7 @@ CONFIG = {calendar.DOMAIN: {"platform": "demo"}}
 
 TEST_AUTOMATION_ACTION = {
     "service": "test.automation",
-    "data_template": {
+    "data": {
         "platform": "{{ trigger.platform }}",
         "event": "{{ trigger.event }}",
         "calendar_event": "{{ trigger.calendar_event }}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add initial implementation of a calendar trigger, that allows more flexible automations based on calendar events, an improvement over the existing "binary sensor" style calendar entity that has many limitations (single active event, issues with overlapping events, etc)

This initial PR only adds support for triggering based on event start, but has the scaffolding in place to allow it to also
work on end time, and support offsets in follow up PRs. There are are additional corner cases to consider for those scenarios, so it seemed worthwhile to first get in all the basic scaffolding and test harnesses so we can do more careful review of how the corner cases are handled on those in more detail.

Related frontend PR: https://github.com/home-assistant/frontend/pull/12343
Related arch discussion: https://github.com/home-assistant/architecture/discussions/700

Overall set of PRs for triggers:
- [X] Typing cleanup (https://github.com/home-assistant/core/pull/68660)
- [X] Add initial trigger for start events (getting scaffolding all setup) (this PR)
- [X] Frontend (https://github.com/home-assistant/frontend/pull/12343)
- [ ] Add trigger for end events
- [ ] Add offset support

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22328

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
