### PR TITLE
Remove unneeded __repr__ in samsungtv logging

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -528,7 +528,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 LOGGER.info(
                     "Failed to get remote for %s, re-authentication required: %s",
                     self.host,
-                    err,
+                    repr(err),
                 )
                 self._notify_reauth_callback()
                 self._remote = None
@@ -536,7 +536,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 LOGGER.info(
                     "Failed to get remote for %s: %s",
                     self.host,
-                    err,
+                    repr(err),
                 )
                 self._remote = None
             except ConnectionFailure as err:
@@ -544,11 +544,11 @@ class SamsungTVWSBridge(SamsungTVBridge):
                     "Unexpected ConnectionFailure trying to get remote for %s, "
                     "please report this issue: %s",
                     self.host,
-                    err,
+                    repr(err),
                 )
                 self._remote = None
             except (WebSocketException, AsyncioTimeoutError, OSError) as err:
-                LOGGER.debug("Failed to get remote for %s: %s", self.host, err)
+                LOGGER.debug("Failed to get remote for %s: %s", self.host, repr(err))
                 self._remote = None
             else:
                 LOGGER.debug("Created SamsungTVWSBridge for %s", self.host)
@@ -768,7 +768,7 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
             try:
                 await self._remote.start_listening()
             except (WebSocketException, AsyncioTimeoutError, OSError) as err:
-                LOGGER.debug("Failed to get remote for %s: %s", self.host, err)
+                LOGGER.debug("Failed to get remote for %s: %s", self.host, repr(err))
                 self._remote = None
             else:
                 LOGGER.debug("Created SamsungTVEncryptedBridge for %s", self.host)

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -528,7 +528,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 LOGGER.info(
                     "Failed to get remote for %s, re-authentication required: %s",
                     self.host,
-                    err.__repr__(),
+                    err,
                 )
                 self._notify_reauth_callback()
                 self._remote = None
@@ -536,7 +536,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 LOGGER.info(
                     "Failed to get remote for %s: %s",
                     self.host,
-                    err.__repr__(),
+                    err,
                 )
                 self._remote = None
             except ConnectionFailure as err:
@@ -544,13 +544,11 @@ class SamsungTVWSBridge(SamsungTVBridge):
                     "Unexpected ConnectionFailure trying to get remote for %s, "
                     "please report this issue: %s",
                     self.host,
-                    err.__repr__(),
+                    err,
                 )
                 self._remote = None
             except (WebSocketException, AsyncioTimeoutError, OSError) as err:
-                LOGGER.debug(
-                    "Failed to get remote for %s: %s", self.host, err.__repr__()
-                )
+                LOGGER.debug("Failed to get remote for %s: %s", self.host, err)
                 self._remote = None
             else:
                 LOGGER.debug("Created SamsungTVWSBridge for %s", self.host)
@@ -614,9 +612,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 await self._remote.close()
             self._remote = None
         except OSError as err:
-            LOGGER.debug(
-                "Error closing connection to %s: %s", self.host, err.__repr__()
-            )
+            LOGGER.debug("Error closing connection to %s: %s", self.host, err)
 
 
 class SamsungTVEncryptedBridge(SamsungTVBridge):
@@ -772,9 +768,7 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
             try:
                 await self._remote.start_listening()
             except (WebSocketException, AsyncioTimeoutError, OSError) as err:
-                LOGGER.debug(
-                    "Failed to get remote for %s: %s", self.host, err.__repr__()
-                )
+                LOGGER.debug("Failed to get remote for %s: %s", self.host, err)
                 self._remote = None
             else:
                 LOGGER.debug("Created SamsungTVEncryptedBridge for %s", self.host)
@@ -809,6 +803,4 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
                 await self._remote.close()
             self._remote = None
         except OSError as err:
-            LOGGER.debug(
-                "Error closing connection to %s: %s", self.host, err.__repr__()
-            )
+            LOGGER.debug("Error closing connection to %s: %s", self.host, err)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove unneeded __repr__ in samsungtv logging

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
