### PR TITLE
Improve totalconnect error handling

### DIFF
--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -4,7 +4,11 @@ from datetime import timedelta
 import logging
 
 from total_connect_client.client import TotalConnectClient
-from total_connect_client.exceptions import AuthenticationError, TotalConnectError
+from total_connect_client.exceptions import (
+    AuthenticationError,
+    ServiceUnavailable,
+    TotalConnectError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
@@ -86,6 +90,10 @@ class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
             # should only encounter if password changes during operation
             raise ConfigEntryAuthFailed(
                 "TotalConnect authentication failed during operation"
+            ) from exception
+        except ServiceUnavailable as exception:
+            raise UpdateFailed(
+                "Error connecting to TotalConnect or the service is unavailable"
             ) from exception
         except TotalConnectError as exception:
             raise UpdateFailed(exception) from exception

--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -89,7 +89,7 @@ class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
         except AuthenticationError as exception:
             # should only encounter if password changes during operation
             raise ConfigEntryAuthFailed(
-                "TotalConnect authentication failed during operation"
+                "TotalConnect authentication failed during operation."
             ) from exception
         except ServiceUnavailable as exception:
             raise UpdateFailed(

--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -93,7 +93,8 @@ class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
             ) from exception
         except ServiceUnavailable as exception:
             raise UpdateFailed(
-                "Error connecting to TotalConnect or the service is unavailable"
+                "Error connecting to TotalConnect or the service is unavailable. "
+                "Check https://status.resideo.com/ for outages."
             ) from exception
         except TotalConnectError as exception:
             raise UpdateFailed(exception) from exception

--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -40,7 +40,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             TotalConnectClient, username, password, usercodes
         )
     except AuthenticationError as exception:
-        raise ConfigEntryAuthFailed("TotalConnect authentication failed") from exception
+        raise ConfigEntryAuthFailed(
+            "TotalConnect authentication failed during setup"
+        ) from exception
 
     coordinator = TotalConnectDataUpdateCoordinator(hass, client)
     await coordinator.async_config_entry_first_refresh()
@@ -83,7 +85,7 @@ class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
         except AuthenticationError as exception:
             # should only encounter if password changes during operation
             raise ConfigEntryAuthFailed(
-                "TotalConnect authentication failed"
+                "TotalConnect authentication failed during operation"
             ) from exception
         except TotalConnectError as exception:
             raise UpdateFailed(exception) from exception

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -168,13 +168,8 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        await self.hass.async_add_executor_job(self._disarm)
-        await self.coordinator.async_request_refresh()
-
-    def _disarm(self, code=None):
-        """Disarm synchronous."""
         try:
