### PR TITLE
Add option for exchange rate sensor precision to Coinbase

### DIFF
--- a/homeassistant/components/coinbase/config_flow.py
+++ b/homeassistant/components/coinbase/config_flow.py
@@ -18,6 +18,8 @@ from .const import (
     API_TYPE_VAULT,
     CONF_CURRENCIES,
     CONF_EXCHANGE_BASE,
+    CONF_EXCHANGE_PRECISION,
+    CONF_EXCHANGE_PRECISION_DEFAULT,
     CONF_EXCHANGE_RATES,
     CONF_OPTIONS,
     CONF_YAML_API_TOKEN,
@@ -177,6 +179,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         default_currencies = self.config_entry.options.get(CONF_CURRENCIES, [])
         default_exchange_rates = self.config_entry.options.get(CONF_EXCHANGE_RATES, [])
         default_exchange_base = self.config_entry.options.get(CONF_EXCHANGE_BASE, "USD")
+        default_exchange_precision = self.config_entry.options.get(
+            CONF_EXCHANGE_PRECISION, CONF_EXCHANGE_PRECISION_DEFAULT
+        )
 
         if user_input is not None:
             # Pass back user selected options, even if bad
@@ -188,6 +193,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
             if CONF_EXCHANGE_RATES in user_input:
                 default_exchange_base = user_input[CONF_EXCHANGE_BASE]
+
+            if CONF_EXCHANGE_PRECISION in user_input:
+                default_exchange_precision = user_input[CONF_EXCHANGE_PRECISION]
 
             try:
                 await validate_options(self.hass, self.config_entry, user_input)
@@ -217,6 +225,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_EXCHANGE_BASE,
                         default=default_exchange_base,
                     ): vol.In(WALLETS),
+                    vol.Optional(
+                        CONF_EXCHANGE_PRECISION, default=default_exchange_precision
+                    ): int,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/coinbase/const.py
+++ b/homeassistant/components/coinbase/const.py
@@ -3,6 +3,8 @@
 CONF_CURRENCIES = "account_balance_currencies"
 CONF_EXCHANGE_BASE = "exchange_base"
 CONF_EXCHANGE_RATES = "exchange_rate_currencies"
+CONF_EXCHANGE_PRECISION = "exchange_rate_precision"
+CONF_EXCHANGE_PRECISION_DEFAULT = 2
 CONF_OPTIONS = "options"
 CONF_TITLE = "title"
 DOMAIN = "coinbase"

--- a/homeassistant/components/coinbase/strings.json
+++ b/homeassistant/components/coinbase/strings.json
@@ -28,7 +28,8 @@
         "data": {
           "account_balance_currencies": "Wallet balances to report.",
           "exchange_rate_currencies": "Exchange rates to report.",
-          "exchange_base": "Base currency for exchange rate sensors."
+          "exchange_base": "Base currency for exchange rate sensors.",
+          "exchnage_rate_precision": "Number of decimal places for exchange rates."
         }
       }
     },

--- a/homeassistant/components/coinbase/translations/en.json
+++ b/homeassistant/components/coinbase/translations/en.json
@@ -14,9 +14,7 @@
             "user": {
                 "data": {
                     "api_key": "API Key",
-                    "api_token": "API Secret",
-                    "currencies": "Account Balance Currencies",
-                    "exchange_rates": "Exchange Rates"
+                    "api_token": "API Secret"
                 },
                 "description": "Please enter the details of your API key as provided by Coinbase.",
                 "title": "Coinbase API Key Details"
@@ -26,9 +24,7 @@
     "options": {
         "error": {
             "currency_unavailable": "One or more of the requested currency balances is not provided by your Coinbase API.",
-            "currency_unavaliable": "One or more of the requested currency balances is not provided by your Coinbase API.",
             "exchange_rate_unavailable": "One or more of the requested exchange rates is not provided by Coinbase.",
-            "exchange_rate_unavaliable": "One or more of the requested exchange rates is not provided by Coinbase.",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -36,7 +32,8 @@
                 "data": {
                     "account_balance_currencies": "Wallet balances to report.",
                     "exchange_base": "Base currency for exchange rate sensors.",
-                    "exchange_rate_currencies": "Exchange rates to report."
+                    "exchange_rate_currencies": "Exchange rates to report.",
+                    "exchnage_rate_precision": "Number of decimal places for exchange rates."
                 },
                 "description": "Adjust Coinbase Options"
             }

--- a/tests/components/coinbase/test_config_flow.py
+++ b/tests/components/coinbase/test_config_flow.py
@@ -8,6 +8,7 @@ from requests.models import Response
 from homeassistant import config_entries
 from homeassistant.components.coinbase.const import (
     CONF_CURRENCIES,
+    CONF_EXCHANGE_PRECISION,
     CONF_EXCHANGE_RATES,
     CONF_YAML_API_TOKEN,
     DOMAIN,
@@ -211,6 +212,7 @@ async def test_option_form(hass):
             user_input={
                 CONF_CURRENCIES: [GOOD_CURRENCY],
                 CONF_EXCHANGE_RATES: [GOOD_EXCHANGE_RATE],
+                CONF_EXCHANGE_PRECISION: 5,
             },
         )
         assert result2["type"] == "create_entry"
@@ -237,6 +239,7 @@ async def test_form_bad_account_currency(hass):
             user_input={
                 CONF_CURRENCIES: [BAD_CURRENCY],
                 CONF_EXCHANGE_RATES: [],
+                CONF_EXCHANGE_PRECISION: 5,
             },
         )
 
@@ -263,6 +266,7 @@ async def test_form_bad_exchange_rate(hass):
             user_input={
                 CONF_CURRENCIES: [],
                 CONF_EXCHANGE_RATES: [BAD_EXCHANGE_RATE],
+                CONF_EXCHANGE_PRECISION: 5,
             },
         )
     assert result2["type"] == "form"
@@ -293,6 +297,7 @@ async def test_option_catch_all_exception(hass):
             user_input={
                 CONF_CURRENCIES: [],
                 CONF_EXCHANGE_RATES: ["ETH"],
+                CONF_EXCHANGE_PRECISION: 5,
             },
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an option for defining the precision of exchange rate sensors to the option flow. In the absence of this being set, we default to the old value (2 decimals).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68559 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
