### PR TITLE
Change newly appeared DISABLED_USERs in tests to RegistryEntryDisablers

### DIFF
--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -108,7 +108,7 @@ async def test_init_accepts_and_migrates_old_entry(aioclient_mock, hass):
         config_entry=original_entry,
         original_name="Switch Disabled",
         suggested_object_id="socket_disabled",
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
     # Update some user-customs
     ent_reg.async_update_entity(old_entity_active_power.entity_id, name="new_name")
@@ -158,7 +158,7 @@ async def test_init_accepts_and_migrates_old_entry(aioclient_mock, hass):
     assert new_entity_disabled_sensor.name is None
     assert new_entity_disabled_sensor.original_name == "Switch Disabled"
     assert new_entity_disabled_sensor.unique_id == "socket_disabled_unique_id"
-    assert new_entity_disabled_sensor.disabled_by == er.DISABLED_USER
+    assert new_entity_disabled_sensor.disabled_by == er.RegistryEntryDisabler.USER
 
 
 async def test_load_detect_api_disabled(aioclient_mock, hass):

--- a/tests/components/tomorrowio/test_init.py
+++ b/tests/components/tomorrowio/test_init.py
@@ -84,7 +84,7 @@ async def test_climacell_migration_logic(
         original_name="ClimaCell - Hourly",
         suggested_object_id="climacell_hourly",
         device_id=old_device.id,
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
     old_entity_nowcast = ent_reg.async_get_or_create(
         "weather",
@@ -140,7 +140,7 @@ async def test_climacell_migration_logic(
     assert new_entity_hourly.original_name == "ClimaCell - Hourly"
     assert new_entity_hourly.device_id != old_device.id
     assert new_entity_hourly.unique_id == f"{_get_unique_id(hass, new_data)}_hourly"
-    assert new_entity_hourly.disabled_by == er.DISABLED_USER
+    assert new_entity_hourly.disabled_by == er.RegistryEntryDisabler.USER
 
     new_entity_nowcast = ent_reg.async_get(old_entity_nowcast.entity_id)
     assert new_entity_nowcast.platform == DOMAIN


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The DISABLED_* constants are deprecated in favour of the RegistryEntryDisabler enum.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
