### PR TITLE
Add 2FA support for Subaru integration setup

### DIFF
--- a/homeassistant/components/subaru/config_flow.py
+++ b/homeassistant/components/subaru/config_flow.py
@@ -19,6 +19,8 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from .const import CONF_COUNTRY, CONF_UPDATE_ENABLED, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+CONF_CONTACT_METHOD = "contact_method"
+CONF_VALIDATION_CODE = "validation_code"
 PIN_SCHEMA = vol.Schema({vol.Required(CONF_PIN): str})
 
 
@@ -47,6 +49,9 @@ class SubaruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.error("Unable to communicate with Subaru API: %s", ex.message)
                 return self.async_abort(reason="cannot_connect")
             else:
+                if not self.controller.device_registered:
+                    _LOGGER.debug("2FA validation is required")
+                    return await self.async_step_two_factor()
                 if self.controller.is_pin_required():
                     return await self.async_step_pin()
                 return self.async_create_entry(
@@ -103,12 +108,59 @@ class SubaruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             device_name=device_name,
             country=data[CONF_COUNTRY],
         )
-        _LOGGER.debug(
-            "Setting up first time connection to Subaru API.  This may take up to 20 seconds"
-        )
+        _LOGGER.debug("Setting up first time connection to Subaru API")
         if await self.controller.connect():
-            _LOGGER.debug("Successfully authenticated and authorized with Subaru API")
+            _LOGGER.debug("Successfully authenticated with Subaru API")
             self.config_data.update(data)
+
+    async def async_step_two_factor(self, user_input=None):
+        """Select contact method and request 2FA code from Subaru."""
+        error = None
+        if user_input:
+            # self.controller.contact_methods is a dict:
+            # {"phone":"555-555-5555", "userName":"my@email.com"}
+            selected_method = next(
+                k
+                for k, v in self.controller.contact_methods.items()
+                if v == user_input[CONF_CONTACT_METHOD]
+            )
+            if await self.controller.request_auth_code(selected_method):
+                return await self.async_step_two_factor_validate()
+            raise SubaruException("2FA request failed")
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_CONTACT_METHOD): vol.In(
+                    list(self.controller.contact_methods.values())
+                )
+            }
+        )
+        return self.async_show_form(
+            step_id="two_factor", data_schema=data_schema, errors=error
+        )
+
+    async def async_step_two_factor_validate(self, user_input=None):
+        """Validate received 2FA code with Subaru."""
+        error = None
+        if user_input:
+            try:
+                vol.Match(r"^[0-9]{6}$")(user_input[CONF_VALIDATION_CODE])
+                if await self.controller.submit_auth_code(
+                    user_input[CONF_VALIDATION_CODE]
+                ):
+                    if self.controller.is_pin_required():
+                        return await self.async_step_pin()
+                    return self.async_create_entry(
+                        title=self.config_data[CONF_USERNAME], data=self.config_data
+                    )
+                error = {"base": "incorrect_validation_code"}
+            except vol.Invalid:
+                error = {"base": "bad_validation_code_format"}
+
+        data_schema = vol.Schema({vol.Required(CONF_VALIDATION_CODE): str})
+        return self.async_show_form(
+            step_id="two_factor_validate", data_schema=data_schema, errors=error
+        )
 
     async def async_step_pin(self, user_input=None):
         """Handle second part of config flow, if required."""

--- a/homeassistant/components/subaru/config_flow.py
+++ b/homeassistant/components/subaru/config_flow.py
@@ -126,7 +126,7 @@ class SubaruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             if await self.controller.request_auth_code(selected_method):
                 return await self.async_step_two_factor_validate()
-            raise SubaruException("2FA request failed")
+            return self.async_abort(reason="two_factor_request_failed")
 
         data_schema = vol.Schema(
             {

--- a/homeassistant/components/subaru/manifest.json
+++ b/homeassistant/components/subaru/manifest.json
@@ -3,7 +3,7 @@
   "name": "Subaru",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/subaru",
-  "requirements": ["subarulink==0.4.2"],
+  "requirements": ["subarulink==0.5.0"],
   "codeowners": ["@G-Two"],
   "iot_class": "cloud_polling",
   "loggers": ["stdiomask", "subarulink"]

--- a/homeassistant/components/subaru/strings.json
+++ b/homeassistant/components/subaru/strings.json
@@ -37,6 +37,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "incorrect_pin": "Incorrect PIN",
       "bad_pin_format": "PIN should be 4 digits",
+      "two_factor_request_failed": "Request for 2FA code failed, please try again",
       "bad_validation_code_format": "Validation code should be 6 digits",
       "incorrect_validation_code": "Incorrect validation code"
     },

--- a/homeassistant/components/subaru/strings.json
+++ b/homeassistant/components/subaru/strings.json
@@ -10,6 +10,20 @@
           "country": "Select country"
         }
       },
