### PR TITLE
Wait for Home Assistant start in here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -243,7 +243,7 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
     async def async_added_to_hass(self) -> None:
         """Wait for start so origin and destination entities can be resolved."""
         await super().async_added_to_hass()
-        async_at_start(self.hass, self.async_update)
+        async_at_start(self.hass, lambda hass: self.async_update())
 
     @property
     def native_value(self) -> str | None:

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -196,7 +197,6 @@ async def async_setup_platform(
         here_client,
         here_travel_time_config,
     )
-    await coordinator.async_config_entry_first_refresh()
 
     sensor = HERETravelTimeSensor(name, traffic_mode, coordinator)
 
@@ -239,6 +239,11 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
         self._traffic_mode = traffic_mode
         self._attr_native_unit_of_measurement = TIME_MINUTES
         self._attr_name = name
+
+    async def async_added_to_hass(self) -> None:
+        """Wait for start so origin and destination entities can be resolved."""
+        await super().async_added_to_hass()
+        async_at_start(self.hass, self.async_update)
 
     @property
     def native_value(self) -> str | None:

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -243,7 +243,11 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
     async def async_added_to_hass(self) -> None:
         """Wait for start so origin and destination entities can be resolved."""
         await super().async_added_to_hass()
-        async_at_start(self.hass, lambda hass: self.async_update())
+
+        async def _update_at_start(_):
+            await self.async_update()
+
+        async_at_start(self.hass, _update_at_start)
 
     @property
     def native_value(self) -> str | None:
@@ -279,7 +283,8 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
     @property
     def attribution(self) -> str | None:
         """Return the attribution."""
-        return self.coordinator.data.get(ATTR_ATTRIBUTION)
+        if self.coordinator.data is not None:
+            return self.coordinator.data.get(ATTR_ATTRIBUTION)
 
     @property
     def icon(self) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Wait for Home Assistant to fully start before starting requests against the API.

The data coordinator depends on other entities e.g. `config.origin_entity_id` and `config.destination_entity_id` to specify the routing information. The integration must wait for those entities to be loaded before it can proceed to do the routing and fetching from the API

Alternative solution as described in #68744

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68661
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
