### PR TITLE
Break out sensors for filesize

### DIFF
--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -165,6 +165,7 @@ class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
     ) -> None:
         """Initialize the data object."""
         super().__init__(coordinator)
+        base_name = path.split('/')[-1]
         self._attr_name = f"{base_name} {description.name}"
         self._attr_unique_id = (
             entry_id if description.key == "file" else f"{entry_id}-{description.key}"

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -164,7 +164,7 @@ class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
     ) -> None:
         """Initialize the data object."""
         super().__init__(coordinator)
-        base_name = path.split('/')[-1]
+        base_name = path.split("/")[-1]
         self._attr_name = f"{base_name} {description.name}"
         self._attr_unique_id = (
             entry_id if description.key == "file" else f"{entry_id}-{description.key}"

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -165,7 +165,7 @@ class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
     ) -> None:
         """Initialize the data object."""
         super().__init__(coordinator)
-        self._attr_name = f"{path.split('/')[-1]} {description.name}"
+        self._attr_name = f"{base_name} {description.name}"
         self._attr_unique_id = (
             entry_id if description.key == "file" else f"{entry_id}-{description.key}"
         )

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -1,7 +1,7 @@
 """Sensor for monitoring the size of a file."""
 from __future__ import annotations
 
-import datetime
+from datetime import datetime, timedelta
 import logging
 import os
 import pathlib
@@ -10,20 +10,60 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
+    SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_FILE_PATH, DATA_MEGABYTES
+from homeassistant.const import CONF_FILE_PATH, DATA_BYTES, DATA_MEGABYTES
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+import homeassistant.util.dt as dt_util
 
 from .const import CONF_FILE_PATHS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 ICON = "mdi:file"
+
+SENSOR_TYPES = (
+    SensorEntityDescription(
+        key="file",
+        entity_registry_enabled_default=True,
+        icon=ICON,
+        name="Size",
+        native_unit_of_measurement=DATA_MEGABYTES,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="bytes",
+        entity_registry_enabled_default=False,
+        icon=ICON,
+        name="Size bytes",
+        native_unit_of_measurement=DATA_BYTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="last_updated",
+        entity_registry_enabled_default=False,
+        icon=ICON,
+        name="Last Updated",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
 
 PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_FILE_PATHS): vol.All(cv.ensure_list, [cv.isfile])}