+      "two_factor": {
+        "title": "Subaru Starlink Configuration",
+        "description": "Two factor authentication required",
+        "data": {
+          "contact_method": "Please select a contact method:"
+        }
+      },
+      "two_factor_validate": {
+        "title": "Subaru Starlink Configuration",
+        "description": "Please enter validation code received",
+        "data": {
+          "validation_code": "Validation code"
+        }
+      },
       "pin": {
         "title": "Subaru Starlink Configuration",
         "description": "Please enter your MySubaru PIN\nNOTE: All vehicles in account must have the same PIN",
@@ -22,7 +36,9 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "incorrect_pin": "Incorrect PIN",
-      "bad_pin_format": "PIN should be 4 digits"
+      "bad_pin_format": "PIN should be 4 digits",
+      "bad_validation_code_format": "Validation code should be 6 digits",
+      "incorrect_validation_code": "Incorrect validation code"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2225,7 +2225,7 @@ streamlabswater==1.0.1
 stringcase==1.2.0
 
 # homeassistant.components.subaru
-subarulink==0.4.2
+subarulink==0.5.0
 
 # homeassistant.components.ecovacs
 sucks==0.9.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1432,7 +1432,7 @@ stookalert==0.1.4
 stringcase==1.2.0
 
 # homeassistant.components.subaru
-subarulink==0.4.2
+subarulink==0.5.0
 
 # homeassistant.components.solarlog
 sunwatcher==0.2.1

--- a/tests/components/subaru/conftest.py
+++ b/tests/components/subaru/conftest.py
@@ -28,6 +28,10 @@ from .api_responses import TEST_VIN_2_EV, VEHICLE_DATA, VEHICLE_STATUS_EV
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 MOCK_API = "homeassistant.components.subaru.SubaruAPI."
+MOCK_API_DEVICE_REGISTERED = f"{MOCK_API}device_registered"
+MOCK_API_2FA_CONTACTS = f"{MOCK_API}contact_methods"
+MOCK_API_2FA_REQUEST = f"{MOCK_API}request_auth_code"
+MOCK_API_2FA_VERIFY = f"{MOCK_API}submit_auth_code"
 MOCK_API_CONNECT = f"{MOCK_API}connect"
 MOCK_API_IS_PIN_REQUIRED = f"{MOCK_API}is_pin_required"
 MOCK_API_TEST_PIN = f"{MOCK_API}test_pin"

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -179,15 +179,15 @@ async def test_two_factor_request_fail(hass, two_factor_start_form):
         return_value=False,
     ) as mock_two_factor_request, patch(
         MOCK_API_2FA_CONTACTS, new_callable=PropertyMock
-    ) as mock_contacts, pytest.raises(
-        SubaruException
-    ):
+    ) as mock_contacts:
         mock_contacts.return_value = MOCK_2FA_CONTACTS
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_start_form["flow_id"],
             user_input={config_flow.CONF_CONTACT_METHOD: "email@addr.com"},
         )
     assert len(mock_two_factor_request.mock_calls) == 1
