### PR TITLE
Rewrite kira tests to use pytest

### DIFF
--- a/tests/components/kira/test_sensor.py
+++ b/tests/components/kira/test_sensor.py
@@ -24,8 +24,9 @@ async def test_kira_sensor(hass: HomeAssistant):
     hass.data[kira.DOMAIN][kira.CONF_SENSOR]["kira"] = mock_kira
     kira.setup_platform(hass, TEST_CONFIG, add_entities, DISCOVERY_INFO)
     assert len(DEVICES) == 1
+
     sensor = DEVICES[0]
-    sensor.name == "kira"
+    assert sensor.name == "kira"
     sensor.hass = hass
 
     code_name = "FAKE_CODE"

--- a/tests/components/kira/test_sensor.py
+++ b/tests/components/kira/test_sensor.py
@@ -1,50 +1,35 @@
 """The tests for Kira sensor platform."""
-import unittest
 from unittest.mock import MagicMock
 
 from homeassistant.components.kira import sensor as kira
-
-from tests.common import get_test_home_assistant
+from homeassistant.core import HomeAssistant
 
 TEST_CONFIG = {kira.DOMAIN: {"sensors": [{"host": "127.0.0.1", "port": 17324}]}}
-
 DISCOVERY_INFO = {"name": "kira", "device": "kira"}
 
 
-class TestKiraSensor(unittest.TestCase):
-    """Tests the Kira Sensor platform."""
+async def test_kira_sensor(hass: HomeAssistant):
+    """Test Kira's ability to send commands."""
 
-    # pylint: disable=invalid-name
     DEVICES = []
 
-    def add_entities(self, devices):
+    def add_entities(devices):
         """Mock add devices."""
         for device in devices:
-            self.DEVICES.append(device)
+            device.hass = hass
+            DEVICES.append(device)
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        mock_kira = MagicMock()
-        self.hass.data[kira.DOMAIN] = {kira.CONF_SENSOR: {}}
-        self.hass.data[kira.DOMAIN][kira.CONF_SENSOR]["kira"] = mock_kira
-        self.addCleanup(self.hass.stop)
+    mock_kira = MagicMock()
+    hass.data[kira.DOMAIN] = {kira.CONF_SENSOR: {}}
+    hass.data[kira.DOMAIN][kira.CONF_SENSOR]["kira"] = mock_kira
+    kira.setup_platform(hass, TEST_CONFIG, add_entities, DISCOVERY_INFO)
+    assert len(DEVICES) == 1
+    sensor = DEVICES[0]
+    sensor.name == "kira"
+    sensor.hass = hass
 
-    # pylint: disable=protected-access
-    def test_kira_sensor_callback(self):
-        """Ensure Kira sensor properly updates its attributes from callback."""
-        kira.setup_platform(self.hass, TEST_CONFIG, self.add_entities, DISCOVERY_INFO)
-        assert len(self.DEVICES) == 1
-        sensor = self.DEVICES[0]
-
-        assert sensor.name == "kira"
-
-        sensor.hass = self.hass
-
-        codeName = "FAKE_CODE"
-        deviceName = "FAKE_DEVICE"
-        codeTuple = (codeName, deviceName)
-        sensor._update_callback(codeTuple)
-
-        assert sensor.state == codeName
-        assert sensor.extra_state_attributes == {kira.CONF_DEVICE: deviceName}
+    code_name = "FAKE_CODE"
+    device_name = "FAKE_DEVICE"
+    sensor._update_callback((code_name, device_name))
+    assert sensor.state == code_name
+    assert sensor.extra_state_attributes == {kira.CONF_DEVICE: device_name}

--- a/tests/components/kira/test_sensor.py
+++ b/tests/components/kira/test_sensor.py
@@ -9,7 +9,7 @@ DISCOVERY_INFO = {"name": "kira", "device": "kira"}
 
 
 async def test_kira_sensor(hass: HomeAssistant):
-    """Test Kira's ability to send commands."""
+    """Tests the Kira Sensor platform."""
 
     DEVICES = []
 


### PR DESCRIPTION
More or less just converted the existing test code that was using
`unittest.Testcase` to pytest instead.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As stated in #40855 this changes the kira test to use pytest instead of unittest.Testcase.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #40855 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
