### PR TITLE
Add update entities to PI-Hole

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -153,7 +153,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 @callback
 def _async_platforms(entry: ConfigEntry) -> list[Platform]:
     """Return platforms to be loaded / unloaded."""
-    platforms = [Platform.BINARY_SENSOR, Platform.SENSOR]
+    platforms = [Platform.BINARY_SENSOR, Platform.UPDATE, Platform.SENSOR]
     if not entry.data[CONF_STATISTICS_ONLY]:
         platforms.append(Platform.SWITCH)
     return platforms

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -119,8 +119,10 @@ class PiHoleBinarySensorEntityDescription(
 
 BINARY_SENSOR_TYPES: tuple[PiHoleBinarySensorEntityDescription, ...] = (
     PiHoleBinarySensorEntityDescription(
+        # Deprecated, scheduled to be removed in 2022.6
         key="core_update_available",
         name="Core Update Available",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.UPDATE,
         extra_value=lambda api: {
             "current_version": api.versions["core_current"],
@@ -129,8 +131,10 @@ BINARY_SENSOR_TYPES: tuple[PiHoleBinarySensorEntityDescription, ...] = (
         state_value=lambda api: bool(api.versions["core_update"]),
     ),
     PiHoleBinarySensorEntityDescription(
+        # Deprecated, scheduled to be removed in 2022.6
         key="web_update_available",
         name="Web Update Available",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.UPDATE,
         extra_value=lambda api: {
             "current_version": api.versions["web_current"],
@@ -139,8 +143,10 @@ BINARY_SENSOR_TYPES: tuple[PiHoleBinarySensorEntityDescription, ...] = (
         state_value=lambda api: bool(api.versions["web_update"]),
     ),
     PiHoleBinarySensorEntityDescription(
+        # Deprecated, scheduled to be removed in 2022.6
         key="ftl_update_available",
         name="FTL Update Available",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.UPDATE,
         extra_value=lambda api: {
             "current_version": api.versions["FTL_current"],

--- a/homeassistant/components/pi_hole/update.py
+++ b/homeassistant/components/pi_hole/update.py
@@ -97,14 +97,16 @@ class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
     @property
     def current_version(self) -> str | None:
         """Version currently in use."""
-        assert isinstance(self.api.versions, dict)
-        return self.entity_description.current_version(self.api.versions)
+        if isinstance(self.api.versions, dict):
+            return self.entity_description.current_version(self.api.versions)
+        return None
 
     @property
     def latest_version(self) -> str | None:
         """Latest version available for install."""
-        assert isinstance(self.api.versions, dict)
-        return self.entity_description.latest_version(self.api.versions)
+        if isinstance(self.api.versions, dict):
+            return self.entity_description.latest_version(self.api.versions)
+        return None
 
     @property
     def release_url(self) -> str | None:

--- a/homeassistant/components/pi_hole/update.py
+++ b/homeassistant/components/pi_hole/update.py
@@ -24,6 +24,7 @@ class PiHoleUpdateEntityDescription(UpdateEntityDescription):
 
     current_version: Callable[[dict], str | None] = lambda api: None
     latest_version: Callable[[dict], str | None] = lambda api: None
+    release_base_url: str | None = None
 
 
 UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
@@ -33,6 +34,7 @@ UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         current_version=lambda versions: versions.get("core_current"),
         latest_version=lambda versions: versions.get("core_latest"),
+        release_base_url="https://github.com/pi-hole/pi-hole/releases/tag",
     ),
     PiHoleUpdateEntityDescription(
         key="web_update_available",
@@ -40,6 +42,7 @@ UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         current_version=lambda versions: versions.get("web_current"),
         latest_version=lambda versions: versions.get("web_latest"),
+        release_base_url="https://github.com/pi-hole/AdminLTE/releases/tag",
     ),
     PiHoleUpdateEntityDescription(
         key="ftl_update_available",
@@ -47,6 +50,7 @@ UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         current_version=lambda versions: versions.get("FTL_current"),
         latest_version=lambda versions: versions.get("FTL_latest"),
+        release_base_url="https://github.com/pi-hole/FTL/releases/tag",
     ),
 )
 
@@ -101,3 +105,10 @@ class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
         """Latest version available for install."""
         assert isinstance(self.api.versions, dict)
         return self.entity_description.latest_version(self.api.versions)
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the full release notes of the latest version available."""
+        if self.latest_version:
+            return f"{self.entity_description.release_base_url}/{self.latest_version}"
+        return None

--- a/homeassistant/components/pi_hole/update.py
+++ b/homeassistant/components/pi_hole/update.py
@@ -1,0 +1,103 @@
+"""Support for update entities of a Pi-hole system."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from hole import Hole
+
+from homeassistant.components.update import UpdateEntity, UpdateEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import PiHoleEntity
+from .const import DATA_KEY_API, DATA_KEY_COORDINATOR, DOMAIN
+
+
+@dataclass
+class PiHoleUpdateEntityDescription(UpdateEntityDescription):
+    """Describes PiHole update entity."""
+
+    current_version: Callable[[dict], str | None] = lambda api: None
+    latest_version: Callable[[dict], str | None] = lambda api: None
+
+
+UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
+    PiHoleUpdateEntityDescription(
+        key="core_update_available",
+        name="Core Update Available",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        current_version=lambda versions: versions.get("core_current"),
+        latest_version=lambda versions: versions.get("core_latest"),
+    ),
+    PiHoleUpdateEntityDescription(
+        key="web_update_available",
+        name="Web Update Available",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        current_version=lambda versions: versions.get("web_current"),
+        latest_version=lambda versions: versions.get("web_latest"),
+    ),
+    PiHoleUpdateEntityDescription(
+        key="ftl_update_available",
+        name="FTL Update Available",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        current_version=lambda versions: versions.get("FTL_current"),
+        latest_version=lambda versions: versions.get("FTL_latest"),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Pi-hole update entities."""
+    name = entry.data[CONF_NAME]
+    hole_data = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        PiHoleUpdateEntity(
+            hole_data[DATA_KEY_API],
+            hole_data[DATA_KEY_COORDINATOR],
+            name,
+            entry.entry_id,
+            description,
+        )
+        for description in UPDATE_ENTITY_TYPES
+    )
+
+
+class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
+    """Representation of a Pi-hole update entity."""
+
+    entity_description: PiHoleUpdateEntityDescription
+
+    def __init__(
+        self,
+        api: Hole,
+        coordinator: DataUpdateCoordinator,
+        name: str,
+        server_unique_id: str,
+        description: PiHoleUpdateEntityDescription,
+    ) -> None:
+        """Initialize a Pi-hole update entity."""
+        super().__init__(api, coordinator, name, server_unique_id)
+        self.entity_description = description
+
+        self._attr_name = f"{name} {description.name}"
+        self._attr_unique_id = f"{self._server_unique_id}/{description.name}"
+
+    @property
+    def current_version(self) -> str | None:
+        """Version currently in use."""
+        assert isinstance(self.api.versions, dict)
+        return self.entity_description.current_version(self.api.versions)
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        assert isinstance(self.api.versions, dict)
+        return self.entity_description.latest_version(self.api.versions)

--- a/homeassistant/components/pi_hole/update.py
+++ b/homeassistant/components/pi_hole/update.py
@@ -25,12 +25,14 @@ class PiHoleUpdateEntityDescription(UpdateEntityDescription):
     current_version: Callable[[dict], str | None] = lambda api: None
     latest_version: Callable[[dict], str | None] = lambda api: None
     release_base_url: str | None = None
+    title: str | None = None
 
 
 UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
     PiHoleUpdateEntityDescription(
         key="core_update_available",
         name="Core Update Available",
+        title="Pi-hole Core",
         entity_category=EntityCategory.DIAGNOSTIC,
         current_version=lambda versions: versions.get("core_current"),
         latest_version=lambda versions: versions.get("core_latest"),
@@ -39,6 +41,7 @@ UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
     PiHoleUpdateEntityDescription(
         key="web_update_available",
         name="Web Update Available",
+        title="Pi-hole Web interface",
         entity_category=EntityCategory.DIAGNOSTIC,
         current_version=lambda versions: versions.get("web_current"),
         latest_version=lambda versions: versions.get("web_latest"),
@@ -47,6 +50,7 @@ UPDATE_ENTITY_TYPES: tuple[PiHoleUpdateEntityDescription, ...] = (
     PiHoleUpdateEntityDescription(
         key="ftl_update_available",
         name="FTL Update Available",
+        title="Pi-hole FTL DNS",
         entity_category=EntityCategory.DIAGNOSTIC,
         current_version=lambda versions: versions.get("FTL_current"),
         latest_version=lambda versions: versions.get("FTL_latest"),
@@ -93,6 +97,7 @@ class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
 
         self._attr_name = f"{name} {description.name}"
         self._attr_unique_id = f"{self._server_unique_id}/{description.name}"
+        self._attr_title = description.title
 
     @property
     def current_version(self) -> str | None:

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -83,7 +83,7 @@ CONF_CONFIG_ENTRY = {
 SWITCH_ENTITY_ID = "switch.pi_hole"
 
 
-def _create_mocked_hole(raise_exception=False):
+def _create_mocked_hole(raise_exception=False, has_versions=True):
     mocked_hole = MagicMock()
     type(mocked_hole).get_data = AsyncMock(
         side_effect=HoleError("") if raise_exception else None
@@ -94,7 +94,10 @@ def _create_mocked_hole(raise_exception=False):
     type(mocked_hole).enable = AsyncMock()
     type(mocked_hole).disable = AsyncMock()
     mocked_hole.data = ZERO_DATA
-    mocked_hole.versions = SAMPLE_VERSIONS
+    if has_versions:
+        mocked_hole.versions = SAMPLE_VERSIONS
+    else:
+        mocked_hole.versions = None
     return mocked_hole
 
 

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -47,106 +47,45 @@ async def test_setup_minimal_config(hass):
 
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("sensor.pi_hole_ads_blocked_today").name
-        == "Pi-Hole Ads Blocked Today"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_ads_percentage_blocked_today").name
-        == "Pi-Hole Ads Percentage Blocked Today"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_dns_queries_cached").name
-        == "Pi-Hole DNS Queries Cached"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_dns_queries_forwarded").name
-        == "Pi-Hole DNS Queries Forwarded"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_dns_queries_today").name
-        == "Pi-Hole DNS Queries Today"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_dns_unique_clients").name
-        == "Pi-Hole DNS Unique Clients"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_dns_unique_domains").name
-        == "Pi-Hole DNS Unique Domains"
-    )
-    assert (
-        hass.states.get("sensor.pi_hole_domains_blocked").name
-        == "Pi-Hole Domains Blocked"
-    )
-    assert hass.states.get("sensor.pi_hole_seen_clients").name == "Pi-Hole Seen Clients"
+    state = hass.states.get("sensor.pi_hole_ads_blocked_today")
+    assert state.name == "Pi-Hole Ads Blocked Today"
+    assert state.state == "0"
 
-    assert hass.states.get("sensor.pi_hole_ads_blocked_today").state == "0"
-    assert hass.states.get("sensor.pi_hole_ads_percentage_blocked_today").state == "0"
-    assert hass.states.get("sensor.pi_hole_dns_queries_cached").state == "0"
-    assert hass.states.get("sensor.pi_hole_dns_queries_forwarded").state == "0"
-    assert hass.states.get("sensor.pi_hole_dns_queries_today").state == "0"
-    assert hass.states.get("sensor.pi_hole_dns_unique_clients").state == "0"
-    assert hass.states.get("sensor.pi_hole_dns_unique_domains").state == "0"
-    assert hass.states.get("sensor.pi_hole_domains_blocked").state == "0"
-    assert hass.states.get("sensor.pi_hole_seen_clients").state == "0"
+    state = hass.states.get("sensor.pi_hole_ads_percentage_blocked_today")
+    assert state.name == "Pi-Hole Ads Percentage Blocked Today"
+    assert state.state == "0"
 
-    assert hass.states.get("binary_sensor.pi_hole").name == "Pi-Hole"
-    assert hass.states.get("binary_sensor.pi_hole").state == "off"
+    state = hass.states.get("sensor.pi_hole_dns_queries_cached")
+    assert state.name == "Pi-Hole DNS Queries Cached"
+    assert state.state == "0"
 
-    assert (
-        hass.states.get("update.pi_hole_core_update_available").name
-        == "Pi-Hole Core Update Available"
-    )
-    assert hass.states.get("update.pi_hole_core_update_available").state == "on"
-    assert (
-        hass.states.get("update.pi_hole_core_update_available").attributes[
-            "current_version"
-        ]
-        == "v5.5"
-    )
-    assert (
-        hass.states.get("update.pi_hole_core_update_available").attributes[
-            "latest_version"
-        ]
-        == "v5.6"
-    )
+    state = hass.states.get("sensor.pi_hole_dns_queries_forwarded")
+    assert state.name == "Pi-Hole DNS Queries Forwarded"
+    assert state.state == "0"
 
-    assert (
-        hass.states.get("update.pi_hole_ftl_update_available").name
-        == "Pi-Hole FTL Update Available"
-    )
-    assert hass.states.get("update.pi_hole_ftl_update_available").state == "on"
-    assert (
-        hass.states.get("update.pi_hole_ftl_update_available").attributes[
-            "current_version"
-        ]
-        == "v5.10"
-    )
-    assert (
-        hass.states.get("update.pi_hole_ftl_update_available").attributes[
-            "latest_version"
-        ]
-        == "v5.11"
-    )
+    state = hass.states.get("sensor.pi_hole_dns_queries_today")
+    assert state.name == "Pi-Hole DNS Queries Today"
+    assert state.state == "0"
 
-    assert (
-        hass.states.get("update.pi_hole_web_update_available").name
-        == "Pi-Hole Web Update Available"
-    )
-    assert hass.states.get("update.pi_hole_web_update_available").state == "on"
-    assert (
-        hass.states.get("update.pi_hole_web_update_available").attributes[
-            "current_version"
-        ]
-        == "v5.7"
-    )
-    assert (
-        hass.states.get("update.pi_hole_web_update_available").attributes[
-            "latest_version"
-        ]
-        == "v5.8"
-    )
+    state = hass.states.get("sensor.pi_hole_dns_unique_clients")
+    assert state.name == "Pi-Hole DNS Unique Clients"
+    assert state.state == "0"
+
+    state = hass.states.get("sensor.pi_hole_dns_unique_domains")
+    assert state.name == "Pi-Hole DNS Unique Domains"
+    assert state.state == "0"
+
+    state = hass.states.get("sensor.pi_hole_domains_blocked")
+    assert state.name == "Pi-Hole Domains Blocked"
+    assert state.state == "0"
+
+    state = hass.states.get("sensor.pi_hole_seen_clients")
+    assert state.name == "Pi-Hole Seen Clients"
+    assert state.state == "0"
+
+    state = hass.states.get("binary_sensor.pi_hole")
+    assert state.name == "Pi-Hole"
+    assert state.state == "off"
 
 
 async def test_setup_name_config(hass):

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -95,54 +95,54 @@ async def test_setup_minimal_config(hass):
     assert hass.states.get("binary_sensor.pi_hole").state == "off"
 
     assert (
-        hass.states.get("binary_sensor.pi_hole_core_update_available").name
+        hass.states.get("update.pi_hole_core_update_available").name
         == "Pi-Hole Core Update Available"
     )
-    assert hass.states.get("binary_sensor.pi_hole_core_update_available").state == "on"
+    assert hass.states.get("update.pi_hole_core_update_available").state == "on"
     assert (
-        hass.states.get("binary_sensor.pi_hole_core_update_available").attributes[
+        hass.states.get("update.pi_hole_core_update_available").attributes[
             "current_version"
         ]
         == "v5.5"
     )
     assert (
-        hass.states.get("binary_sensor.pi_hole_core_update_available").attributes[
+        hass.states.get("update.pi_hole_core_update_available").attributes[
             "latest_version"
         ]
         == "v5.6"
     )
 
     assert (
-        hass.states.get("binary_sensor.pi_hole_ftl_update_available").name
+        hass.states.get("update.pi_hole_ftl_update_available").name
         == "Pi-Hole FTL Update Available"
     )
-    assert hass.states.get("binary_sensor.pi_hole_ftl_update_available").state == "on"
+    assert hass.states.get("update.pi_hole_ftl_update_available").state == "on"
     assert (
-        hass.states.get("binary_sensor.pi_hole_ftl_update_available").attributes[
+        hass.states.get("update.pi_hole_ftl_update_available").attributes[
             "current_version"
         ]
         == "v5.10"
     )
     assert (
-        hass.states.get("binary_sensor.pi_hole_ftl_update_available").attributes[
+        hass.states.get("update.pi_hole_ftl_update_available").attributes[
             "latest_version"
         ]
         == "v5.11"
     )
 
     assert (
-        hass.states.get("binary_sensor.pi_hole_web_update_available").name
+        hass.states.get("update.pi_hole_web_update_available").name
         == "Pi-Hole Web Update Available"
     )
-    assert hass.states.get("binary_sensor.pi_hole_web_update_available").state == "on"
+    assert hass.states.get("update.pi_hole_web_update_available").state == "on"
     assert (
-        hass.states.get("binary_sensor.pi_hole_web_update_available").attributes[
+        hass.states.get("update.pi_hole_web_update_available").attributes[
             "current_version"
         ]
         == "v5.7"
     )
     assert (
-        hass.states.get("binary_sensor.pi_hole_web_update_available").attributes[
+        hass.states.get("update.pi_hole_web_update_available").attributes[
             "latest_version"
         ]
         == "v5.8"

--- a/tests/components/pi_hole/test_update.py
+++ b/tests/components/pi_hole/test_update.py
@@ -1,0 +1,80 @@
+"""Test pi_hole component."""
+
+from homeassistant.components import pi_hole
+from homeassistant.const import STATE_ON, STATE_UNKNOWN
+from homeassistant.setup import async_setup_component
+
+from . import _create_mocked_hole, _patch_config_flow_hole, _patch_init_hole
+
+
+async def test_update(hass):
+    """Tests update entity."""
+    mocked_hole = _create_mocked_hole()
+    with _patch_config_flow_hole(mocked_hole), _patch_init_hole(mocked_hole):
+        assert await async_setup_component(
+            hass, pi_hole.DOMAIN, {pi_hole.DOMAIN: [{"host": "pi.hole"}]}
+        )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("update.pi_hole_core_update_available")
+    assert state.name == "Pi-Hole Core Update Available"
+    assert state.state == STATE_ON
+    assert state.attributes["current_version"] == "v5.5"
+    assert state.attributes["latest_version"] == "v5.6"
+    assert (
+        state.attributes["release_url"]
+        == "https://github.com/pi-hole/pi-hole/releases/tag/v5.6"
+    )
+
+    state = hass.states.get("update.pi_hole_ftl_update_available")
+    assert state.name == "Pi-Hole FTL Update Available"
+    assert state.state == STATE_ON
+    assert state.attributes["current_version"] == "v5.10"
+    assert state.attributes["latest_version"] == "v5.11"
+    assert (
+        state.attributes["release_url"]
+        == "https://github.com/pi-hole/FTL/releases/tag/v5.11"
+    )
+
+    state = hass.states.get("update.pi_hole_web_update_available")
+    assert state.name == "Pi-Hole Web Update Available"
+    assert state.state == STATE_ON
+    assert state.attributes["current_version"] == "v5.7"
+    assert state.attributes["latest_version"] == "v5.8"
+    assert (
+        state.attributes["release_url"]
+        == "https://github.com/pi-hole/AdminLTE/releases/tag/v5.8"
+    )
+
+
+async def test_update_no_versions(hass):
+    """Tests update entity when no version data available."""
+    mocked_hole = _create_mocked_hole(has_versions=False)
+    with _patch_config_flow_hole(mocked_hole), _patch_init_hole(mocked_hole):
+        assert await async_setup_component(
+            hass, pi_hole.DOMAIN, {pi_hole.DOMAIN: [{"host": "pi.hole"}]}
+        )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("update.pi_hole_core_update_available")
+    assert state.name == "Pi-Hole Core Update Available"
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes["current_version"] is None
+    assert state.attributes["latest_version"] is None
+    assert state.attributes["release_url"] is None
+
+    state = hass.states.get("update.pi_hole_ftl_update_available")
+    assert state.name == "Pi-Hole FTL Update Available"
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes["current_version"] is None
+    assert state.attributes["latest_version"] is None
+    assert state.attributes["release_url"] is None
+
+    state = hass.states.get("update.pi_hole_web_update_available")
+    assert state.name == "Pi-Hole Web Update Available"
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes["current_version"] is None
+    assert state.attributes["latest_version"] is None
+    assert state.attributes["release_url"] is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The binary sensor entities that would show if there was an update available for the Core, Web or FTL component has been deprecated and will be removed in Home Assistant 2022.6.
The PI-Hole integration now provides update entities as a replacement for the deprecated entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