+    assert result["type"] == "abort"
+    assert result["reason"] == "two_factor_request_failed"
 
 
 async def test_two_factor_verify_success(hass, two_factor_verify_form):

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -2,7 +2,7 @@
 # pylint: disable=redefined-outer-name
 from copy import deepcopy
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from subarulink.exceptions import InvalidCredentials, InvalidPIN, SubaruException
@@ -14,7 +14,11 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_PIN
 from homeassistant.setup import async_setup_component
 
 from .conftest import (
+    MOCK_API_2FA_CONTACTS,
+    MOCK_API_2FA_REQUEST,
+    MOCK_API_2FA_VERIFY,
     MOCK_API_CONNECT,
+    MOCK_API_DEVICE_REGISTERED,
     MOCK_API_IS_PIN_REQUIRED,
     MOCK_API_TEST_PIN,
     MOCK_API_UPDATE_SAVED_PIN,
@@ -28,6 +32,10 @@ from .conftest import (
 from tests.common import MockConfigEntry
 
 ASYNC_SETUP_ENTRY = "homeassistant.components.subaru.async_setup_entry"
+MOCK_2FA_CONTACTS = {
+    "phone": "123-123-1234",
+    "userName": "email@addr.com",
+}
 
 
 async def test_user_form_init(user_form):
@@ -89,19 +97,22 @@ async def test_user_form_invalid_auth(hass, user_form):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_user_form_pin_not_required(hass, user_form):
+async def test_user_form_pin_not_required(hass, two_factor_verify_form):
     """Test successful login when no PIN is required."""
-    with patch(MOCK_API_CONNECT, return_value=True,) as mock_connect, patch(
+    with patch(
+        MOCK_API_2FA_VERIFY,
+        return_value=True,
+    ) as mock_two_factor_verify, patch(
         MOCK_API_IS_PIN_REQUIRED,
         return_value=False,
     ) as mock_is_pin_required, patch(
         ASYNC_SETUP_ENTRY, return_value=True
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
-            user_form["flow_id"],
-            TEST_CREDS,
+            two_factor_verify_form["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
         )
-    assert len(mock_connect.mock_calls) == 1
+    assert len(mock_two_factor_verify.mock_calls) == 1
     assert len(mock_is_pin_required.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -117,9 +128,116 @@ async def test_user_form_pin_not_required(hass, user_form):
         "data": deepcopy(TEST_CONFIG),
         "options": {},
     }
+
     expected["data"][CONF_PIN] = None
     result["data"][CONF_DEVICE_ID] = TEST_DEVICE_ID
     assert result == expected
+
+
+async def test_registered_pin_required(hass, user_form):
+    """Test if the device is already registered and PIN required."""
+    with patch(MOCK_API_CONNECT, return_value=True), patch(
+        MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock
+    ) as mock_device_registered, patch(MOCK_API_IS_PIN_REQUIRED, return_value=True):
+        mock_device_registered.return_value = True
+        await hass.config_entries.flow.async_configure(
+            user_form["flow_id"], user_input=TEST_CREDS
+        )
+
+
+async def test_registered_no_pin_required(hass, user_form):
+    """Test if the device is already registered and PIN not required."""
+    with patch(MOCK_API_CONNECT, return_value=True), patch(
+        MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock
+    ) as mock_device_registered, patch(MOCK_API_IS_PIN_REQUIRED, return_value=False):
+        mock_device_registered.return_value = True
+        await hass.config_entries.flow.async_configure(
+            user_form["flow_id"], user_input=TEST_CREDS
+        )
+
+
+async def test_two_factor_request_success(hass, two_factor_start_form):
+    """Test two factor contact method selection."""
+    with patch(
+        MOCK_API_2FA_REQUEST,
+        return_value=True,
+    ) as mock_two_factor_request, patch(
+        MOCK_API_2FA_CONTACTS, new_callable=PropertyMock
+    ) as mock_contacts:
+        mock_contacts.return_value = MOCK_2FA_CONTACTS
+        await hass.config_entries.flow.async_configure(
+            two_factor_start_form["flow_id"],
+            user_input={config_flow.CONF_CONTACT_METHOD: "email@addr.com"},
+        )
+    assert len(mock_two_factor_request.mock_calls) == 1
+
+
+async def test_two_factor_request_fail(hass, two_factor_start_form):
+    """Test two factor auth request failure."""
+    with patch(
+        MOCK_API_2FA_REQUEST,
+        return_value=False,
+    ) as mock_two_factor_request, patch(
+        MOCK_API_2FA_CONTACTS, new_callable=PropertyMock
+    ) as mock_contacts, pytest.raises(
+        SubaruException
+    ):
+        mock_contacts.return_value = MOCK_2FA_CONTACTS
+        await hass.config_entries.flow.async_configure(
+            two_factor_start_form["flow_id"],
+            user_input={config_flow.CONF_CONTACT_METHOD: "email@addr.com"},
+        )
+    assert len(mock_two_factor_request.mock_calls) == 1
+
+
+async def test_two_factor_verify_success(hass, two_factor_verify_form):
+    """Test two factor verification."""
+    with patch(
+        MOCK_API_2FA_VERIFY,
+        return_value=True,
+    ) as mock_two_factor_verify, patch(
+        MOCK_API_IS_PIN_REQUIRED, return_value=True
+    ) as mock_is_in_required:
+        await hass.config_entries.flow.async_configure(
+            two_factor_verify_form["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert len(mock_two_factor_verify.mock_calls) == 1
+    assert len(mock_is_in_required.mock_calls) == 1
+
+
+async def test_two_factor_verify_bad_format(hass, two_factor_verify_form):
+    """Test two factor verification bad format."""
+    with patch(
+        MOCK_API_2FA_VERIFY,
+        return_value=False,
+    ) as mock_two_factor_verify, patch(
+        MOCK_API_IS_PIN_REQUIRED, return_value=True
+    ) as mock_is_pin_required:
+        result = await hass.config_entries.flow.async_configure(
+            two_factor_verify_form["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "1234567"},
+        )
+    assert len(mock_two_factor_verify.mock_calls) == 0
+    assert len(mock_is_pin_required.mock_calls) == 0
+    assert result["errors"] == {"base": "bad_validation_code_format"}
+
+
+async def test_two_factor_verify_fail(hass, two_factor_verify_form):
+    """Test two factor verification failure."""
+    with patch(
+        MOCK_API_2FA_VERIFY,
+        return_value=False,
+    ) as mock_two_factor_verify, patch(
+        MOCK_API_IS_PIN_REQUIRED, return_value=True
+    ) as mock_is_pin_required:
+        result = await hass.config_entries.flow.async_configure(
+            two_factor_verify_form["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert len(mock_two_factor_verify.mock_calls) == 1
+    assert len(mock_is_pin_required.mock_calls) == 0
+    assert result["errors"] == {"base": "incorrect_validation_code"}
 
 
 async def test_pin_form_init(pin_form):
@@ -232,14 +350,41 @@ async def user_form(hass):
 
 
 @pytest.fixture
-async def pin_form(hass, user_form):
-    """Return second form (PIN input) for Subaru config flow."""
-    with patch(MOCK_API_CONNECT, return_value=True,), patch(
-        MOCK_API_IS_PIN_REQUIRED,
-        return_value=True,
-    ):
+async def two_factor_start_form(hass, user_form):
+    """Return two factor form for Subaru config flow."""
+    with patch(MOCK_API_CONNECT, return_value=True), patch(
+        MOCK_API_2FA_CONTACTS, new_callable=PropertyMock
+    ) as mock_contacts:
+        mock_contacts.return_value = MOCK_2FA_CONTACTS
         return await hass.config_entries.flow.async_configure(
             user_form["flow_id"], user_input=TEST_CREDS
+        )
+
+
+@pytest.fixture
+async def two_factor_verify_form(hass, two_factor_start_form):
+    """Return two factor form for Subaru config flow."""
+    with patch(
+        MOCK_API_2FA_REQUEST,
+        return_value=True,
+    ), patch(MOCK_API_2FA_CONTACTS, new_callable=PropertyMock) as mock_contacts:
+        mock_contacts.return_value = MOCK_2FA_CONTACTS
+        return await hass.config_entries.flow.async_configure(
+            two_factor_start_form["flow_id"],
+            user_input={config_flow.CONF_CONTACT_METHOD: "email@addr.com"},
+        )
+
+
+@pytest.fixture
+async def pin_form(hass, two_factor_verify_form):
+    """Return PIN input form for Subaru config flow."""
+    with patch(
+        MOCK_API_2FA_VERIFY,
+        return_value=True,
+    ), patch(MOCK_API_IS_PIN_REQUIRED, return_value=True):
+        return await hass.config_entries.flow.async_configure(
+            two_factor_verify_form["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
         )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MySubaru service now requires users to authorize devices via 2FA. The HA integration presents itself as a "device" and must be validated via 2FA. The config flow does not currently support this and will prevent the successful addition of a new account. Users that have already used the HA integration will not be affected (their device registration that automatically occurred without 2FA is grandfathered) unless they delete the integration, at which point they will need to use 2FA after reinstalling.

This change updates the subarulink dependency to v0.5.0, which adds support for 2FA [changelog](https://github.com/G-Two/subarulink/releases) and updates the UI config flow to allow the user to validate HA with Subaru. This validation only needs to occur once during initial setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68747 
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