@@ -62,36 +102,81 @@ async def async_setup_entry(
     get_path = await hass.async_add_executor_job(pathlib.Path, path)
     fullpath = str(get_path.absolute())
 
+    coordinator = FileSizeCoordinator(hass, fullpath)
+    await coordinator.async_config_entry_first_refresh()
+
     if get_path.exists() and get_path.is_file():
-        async_add_entities([FilesizeEntity(fullpath, entry.entry_id)], True)
+        async_add_entities(
+            [
+                FilesizeEntity(description, fullpath, entry.entry_id, coordinator)
+                for description in SENSOR_TYPES
+            ]
+        )
 
 
-class FilesizeEntity(SensorEntity):
-    """Encapsulates file size information."""
+class FileSizeCoordinator(DataUpdateCoordinator):
+    """Filesize coordinator."""
 
-    _attr_native_unit_of_measurement = DATA_MEGABYTES
-    _attr_icon = ICON
+    def __init__(self, hass: HomeAssistant, path: str) -> None:
+        """Initialize filesize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=60),
+        )
+        self._path = path
 
-    def __init__(self, path: str, entry_id: str) -> None:
-        """Initialize the data object."""
-        self._path = path  # Need to check its a valid path
-        self._attr_name = path.split("/")[-1]
-        self._attr_unique_id = entry_id
-
-    def update(self) -> None:
-        """Update the sensor."""
+    async def _async_update_data(self) -> dict[str, float | int | datetime]:
+        """Fetch file information."""
         try:
             statinfo = os.stat(self._path)
         except OSError as error:
-            _LOGGER.error("Can not retrieve file statistics %s", error)
-            self._attr_native_value = None
-            return
+            raise UpdateFailed(f"Can not retrieve file statistics {error}") from error
 
         size = statinfo.st_size
-        last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime).isoformat()
-        self._attr_native_value = round(size / 1e6, 2) if size else None
-        self._attr_extra_state_attributes = {
-            "path": self._path,
-            "last_updated": last_updated,
+        last_updated = datetime.fromtimestamp(statinfo.st_mtime).replace(
+            tzinfo=dt_util.UTC
+        )
+        _LOGGER.debug("size %s, last updated %s", size, last_updated)
+        data: dict[str, int | float | datetime] = {
+            "file": round(size / 1e6, 2),
             "bytes": size,
+            "last_updated": last_updated,
         }
+
+        return data
+
+
+class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
+    """Encapsulates file size information."""
+
+    entity_description: SensorEntityDescription
+
+    def __init__(
+        self,
+        description: SensorEntityDescription,
+        path: str,
+        entry_id: str,
+        coordinator: FileSizeCoordinator,
+    ) -> None:
+        """Initialize the data object."""
+        super().__init__(coordinator)
+        self._attr_name = f"{path.split('/')[-1]} {description.name}"
+        self._attr_unique_id = (
+            entry_id if description.key == "file" else f"{entry_id}-{description.key}"
+        )
+        self.entity_description = description
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, entry_id)},
+            name=path.split("/")[-1],
+        )
+
+    @property
+    def native_value(self) -> float | int | datetime:
+        """Return the value of the sensor."""
+        value: float | int | datetime = self.coordinator.data[
+            self.entity_description.key
+        ]
+        return value

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -173,7 +173,7 @@ class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, entry_id)},
-            name=path.split("/")[-1],
+            name=base_name,
         )
 
     @property

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -39,7 +39,6 @@ ICON = "mdi:file"
 SENSOR_TYPES = (
     SensorEntityDescription(
         key="file",
-        entity_registry_enabled_default=True,
         icon=ICON,
         name="Size",
         native_unit_of_measurement=DATA_MEGABYTES,

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -1,14 +1,13 @@
 """The tests for the filesize sensor."""
 import os
 
+from homeassistant.components.filesize.const import DOMAIN
 from homeassistant.const import CONF_FILE_PATH, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component
 
 from . import TEST_FILE, TEST_FILE_NAME, create_file
-
-from homeassistant.components.filesize.const import DOMAIN
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -4,8 +4,11 @@ import os
 from homeassistant.const import CONF_FILE_PATH, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
+from homeassistant.setup import async_setup_component
 
 from . import TEST_FILE, TEST_FILE_NAME, create_file
+
+from homeassistant.components.filesize.const import DOMAIN
 
 from tests.common import MockConfigEntry
 
@@ -69,3 +72,23 @@ async def test_state_unavailable(
 
     state = hass.states.get("sensor.file_txt_size")
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_import_query(hass: HomeAssistant, tmpdir: str) -> None:
+    """Test import from yaml."""
+    testfile = f"{tmpdir}/file.txt"
+    create_file(testfile)
+    hass.config.allowlist_external_dirs = {tmpdir}
+    config = {
+        "sensor": {
+            "platform": "filesize",
+            "file_paths": [testfile],
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    assert hass.config_entries.async_entries(DOMAIN)
+    data = hass.config_entries.async_entries(DOMAIN)[0].data
+    assert data[CONF_FILE_PATH] == testfile

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -1,7 +1,7 @@
 """The tests for the filesize sensor."""
 import os
 
-from homeassistant.const import CONF_FILE_PATH, STATE_UNKNOWN
+from homeassistant.const import CONF_FILE_PATH, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -38,19 +38,18 @@ async def test_valid_path(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.file_txt")
+    state = hass.states.get("sensor.file_txt_size")
     assert state
     assert state.state == "0.0"
-    assert state.attributes.get("bytes") == 4
 
     await hass.async_add_executor_job(os.remove, testfile)
 
 
-async def test_state_unknown(
+async def test_state_unavailable(
     hass: HomeAssistant, tmpdir: str, mock_config_entry: MockConfigEntry
 ) -> None:
     """Verify we handle state unavailable."""
-    testfile = f"{tmpdir}/file"
+    testfile = f"{tmpdir}/file.txt"
     create_file(testfile)
     hass.config.allowlist_external_dirs = {tmpdir}
     mock_config_entry.add_to_hass(hass)
@@ -61,12 +60,12 @@ async def test_state_unknown(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.file")
+    state = hass.states.get("sensor.file_txt_size")
     assert state
     assert state.state == "0.0"
 
     await hass.async_add_executor_job(os.remove, testfile)
-    await async_update_entity(hass, "sensor.file")
+    await async_update_entity(hass, "sensor.file_txt_size")
 
-    state = hass.states.get("sensor.file")
-    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.file_txt_size")
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Additional attributes for the filesize sensors has been extracted into their own sensors which are disabled by default. If you were previously using any of these attributes your automations, scripts etc. needs to be updated to use the new sensors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As per review comments from PR #67668 the attribute for bytes and last updated are now their own sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
