### PR TITLE
Add zha typing [core.device] (1)

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -26,12 +26,8 @@ from . import (  # noqa: F401
     security,
     smartenergy,
 )
-from .. import (
-    const,
-    device as zha_core_device,
-    discovery as zha_disc,
-    registries as zha_regs,
-)
+from .. import const, discovery as zha_disc, registries as zha_regs
+from ..device import DeviceStatus
 
 if TYPE_CHECKING:
     from ...entity import ZhaEntity
@@ -154,7 +150,7 @@ class Channels:
         channels: list[base.ZigbeeChannel],
     ):
         """Signal new entity addition."""
-        if self.zha_device.status == zha_core_device.DeviceStatus.INITIALIZED:
+        if self.zha_device.status == DeviceStatus.INITIALIZED:
             return
 
         self.zha_device.hass.data[const.DATA_ZHA][component].append(

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -26,8 +26,12 @@ from . import (  # noqa: F401
     security,
     smartenergy,
 )
-from .. import const, discovery as zha_disc, registries as zha_regs
-from ..device import DeviceStatus
+from .. import (
+    const,
+    device as zha_core_device,
+    discovery as zha_disc,
+    registries as zha_regs,
+)
 
 if TYPE_CHECKING:
     from ...entity import ZhaEntity
@@ -150,7 +154,7 @@ class Channels:
         channels: list[base.ZigbeeChannel],
     ):
         """Signal new entity addition."""
-        if self.zha_device.status == DeviceStatus.INITIALIZED:
+        if self.zha_device.status == zha_core_device.DeviceStatus.INITIALIZED:
             return
 
         self.zha_device.hass.data[const.DATA_ZHA][component].append(

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -133,7 +133,7 @@ class ZHADevice(LogMixin):
                 self.hass, self._check_available, timedelta(seconds=keep_alive_interval)
             )
         )
-        self.status = DeviceStatus.CREATED
+        self.status: DeviceStatus = DeviceStatus.CREATED
         self._channels = channels.Channels(self)
 
     @property

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from datetime import timedelta
 from enum import Enum
 import logging
@@ -13,6 +14,7 @@ from zigpy import types
 import zigpy.exceptions
 from zigpy.profiles import PROFILES
 import zigpy.quirks
+from zigpy.types.named import EUI64, NWK
 from zigpy.zcl.clusters.general import Groups
 import zigpy.zdo.types as zdo_types
 
@@ -88,6 +90,8 @@ class DeviceStatus(Enum):
 class ZHADevice(LogMixin):
     """ZHA Zigbee device object."""
 
+    _ha_device_id: str
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -101,7 +105,7 @@ class ZHADevice(LogMixin):
         self._available = False
         self._available_signal = f"{self.name}_{self.ieee}_{SIGNAL_AVAILABLE}"
         self._checkins_missed_count = 0
-        self.unsubs = []
+        self.unsubs: list[Callable[[], None]] = []
         self.quirk_applied = isinstance(self._zigpy_device, zigpy.quirks.CustomDevice)
         self.quirk_class = (
             f"{self._zigpy_device.__class__.__module__}."
@@ -129,16 +133,15 @@ class ZHADevice(LogMixin):
                 self.hass, self._check_available, timedelta(seconds=keep_alive_interval)
             )
         )
-        self._ha_device_id = None
         self.status = DeviceStatus.CREATED
         self._channels = channels.Channels(self)
 
     @property
-    def device_id(self):
+    def device_id(self) -> str:
         """Return the HA device registry device id."""
         return self._ha_device_id
 
-    def set_device_id(self, device_id):
+    def set_device_id(self, device_id: str) -> None:
         """Set the HA device registry device id."""
         self._ha_device_id = device_id
 
