### PR TITLE
Add option to connect to elkm1 non-secure when secure is discovered

### DIFF
--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -279,14 +279,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 return result
 
+        default_proto = PORT_PROTOCOL_MAP.get(device.port, DEFAULT_SECURE_PROTOCOL)
         return self.async_show_form(
             step_id="discovered_connection",
             data_schema=vol.Schema(
                 {
                     **BASE_SCHEMA,
-                    vol.Required(
-                        CONF_PROTOCOL, default=DEFAULT_SECURE_PROTOCOL
-                    ): vol.In(ALL_PROTOCOLS),
+                    vol.Required(CONF_PROTOCOL, default=default_proto): vol.In(
+                        ALL_PROTOCOLS
+                    ),
                 }
             ),
             errors=errors,

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -37,7 +37,9 @@ from .discovery import (
 
 CONF_DEVICE = "device"
 
+NON_SECURE_PORT = 2101
 SECURE_PORT = 2601
+STANDARD_PORTS = {NON_SECURE_PORT, SECURE_PORT}
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/elkm1/strings.json
+++ b/homeassistant/components/elkm1/strings.json
@@ -38,6 +38,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",      
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "An ElkM1 with this prefix is already configured",

--- a/homeassistant/components/elkm1/strings.json
+++ b/homeassistant/components/elkm1/strings.json
@@ -39,7 +39,7 @@
     },
     "abort": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]",      
+      "unknown": "[%key:common::config_flow::error::unknown%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "An ElkM1 with this prefix is already configured",

