### PR TITLE
Add update entites for Shelly devices

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -76,6 +76,7 @@ BLOCK_PLATFORMS: Final = [
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.UPDATE,
 ]
 BLOCK_SLEEPING_PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
@@ -90,6 +91,7 @@ RPC_PLATFORMS: Final = [
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.UPDATE,
 ]
 
 

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -144,6 +144,7 @@ REST_SENSORS: Final = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "fwupdate": RestBinarySensorDescription(
+        # Deprecated, scheduled to be removed in 2022.6 (#68719)
         key="fwupdate",
         name="Firmware Update",
         device_class=BinarySensorDeviceClass.UPDATE,
@@ -176,6 +177,7 @@ RPC_SENSORS: Final = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "fwupdate": RpcBinarySensorDescription(
+        # Deprecated, scheduled to be removed in 2022.6 (#68719)
         key="sys",
         sub_key="available_updates",
         name="Firmware Update",

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -38,13 +38,16 @@ class ShellyButtonDescription(ButtonEntityDescription, ShellyButtonDescriptionMi
 
 BUTTONS: Final = [
     ShellyButtonDescription(
+        # Deprecated, scheduled to be removed in 2022.6 (#68719)
         key="ota_update",
         name="OTA Update",
         device_class=ButtonDeviceClass.UPDATE,
+        entity_registry_enabled_default=False,
         entity_category=EntityCategory.CONFIG,
         press_action=lambda wrapper: wrapper.async_trigger_ota_update(),
     ),
     ShellyButtonDescription(
+        # Deprecated, scheduled to be removed in 2022.6 (#68719)
         key="ota_update_beta",
         name="OTA Update Beta",
         device_class=ButtonDeviceClass.UPDATE,

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -444,7 +444,7 @@ class ShellyRestAttributeEntity(update_coordinator.CoordinatorEntity):
 
     def __init__(
         self,
-        wrapper: BlockDeviceWrapper,
+        wrapper: ShellyDeviceRestWrapper,
         attribute: str,
         description: RestEntityDescription,
     ) -> None:
@@ -489,6 +489,7 @@ class ShellyRpcAttributeEntity(ShellyRpcEntity, entity.Entity):
     """Helper class to represent a rpc attribute."""
 
     entity_description: RpcEntityDescription
+    wrapper: RpcDeviceWrapper
 
     def __init__(
         self,

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -93,7 +93,7 @@ RPC_UPDATE_ENTITY: Final = {
     "fwupdate_beta": RpcUpdateEntityDescription(
         key="sys",
         sub_key="available_updates",
-        name="Firmware Update Beta",
+        name="Beta Firmware Update",
         entity_registry_enabled_default=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         current_version=lambda shelly: shelly.get("ver"),

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -1,0 +1,229 @@
+"""Support for Synology DSM update platform."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any, Final
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityDescription,
+)
+from homeassistant.components.update.const import UpdateEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import BlockDeviceWrapper, RpcDeviceWrapper
+from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN
+from .entity import (
+    RestEntityDescription,
+    RpcEntityDescription,
+    ShellyRestAttributeEntity,
+    ShellyRpcAttributeEntity,
+    async_setup_entry_rest,
+    async_setup_entry_rpc,
+)
+from .utils import get_device_entry_gen
+
+
+@dataclass
+class RestUpdateEntityDescription(RestEntityDescription, UpdateEntityDescription):
+    """Class to describe a REST update entity."""
+
+    current_version: Callable[[dict], str | None] | None = None
+    latest_version: Callable[[dict], str | None] | None = None
+    release_url: str | None = None
+    install_callback: Callable[
+        [BlockDeviceWrapper], Coroutine[Any, Any, None]
+    ] | None = None
+
+
+@dataclass
+class RpcUpdateEntityDescription(RpcEntityDescription, UpdateEntityDescription):
+    """Class to describe a RPC update entity."""
+
+    current_version: Callable[[dict], str | None] | None = None
+    latest_version: Callable[[dict[str, dict]], str | None] | None = None
+    release_url: str | None = None
+    install_callback: Callable[
+        [RpcDeviceWrapper], Coroutine[Any, Any, None]
+    ] | None = None
+
+
+BLOCK_UPDATE_ENTITIES: Final = {
+    "fwupdate": RestUpdateEntityDescription(
+        key="fwupdate",
+        name="Firmware Update",
+        device_class=UpdateDeviceClass.FIRMWARE,
+        current_version=lambda update: update.get("old_version"),
+        latest_version=lambda update: update.get("new_version"),
+        release_url="https://shelly-api-docs.shelly.cloud/gen1/#changelog",
+        install_callback=lambda wrapper: wrapper.async_trigger_ota_update(),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    "fwupdate_beta": RestUpdateEntityDescription(
+        key="fwupdate_beta",
+        name="Firmware Update Beta",
+        entity_registry_enabled_default=False,
+        device_class=UpdateDeviceClass.FIRMWARE,
+        current_version=lambda update: update.get("old_version"),
+        latest_version=lambda update: update.get("beta_version"),
+        install_callback=lambda wrapper: wrapper.async_trigger_ota_update(beta=True),
+        entity_category=EntityCategory.CONFIG,
+    ),
+}
+
+RPC_UPDATE_ENTITY: Final = {
+    "fwupdate": RpcUpdateEntityDescription(
+        key="sys",
+        sub_key="available_updates",
+        name="Firmware Update",
+        device_class=UpdateDeviceClass.FIRMWARE,
+        current_version=lambda shelly: shelly.get("ver"),
+        latest_version=lambda status: status.get("stable", {"version": None}).get(
+            "version"
+        ),
+        release_url="https://shelly-api-docs.shelly.cloud/gen2/changelog",
+        install_callback=lambda wrapper: wrapper.async_trigger_ota_update(),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    "fwupdate_beta": RpcUpdateEntityDescription(
+        key="sys",
+        sub_key="available_updates",
+        name="Firmware Update Beta",
+        entity_registry_enabled_default=False,
+        device_class=UpdateDeviceClass.FIRMWARE,
+        current_version=lambda shelly: shelly.get("ver"),
+        latest_version=lambda status: status.get("beta", {"version": None}).get(
+            "version"
+        ),
+        install_callback=lambda wrapper: wrapper.async_trigger_ota_update(beta=True),
+        entity_category=EntityCategory.CONFIG,
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up shelly update entity."""
+    if get_device_entry_gen(config_entry) == 2:
+        await async_setup_entry_rpc(
+            hass, config_entry, async_add_entities, RPC_UPDATE_ENTITY, RpcUpdateEntitry
+        )
+    else:
+        await async_setup_entry_rest(
+            hass,
+            config_entry,
+            async_add_entities,
+            BLOCK_UPDATE_ENTITIES,
+            RestUpdateEntity,
+        )
+
+
+class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
+    """Represent a REST update entity."""
+
+    entity_description: RestUpdateEntityDescription
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    @property
+    def current_version(self) -> str | None:
+        """Version currently in use."""
+        if (
+            self.entity_description.current_version is None
+            or (update := self.wrapper.device.status.get("update")) is None
+        ):
+            return None
+
+        return self.entity_description.current_version(update)
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        if (
+            self.entity_description.latest_version is None
+            or (update := self.wrapper.device.status.get("update")) is None
+        ):
+            return None
+
+        if (result := self.entity_description.latest_version(update)) is not None:
+            return result
+
+        return self.current_version
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the full release notes of the latest version available."""
+        return self.entity_description.release_url
+
+    async def async_install(
+        self,
+        version: str | None = None,
+        backup: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Triggers the Shelly button press service."""
+        assert self.registry_entry
+        assert self.registry_entry.config_entry_id
+        block_wrapper: BlockDeviceWrapper = self.hass.data[DOMAIN][DATA_CONFIG_ENTRY][
+            self.registry_entry.config_entry_id
+        ][BLOCK]
+        if self.entity_description.install_callback is not None:
+            await self.entity_description.install_callback(block_wrapper)
+
+
+class RpcUpdateEntitry(ShellyRpcAttributeEntity, UpdateEntity):
+    """Represent a RPC update entity."""
+
+    entity_description: RpcUpdateEntityDescription
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    @property
+    def current_version(self) -> str | None:
+        """Version currently in use."""
+        if (
+            self.entity_description.current_version is None
+            or self.wrapper.device.shelly is None
+        ):
+            return None
+
+        return self.entity_description.current_version(
+            self.wrapper.device.shelly,
+        )
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        if (
+            self.entity_description.latest_version is None
+            or (
+                status := self.wrapper.device.status.get(self.key, {}).get(
+                    self.entity_description.sub_key
+                )
+            )
+            is None
+        ):
+            return None
+
+        return self.entity_description.latest_version(status)
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the full release notes of the latest version available."""
+        return self.entity_description.release_url
+
+    async def async_install(
+        self,
+        version: str | None = None,
+        backup: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Triggers the Shelly button press service."""
+        if self.entity_description.install_callback is not None:
+            await self.entity_description.install_callback(self.wrapper)

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -66,7 +66,7 @@ BLOCK_UPDATE_ENTITIES: Final = {
     ),
     "fwupdate_beta": RestUpdateEntityDescription(
         key="fwupdate_beta",
-        name="Firmware Update Beta",
+        name="Beta Firmware Update",
         entity_registry_enabled_default=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         current_version=lambda update: update.get("old_version"),

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -57,6 +57,7 @@ BLOCK_UPDATE_ENTITIES: Final = {
     "fwupdate": RestUpdateEntityDescription(
         key="fwupdate",
         name="Firmware Update",
+        entity_registry_enabled_default=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         current_version=lambda update: update.get("old_version"),
         latest_version=lambda update: update.get("new_version"),
@@ -81,6 +82,7 @@ RPC_UPDATE_ENTITY: Final = {
         key="sys",
         sub_key="available_updates",
         name="Firmware Update",
+        entity_registry_enabled_default=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         current_version=lambda shelly: shelly.get("ver"),
         latest_version=lambda status: status.get("stable", {"version": None}).get(

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -3,13 +3,20 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from homeassistant.components.shelly import BlockDeviceWrapper, RpcDeviceWrapper
+from homeassistant.components.shelly import (
+    BlockDeviceWrapper,
+    RpcDeviceWrapper,
+    RpcPollingWrapper,
+    ShellyDeviceRestWrapper,
+)
 from homeassistant.components.shelly.const import (
     BLOCK,
     DATA_CONFIG_ENTRY,
     DOMAIN,
     EVENT_SHELLY_CLICK,
+    REST,
     RPC,
+    RPC_POLL,
 )
 from homeassistant.setup import async_setup_component
 
@@ -68,7 +75,8 @@ MOCK_CONFIG = {
 MOCK_SHELLY = {
     "mac": "test-mac",
     "auth": False,
-    "fw": "20201124-092854/v1.9.0@57ac4ad8",
+    "fw": "lates_greatest",
+    "ver": "lates_greatest",
     "num_outputs": 2,
 }
 
@@ -89,7 +97,7 @@ MOCK_STATUS_RPC = {
     "sys": {
         "available_updates": {
             "beta": {"version": "some_beta_version"},
-            "stable": {"version": "some_beta_version"},
+            "stable": {"version": "some_new_version"},
         }
     },
 }
@@ -149,8 +157,11 @@ async def coap_wrapper(hass):
     wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][
         BLOCK
     ] = BlockDeviceWrapper(hass, config_entry, device)
-
     wrapper.async_setup()
+
+    hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][
+        REST
+    ] = ShellyDeviceRestWrapper(hass, device, config_entry)
 
     return wrapper
 
@@ -186,7 +197,10 @@ async def rpc_wrapper(hass):
     wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][
         RPC
     ] = RpcDeviceWrapper(hass, config_entry, device)
-
     wrapper.async_setup()
+
+    hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][
+        RPC_POLL
+    ] = RpcPollingWrapper(hass, config_entry, device)
 
     return wrapper

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -19,6 +19,14 @@ async def test_block_button(hass: HomeAssistant, coap_wrapper):
         suggested_object_id="test_name_ota_update_beta",
         disabled_by=None,
     )
+    entity_registry.async_get_or_create(
+        BUTTON_DOMAIN,
+        DOMAIN,
+        "test_name_ota_update",
+        suggested_object_id="test_name_ota_update",
+        disabled_by=None,
+    )
+
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(coap_wrapper.entry, BUTTON_DOMAIN)
     )
@@ -81,6 +89,13 @@ async def test_rpc_button(hass: HomeAssistant, rpc_wrapper):
         DOMAIN,
         "test_name_ota_update_beta",
         suggested_object_id="test_name_ota_update_beta",
+        disabled_by=None,
+    )
+    entity_registry.async_get_or_create(
+        BUTTON_DOMAIN,
+        DOMAIN,
+        "test_name_ota_update",
+        suggested_object_id="test_name_ota_update",
         disabled_by=None,
     )
 

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -73,7 +73,7 @@ async def test_rpc_config_entry_diagnostics(
             "sys": {
                 "available_updates": {
                     "beta": {"version": "some_beta_version"},
-                    "stable": {"version": "some_beta_version"},
+                    "stable": {"version": "some_new_version"},
                 }
             }
         },

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -1,0 +1,126 @@
+"""Tests for Shelly button platform."""
+import pytest
+
+from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
+from homeassistant.components.update.const import SERVICE_INSTALL
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+
+@pytest.mark.parametrize(
+    "status,result_state",
+    [
+        ({"update": None}, STATE_UNKNOWN),
+        (
+            {
+                "update": {
+                    "has_update": False,
+                    "old_version": "latest_greatest",
+                    "new_version": "latest_greatest",
+                },
+            },
+            STATE_OFF,
+        ),
+        (
+            {
+                "update": {
+                    "has_update": False,
+                    "old_version": "latest_greatest",
+                    "new_version": None,
+                },
+            },
+            STATE_OFF,
+        ),
+        (
+            {},
+            STATE_ON,
+        ),
+    ],
+)
+async def test_coap_update_entity(
+    hass: HomeAssistant, coap_wrapper, status: dict, result_state
+):
+    """Test coap update entities."""
+    assert coap_wrapper
+    coap_wrapper.device.status = {**coap_wrapper.device.status, **status}
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(coap_wrapper.entry, UPDATE_DOMAIN)
+    )
+    await hass.async_block_till_done()
+
+    # stable channel update entity
+    state = hass.states.get("update.test_name_firmware_update")
+    assert state
+    assert state.state == result_state
+
+    if result_state == STATE_ON:
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coap_wrapper.device.trigger_ota_update.call_count == 1
+        coap_wrapper.device.trigger_ota_update.assert_called_with(beta=False)
+
+
+@pytest.mark.parametrize(
+    "status,shelly,result_state",
+    [
+        (
+            {"sys": {"available_updates": {"stable": {"version": "lates_greatest"}}}},
+            {},
+            STATE_OFF,
+        ),
+        (
+            {},
+            None,
+            STATE_UNKNOWN,
+        ),
+        (
+            {"sys": {"available_updates": None}},
+            {},
+            STATE_UNKNOWN,
+        ),
+        (
+            {},
+            {},
+            STATE_ON,
+        ),
+    ],
+)
+async def test_rpc_update_entity(
+    hass: HomeAssistant, rpc_wrapper, status, shelly, result_state
+):
+    """Test rpc update entities."""
+    assert rpc_wrapper
+    rpc_wrapper.device.status = {**rpc_wrapper.device.status, **status}
+
+    if shelly is not None:
+        rpc_wrapper.device.shelly = {**rpc_wrapper.device.shelly, **shelly}
+    else:
+        rpc_wrapper.device.shelly = None
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(rpc_wrapper.entry, UPDATE_DOMAIN)
+    )
+    await hass.async_block_till_done()
+
+    # stable channel update entity
+    state = hass.states.get("update.test_name_firmware_update")
+    assert state
+    assert state.state == result_state
+
+    if result_state == STATE_ON:
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert rpc_wrapper.device.trigger_ota_update.call_count == 1
+        rpc_wrapper.device.trigger_ota_update.assert_called_with(beta=False)

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -1,10 +1,12 @@
 """Tests for Shelly button platform."""
 import pytest
 
+from homeassistant.components.shelly.const import DOMAIN
 from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 from homeassistant.components.update.const import SERVICE_INSTALL
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import async_get
 
 
 @pytest.mark.parametrize(
@@ -43,6 +45,15 @@ async def test_coap_update_entity(
     """Test coap update entities."""
     assert coap_wrapper
     coap_wrapper.device.status = {**coap_wrapper.device.status, **status}
+
+    entity_registry = async_get(hass)
+    entity_registry.async_get_or_create(
+        UPDATE_DOMAIN,
+        DOMAIN,
+        "test-mac-fwupdate",
+        suggested_object_id="test_name_firmware_update",
+        disabled_by=None,
+    )
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(coap_wrapper.entry, UPDATE_DOMAIN)
@@ -103,6 +114,15 @@ async def test_rpc_update_entity(
         rpc_wrapper.device.shelly = {**rpc_wrapper.device.shelly, **shelly}
     else:
         rpc_wrapper.device.shelly = None
+
+    entity_registry = async_get(hass)
+    entity_registry.async_get_or_create(
+        UPDATE_DOMAIN,
+        DOMAIN,
+        "12345678-sys-fwupdate",
+        suggested_object_id="test_name_firmware_update",
+        disabled_by=None,
+    )
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(rpc_wrapper.entry, UPDATE_DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The binary sensor and button entities related to OTA updates have been deprecated and will be removed in Home Assistant 2022.6.
The Shelly integration now provides update entities as a replacement for the deprecated entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds two update entities per device, one for the stable and one for the beta (_disabled by default_) channel

open points
- ~~add python tests~~
- do real tests (_especial with gen2 devices_) -> volunteers are welcome 🙂 
- ~~consider to remove or first deprecate the binary sensors and buttons related to OTA update~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
