### PR TITLE
Run KNX protocol logic in a separate thread

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -394,6 +394,7 @@ class KNXModule:
                 connection_type=ConnectionType.ROUTING,
                 local_ip=self.config.get(ConnectionSchema.CONF_KNX_LOCAL_IP),
                 auto_reconnect=True,
+                threaded=True,
             )
         if _conn_type == CONF_KNX_TUNNELING:
             return ConnectionConfig(
@@ -403,6 +404,7 @@ class KNXModule:
                 local_ip=self.config.get(ConnectionSchema.CONF_KNX_LOCAL_IP),
                 route_back=self.config.get(ConnectionSchema.CONF_KNX_ROUTE_BACK, False),
                 auto_reconnect=True,
+                threaded=True,
             )
         if _conn_type == CONF_KNX_TUNNELING_TCP:
             return ConnectionConfig(
@@ -410,8 +412,12 @@ class KNXModule:
                 gateway_ip=self.config[CONF_HOST],
                 gateway_port=self.config[CONF_PORT],
                 auto_reconnect=True,
+                threaded=True,
             )
-        return ConnectionConfig(auto_reconnect=True)
+        return ConnectionConfig(
+            auto_reconnect=True,
+            threaded=True,
+        )
 
     async def connection_state_changed_cb(self, state: XknxConnectionState) -> None:
         """Call invoked after a KNX connection state change was received."""

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -28,7 +28,7 @@ from tests.common import MockConfigEntry
                 CONF_KNX_INDIVIDUAL_ADDRESS: XKNX.DEFAULT_ADDRESS,
                 CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,
             },
-            ConnectionConfig(),
+            ConnectionConfig(threaded=True),
         ),
         (
             {
@@ -36,7 +36,9 @@ from tests.common import MockConfigEntry
                 ConnectionSchema.CONF_KNX_LOCAL_IP: "192.168.1.1",
             },
             ConnectionConfig(
-                connection_type=ConnectionType.ROUTING, local_ip="192.168.1.1"
+                connection_type=ConnectionType.ROUTING,
+                local_ip="192.168.1.1",
+                threaded=True,
             ),
         ),
         (
@@ -54,6 +56,7 @@ from tests.common import MockConfigEntry
                 gateway_port=3675,
                 local_ip="192.168.1.112",
                 auto_reconnect=True,
+                threaded=True,
             ),
         ),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Run KNX protocol logic (which is timing critical) in a separate daemonic thread.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59170
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