--- a/homeassistant/components/elkm1/translations/en.json
+++ b/homeassistant/components/elkm1/translations/en.json
@@ -4,7 +4,9 @@
             "address_already_configured": "An ElkM1 with this address is already configured",
             "already_configured": "An ElkM1 with this prefix is already configured",
             "already_in_progress": "Configuration flow is already in progress",
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -37,13 +39,7 @@
             },
             "user": {
                 "data": {
-                    "address": "The IP address or domain or serial port if connecting via serial.",
-                    "device": "Device",
-                    "password": "Password",
-                    "prefix": "A unique prefix (leave blank if you only have one ElkM1).",
-                    "protocol": "Protocol",
-                    "temperature_unit": "The temperature unit ElkM1 uses.",
-                    "username": "Username"
+                    "device": "Device"
                 },
                 "description": "Choose a discovered system or 'Manual Entry' if no devices have been discovered.",
                 "title": "Connect to Elk-M1 Control"

--- a/tests/components/elkm1/__init__.py
+++ b/tests/components/elkm1/__init__.py
@@ -9,6 +9,7 @@ MOCK_IP_ADDRESS = "127.0.0.1"
 MOCK_MAC = "aa:bb:cc:dd:ee:ff"
 ELK_DISCOVERY = ElkSystem(MOCK_MAC, MOCK_IP_ADDRESS, 2601)
 ELK_NON_SECURE_DISCOVERY = ElkSystem(MOCK_MAC, MOCK_IP_ADDRESS, 2101)
+ELK_DISCOVERY_NON_STANDARD_PORT = ElkSystem(MOCK_MAC, MOCK_IP_ADDRESS, 444)
 
 
 def mock_elk(invalid_auth=None, sync_complete=None, exception=None):

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
 
 from . import (
     ELK_DISCOVERY,
+    ELK_DISCOVERY_NON_STANDARD_PORT,
     ELK_NON_SECURE_DISCOVERY,
     MOCK_IP_ADDRESS,
     MOCK_MAC,
@@ -24,6 +25,8 @@ from tests.common import MockConfigEntry
 
 DHCP_DISCOVERY = dhcp.DhcpServiceInfo(MOCK_IP_ADDRESS, "", MOCK_MAC)
 ELK_DISCOVERY_INFO = asdict(ELK_DISCOVERY)
+ELK_DISCOVERY_INFO_NON_STANDARD_PORT = asdict(ELK_DISCOVERY_NON_STANDARD_PORT)
+
 MODULE = "homeassistant.components.elkm1"
 
 
@@ -301,7 +304,7 @@ async def test_form_user_with_secure_elk_with_discovery(hass):
     assert result3["title"] == "ElkM1 ddeeff"
     assert result3["data"] == {
         "auto_configure": True,
-        "host": "elks://127.0.0.1:2601",
+        "host": "elks://127.0.0.1",
         "password": "test-password",
         "prefix": "",
         "username": "test-username",
@@ -838,6 +841,43 @@ async def test_form_import_non_secure_device_discovered(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_form_import_non_secure_non_stanadard_port_device_discovered(hass):
+    """Test we can import non-secure non standard port with discovery."""
+
+    mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
+    with _patch_discovery(), _patch_elk(elk=mocked_elk), patch(
+        "homeassistant.components.elkm1.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.elkm1.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "host": "elk://127.0.0.1:444",
+                "username": "",
+                "password": "",
+                "auto_configure": True,
+                "prefix": "ohana",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "ohana"
+    assert result["result"].unique_id == MOCK_MAC
+    assert result["data"] == {
+        "auto_configure": True,
+        "host": "elk://127.0.0.1:444",
+        "password": "",
+        "prefix": "ohana",
+        "username": "",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_form_import_non_secure_device_discovered_invalid_auth(hass):
     """Test we abort import with invalid auth."""
 
@@ -1037,7 +1077,52 @@ async def test_discovered_by_discovery(hass):
     assert result2["title"] == "ElkM1 ddeeff"
     assert result2["data"] == {
         "auto_configure": True,
-        "host": "elks://127.0.0.1:2601",
+        "host": "elks://127.0.0.1",
+        "password": "test-password",
+        "prefix": "",
+        "username": "test-username",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_discovered_by_discovery_non_standard_port(hass):
+    """Test we can setup when discovered from discovery with a non-standard port."""
+
+    with _patch_discovery(), _patch_elk():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+            data=ELK_DISCOVERY_INFO_NON_STANDARD_PORT,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "discovered_connection"
+    assert result["errors"] == {}
+
+    mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
+
+    with _patch_discovery(), _patch_elk(elk=mocked_elk), patch(
+        "homeassistant.components.elkm1.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.elkm1.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "ElkM1 ddeeff"
+    assert result2["data"] == {
+        "auto_configure": True,
+        "host": "elks://127.0.0.1:444",
         "password": "test-password",
         "prefix": "",
         "username": "test-username",
@@ -1101,7 +1186,7 @@ async def test_discovered_by_dhcp_udp_responds(hass):
     assert result2["title"] == "ElkM1 ddeeff"
     assert result2["data"] == {
         "auto_configure": True,
-        "host": "elks://127.0.0.1:2601",
+        "host": "elks://127.0.0.1",
         "password": "test-password",
         "prefix": "",
         "username": "test-username",
@@ -1145,7 +1230,7 @@ async def test_discovered_by_dhcp_udp_responds_with_nonsecure_port(hass):
     assert result2["title"] == "ElkM1 ddeeff"
     assert result2["data"] == {
         "auto_configure": True,
-        "host": "elk://127.0.0.1:2101",
+        "host": "elk://127.0.0.1",
         "password": "",
         "prefix": "",
         "username": "",
@@ -1191,7 +1276,7 @@ async def test_discovered_by_dhcp_udp_responds_existing_config_entry(hass):
     assert result2["title"] == "ElkM1 ddeeff"
     assert result2["data"] == {
         "auto_configure": True,
-        "host": "elks://127.0.0.1:2601",
+        "host": "elks://127.0.0.1",
         "password": "test-password",
         "prefix": "ddeeff",
         "username": "test-username",


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add option to connect to elkm1 non-secure when secure is discovered

It looks like there is a use case for connecting non-securely when secure is discovered
that was missed when discovery was added.

https://community.home-assistant.io/t/elk-m1-interface/4461/975?u=bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
