### PR TITLE
Bump asyncsleepiq to 1.2.1

### DIFF
--- a/homeassistant/components/sleepiq/manifest.json
+++ b/homeassistant/components/sleepiq/manifest.json
@@ -3,7 +3,7 @@
   "name": "SleepIQ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sleepiq",
-  "requirements": ["asyncsleepiq==1.2.0"],
+  "requirements": ["asyncsleepiq==1.2.1"],
   "codeowners": ["@mfugate1", "@kbickar"],
   "dhcp": [
     {

--- a/homeassistant/components/sleepiq/select.py
+++ b/homeassistant/components/sleepiq/select.py
@@ -1,16 +1,7 @@
 """Support for SleepIQ foundation preset selection."""
 from __future__ import annotations
 
-from asyncsleepiq import (
-    FAVORITE,
-    FLAT,
-    READ,
-    SNORE,
-    WATCH_TV,
-    ZERO_G,
-    SleepIQBed,
-    SleepIQPreset,
-)
+from asyncsleepiq import BED_PRESETS, SleepIQBed, SleepIQPreset
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -21,16 +12,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN
 from .coordinator import SleepIQData
 from .entity import SleepIQBedEntity
-
-FOUNDATION_PRESET_NAMES = {
-    "Not at preset": 0,
-    "Favorite": FAVORITE,
-    "Read": READ,
-    "Watch TV": WATCH_TV,
-    "Flat": FLAT,
-    "Zero G": ZERO_G,
-    "Snore": SNORE,
-}
 
 
 async def async_setup_entry(
@@ -50,7 +31,7 @@ async def async_setup_entry(
 class SleepIQSelectEntity(SleepIQBedEntity, SelectEntity):
     """Representation of a SleepIQ select entity."""
 
-    _attr_options = list(FOUNDATION_PRESET_NAMES.keys())
+    _attr_options = list(BED_PRESETS)
 
     def __init__(
         self, coordinator: DataUpdateCoordinator, bed: SleepIQBed, preset: SleepIQPreset
@@ -77,6 +58,6 @@ class SleepIQSelectEntity(SleepIQBedEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the current preset."""
-        await self.preset.set_preset(FOUNDATION_PRESET_NAMES[option])
+        await self.preset.set_preset(option)
         self._attr_current_option = option
         self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -335,7 +335,7 @@ async-upnp-client==0.27.0
 asyncpysupla==0.0.5
 
 # homeassistant.components.sleepiq
-asyncsleepiq==1.2.0
+asyncsleepiq==1.2.1
 
 # homeassistant.components.aten_pe
 atenpdu==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -265,7 +265,7 @@ arcam-fmj==0.12.0
 async-upnp-client==0.27.0
 
 # homeassistant.components.sleepiq
-asyncsleepiq==1.2.0
+asyncsleepiq==1.2.1
 
 # homeassistant.components.aurora
 auroranoaa==0.0.2

--- a/tests/components/sleepiq/test_select.py
+++ b/tests/components/sleepiq/test_select.py
@@ -1,8 +1,6 @@
 """Tests for the SleepIQ select platform."""
 from unittest.mock import MagicMock
 
-from asyncsleepiq import ZERO_G
-
 from homeassistant.components.select import DOMAIN, SERVICE_SELECT_OPTION
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -75,7 +73,7 @@ async def test_split_foundation_preset(
 
     mock_asyncsleepiq.beds[BED_ID].foundation.presets[0].set_preset.assert_called_once()
     mock_asyncsleepiq.beds[BED_ID].foundation.presets[0].set_preset.assert_called_with(
-        ZERO_G
+        "Zero G"
     )
 
 
@@ -116,4 +114,4 @@ async def test_single_foundation_preset(
     ].set_preset.assert_called_once()
     mock_asyncsleepiq_single_foundation.beds[BED_ID].foundation.presets[
         0
-    ].set_preset.assert_called_with(ZERO_G)
+    ].set_preset.assert_called_with("Zero G")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump asyncsleepiq library to 1.2.1. I moved the foundation preset name -> int mapping into the library.

Release notes: https://github.com/kbickar/asyncsleepiq/releases/tag/v1.2.1
Full changelog: https://github.com/kbickar/asyncsleepiq/compare/v1.2.0...v1.2.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
