### PR TITLE
Mock out all default onboarding integrations in test

### DIFF
--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -392,7 +392,7 @@ async def test_onboarding_core_sets_up_met(
 
 
 async def test_onboarding_core_sets_up_radio_browser(
-    hass, hass_storage, hass_client, mock_default_intergrations
+    hass, hass_storage, hass_client, mock_default_integrations
 ):
     """Test finishing the core step set up the radio browser."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -85,7 +85,7 @@ async def mock_supervisor_fixture(hass, aioclient_mock):
 
 
 @pytest.fixture
-def mock_default_intergrations():
+def mock_default_integrations():
     """Mock the default integrations set up during onboarding."""
     with patch(
         "homeassistant.components.rpi_power.config_flow.new_under_voltage"
@@ -374,7 +374,7 @@ async def test_onboarding_integration_requires_auth(
 
 
 async def test_onboarding_core_sets_up_met(
-    hass, hass_storage, hass_client, mock_default_intergrations
+    hass, hass_storage, hass_client, mock_default_integrations
 ):
     """Test finishing the core step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
@@ -410,7 +410,7 @@ async def test_onboarding_core_sets_up_radio_browser(
 
 
 async def test_onboarding_core_sets_up_rpi_power(
-    hass, hass_storage, hass_client, aioclient_mock, rpi, mock_default_intergrations
+    hass, hass_storage, hass_client, aioclient_mock, rpi, mock_default_integrations
 ):
     """Test that the core step sets up rpi_power on RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
@@ -431,7 +431,7 @@ async def test_onboarding_core_sets_up_rpi_power(
 
 
 async def test_onboarding_core_no_rpi_power(
-    hass, hass_storage, hass_client, aioclient_mock, no_rpi, mock_default_intergrations
+    hass, hass_storage, hass_client, aioclient_mock, no_rpi, mock_default_integrations
 ):
     """Test that the core step do not set up rpi_power on non RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -14,12 +14,6 @@ from homeassistant.setup import async_setup_component
 from . import mock_storage
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI, register_auth_provider
-from tests.components.met.conftest import mock_weather  # noqa: F401
-
-
-@pytest.fixture(autouse=True)
-def always_mock_weather(mock_weather):  # noqa: F811
-    """Mock the Met weather provider."""
 
 
 @pytest.fixture(autouse=True)
@@ -86,6 +80,21 @@ async def mock_supervisor_fixture(hass, aioclient_mock):
         return_value={"panels": {}},
     ), patch.dict(
         os.environ, {"HASSIO_TOKEN": "123456"}
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_default_intergrations():
+    """Mock the default integrations set up during onboarding."""
+    with patch(
+        "homeassistant.components.rpi_power.config_flow.new_under_voltage"
+    ), patch(
+        "homeassistant.components.rpi_power.binary_sensor.new_under_voltage"
+    ), patch(
+        "homeassistant.components.met.async_setup_entry", return_value=True
+    ), patch(
+        "homeassistant.components.radio_browser.async_setup_entry", return_value=True
     ):
         yield
 
@@ -364,7 +373,9 @@ async def test_onboarding_integration_requires_auth(
     assert resp.status == 401
 
 
-async def test_onboarding_core_sets_up_met(hass, hass_storage, hass_client):
+async def test_onboarding_core_sets_up_met(
+    hass, hass_storage, hass_client, mock_default_intergrations
+):
     """Test finishing the core step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -372,19 +383,17 @@ async def test_onboarding_core_sets_up_met(hass, hass_storage, hass_client):
     await hass.async_block_till_done()
 
     client = await hass_client()
-    with patch(
-        "homeassistant.components.met.async_setup_entry", return_value=True
-    ) as mock_setup:
-        resp = await client.post("/api/onboarding/core_config")
+    resp = await client.post("/api/onboarding/core_config")
 
     assert resp.status == 200
 
     await hass.async_block_till_done()
     assert len(hass.config_entries.async_entries("met")) == 1
-    assert len(mock_setup.mock_calls) == 1
 
 
-async def test_onboarding_core_sets_up_radio_browser(hass, hass_storage, hass_client):
+async def test_onboarding_core_sets_up_radio_browser(
+    hass, hass_storage, hass_client, mock_default_intergrations
+):
     """Test finishing the core step set up the radio browser."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -392,21 +401,16 @@ async def test_onboarding_core_sets_up_radio_browser(hass, hass_storage, hass_cl
     await hass.async_block_till_done()
 
     client = await hass_client()
-
-    with patch(
-        "homeassistant.components.radio_browser.async_setup_entry", return_value=True
-    ) as mock_setup:
-        resp = await client.post("/api/onboarding/core_config")
+    resp = await client.post("/api/onboarding/core_config")
 
     assert resp.status == 200
 
     await hass.async_block_till_done()
     assert len(hass.config_entries.async_entries("radio_browser")) == 1
-    assert len(mock_setup.mock_calls) == 1
 
 
 async def test_onboarding_core_sets_up_rpi_power(
-    hass, hass_storage, hass_client, aioclient_mock, rpi
+    hass, hass_storage, hass_client, aioclient_mock, rpi, mock_default_intergrations
 ):
     """Test that the core step sets up rpi_power on RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
@@ -416,21 +420,18 @@ async def test_onboarding_core_sets_up_rpi_power(
 
     client = await hass_client()
 
-    with patch(
-        "homeassistant.components.rpi_power.config_flow.new_under_voltage"
-    ), patch("homeassistant.components.rpi_power.binary_sensor.new_under_voltage"):
-        resp = await client.post("/api/onboarding/core_config")
+    resp = await client.post("/api/onboarding/core_config")
 
-        assert resp.status == 200
+    assert resp.status == 200
 
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     rpi_power_state = hass.states.get("binary_sensor.rpi_power_status")
     assert rpi_power_state
 
 
 async def test_onboarding_core_no_rpi_power(
-    hass, hass_storage, hass_client, aioclient_mock, no_rpi
+    hass, hass_storage, hass_client, aioclient_mock, no_rpi, mock_default_intergrations
 ):
     """Test that the core step do not set up rpi_power on non RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
@@ -440,14 +441,11 @@ async def test_onboarding_core_no_rpi_power(
 
     client = await hass_client()
 
-    with patch(
-        "homeassistant.components.rpi_power.config_flow.new_under_voltage"
-    ), patch("homeassistant.components.rpi_power.binary_sensor.new_under_voltage"):
-        resp = await client.post("/api/onboarding/core_config")
+    resp = await client.post("/api/onboarding/core_config")
 
-        assert resp.status == 200
+    assert resp.status == 200
 
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     rpi_power_state = hass.states.get("binary_sensor.rpi_power_status")
     assert not rpi_power_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We have been experiencing some test failures with onboarding again (even though we've fixed a bunch previously).

The source of the issue, is that e.g., the radio browser tests, also set up Met.no and Raspberry Pi Power (and the other way around in all other combinations).

This PR adds a fixture that fully mock out all default integrations set up during onboarding and uses those in all these related tests. That way, they are all mocked all the time. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
