### PR TITLE
Add release_notes method to update entities

### DIFF
--- a/homeassistant/components/demo/update.py
+++ b/homeassistant/components/demo/update.py
@@ -156,12 +156,7 @@ class DemoUpdate(UpdateEntity):
 
     def release_notes(self) -> str | None:
         """Return the release notes."""
-        return f"""
-        Long release notes.
-
-        **With** markdown support!
-
-        ***
-
-        {self.release_summary}
-        """
+        return (
+            "Long release notes.\n\n**With** "
+            f"markdown support!\n\n***\n\n{self.release_summary}"
+        )

--- a/homeassistant/components/demo/update.py
+++ b/homeassistant/components/demo/update.py
@@ -71,6 +71,7 @@ async def async_setup_platform(
                 latest_version="1.94.2",
                 support_progress=True,
                 release_summary="Added support for effects",
+                support_release_notes=True,
                 release_url="https://www.example.com/release/1.93.3",
                 device_class=UpdateDeviceClass.FIRMWARE,
             ),
@@ -109,6 +110,7 @@ class DemoUpdate(UpdateEntity):
         release_url: str | None = None,
         support_progress: bool = False,
         support_install: bool = True,
+        support_release_notes: bool = False,
         device_class: UpdateDeviceClass | None = None,
     ) -> None:
         """Initialize the Demo select entity."""
@@ -133,6 +135,9 @@ class DemoUpdate(UpdateEntity):
         if support_progress:
             self._attr_supported_features |= UpdateEntityFeature.PROGRESS
 
+        if support_release_notes:
+            self._attr_supported_features |= UpdateEntityFeature.RELEASE_NOTES
+
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -148,3 +153,15 @@ class DemoUpdate(UpdateEntity):
             version if version is not None else self.latest_version
         )
         self.async_write_ha_state()
+
+    def release_notes(self) -> str | None:
+        """Return the release notes."""
+        return f"""
+        Long release notes.
+
+        **With** markdown support!
+
+        ***
+
+        {self.release_summary}
+        """

--- a/homeassistant/components/update/const.py
+++ b/homeassistant/components/update/const.py
@@ -14,6 +14,7 @@ class UpdateEntityFeature(IntEnum):
     SPECIFIC_VERSION = 2
     PROGRESS = 4
     BACKUP = 8
+    RELEASE_NOTES = 16
 
 
 SERVICE_INSTALL: Final = "install"

--- a/tests/testing_config/custom_components/test/update.py
+++ b/tests/testing_config/custom_components/test/update.py
@@ -62,6 +62,10 @@ class MockUpdateEntity(MockEntity, UpdateEntity):
             self._values["current_version"] = self.latest_version
             _LOGGER.info("Installed latest update")
 
+    def release_notes(self) -> str | None:
+        """Return the release notes of the latest version."""
+        return "Release notes"
+
 
 def init(empty=False):
     """Initialize the platform with entities."""
@@ -123,6 +127,13 @@ def init(empty=False):
                 unique_id="no_install",
                 current_version="1.0.0",
                 latest_version="1.0.1",
+            ),
+            MockUpdateEntity(
+                name="Update with release notes",
+                unique_id="with_release_notes",
+                current_version="1.0.0",
+                latest_version="1.0.1",
+                supported_features=UpdateEntityFeature.RELEASE_NOTES,
             ),
         ]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1257

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
