### PR TITLE
Use DmrDevice to communicate with SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -42,7 +42,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, STATE_OFF, STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_component
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -221,6 +221,10 @@ class SamsungTVDevice(MediaPlayerEntity):
         if startup_tasks:
             await asyncio.gather(*startup_tasks)
 
+        self._update_from_upnp()
+
+    @callback
+    def _update_from_upnp(self) -> None:
         if (dmr_device := self._dmr_device) is None:
             return
 
@@ -301,9 +305,9 @@ class SamsungTVDevice(MediaPlayerEntity):
         self, service: UpnpService, state_variables: Sequence[UpnpStateVariable]
     ) -> None:
         """State variable(s) changed, let home-assistant know."""
-        force_refresh = False
+        self._update_from_upnp()
 
-        self.async_schedule_update_ha_state(force_refresh)
+        self.async_write_ha_state()
 
     async def _async_launch_app(self, app_id: str) -> None:
         """Send launch_app to the tv."""

--- a/tests/components/samsungtv/__init__.py
+++ b/tests/components/samsungtv/__init__.py
@@ -2,9 +2,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import Mock
-
-from async_upnp_client.client import UpnpAction, UpnpService
 
 from homeassistant.components.samsungtv.const import DOMAIN, ENTRY_RELOAD_COOLDOWN
 from homeassistant.config_entries import ConfigEntry
@@ -36,24 +33,3 @@ async def setup_samsungtv_entry(hass: HomeAssistant, data: ConfigType) -> Config
     await hass.async_block_till_done()
 
     return entry
-
-
-def upnp_get_action_mock(device: Mock, service_type: str, action: str) -> Mock:
-    """Get or Add UpnpService/UpnpAction to UpnpDevice mock."""
-    upnp_service: Mock | None
-    if (upnp_service := device.services.get(service_type)) is None:
-        upnp_service = Mock(UpnpService)
-        upnp_service.actions = {}
-
-        def _get_action(action: str):
-            return upnp_service.actions.get(action)
-
-        upnp_service.action.side_effect = _get_action
-        device.services[service_type] = upnp_service
-
-    upnp_action: Mock | None
-    if (upnp_action := upnp_service.actions.get(action)) is None:
-        upnp_action = Mock(UpnpAction)
-        upnp_service.actions[action] = upnp_action
-
-    return upnp_action

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -78,6 +78,17 @@ async def upnp_device_fixture(upnp_factory: Mock) -> Mock:
         yield upnp_device
 
 
+@pytest.fixture(name="dmr_device")
+async def dmr_device_fixture(upnp_device: Mock) -> Mock:
+    """Patch async_upnp_client."""
+    with patch(
+        "homeassistant.components.samsungtv.media_player.DmrDevice",
+        autospec=True,
+    ) as dmr_device_class:
+        dmr_device: Mock = dmr_device_class.return_value
+        yield dmr_device
+
+
 @pytest.fixture(name="remote")
 def remote_fixture() -> Mock:
     """Patch the samsungctl Remote."""

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -100,6 +100,13 @@ async def dmr_device_fixture(upnp_device: Mock) -> Mock:
         dmr_device: Mock = dmr_device_class.return_value
         dmr_device.volume_level = 0.44
         dmr_device.is_volume_muted = False
+        dmr_device.on_event = None
+
+        def _raise_event(service, state_variables):
+            if dmr_device.on_event:
+                dmr_device.on_event(service, state_variables)
+
+        dmr_device.raise_event = _raise_event
         yield dmr_device
 
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1390,3 +1390,24 @@ async def test_upnp_missing_service(
         True,
     )
     assert "Upnp services are not available" in caplog.text
+
+
+@pytest.mark.usefixtures("remotews")
+async def test_upnp_shutdown(
+    hass: HomeAssistant,
+    dmr_device: Mock,
+    upnp_notify_server: Mock,
+) -> None:
+    """Ensure that Upnp cleanup takes effect."""
+    entry = await setup_samsungtv_entry(hass, MOCK_ENTRY_WS)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+
+    assert await entry.async_unload(hass)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_UNAVAILABLE
+
+    dmr_device.async_unsubscribe_services.assert_called_once()
+    upnp_notify_server.async_stop_server.assert_called_once()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1417,7 +1417,7 @@ async def test_upnp_shutdown(
     upnp_notify_server.async_stop_server.assert_called_once()
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remotews", "rest_api", "upnp_notify_server")
 async def test_upnp_subscribe_events(hass: HomeAssistant, dmr_device: Mock) -> None:
     """Test for Upnp event feedback."""
     await setup_samsungtv_entry(hass, MOCK_ENTRY_WS)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1392,7 +1392,7 @@ async def test_upnp_missing_service(
     assert "Upnp services are not available" in caplog.text
 
 
-@pytest.mark.usefixtures("remotews")
+@pytest.mark.usefixtures("remotews", "rest_api")
 async def test_upnp_shutdown(
     hass: HomeAssistant,
     dmr_device: Mock,

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -4,7 +4,11 @@ from datetime import datetime, timedelta
 import logging
 from unittest.mock import DEFAULT as DEFAULT_MOCK, AsyncMock, Mock, call, patch
 
-from async_upnp_client.exceptions import UpnpActionResponseError
+from async_upnp_client.exceptions import (
+    UpnpActionResponseError,
+    UpnpError,
+    UpnpResponseError,
+)
 import pytest
 from samsungctl import exceptions
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
@@ -1411,3 +1415,57 @@ async def test_upnp_shutdown(
 
     dmr_device.async_unsubscribe_services.assert_called_once()
     upnp_notify_server.async_stop_server.assert_called_once()
+
+
+@pytest.mark.usefixtures("remotews", "rest_api")
+async def test_upnp_subscribe_events(hass: HomeAssistant, dmr_device: Mock) -> None:
+    """Test for Upnp event feedback."""
+    await setup_samsungtv_entry(hass, MOCK_ENTRY_WS)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == 0.44
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is False
+
+    # DMR Devices gets updated, and raise event
+    dmr_device.volume_level = 0
+    dmr_device.is_volume_muted = True
+    dmr_device.raise_event(None, None)
+
+    # State gets updated without the need to wait for next update
+    state = hass.states.get(ENTITY_ID)
+    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == 0
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is True
+
+
+@pytest.mark.usefixtures("remotews", "rest_api")
+async def test_upnp_subscribe_events_upnperror(
+    hass: HomeAssistant,
+    dmr_device: Mock,
+    upnp_notify_server: Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test for failure to subscribe Upnp services."""
+    with patch.object(dmr_device, "async_subscribe_services", side_effect=UpnpError):
+        await setup_samsungtv_entry(hass, MOCK_ENTRY_WS)
+
+    upnp_notify_server.async_stop_server.assert_called_once()
+    assert "Error while subscribing during device connect" in caplog.text
+
+
+@pytest.mark.usefixtures("remotews", "rest_api")
+async def test_upnp_subscribe_events_upnpresponseerror(
+    hass: HomeAssistant,
+    dmr_device: Mock,
+    upnp_notify_server: Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test for failure to subscribe Upnp services."""
+    with patch.object(
+        dmr_device,
+        "async_subscribe_services",
+        side_effect=UpnpResponseError(status=501),
+    ):
+        await setup_samsungtv_entry(hass, MOCK_ENTRY_WS)
+
+    upnp_notify_server.async_stop_server.assert_not_called()
+    assert "Device rejected subscription" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use higher level DmrDevice to communicate with SamsungTV, as discussed in https://github.com/home-assistant/core/pull/68663#discussion_r836000360

cc @bdraco / @MartinHjelmare 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
