### PR TITLE
Revert light.switch to 2022.3

### DIFF
--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -1,15 +1,29 @@
 """Light support for switch entities."""
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 
-from homeassistant.components.light import PLATFORM_SCHEMA
-from homeassistant.components.switch_as_x import LightSwitch
-from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.components.light import (
+    COLOR_MODE_ONOFF,
+    PLATFORM_SCHEMA,
+    LightEntity,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import DOMAIN as SWITCH_DOMAIN
@@ -44,3 +58,60 @@ async def async_setup_platform(
             )
         ]
     )
+
+
+class LightSwitch(LightEntity):
+    """Represents a Switch as a Light."""
+
+    _attr_color_mode = COLOR_MODE_ONOFF
+    _attr_should_poll = False
+    _attr_supported_color_modes = {COLOR_MODE_ONOFF}
+
+    def __init__(self, name: str, switch_entity_id: str, unique_id: str | None) -> None:
+        """Initialize Light Switch."""
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        self._switch_entity_id = switch_entity_id
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Forward the turn_on command to the switch in this light switch."""
+        await self.hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._switch_entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Forward the turn_off command to the switch in this light switch."""
+        await self.hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._switch_entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+
+        @callback
+        def async_state_changed_listener(event: Event | None = None) -> None:
+            """Handle child updates."""
+            if (
+                state := self.hass.states.get(self._switch_entity_id)
+            ) is None or state.state == STATE_UNAVAILABLE:
+                self._attr_available = False
+                return
+            self._attr_available = True
+            self._attr_is_on = state.state == STATE_ON
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._switch_entity_id], async_state_changed_listener
+            )
+        )
+        # Call once on adding
+        async_state_changed_listener()

--- a/tests/components/switch/test_light.py
+++ b/tests/components/switch/test_light.py
@@ -1,10 +1,18 @@
 """The tests for the Light Switch platform."""
 
+from homeassistant.components.light import (
+    ATTR_COLOR_MODE,
+    ATTR_SUPPORTED_COLOR_MODES,
+    COLOR_MODE_ONOFF,
+)
 from homeassistant.setup import async_setup_component
+
+from tests.components.light import common
+from tests.components.switch import common as switch_common
 
 
 async def test_default_state(hass):
-    """Test light switch yaml config."""
+    """Test light switch default state."""
     await async_setup_component(
         hass,
         "light",
@@ -18,21 +26,73 @@ async def test_default_state(hass):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.christmas_tree_lights")
+    state = hass.states.get("light.christmas_tree_lights")
+    assert state is not None
+    assert state.state == "unavailable"
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes.get("brightness") is None
+    assert state.attributes.get("hs_color") is None
+    assert state.attributes.get("color_temp") is None
+    assert state.attributes.get("white_value") is None
+    assert state.attributes.get("effect_list") is None
+    assert state.attributes.get("effect") is None
+    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [COLOR_MODE_ONOFF]
+    assert state.attributes.get(ATTR_COLOR_MODE) is None
 
 
-async def test_default_state_no_name(hass):
-    """Test light switch default name."""
+async def test_light_service_calls(hass):
+    """Test service calls to light."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
     await async_setup_component(
         hass,
         "light",
-        {
-            "light": {
-                "platform": "switch",
-                "entity_id": "switch.test",
-            }
-        },
+        {"light": [{"platform": "switch", "entity_id": "switch.decorative_lights"}]},
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.light_switch")
+    assert hass.states.get("light.light_switch").state == "on"
+
+    await common.async_toggle(hass, "light.light_switch")
+
+    assert hass.states.get("switch.decorative_lights").state == "off"
+    assert hass.states.get("light.light_switch").state == "off"
+
+    await common.async_turn_on(hass, "light.light_switch")
+
+    assert hass.states.get("switch.decorative_lights").state == "on"
+    assert hass.states.get("light.light_switch").state == "on"
+    assert (
+        hass.states.get("light.light_switch").attributes.get(ATTR_COLOR_MODE)
+        == COLOR_MODE_ONOFF
+    )
+
+    await common.async_turn_off(hass, "light.light_switch")
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.decorative_lights").state == "off"
+    assert hass.states.get("light.light_switch").state == "off"
+
+
+async def test_switch_service_calls(hass):
+    """Test service calls to switch."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await async_setup_component(
+        hass,
+        "light",
+        {"light": [{"platform": "switch", "entity_id": "switch.decorative_lights"}]},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.light_switch").state == "on"
+
+    await switch_common.async_turn_off(hass, "switch.decorative_lights")
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.decorative_lights").state == "off"
+    assert hass.states.get("light.light_switch").state == "off"
+
+    await switch_common.async_turn_on(hass, "switch.decorative_lights")
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.decorative_lights").state == "on"
+    assert hass.states.get("light.light_switch").state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert light.switch to 2022.3

This is done to avoid things breaking if / when the `switch_as_x` integration evolves

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
