### PR TITLE
Cleanup calendar APIs and introduce a dataclass for representing events

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 from homeassistant.components.calendar import (
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
+    CalendarEntity,
     CalendarEvent,
-    CalendarEventDevice,
     extract_offset,
     is_offset_reached,
 )
@@ -104,7 +104,7 @@ def setup_platform(
             device_id = f"{cust_calendar[CONF_CALENDAR]} {cust_calendar[CONF_NAME]}"
             entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)
             calendar_devices.append(
-                WebDavCalendarEventDevice(
+                WebDavCalendarEntity(
                     name, calendar, entity_id, days, True, cust_calendar[CONF_SEARCH]
                 )
             )
@@ -115,13 +115,13 @@ def setup_platform(
             device_id = calendar.name
             entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)
             calendar_devices.append(
-                WebDavCalendarEventDevice(name, calendar, entity_id, days)
+                WebDavCalendarEntity(name, calendar, entity_id, days)
             )
 
     add_entities(calendar_devices, True)
 
 
-class WebDavCalendarEventDevice(CalendarEventDevice):
+class WebDavCalendarEntity(CalendarEntity):
     """A device for getting the next Task from a WebDav Calendar."""
 
     def __init__(self, name, calendar, entity_id, days, all_day=False, search=None):

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -12,9 +12,9 @@ import voluptuous as vol
 from homeassistant.components.calendar import (
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
+    CalendarEvent,
     CalendarEventDevice,
     extract_offset,
-    get_date,
     is_offset_reached,
 )
 from homeassistant.const import (
@@ -128,11 +128,11 @@ class WebDavCalendarEventDevice(CalendarEventDevice):
         """Create the WebDav Calendar Event Device."""
         self.data = WebDavCalendarData(calendar, days, all_day, search)
         self.entity_id = entity_id
-        self._event = None
+        self._event: CalendarEvent | None = None
         self._attr_name = name
 
     @property
-    def event(self):
+    def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return self._event
 
@@ -147,11 +147,11 @@ class WebDavCalendarEventDevice(CalendarEventDevice):
         if event is None:
             self._event = event
             return
-        (summary, offset) = extract_offset(event["summary"], OFFSET)
-        event["summary"] = summary
+        (summary, offset) = extract_offset(event.summary, OFFSET)
+        event.summary = summary
         self._event = event
         self._attr_extra_state_attributes = {
-            "offset_reached": is_offset_reached(get_date(event["start"]), offset)
+            "offset_reached": is_offset_reached(event.start_datetime_local, offset)
         }
 
 
@@ -166,7 +166,9 @@ class WebDavCalendarData:
         self.search = search
         self.event = None
 
-    async def async_get_events(self, hass, start_date, end_date):
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
         # Get event list from the current calendar
         vevent_list = await hass.async_add_executor_job(
@@ -180,22 +182,15 @@ class WebDavCalendarData:
             vevent = event.instance.vevent
             if not self.is_matching(vevent, self.search):
                 continue
-            uid = None
-            if hasattr(vevent, "uid"):
-                uid = vevent.uid.value
-            data = {
-                "uid": uid,
-                "summary": vevent.summary.value,
-                "start": self.get_hass_date(vevent.dtstart.value),
-                "end": self.get_hass_date(self.get_end_date(vevent)),
-                "location": self.get_attr_value(vevent, "location"),
-                "description": self.get_attr_value(vevent, "description"),
-            }
-
-            data["start"] = get_date(data["start"]).isoformat()
-            data["end"] = get_date(data["end"]).isoformat()
-
-            event_list.append(data)
+            event_list.append(
+                CalendarEvent(
+                    summary=vevent.summary.value,
+                    start=vevent.dtstart.value,
+                    end=self.get_end_date(vevent),
+                    location=self.get_attr_value(vevent, "location"),
+                    description=self.get_attr_value(vevent, "description"),
+                )
+            )
 
         return event_list
 
@@ -269,13 +264,13 @@ class WebDavCalendarData:
             return
 
         # Populate the entity attributes with the event values
-        self.event = {
-            "summary": vevent.summary.value,
-            "start": self.get_hass_date(vevent.dtstart.value),
-            "end": self.get_hass_date(self.get_end_date(vevent)),
-            "location": self.get_attr_value(vevent, "location"),
-            "description": self.get_attr_value(vevent, "description"),
-        }
+        self.event = CalendarEvent(
+            summary=vevent.summary.value,
+            start=vevent.dtstart.value,
+            end=self.get_end_date(vevent),
+            location=self.get_attr_value(vevent, "location"),
+            description=self.get_attr_value(vevent, "description"),
+        )
 
     @staticmethod
     def is_matching(vevent, search):
@@ -304,14 +299,6 @@ class WebDavCalendarData:
         return dt.now() >= WebDavCalendarData.to_datetime(
             WebDavCalendarData.get_end_date(vevent)
         )
-
-    @staticmethod
-    def get_hass_date(obj):
-        """Return if the event matches."""
-        if isinstance(obj, datetime):
-            return {"dateTime": obj.isoformat()}
-
-        return {"date": obj.isoformat()}
 
     @staticmethod
     def to_datetime(obj):

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -177,6 +177,14 @@ def is_offset_reached(
 class CalendarEventDevice(Entity):
     """Legacy API for calendar event entities."""
 
+    def __init_subclass__(cls, **kwargs):
+        """Print deprecation warning."""
+        super().__init_subclass__(**kwargs)
+        _LOGGER.warning(
+            "CalendarEventDevice is deprecated, modify %s to extend CalendarEntity",
+            cls.__name__,
+        )
+
     @property
     def event(self) -> dict[str, Any] | None:
         """Return the next upcoming event."""
@@ -186,10 +194,7 @@ class CalendarEventDevice(Entity):
     @property
     def state_attributes(self) -> dict[str, Any] | None:
         """Return the entity state attributes."""
-        _LOGGER.warning(
-            "CalendarEventDevice entity has been deprecated and will be removed in 2022.6, "
-            "and is replaced with CalendarEntitiy. Please report issue to component maintainer",
-        )
+
         if (event := self.event) is None:
             return None
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -135,7 +135,7 @@ def is_offset_reached(
     return start + offset_time <= dt.now(start.tzinfo)
 
 
-class CalendarEventDevice(Entity):
+class CalendarEntity(Entity):
     """Base class for calendar event entities."""
 
     @property
@@ -199,7 +199,7 @@ class CalendarEventView(http.HomeAssistantView):
         end = request.query.get("end")
         if start is None or end is None or entity is None:
             return web.Response(status=HTTPStatus.BAD_REQUEST)
-        assert isinstance(entity, CalendarEventDevice)
+        assert isinstance(entity, CalendarEntity)
         try:
             start_date = dt.parse_datetime(start)
             end_date = dt.parse_datetime(end)

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -119,6 +119,7 @@ def _get_api_date(dt_or_d: datetime.datetime | datetime.date) -> dict[str, str]:
 def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
     """Normalize a calendar event."""
     normalized_event: dict[str, Any] = {}
+
     start = event.get("start")
     end = event.get("end")
     start = get_date(start) if start is not None else None
@@ -130,6 +131,7 @@ def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
     end = end.strftime(DATE_STR_FORMAT) if end is not None else None
     normalized_event["start"] = start
     normalized_event["end"] = end
+
     # cleanup the string so we don't have a bunch of double+ spaces
     summary = event.get("summary", "")
     normalized_event["message"] = re.sub("  +", "", summary).strip()
@@ -184,6 +186,10 @@ class CalendarEventDevice(Entity):
     @property
     def state_attributes(self) -> dict[str, Any] | None:
         """Return the entity state attributes."""
+        _LOGGER.warning(
+            "CalendarEventDevice entity has been deprecated and will be removed in 2022.6, "
+            "and is replaced with CalendarEntitiy. Please report issue to component maintainer",
+        )
         if (event := self.event) is None:
             return None
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -177,7 +177,7 @@ def is_offset_reached(
 class CalendarEventDevice(Entity):
     """Legacy API for calendar event entities."""
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         """Print deprecation warning."""
         super().__init_subclass__(**kwargs)
         _LOGGER.warning(

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -19,8 +19,8 @@ def setup_platform(
     """Set up the Demo Calendar platform."""
     add_entities(
         [
-            DemoGoogleCalendar(hass, calendar_data_future(), "Calendar 1"),
-            DemoGoogleCalendar(hass, calendar_data_current(), "Calendar 2"),
+            DemoGoogleCalendar(calendar_data_future(), "Calendar 1"),
+            DemoGoogleCalendar(calendar_data_current(), "Calendar 2"),
         ]
     )
 
@@ -48,7 +48,7 @@ def calendar_data_current() -> CalendarEvent:
 class DemoGoogleCalendar(CalendarEntity):
     """Representation of a Demo Calendar element."""
 
-    def __init__(self, hass: HomeAssistant, event: CalendarEvent, name: str) -> None:
+    def __init__(self, event: CalendarEvent, name: str) -> None:
         """Initialize demo calendar."""
         self._event = event
         self._name = name

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime
 
-from homeassistant.components.calendar import CalendarEvent, CalendarEventDevice
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -45,7 +45,7 @@ def calendar_data_current() -> CalendarEvent:
     )
 
 
-class DemoGoogleCalendar(CalendarEventDevice):
+class DemoGoogleCalendar(CalendarEntity):
     """Representation of a Demo Calendar element."""
 
     def __init__(self, hass: HomeAssistant, event: CalendarEvent, name: str) -> None:

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -10,8 +10,8 @@ from httplib2 import ServerNotFoundError
 
 from homeassistant.components.calendar import (
     ENTITY_ID_FORMAT,
+    CalendarEntity,
     CalendarEvent,
-    CalendarEventDevice,
     extract_offset,
     is_offset_reached,
 )
@@ -94,7 +94,7 @@ def _async_setup_entities(
         entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, data[CONF_DEVICE_ID], hass=hass
         )
-        entity = GoogleCalendarEventDevice(
+        entity = GoogleCalendarEntity(
             calendar_service, disc_info[CONF_CAL_ID], data, entity_id
         )
         entities.append(entity)
@@ -102,7 +102,7 @@ def _async_setup_entities(
     async_add_entities(entities, True)
 
 
-class GoogleCalendarEventDevice(CalendarEventDevice):
+class GoogleCalendarEntity(CalendarEntity):
     """A calendar event device."""
 
     def __init__(

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -182,12 +182,11 @@ class GoogleCalendarEntity(CalendarEntity):
 
         # Pick the first visible event and apply offset calculations.
         valid_items = filter(self._event_filter, items)
-        self._event = copy.deepcopy(next(valid_items, None))
-        if self._event:
-            (summary, offset) = extract_offset(
-                self._event.get("summary", ""), self._offset
-            )
-            self._event["summary"] = summary
+        event = copy.deepcopy(next(valid_items, None))
+        if event:
+            (summary, offset) = extract_offset(event.get("summary", ""), self._offset)
+            event["summary"] = summary
+            self._event = _get_calendar_event(event)
             self._offset_reached = is_offset_reached(
                 self._event.start_datetime_local, offset
             )

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -196,7 +196,7 @@ class GoogleCalendarEntity(CalendarEntity):
 
 
 def _get_date_or_datetime(date_dict: dict[str, str]) -> datetime | date:
-    """Get the dateTime from date or dateTime as a local."""
+    """Convert a google calendar API response to a datetime or date object."""
     if "date" in date_dict:
         parsed_date = dt.parse_date(date_dict["date"])
         assert parsed_date

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -7,7 +7,7 @@ import logging
 from todoist.api import TodoistAPI
 import voluptuous as vol
 
-from homeassistant.components.calendar import PLATFORM_SCHEMA, CalendarEventDevice
+from homeassistant.components.calendar import PLATFORM_SCHEMA, CalendarEntity
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
@@ -136,7 +136,7 @@ def setup_platform(
         # Project is an object, not a dict!
         # Because of that, we convert what we need to a dict.
         project_data = {CONF_NAME: project[NAME], CONF_ID: project[ID]}
-        project_devices.append(TodoistProjectDevice(hass, project_data, labels, api))
+        project_devices.append(TodoistProjectEntity(hass, project_data, labels, api))
         # Cache the names so we can easily look up name->ID.
         project_id_lookup[project[NAME].lower()] = project[ID]
 
@@ -166,7 +166,7 @@ def setup_platform(
 
         # Create the custom project and add it to the devices array.
         project_devices.append(
-            TodoistProjectDevice(
+            TodoistProjectEntity(
                 hass,
                 project,
                 labels,
@@ -271,7 +271,7 @@ def _parse_due_date(data: DueDate, timezone_offset: int) -> datetime | None:
     return dt.as_utc(nowtime)
 
 
-class TodoistProjectDevice(CalendarEventDevice):
+class TodoistProjectEntity(CalendarEntity):
     """A device for getting the next Task from a Todoist Project."""
 
     def __init__(
@@ -284,7 +284,7 @@ class TodoistProjectDevice(CalendarEventDevice):
         whitelisted_labels=None,
         whitelisted_projects=None,
     ):
-        """Create the Todoist Calendar Event Device."""
+        """Create the Todoist Calendar Entity."""
         self.data = TodoistProjectData(
             data,
             labels,
@@ -336,7 +336,7 @@ class TodoistProjectDevice(CalendarEventDevice):
 
 class TodoistProjectData:
     """
-    Class used by the Task Device service object to hold all Todoist Tasks.
+    Class used by the Task Entity service object to hold all Todoist Tasks.
 
     This is analogous to the GoogleCalendarData found in the Google Calendar
     component.

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -1,18 +1,21 @@
 """Support for Todoist task management (https://todoist.com)."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 import logging
 
 from todoist.api import TodoistAPI
 import voluptuous as vol
 
-from homeassistant.components.calendar import PLATFORM_SCHEMA, CalendarEntity
+from homeassistant.components.calendar import (
+    PLATFORM_SCHEMA,
+    CalendarEntity,
+    CalendarEvent,
+)
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt
 
@@ -28,7 +31,6 @@ from .const import (
     CONF_PROJECT_LABEL_WHITELIST,
     CONF_PROJECT_WHITELIST,
     CONTENT,
-    DATETIME,
     DESCRIPTION,
     DOMAIN,
     DUE,
@@ -102,7 +104,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-SCAN_INTERVAL = timedelta(minutes=15)
+SCAN_INTERVAL = timedelta(minutes=1)
 
 
 def setup_platform(
@@ -176,7 +178,6 @@ def setup_platform(
                 project_id_filter,
             )
         )
-
     add_entities(project_devices)
 
     def handle_new_task(call: ServiceCall) -> None:
@@ -297,9 +298,9 @@ class TodoistProjectEntity(CalendarEntity):
         self._name = data[CONF_NAME]
 
     @property
-    def event(self):
+    def event(self) -> CalendarEvent:
         """Return the next upcoming event."""
-        return self.data.event
+        return self.data.calendar_event
 
     @property
     def name(self):
@@ -314,7 +315,12 @@ class TodoistProjectEntity(CalendarEntity):
             task[SUMMARY] for task in self.data.all_project_tasks
         ]
 
-    async def async_get_events(self, hass, start_date, end_date):
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
         return await self.data.async_get_events(hass, start_date, end_date)
 
@@ -408,6 +414,22 @@ class TodoistProjectData:
             self._project_id_whitelist = whitelisted_projects
         else:
             self._project_id_whitelist = []
+
+    @property
+    def calendar_event(self) -> CalendarEvent | None:
+        """Return the next upcoming calendar event."""
+        if not self.event:
+            return None
+        if not self.event.get(END) or self.event.get(ALL_DAY):
+            start = self.event[START].date()
+            return CalendarEvent(
+                summary=self.event[SUMMARY],
+                start=start,
+                end=start + timedelta(days=1),
+            )
+        return CalendarEvent(
+            summary=self.event[SUMMARY], start=self.event[START], end=self.event[END]
+        )
 
     def create_todoist_task(self, data):
         """
@@ -566,7 +588,7 @@ class TodoistProjectData:
             if task["due"] is None:
                 continue
             # @NOTE: _parse_due_date always returns the date in UTC time.
-            due_date = _parse_due_date(
+            due_date: datetime | None = _parse_due_date(
                 task["due"], self._api.state["user"]["tz_info"]["hours"]
             )
             if not due_date:
@@ -580,20 +602,16 @@ class TodoistProjectData:
             )
 
             if start_date < due_date < end_date:
+                due_date_value: datetime | date = due_date
                 if due_date == midnight:
                     # If the due date has no time data, return just the date so that it
                     # will render correctly as an all day event on a calendar.
-                    due_date_value = due_date.strftime("%Y-%m-%d")
-                else:
-                    due_date_value = due_date.isoformat()
-                event = {
-                    "uid": task["id"],
-                    "title": task["content"],
-                    "start": due_date_value,
-                    "end": due_date_value,
-                    "allDay": True,
-                    "summary": task["content"],
-                }
+                    due_date_value = due_date.date()
+                event = CalendarEvent(
+                    summary=task["content"],
+                    start=due_date_value,
+                    end=due_date_value,
+                )
                 events.append(event)
         return events
 
@@ -644,22 +662,10 @@ class TodoistProjectData:
             project_tasks.remove(best_task)
             self.all_project_tasks.append(best_task)
 
-        self.event = self.all_project_tasks[0]
-
-        # Convert datetime to a string again
-        if self.event is not None:
-            if self.event[START] is not None:
-                self.event[START] = {
-                    DATETIME: self.event[START].strftime(DATE_STR_FORMAT)
-                }
-            if self.event[END] is not None:
-                self.event[END] = {DATETIME: self.event[END].strftime(DATE_STR_FORMAT)}
-            else:
-                # Home Assistant gets cranky if a calendar event never ends
-                # Let's set our "due date" to tomorrow
-                self.event[END] = {
-                    DATETIME: (datetime.utcnow() + timedelta(days=1)).strftime(
-                        DATE_STR_FORMAT
-                    )
-                }
+        event = self.all_project_tasks[0]
+        if event is None or event[START] is None:
+            _LOGGER.debug("No valid event or event start for %s", self._name)
+            self.event = None
+            return
+        self.event = event
         _LOGGER.debug("Updated %s", self._name)

--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from homeassistant.components.calendar import CalendarEvent, CalendarEventDevice
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
@@ -25,7 +25,7 @@ async def async_setup_entry(
     async_add_entities([TwenteMilieuCalendar(coordinator, entry)])
 
 
-class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEventDevice):
+class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
     """Defines a Twente Milieu calendar."""
 
     _attr_name = "Twente Milieu"

--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
-from homeassistant.components.calendar import CalendarEventDevice
+from homeassistant.components.calendar import CalendarEvent, CalendarEventDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
@@ -40,26 +39,25 @@ class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEventDevice):
         """Initialize the Twente Milieu entity."""
         super().__init__(coordinator, entry)
         self._attr_unique_id = str(entry.data[CONF_ID])
-        self._event: dict[str, Any] | None = None
+        self._event: CalendarEvent | None = None
 
     @property
-    def event(self) -> dict[str, Any] | None:
+    def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return self._event
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
-    ) -> list[dict[str, Any]]:
+    ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
-        events: list[dict[str, Any]] = []
+        events: list[CalendarEvent] = []
         for waste_type, waste_dates in self.coordinator.data.items():
             events.extend(
-                {
-                    "all_day": True,
-                    "start": {"date": waste_date.isoformat()},
-                    "end": {"date": waste_date.isoformat()},
-                    "summary": WASTE_TYPE_TO_DESCRIPTION[waste_type],
-                }
+                CalendarEvent(
+                    summary=WASTE_TYPE_TO_DESCRIPTION[waste_type],
+                    start=waste_date,
+                    end=waste_date,
+                )
                 for waste_date in waste_dates
                 if start_date.date() <= waste_date <= end_date.date()
             )
@@ -86,12 +84,11 @@ class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEventDevice):
 
         self._event = None
         if next_waste_pickup_date is not None and next_waste_pickup_type is not None:
-            self._event = {
-                "all_day": True,
-                "start": {"date": next_waste_pickup_date.isoformat()},
-                "end": {"date": next_waste_pickup_date.isoformat()},
-                "summary": WASTE_TYPE_TO_DESCRIPTION[next_waste_pickup_type],
-            }
+            self._event = CalendarEvent(
+                summary=WASTE_TYPE_TO_DESCRIPTION[next_waste_pickup_type],
+                start=next_waste_pickup_date,
+                end=next_waste_pickup_date,
+            )
 
         super()._handle_coordinator_update()
 

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -934,11 +934,8 @@ async def test_get_events_custom_calendars(hass, calendar, get_api_events):
     events = await get_api_events("calendar.private_private")
     assert events == [
         {
-            "description": "Surprisingly rainy",
-            "end": "2017-11-27T10:00:00-08:00",
-            "location": "Hamburg",
-            "start": "2017-11-27T09:00:00-08:00",
+            "end": {"dateTime": "2017-11-27T10:00:00-08:00"},
+            "start": {"dateTime": "2017-11-27T09:00:00-08:00"},
             "summary": "This is a normal event",
-            "uid": "1",
         }
     ]

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -23,7 +23,6 @@ async def test_events_http_api(hass, hass_client):
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert events[0]["summary"] == "Future Event"
-    assert events[0]["title"] == "Future Event"
 
 
 async def test_calendars_http_api(hass, hass_client):

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -36,4 +36,24 @@ async def test_calendars_http_api(hass, hass_client):
     assert data == [
         {"entity_id": "calendar.calendar_1", "name": "Calendar 1"},
         {"entity_id": "calendar.calendar_2", "name": "Calendar 2"},
+        {"entity_id": "calendar.calendar_3", "name": "Calendar 3"},
     ]
+
+
+async def test_events_http_api_shim(hass, hass_client):
+    """Test the legacy shim calendar demo view."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+    client = await hass_client()
+    response = await client.get("/api/calendars/calendar.calendar_3")
+    assert response.status == HTTPStatus.BAD_REQUEST
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+    response = await client.get(
+        "/api/calendars/calendar.calendar_1?start={}&end={}".format(
+            start.isoformat(), end.isoformat()
+        )
+    )
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert events[0]["summary"] == "Future Event"

--- a/tests/components/twentemilieu/test_calendar.py
+++ b/tests/components/twentemilieu/test_calendar.py
@@ -76,7 +76,6 @@ async def test_api_events(
     events = await response.json()
     assert len(events) == 1
     assert events[0] == {
-        "all_day": True,
         "start": {"date": "2022-01-06"},
         "end": {"date": "2022-01-06"},
         "summary": "Christmas Tree Pickup",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Renamed `CalendarDeviceEntity` to `CalendarEntity`, and simplified the APIs. See developer documentation which was updated with the new APIs.  The websocket API has been simplified to remove arbitrary key/values that are not used by the frontend.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup CalendarDeviceEntity APIs and introduce a dataclass for representing events. Previously, all integrations had slightly different behaviors and inconsistencies.


See https://github.com/home-assistant/developers.home-assistant/pull/1256 for associated documentation PR, which could be helpful to align on first before reviewing this. Notably, some integrations may still not follow this spec after this PR w.r.t. honoring start/end date inclusive vs exclusive checks, which can be updated once we agree on consistent behavior.

The websocket API was reduced significantly to return only the event start, end, and summary based on what is actually used by the frontend https://sourcegraph.com/github.com/home-assistant/frontend/-/blob/src/data/calendar.ts?L43 -- note the frontend currently supports 3 date/time formats, and this stops using the string only format, picking the dict formats as it required the fewest changes to tests. However, given all three fields are treated the same by the frontend there are opportunities to simplify further if we want to switch to just the plain string format if we like: https://sourcegraph.com/github.com/home-assistant/frontend/-/blob/src/data/calendar.ts?L61

I have currently only manually tested with `google`.

Note to reviewer: 
- Please review closely the changes to date / datetime and conversion to local time since that logic was re-written to split responsibilities in a way that felt more logical and simpler, however I am not a timezone expert and may have missed an important detail that was not covered by existing tests.
-`todoist` has little test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/developers.home-assistant/pull/1256

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