@@ -159,24 +162,24 @@ class ZHADevice(LogMixin):
         self._channels = value
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return device name."""
         return f"{self.manufacturer} {self.model}"
 
     @property
-    def ieee(self):
+    def ieee(self) -> EUI64:
         """Return ieee address for device."""
         return self._zigpy_device.ieee
 
     @property
-    def manufacturer(self):
+    def manufacturer(self) -> str:
         """Return manufacturer for device."""
         if self._zigpy_device.manufacturer is None:
             return UNKNOWN_MANUFACTURER
         return self._zigpy_device.manufacturer
 
     @property
-    def model(self):
+    def model(self) -> str:
         """Return model for device."""
         if self._zigpy_device.model is None:
             return UNKNOWN_MODEL
@@ -191,7 +194,7 @@ class ZHADevice(LogMixin):
         return self._zigpy_device.node_desc.manufacturer_code
 
     @property
-    def nwk(self):
+    def nwk(self) -> NWK:
         """Return nwk for device."""
         return self._zigpy_device.nwk
 
@@ -206,7 +209,7 @@ class ZHADevice(LogMixin):
         return self._zigpy_device.rssi
 
     @property
-    def last_seen(self):
+    def last_seen(self) -> float | None:
         """Return last_seen for device."""
         return self._zigpy_device.last_seen
 
@@ -227,7 +230,7 @@ class ZHADevice(LogMixin):
         return self._zigpy_device.node_desc.logical_type.name
 
     @property
-    def power_source(self):
+    def power_source(self) -> str:
         """Return the power source for the device."""
         return (
             POWER_MAINS_POWERED if self.is_mains_powered else POWER_BATTERY_OR_UNKNOWN
@@ -258,14 +261,14 @@ class ZHADevice(LogMixin):
         return self._zigpy_device.node_desc.is_end_device
 
     @property
-    def is_groupable(self):
+    def is_groupable(self) -> bool:
         """Return true if this device has a group cluster."""
         return self.is_coordinator or (
-            self.available and self.async_get_groupable_endpoints()
+            self.available and bool(self.async_get_groupable_endpoints())
         )
 
     @property
-    def skip_configuration(self):
+    def skip_configuration(self) -> bool:
         """Return true if the device should not issue configuration related commands."""
         return self._zigpy_device.skip_configuration
 
@@ -275,7 +278,7 @@ class ZHADevice(LogMixin):
         return self._zha_gateway
 
     @property
-    def device_automation_triggers(self):
+    def device_automation_triggers(self) -> dict[tuple[str, str], dict[str, str]]:
         """Return the device automation triggers for this device."""
         triggers = {
             ("device_offline", "device_offline"): {
@@ -289,7 +292,7 @@ class ZHADevice(LogMixin):
         return triggers
 
     @property
-    def available_signal(self):
+    def available_signal(self) -> str:
         """Signal to use to subscribe to device availability changes."""
         return self._available_signal
 
@@ -332,7 +335,7 @@ class ZHADevice(LogMixin):
         return zha_dev
 
     @callback
-    def async_update_sw_build_id(self, sw_version: int):
+    def async_update_sw_build_id(self, sw_version: int) -> None:
         """Update device sw version."""
         if self.device_id is None:
             return
@@ -340,7 +343,7 @@ class ZHADevice(LogMixin):
             self.device_id, sw_version=f"0x{sw_version:08x}"
         )
 
-    async def _check_available(self, *_):
+    async def _check_available(self, *_: Any) -> None:
         # don't flip the availability state of the coordinator
         if self.is_coordinator:
             return
@@ -400,7 +403,7 @@ class ZHADevice(LogMixin):
         async_dispatcher_send(self.hass, f"{self._available_signal}_entity")
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         """Return a device description for device."""
         ieee = str(self.ieee)
         time_struct = time.localtime(self.last_seen)
@@ -423,7 +426,7 @@ class ZHADevice(LogMixin):
             ATTR_SIGNATURE: self.zigbee_signature,
         }
 
-    async def async_configure(self):
+    async def async_configure(self) -> None:
         """Configure the device."""
         should_identify = async_get_zha_config_value(
             self._zha_gateway.config_entry,
@@ -446,7 +449,7 @@ class ZHADevice(LogMixin):
                 EFFECT_OKAY, EFFECT_DEFAULT_VARIANT
             )
 
-    async def async_initialize(self, from_cache=False):
+    async def async_initialize(self, from_cache: bool = False) -> None:
         """Initialize channels."""
         self.debug("started initialization")
         await self._channels.async_initialize(from_cache)
@@ -461,15 +464,15 @@ class ZHADevice(LogMixin):
             unsubscribe()
 
     @callback
-    def async_update_last_seen(self, last_seen):
+    def async_update_last_seen(self, last_seen: float | None) -> None:
         """Set last seen on the zigpy device."""
         if self._zigpy_device.last_seen is None and last_seen is not None:
             self._zigpy_device.last_seen = last_seen
 
     @property
-    def zha_device_info(self):
+    def zha_device_info(self) -> dict[str, Any]:
         """Get ZHA device information."""
-        device_info = {}
+        device_info: dict[str, Any] = {}
         device_info.update(self.device_info)
         device_info["entities"] = [
             {
@@ -496,7 +499,7 @@ class ZHADevice(LogMixin):
         ]
 
         # Return endpoint device type Names
-        names = []
+        names: list[dict[str, str]] = []
         for endpoint in (ep for epid, ep in self.device.endpoints.items() if epid):
             profile = PROFILES.get(endpoint.profile_id)
             if profile and endpoint.device_type is not None:
@@ -768,7 +771,7 @@ class ZHADevice(LogMixin):
                 fmt = f"{log_msg[1]} completed: %s"
             zdo.debug(fmt, *(log_msg[2] + (outcome,)))
 
-    def log(self, level, msg, *args):
+    def log(self, level: int, msg: str, *args: Any) -> None:
         """Log a message."""
         msg = f"[%s](%s): {msg}"
         args = (self.nwk, self.model) + args

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -15,7 +15,7 @@ import itertools
 import logging
 from random import uniform
 import re
-from typing import Any
+from typing import Any, TypeVar
 
 import voluptuous as vol
 import zigpy.exceptions
@@ -23,6 +23,7 @@ import zigpy.types
 import zigpy.util
 import zigpy.zdo.types as zdo_types
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import State, callback
 
 from .const import (
@@ -34,6 +35,8 @@ from .const import (
 )
 from .registries import BINDABLE_CLUSTERS
 from .typing import ZhaDeviceType, ZigpyClusterType
+
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -130,7 +133,9 @@ def async_is_bindable_target(source_zha_device, target_zha_device):
 
 
 @callback
-def async_get_zha_config_value(config_entry, section, config_key, default):
+def async_get_zha_config_value(
+    config_entry: ConfigEntry, section: str, config_key: str, default: _T
+) -> _T:
     """Get the value for the specified configuration from the zha config entry."""
     return (
         config_entry.options.get(CUSTOM_CONFIGURATION, {})


### PR DESCRIPTION
## Proposed change
* Add annotations to various small methods and properties
* Don't set `_ha_device_id` to `None`. `set_device_id` is called right after initialization.
https://github.com/home-assistant/core/blob/4dc8aff3d564145d8d28492e2c3510e3f238cb45/homeassistant/components/zha/core/gateway.py#L523-L533

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
