### PR TITLE
Improve caldav tests to use APIs rather than entity methods

### DIFF
--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -279,10 +279,12 @@ def mock_private_cal():
 def get_api_events(hass_client):
     """Fixture to return events for a specific calendar using the API."""
 
-    async def api_call(entity_id, start, end):
+    async def api_call(entity_id):
         client = await hass_client()
         response = await client.get(
-            f"/api/calendars/{entity_id}?start={start}&end={end}"
+            # The start/end times are arbitrary since they are ignored by `_mock_calendar`
+            # which just returns all events for the calendar.
+            f"/api/calendars/{entity_id}?start=2022-01-01&end=2022-01-01"
         )
         assert response.status == HTTPStatus.OK
         return await response.json()
@@ -914,12 +916,9 @@ async def test_get_events(hass, calendar, get_api_events):
     assert await async_setup_component(hass, "calendar", {"calendar": CALDAV_CONFIG})
     await hass.async_block_till_done()
 
-    events = await get_api_events(
-        "calendar.private",
-        "2015-11-27",
-        "2015-11-28",
-    )
+    events = await get_api_events("calendar.private")
     assert len(events) == 14
+    assert calendar.call
 
 
 async def test_get_events_custom_calendars(hass, calendar, get_api_events):
@@ -932,11 +931,7 @@ async def test_get_events_custom_calendars(hass, calendar, get_api_events):
     assert await async_setup_component(hass, "calendar", {"calendar": config})
     await hass.async_block_till_done()
 
-    events = await get_api_events(
-        "calendar.private_private",
-        "2015-11-27",
-        "2015-11-28",
-    )
+    events = await get_api_events("calendar.private_private")
     assert events == [
         {
             "description": "Surprisingly rainy",

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1,5 +1,6 @@
 """The tests for the webdav calendar component."""
 import datetime
+from http import HTTPStatus
 from unittest.mock import MagicMock, Mock, patch
 
 from caldav.objects import Event
@@ -272,6 +273,21 @@ def mock_private_cal():
     patch_dav_client = patch("caldav.DAVClient", return_value=client)
     with patch_dav_client:
         yield _calendar
+
+
+@pytest.fixture
+def get_api_events(hass_client):
+    """Fixture to return events for a specific calendar using the API."""
+
+    async def api_call(entity_id, start, end):
+        client = await hass_client()
+        response = await client.get(
+            f"/api/calendars/{entity_id}?start={start}&end={end}"
+        )
+        assert response.status == HTTPStatus.OK
+        return await response.json()
+
+    return api_call
 
 
 def _local_datetime(hours, minutes):
@@ -893,18 +909,20 @@ async def test_event_rrule_hourly_ended(mock_now, hass, calendar):
     assert state.state == STATE_OFF
 
 
-async def test_get_events(hass, calendar):
+async def test_get_events(hass, calendar, get_api_events):
     """Test that all events are returned on API."""
     assert await async_setup_component(hass, "calendar", {"calendar": CALDAV_CONFIG})
     await hass.async_block_till_done()
-    entity = hass.data["calendar"].get_entity("calendar.private")
-    events = await entity.async_get_events(
-        hass, datetime.date(2015, 11, 27), datetime.date(2015, 11, 28)
+
+    events = await get_api_events(
+        "calendar.private",
+        "2015-11-27",
+        "2015-11-28",
     )
     assert len(events) == 14
 
 
-async def test_get_events_custom_calendars(hass, calendar):
+async def test_get_events_custom_calendars(hass, calendar, get_api_events):
     """Test that only searched events are returned on API."""
     config = dict(CALDAV_CONFIG)
     config["custom_calendars"] = [
@@ -914,9 +932,18 @@ async def test_get_events_custom_calendars(hass, calendar):
     assert await async_setup_component(hass, "calendar", {"calendar": config})
     await hass.async_block_till_done()
 
-    entity = hass.data["calendar"].get_entity("calendar.private_private")
-    events = await entity.async_get_events(
-        hass, datetime.date(2015, 11, 27), datetime.date(2015, 11, 28)
+    events = await get_api_events(
+        "calendar.private_private",
+        "2015-11-27",
+        "2015-11-28",
     )
-    assert len(events) == 1
-    assert events[0]["summary"] == "This is a normal event"
+    assert events == [
+        {
+            "description": "Surprisingly rainy",
+            "end": "2017-11-27T10:00:00-08:00",
+            "location": "Hamburg",
+            "start": "2017-11-27T09:00:00-08:00",
+            "summary": "This is a normal event",
+            "uid": "1",
+        }
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update caldav tests to use the best practice of exercising the public APIs rather than directly calling the entity methods directly. This is motivated by additional calendar API cleanup and possibly future breaking changes. This also shows how each calendar API response uses a slightly different set of fields at the moment (related PR https://github.com/home-assistant/core/pull/68767)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
