### PR TITLE
Add test coverage for google calendar event response format

### DIFF
--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -6,6 +6,7 @@ import datetime
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
+import urllib
 
 import httplib2
 import pytest
@@ -74,12 +75,21 @@ def upcoming() -> dict[str, Any]:
     }
 
 
+def upcoming_date() -> dict[str, Any]:
+    """Create a test event with an arbitrary start/end date fetched from the api url."""
+    now = dt_util.now()
+    return {
+        "start": {"date": now.date().isoformat()},
+        "end": {"date": now.date().isoformat()},
+    }
+
+
 def upcoming_event_url() -> str:
     """Return a calendar API to return events created by upcoming()."""
     now = dt_util.now()
     start = (now - datetime.timedelta(minutes=60)).isoformat()
     end = (now + datetime.timedelta(minutes=60)).isoformat()
-    return f"/api/calendars/{TEST_ENTITY}?start={start}&end={end}"
+    return f"/api/calendars/{TEST_ENTITY}?start={urllib.parse.quote(start)}&end={urllib.parse.quote(end)}"
 
 
 async def test_all_day_event(
@@ -365,10 +375,12 @@ async def test_http_event_api_failure(
     assert events == []
 
 
+@pytest.mark.freeze_time("2022-03-27 12:05:00+00:00")
 async def test_http_api_event(
     hass, hass_client, mock_events_list_items, component_setup
 ):
     """Test querying the API and fetching events from the server."""
+    hass.config.set_time_zone("Asia/Baghdad")
     event = {
         **TEST_EVENT,
         **upcoming(),
@@ -381,8 +393,35 @@ async def test_http_api_event(
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert len(events) == 1
-    assert "summary" in events[0]
-    assert events[0]["summary"] == event["summary"]
+    assert {k: events[0].get(k) for k in ["summary", "start", "end"]} == {
+        "summary": TEST_EVENT["summary"],
+        "start": {"dateTime": "2022-03-27T15:05:00+03:00"},
+        "end": {"dateTime": "2022-03-27T15:10:00+03:00"},
+    }
+
+
+@pytest.mark.freeze_time("2022-03-27 12:05:00+00:00")
+async def test_http_api_all_day_event(
+    hass, hass_client, mock_events_list_items, component_setup
+):
+    """Test querying the API and fetching events from the server."""
+    event = {
+        **TEST_EVENT,
+        **upcoming_date(),
+    }
+    mock_events_list_items([event])
+    assert await component_setup()
+
+    client = await hass_client()
+    response = await client.get(upcoming_event_url())
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert len(events) == 1
+    assert {k: events[0].get(k) for k in ["summary", "start", "end"]} == {
+        "summary": TEST_EVENT["summary"],
+        "start": {"date": "2022-03-27"},
+        "end": {"date": "2022-03-27"},
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add test coverage for the calendar event response format as I am about to do some
refactoring and simplification. Notably, each calendar implementation uses a slightly different
API response, and this is codifying that. (Related PR https://github.com/home-assistant/core/pull/68745/files)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