-            ArmingHelper(self._partition).disarm()
+            await self.hass.async_add_executor_job(self._disarm)
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(
@@ -184,16 +179,16 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             raise HomeAssistantError(
                 f"TotalConnect failed to disarm {self._name}."
             ) from error
+        await self.coordinator.async_request_refresh()
+
+    def _disarm(self, code=None):
+        """Disarm synchronous."""
+        ArmingHelper(self._partition).disarm()
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
-        await self.hass.async_add_executor_job(self._arm_home)
-        await self.coordinator.async_request_refresh()
-
-    def _arm_home(self):
-        """Arm home synchronous."""
         try:
-            ArmingHelper(self._partition).arm_stay()
+            await self.hass.async_add_executor_job(self._arm_home)
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(
@@ -203,16 +198,16 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home {self._name}."
             ) from error
+        await self.coordinator.async_request_refresh()
+
+    def _arm_home(self):
+        """Arm home synchronous."""
+        ArmingHelper(self._partition).arm_stay()
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        await self.hass.async_add_executor_job(self._arm_away)
-        await self.coordinator.async_request_refresh()
-
-    def _arm_away(self, code=None):
-        """Arm away synchronous."""
         try:
-            ArmingHelper(self._partition).arm_away()
+            await self.hass.async_add_executor_job(self._arm_away)
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(
@@ -222,16 +217,16 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away {self._name}."
             ) from error
+        await self.coordinator.async_request_refresh()
+
+    def _arm_away(self, code=None):
+        """Arm away synchronous."""
+        ArmingHelper(self._partition).arm_away()
 
     async def async_alarm_arm_night(self, code=None):
         """Send arm night command."""
-        await self.hass.async_add_executor_job(self._arm_night)
-        await self.coordinator.async_request_refresh()
-
-    def _arm_night(self, code=None):
-        """Arm night synchronous."""
         try:
-            ArmingHelper(self._partition).arm_stay_night()
+            await self.hass.async_add_executor_job(self._arm_night)
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(
@@ -241,16 +236,16 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             raise HomeAssistantError(
                 f"TotalConnect failed to arm night {self._name}."
             ) from error
+        await self.coordinator.async_request_refresh()
+
+    def _arm_night(self, code=None):
+        """Arm night synchronous."""
+        ArmingHelper(self._partition).arm_stay_night()
 
     async def async_alarm_arm_home_instant(self, code=None):
         """Send arm home instant command."""
-        await self.hass.async_add_executor_job(self._arm_home_instant)
-        await self.coordinator.async_request_refresh()
-
-    def _arm_home_instant(self):
-        """Arm home instant synchronous."""
         try:
-            ArmingHelper(self._partition).arm_stay_instant()
+            await self.hass.async_add_executor_job(self._arm_home_instant)
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(
@@ -260,16 +255,16 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home instant {self._name}."
             ) from error
+        await self.coordinator.async_request_refresh()
+
+    def _arm_home_instant(self):
+        """Arm home instant synchronous."""
+        ArmingHelper(self._partition).arm_stay_instant()
 
     async def async_alarm_arm_away_instant(self, code=None):
         """Send arm away instant command."""
-        await self.hass.async_add_executor_job(self._arm_away_instant)
-        await self.coordinator.async_request_refresh()
-
-    def _arm_away_instant(self, code=None):
-        """Arm away instant synchronous."""
         try:
-            ArmingHelper(self._partition).arm_away_instant()
+            await self.hass.async_add_executor_job(self._arm_away_instant)
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(
@@ -279,3 +274,8 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away instant {self._name}."
             ) from error
+        await self.coordinator.async_request_refresh()
+
+    def _arm_away_instant(self, code=None):
+        """Arm away instant synchronous."""
+        ArmingHelper(self._partition).arm_away_instant()

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -1,4 +1,6 @@
 """Interfaces with TotalConnect alarm control panels."""
+import logging
+
 from total_connect_client import ArmingHelper
 from total_connect_client.exceptions import BadResultCodeError, UsercodeInvalid
 
@@ -20,7 +22,7 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -29,6 +31,8 @@ from .const import DOMAIN
 
 SERVICE_ALARM_ARM_AWAY_INSTANT = "arm_away_instant"
 SERVICE_ALARM_ARM_HOME_INSTANT = "arm_home_instant"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -175,10 +179,9 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Disarm synchronous."""
         try:
             ArmingHelper(self._partition).disarm()
-        except UsercodeInvalid as error:
-            raise ConfigEntryAuthFailed(
-                "TotalConnect usercode is invalid. Did not disarm."
-            ) from error
+        except UsercodeInvalid:
+            _LOGGER.error("TotalConnect usercode is invalid. Did not disarm")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to disarm {self._name}."
@@ -193,10 +196,9 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm home synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay()
-        except UsercodeInvalid as error:
-            raise ConfigEntryAuthFailed(
-                "TotalConnect usercode is invalid. Did not arm home."
-            ) from error
+        except UsercodeInvalid:
+            _LOGGER.error("TotalConnect usercode is invalid. Did not arm home")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home {self._name}."
@@ -211,10 +213,9 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm away synchronous."""
         try:
             ArmingHelper(self._partition).arm_away()
-        except UsercodeInvalid as error:
-            raise ConfigEntryAuthFailed(
-                "TotalConnect usercode is invalid. Did not arm away."
-            ) from error
+        except UsercodeInvalid:
+            _LOGGER.error("TotalConnect usercode is invalid. Did not arm away")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away {self._name}."
@@ -229,10 +230,9 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm night synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay_night()
-        except UsercodeInvalid as error:
-            raise ConfigEntryAuthFailed(
-                "TotalConnect usercode is invalid. Did not arm night."
-            ) from error
+        except UsercodeInvalid:
+            _LOGGER.error("TotalConnect usercode is invalid. Did not arm night")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm night {self._name}."
@@ -247,10 +247,9 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm home instant synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay_instant()
-        except UsercodeInvalid as error:
-            raise ConfigEntryAuthFailed(
-                "TotalConnect usercode is invalid. Did not arm home instant."
-            ) from error
+        except UsercodeInvalid:
+            _LOGGER.error("TotalConnect usercode is invalid. Did not arm home instant")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home instant {self._name}."
@@ -265,10 +264,9 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm away instant synchronous."""
         try:
             ArmingHelper(self._partition).arm_away_instant()
-        except UsercodeInvalid as error:
-            raise ConfigEntryAuthFailed(
-                "TotalConnect usercode is invalid. Did not arm away instant."
-            ) from error
+        except UsercodeInvalid:
+            _LOGGER.error("TotalConnect usercode is invalid. Did not arm away instant")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away instant {self._name}."

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -1,6 +1,4 @@
 """Interfaces with TotalConnect alarm control panels."""
-import logging
-
 from total_connect_client import ArmingHelper
 from total_connect_client.exceptions import BadResultCodeError, UsercodeInvalid
 
@@ -31,8 +29,6 @@ from .const import DOMAIN
 
 SERVICE_ALARM_ARM_AWAY_INSTANT = "arm_away_instant"
 SERVICE_ALARM_ARM_HOME_INSTANT = "arm_home_instant"
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -179,9 +175,11 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Disarm synchronous."""
         try:
             ArmingHelper(self._partition).disarm()
-        except UsercodeInvalid:
-            _LOGGER.error("TotalConnect usercode is invalid. Did not disarm")
+        except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "TotalConnect usercode is invalid. Did not disarm"
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to disarm {self._name}."
@@ -196,9 +194,11 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm home synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay()
-        except UsercodeInvalid:
-            _LOGGER.error("TotalConnect usercode is invalid. Did not arm home")
+        except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "TotalConnect usercode is invalid. Did not arm home"
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home {self._name}."
@@ -213,9 +213,11 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm away synchronous."""
         try:
             ArmingHelper(self._partition).arm_away()
-        except UsercodeInvalid:
-            _LOGGER.error("TotalConnect usercode is invalid. Did not arm away")
+        except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "TotalConnect usercode is invalid. Did not arm away"
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away {self._name}."
@@ -230,9 +232,11 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm night synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay_night()
-        except UsercodeInvalid:
-            _LOGGER.error("TotalConnect usercode is invalid. Did not arm night")
+        except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "TotalConnect usercode is invalid. Did not arm night"
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm night {self._name}."
@@ -247,9 +251,11 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm home instant synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay_instant()
-        except UsercodeInvalid:
-            _LOGGER.error("TotalConnect usercode is invalid. Did not arm home instant")
+        except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "TotalConnect usercode is invalid. Did not arm home instant"
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home instant {self._name}."
@@ -264,9 +270,11 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm away instant synchronous."""
         try:
             ArmingHelper(self._partition).arm_away_instant()
-        except UsercodeInvalid:
-            _LOGGER.error("TotalConnect usercode is invalid. Did not arm away instant")
+        except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "TotalConnect usercode is invalid. Did not arm away instant"
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away instant {self._name}."

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -1,8 +1,6 @@
 """Interfaces with TotalConnect alarm control panels."""
-import logging
-
 from total_connect_client import ArmingHelper
-from total_connect_client.exceptions import BadResultCodeError
+from total_connect_client.exceptions import BadResultCodeError, UsercodeInvalid
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel.const import (
@@ -22,14 +20,12 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 SERVICE_ALARM_ARM_AWAY_INSTANT = "arm_away_instant"
 SERVICE_ALARM_ARM_HOME_INSTANT = "arm_home_instant"
@@ -179,6 +175,10 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Disarm synchronous."""
         try:
             ArmingHelper(self._partition).disarm()
+        except UsercodeInvalid as error:
+            raise ConfigEntryAuthFailed(
+                "TotalConnect usercode is invalid. Did not disarm."
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to disarm {self._name}."
@@ -193,6 +193,10 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm home synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay()
+        except UsercodeInvalid as error:
+            raise ConfigEntryAuthFailed(
+                "TotalConnect usercode is invalid. Did not arm home."
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home {self._name}."
@@ -207,6 +211,10 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm away synchronous."""
         try:
             ArmingHelper(self._partition).arm_away()
+        except UsercodeInvalid as error:
+            raise ConfigEntryAuthFailed(
+                "TotalConnect usercode is invalid. Did not arm away."
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away {self._name}."
@@ -221,6 +229,10 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm night synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay_night()
+        except UsercodeInvalid as error:
+            raise ConfigEntryAuthFailed(
+                "TotalConnect usercode is invalid. Did not arm night."
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm night {self._name}."
@@ -235,6 +247,10 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm home instant synchronous."""
         try:
             ArmingHelper(self._partition).arm_stay_instant()
+        except UsercodeInvalid as error:
+            raise ConfigEntryAuthFailed(
+                "TotalConnect usercode is invalid. Did not arm home instant."
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm home instant {self._name}."
@@ -249,6 +265,10 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         """Arm away instant synchronous."""
         try:
             ArmingHelper(self._partition).arm_away_instant()
+        except UsercodeInvalid as error:
+            raise ConfigEntryAuthFailed(
+                "TotalConnect usercode is invalid. Did not arm away instant."
+            ) from error
         except BadResultCodeError as error:
             raise HomeAssistantError(
                 f"TotalConnect failed to arm away instant {self._name}."

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "totalconnect",
   "name": "Total Connect",
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
-  "requirements": ["total_connect_client==2022.2.1"],
+  "requirements": ["total_connect_client==2022.3"],
   "dependencies": [],
   "codeowners": ["@austinmroczek"],
   "config_flow": true,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2306,7 +2306,7 @@ tololib==0.1.0b3
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2022.2.1
+total_connect_client==2022.3
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1476,7 +1476,7 @@ tololib==0.1.0b3
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2022.2.1
+total_connect_client==2022.3
 
 # homeassistant.components.transmission
 transmissionrpc==0.11

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.util import dt
 
 from .common import (
@@ -110,7 +110,7 @@ async def test_arm_home_success(hass: HomeAssistant) -> None:
 
 async def test_arm_home_failure(hass: HomeAssistant) -> None:
     """Test arm home method failure."""
-    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         await setup_platform(hass, ALARM_DOMAIN)
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
@@ -124,6 +124,16 @@ async def test_arm_home_failure(hass: HomeAssistant) -> None:
         assert f"{err.value}" == "TotalConnect failed to arm home test."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 2
+
+        # usercode is invalid
+        with pytest.raises(ConfigEntryAuthFailed) as err:
+            await hass.services.async_call(
+                ALARM_DOMAIN, SERVICE_ALARM_ARM_HOME, DATA, blocking=True
+            )
+            await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm home."
+        assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        assert mock_request.call_count == 3
 
 
 async def test_arm_home_instant_success(hass: HomeAssistant) -> None:
@@ -148,7 +158,7 @@ async def test_arm_home_instant_success(hass: HomeAssistant) -> None:
 
 async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
     """Test arm home instant method failure."""
-    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         await setup_platform(hass, ALARM_DOMAIN)
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
@@ -162,6 +172,19 @@ async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
         assert f"{err.value}" == "TotalConnect failed to arm home instant test."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 2
+
+        # usercode is invalid
+        with pytest.raises(ConfigEntryAuthFailed) as err:
+            await hass.services.async_call(
+                DOMAIN, SERVICE_ALARM_ARM_HOME_INSTANT, DATA, blocking=True
+            )
+            await hass.async_block_till_done()
+        assert (
+            f"{err.value}"
+            == "TotalConnect usercode is invalid. Did not arm home instant."
+        )
+        assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        assert mock_request.call_count == 3
 
 
 async def test_arm_away_instant_success(hass: HomeAssistant) -> None:
@@ -186,7 +209,7 @@ async def test_arm_away_instant_success(hass: HomeAssistant) -> None:
 
 async def test_arm_away_instant_failure(hass: HomeAssistant) -> None:
     """Test arm home instant method failure."""
-    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         await setup_platform(hass, ALARM_DOMAIN)
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
@@ -201,23 +224,18 @@ async def test_arm_away_instant_failure(hass: HomeAssistant) -> None:
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 2
 
-
-async def test_arm_home_invalid_usercode(hass: HomeAssistant) -> None:
-    """Test arm home method with invalid usercode."""
-    responses = [RESPONSE_DISARMED, RESPONSE_USER_CODE_INVALID]
-    with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
-        assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        assert mock_request.call_count == 1
-
-        with pytest.raises(HomeAssistantError) as err:
+        # usercode is invalid
+        with pytest.raises(ConfigEntryAuthFailed) as err:
             await hass.services.async_call(
-                ALARM_DOMAIN, SERVICE_ALARM_ARM_HOME, DATA, blocking=True
+                DOMAIN, SERVICE_ALARM_ARM_AWAY_INSTANT, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert f"{err.value}" == "TotalConnect failed to arm home test."
+        assert (
+            f"{err.value}"
+            == "TotalConnect usercode is invalid. Did not arm away instant."
+        )
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        assert mock_request.call_count == 2
+        assert mock_request.call_count == 3
 
 
 async def test_arm_away_success(hass: HomeAssistant) -> None:
@@ -241,7 +259,7 @@ async def test_arm_away_success(hass: HomeAssistant) -> None:
 
 async def test_arm_away_failure(hass: HomeAssistant) -> None:
     """Test arm away method failure."""
-    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         await setup_platform(hass, ALARM_DOMAIN)
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
@@ -255,6 +273,16 @@ async def test_arm_away_failure(hass: HomeAssistant) -> None:
         assert f"{err.value}" == "TotalConnect failed to arm away test."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 2
+
+        # usercode is invalid
+        with pytest.raises(ConfigEntryAuthFailed) as err:
+            await hass.services.async_call(
+                ALARM_DOMAIN, SERVICE_ALARM_ARM_AWAY, DATA, blocking=True
+            )
+            await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm away."
+        assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        assert mock_request.call_count == 3
 
 
 async def test_disarm_success(hass: HomeAssistant) -> None:
@@ -278,7 +306,11 @@ async def test_disarm_success(hass: HomeAssistant) -> None:
 
 async def test_disarm_failure(hass: HomeAssistant) -> None:
     """Test disarm method failure."""
-    responses = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_FAILURE]
+    responses = [
+        RESPONSE_ARMED_AWAY,
+        RESPONSE_DISARM_FAILURE,
+        RESPONSE_USER_CODE_INVALID,
+    ]
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         await setup_platform(hass, ALARM_DOMAIN)
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
@@ -293,23 +325,15 @@ async def test_disarm_failure(hass: HomeAssistant) -> None:
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
         assert mock_request.call_count == 2
 
-
-async def test_disarm_invalid_usercode(hass: HomeAssistant) -> None:
-    """Test disarm method failure."""
-    responses = [RESPONSE_ARMED_AWAY, RESPONSE_USER_CODE_INVALID]
-    with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
-        assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
-        assert mock_request.call_count == 1
-
-        with pytest.raises(HomeAssistantError) as err:
+        # usercode is invalid
+        with pytest.raises(ConfigEntryAuthFailed) as err:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_DISARM, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert f"{err.value}" == "TotalConnect failed to disarm test."
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not disarm."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
-        assert mock_request.call_count == 2
+        assert mock_request.call_count == 3
 
 
 async def test_arm_night_success(hass: HomeAssistant) -> None:
@@ -333,7 +357,7 @@ async def test_arm_night_success(hass: HomeAssistant) -> None:
 
 async def test_arm_night_failure(hass: HomeAssistant) -> None:
     """Test arm night method failure."""
-    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         await setup_platform(hass, ALARM_DOMAIN)
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
@@ -347,6 +371,16 @@ async def test_arm_night_failure(hass: HomeAssistant) -> None:
         assert f"{err.value}" == "TotalConnect failed to arm night test."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 2
+
+        # usercode is invalid
+        with pytest.raises(ConfigEntryAuthFailed) as err:
+            await hass.services.async_call(
+                ALARM_DOMAIN, SERVICE_ALARM_ARM_NIGHT, DATA, blocking=True
+            )
+            await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm night."
+        assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        assert mock_request.call_count == 3
 
 
 async def test_arming(hass: HomeAssistant) -> None:

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt
 
 from .common import (
@@ -62,6 +62,8 @@ ENTITY_ID_2 = "alarm_control_panel.test_partition_2"
 CODE = "-1"
 DATA = {ATTR_ENTITY_ID: ENTITY_ID}
 DELAY = timedelta(seconds=10)
+
+REAUTH = "homeassistant.config_entries.ConfigEntry.async_start_reauth"
 
 
 async def test_attributes(hass: HomeAssistant) -> None:
@@ -127,13 +129,13 @@ async def test_arm_home_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with pytest.raises(ConfigEntryAuthFailed) as err:
+        with patch(REAUTH) as config_entry_reauth:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_ARM_HOME, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm home."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        config_entry_reauth.assert_called()
         assert mock_request.call_count == 3
 
 
@@ -175,16 +177,13 @@ async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with pytest.raises(ConfigEntryAuthFailed) as err:
+        with patch(REAUTH) as config_entry_reauth:
             await hass.services.async_call(
                 DOMAIN, SERVICE_ALARM_ARM_HOME_INSTANT, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert (
-            f"{err.value}"
-            == "TotalConnect usercode is invalid. Did not arm home instant."
-        )
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        config_entry_reauth.assert_called()
         assert mock_request.call_count == 3
 
 
@@ -226,16 +225,13 @@ async def test_arm_away_instant_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with pytest.raises(ConfigEntryAuthFailed) as err:
+        with patch(REAUTH) as config_entry_reauth:
             await hass.services.async_call(
                 DOMAIN, SERVICE_ALARM_ARM_AWAY_INSTANT, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert (
-            f"{err.value}"
-            == "TotalConnect usercode is invalid. Did not arm away instant."
-        )
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        config_entry_reauth.assert_called()
         assert mock_request.call_count == 3
 
 
@@ -276,13 +272,13 @@ async def test_arm_away_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with pytest.raises(ConfigEntryAuthFailed) as err:
+        with patch(REAUTH) as config_entry_reauth:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_ARM_AWAY, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm away."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        config_entry_reauth.assert_called()
         assert mock_request.call_count == 3
 
 
@@ -327,13 +323,13 @@ async def test_disarm_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with pytest.raises(ConfigEntryAuthFailed) as err:
+        with patch(REAUTH) as config_entry_reauth:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_DISARM, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not disarm."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
+        config_entry_reauth.assert_called()
         assert mock_request.call_count == 3
 
 
@@ -374,13 +370,13 @@ async def test_arm_night_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with pytest.raises(ConfigEntryAuthFailed) as err:
+        with patch(REAUTH) as config_entry_reauth:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_ARM_NIGHT, DATA, blocking=True
             )
             await hass.async_block_till_done()
-        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm night."
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
+        config_entry_reauth.assert_called()
         assert mock_request.call_count == 3
 
 

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -63,8 +63,6 @@ CODE = "-1"
 DATA = {ATTR_ENTITY_ID: ENTITY_ID}
 DELAY = timedelta(seconds=10)
 
-REAUTH = "homeassistant.config_entries.ConfigEntry.async_start_reauth"
-
 
 async def test_attributes(hass: HomeAssistant) -> None:
     """Test the alarm control panel attributes are correct."""
@@ -129,13 +127,15 @@ async def test_arm_home_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with patch(REAUTH) as config_entry_reauth:
+        with pytest.raises(HomeAssistantError) as err:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_ARM_HOME, DATA, blocking=True
             )
             await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm home"
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        config_entry_reauth.assert_called()
+        # should have started a re-auth flow
+        assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
         assert mock_request.call_count == 3
 
 
@@ -177,13 +177,18 @@ async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with patch(REAUTH) as config_entry_reauth:
+        with pytest.raises(HomeAssistantError) as err:
             await hass.services.async_call(
                 DOMAIN, SERVICE_ALARM_ARM_HOME_INSTANT, DATA, blocking=True
             )
             await hass.async_block_till_done()
+        assert (
+            f"{err.value}"
+            == "TotalConnect usercode is invalid. Did not arm home instant"
+        )
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        config_entry_reauth.assert_called()
+        # should have started a re-auth flow
+        assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
         assert mock_request.call_count == 3
 
 
@@ -225,13 +230,18 @@ async def test_arm_away_instant_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with patch(REAUTH) as config_entry_reauth:
+        with pytest.raises(HomeAssistantError) as err:
             await hass.services.async_call(
                 DOMAIN, SERVICE_ALARM_ARM_AWAY_INSTANT, DATA, blocking=True
             )
             await hass.async_block_till_done()
+        assert (
+            f"{err.value}"
+            == "TotalConnect usercode is invalid. Did not arm away instant"
+        )
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        config_entry_reauth.assert_called()
+        # should have started a re-auth flow
+        assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
         assert mock_request.call_count == 3
 
 
@@ -272,13 +282,15 @@ async def test_arm_away_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with patch(REAUTH) as config_entry_reauth:
+        with pytest.raises(HomeAssistantError) as err:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_ARM_AWAY, DATA, blocking=True
             )
             await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm away"
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        config_entry_reauth.assert_called()
+        # should have started a re-auth flow
+        assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
         assert mock_request.call_count == 3
 
 
@@ -323,13 +335,15 @@ async def test_disarm_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with patch(REAUTH) as config_entry_reauth:
+        with pytest.raises(HomeAssistantError) as err:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_DISARM, DATA, blocking=True
             )
             await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not disarm"
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
-        config_entry_reauth.assert_called()
+        # should have started a re-auth flow
+        assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
         assert mock_request.call_count == 3
 
 
@@ -370,13 +384,15 @@ async def test_arm_night_failure(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 2
 
         # usercode is invalid
-        with patch(REAUTH) as config_entry_reauth:
+        with pytest.raises(HomeAssistantError) as err:
             await hass.services.async_call(
                 ALARM_DOMAIN, SERVICE_ALARM_ARM_NIGHT, DATA, blocking=True
             )
             await hass.async_block_till_done()
+        assert f"{err.value}" == "TotalConnect usercode is invalid. Did not arm night"
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
-        config_entry_reauth.assert_called()
+        # should have started a re-auth flow
+        assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
         assert mock_request.call_count == 3
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improves overall TotalConnect error handling.
- Catches error when TotalConnect service is unavailable
- Catches invalid usercode during arm/disarm functions
- Tests for all of the above
- Bumps total_connect_client to version 2022.3.  [Changelog](https://github.com/craigjmidwinter/total-connect-client/releases/tag/2022.3)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68023, fixes #68126
- This PR is related to issue: 
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [n/a] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [n/a] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [todo] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
