### PR TITLE
Return cached device_info if refresh fails in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -696,7 +696,7 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
             rest_api = SamsungTVAsyncRest(
                 host=self.host,
                 session=async_get_clientsession(self.hass),
-                port=self.port,
+                port=rest_api_port,
                 timeout=TIMEOUT_WEBSOCKET,
             )
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -705,6 +705,7 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
                 LOGGER.debug("Device info on %s is: %s", self.host, device_info)
                 self._device_info = device_info
                 self._rest_api_port = rest_api_port
+                return device_info
 
         return self._device_info
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -386,7 +386,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         if self._get_device_spec("PowerState") is not None:
             LOGGER.debug("Checking if TV %s is on using device info", self.host)
             # Ensure we get an updated value
-            info = await self.async_device_info()
+            info = await self.async_device_info(force=True)
             return info is not None and info["device"]["PowerState"] == "on"
 
         LOGGER.debug("Checking if TV %s is on using websocket", self.host)
@@ -446,7 +446,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
         return RESULT_CANNOT_CONNECT
 
-    async def async_device_info(self) -> dict[str, Any] | None:
+    async def async_device_info(self, force: bool = False) -> dict[str, Any] | None:
         """Try to gather infos of this TV."""
         if self._rest_api is None:
             assert self.port
@@ -463,7 +463,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             self._device_info = device_info
             return device_info
 
-        return None
+        return None if force else self._device_info
 
     async def async_launch_app(self, app_id: str) -> None:
         """Send the launch_app command using websocket protocol."""
@@ -705,9 +705,8 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
             LOGGER.debug("Device info on %s is: %s", self.host, device_info)
             self._device_info = device_info
             self._rest_api_port = rest_api_port
-            return device_info
 
-        return None
+        return self._device_info
 
     async def async_send_keys(self, keys: list[str]) -> None:
         """Send a list of keys using websocket protocol."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -700,11 +700,11 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
                 timeout=TIMEOUT_WEBSOCKET,
             )
 
-        with contextlib.suppress(*REST_EXCEPTIONS):
-            device_info: dict[str, Any] = await rest_api.rest_device_info()
-            LOGGER.debug("Device info on %s is: %s", self.host, device_info)
-            self._device_info = device_info
-            self._rest_api_port = rest_api_port
+            with contextlib.suppress(*REST_EXCEPTIONS):
+                device_info: dict[str, Any] = await rest_api.rest_device_info()
+                LOGGER.debug("Device info on %s is: %s", self.host, device_info)
+                self._device_info = device_info
+                self._rest_api_port = rest_api_port
 
         return self._device_info
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -397,7 +397,7 @@ async def test_update_off_encryptedws(
     """Testing update tv off."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
 
-    rest_api.rest_device_info.assert_called_once()
+    assert rest_api.rest_device_info.call_count == 2
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -412,7 +412,7 @@ async def test_update_off_encryptedws(
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_OFF
-    rest_api.rest_device_info.assert_called_once()
+    assert rest_api.rest_device_info.call_count == 2
 
 
 @pytest.mark.usefixtures("remote")

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -397,7 +397,7 @@ async def test_update_off_encryptedws(
     """Testing update tv off."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
 
-    assert rest_api.rest_device_info.call_count == 2
+    rest_api.rest_device_info.assert_called_once()
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -412,7 +412,7 @@ async def test_update_off_encryptedws(
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_OFF
-    assert rest_api.rest_device_info.call_count == 2
+    rest_api.rest_device_info.assert_called_once()
 
 
 @pytest.mark.usefixtures("remote")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the TV is offline, diagnostics doesn't return any information about the TV.
Since we already cache the old device_info, we should return it if a refresh fails.

An exception is made for the websocket `async_is_on` check as that needs to return `None` on failure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
