### PR TITLE
Fix HVAC modes for Airzone slave zones

### DIFF
--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -119,9 +119,6 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
         self._attr_temperature_unit = TEMP_UNIT_LIB_TO_HASS[
             self.get_zone_value(AZD_TEMP_UNIT)
         ]
-        self._attr_hvac_modes = [
-            HVAC_MODE_LIB_TO_HASS[mode] for mode in self.get_zone_value(AZD_MODES)
-        ]
         self._async_update_attrs()
 
     async def _async_update_hvac_params(self, params) -> None:
@@ -184,4 +181,7 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
         else:
             self._attr_hvac_action = CURRENT_HVAC_OFF
             self._attr_hvac_mode = HVAC_MODE_OFF
+        self._attr_hvac_modes = [
+            HVAC_MODE_LIB_TO_HASS[mode] for mode in self.get_zone_value(AZD_MODES)
+        ]
         self._attr_target_temperature = self.get_zone_value(AZD_TEMP_SET)

--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -141,10 +141,14 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
         if hvac_mode == HVAC_MODE_OFF:
             params[API_ON] = 0
         else:
-            if self.get_zone_value(AZD_MASTER):
-                mode = HVAC_MODE_HASS_TO_LIB[hvac_mode]
-                if mode != self.get_zone_value(AZD_MODE):
+            mode = HVAC_MODE_HASS_TO_LIB[hvac_mode]
+            if mode != self.get_zone_value(AZD_MODE):
+                if self.get_zone_value(AZD_MASTER):
                     params[API_MODE] = mode
+                else:
+                    raise HomeAssistantError(
+                        f"Mode can't be changed on slave zone {self.name}"
+                    )
             params[API_ON] = 1
         _LOGGER.debug("Set hvac_mode=%s params=%s", hvac_mode, params)
         await self._async_update_hvac_params(params)

--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -119,6 +119,9 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
         self._attr_temperature_unit = TEMP_UNIT_LIB_TO_HASS[
             self.get_zone_value(AZD_TEMP_UNIT)
         ]
+        self._attr_hvac_modes = [
+            HVAC_MODE_LIB_TO_HASS[mode] for mode in self.get_zone_value(AZD_MODES)
+        ]
         self._async_update_attrs()
 
     async def _async_update_hvac_params(self, params) -> None:
@@ -185,7 +188,4 @@ class AirzoneClimate(AirzoneEntity, ClimateEntity):
         else:
             self._attr_hvac_action = CURRENT_HVAC_OFF
             self._attr_hvac_mode = HVAC_MODE_OFF
-        self._attr_hvac_modes = [
-            HVAC_MODE_LIB_TO_HASS[mode] for mode in self.get_zone_value(AZD_MODES)
-        ]
         self._attr_target_temperature = self.get_zone_value(AZD_TEMP_SET)

--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -3,7 +3,7 @@
   "name": "Airzone",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airzone",
-  "requirements": ["aioairzone==0.2.1"],
+  "requirements": ["aioairzone==0.2.2"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioairzone"]

--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -3,7 +3,7 @@
   "name": "Airzone",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airzone",
-  "requirements": ["aioairzone==0.2.2"],
+  "requirements": ["aioairzone==0.2.3"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioairzone"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.5
 
 # homeassistant.components.airzone
-aioairzone==0.2.1
+aioairzone==0.2.2
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.5
 
 # homeassistant.components.airzone
-aioairzone==0.2.2
+aioairzone==0.2.3
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.5
 
 # homeassistant.components.airzone
-aioairzone==0.2.2
+aioairzone==0.2.3
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.5
 
 # homeassistant.components.airzone
-aioairzone==0.2.1
+aioairzone==0.2.2
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -12,6 +12,7 @@ from aioairzone.const import (
     API_ZONE_ID,
 )
 from aioairzone.exceptions import AirzoneError
+import pytest
 
 from homeassistant.components.airzone.const import API_TEMPERATURE_STEP
 from homeassistant.components.climate.const import (
@@ -161,8 +162,8 @@ async def test_airzone_climate_set_hvac_mode(hass):
             blocking=True,
         )
 
-        state = hass.states.get("climate.salon")
-        assert state.state == HVAC_MODE_COOL
+    state = hass.states.get("climate.salon")
+    assert state.state == HVAC_MODE_COOL
 
     HVAC_MOCK_2 = {
         API_DATA: [
@@ -187,8 +188,8 @@ async def test_airzone_climate_set_hvac_mode(hass):
             blocking=True,
         )
 
-        state = hass.states.get("climate.salon")
-        assert state.state == HVAC_MODE_OFF
+    state = hass.states.get("climate.salon")
+    assert state.state == HVAC_MODE_OFF
 
 
 async def test_airzone_climate_set_hvac_slave_error(hass):
@@ -209,23 +210,19 @@ async def test_airzone_climate_set_hvac_slave_error(hass):
     with patch(
         "homeassistant.components.airzone.AirzoneLocalApi.http_request",
         return_value=HVAC_MOCK,
-    ):
-        try:
-            await hass.services.async_call(
-                CLIMATE_DOMAIN,
-                SERVICE_SET_HVAC_MODE,
-                {
-                    ATTR_ENTITY_ID: "climate.dorm_2",
-                    ATTR_HVAC_MODE: HVAC_MODE_COOL,
-                },
-                blocking=True,
-            )
-            assert False
-        except HomeAssistantError:
-            assert True
+    ), pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.dorm_2",
+                ATTR_HVAC_MODE: HVAC_MODE_COOL,
+            },
+            blocking=True,
+        )
 
-        state = hass.states.get("climate.dorm_2")
-        assert state.state == HVAC_MODE_OFF
+    state = hass.states.get("climate.dorm_2")
+    assert state.state == HVAC_MODE_OFF
 
 
 async def test_airzone_climate_set_temp(hass):
@@ -257,8 +254,8 @@ async def test_airzone_climate_set_temp(hass):
             blocking=True,
         )
 
-        state = hass.states.get("climate.dorm_2")
-        assert state.attributes.get(ATTR_TEMPERATURE) == 20.5
+    state = hass.states.get("climate.dorm_2")
+    assert state.attributes.get(ATTR_TEMPERATURE) == 20.5
 
 
 async def test_airzone_climate_set_temp_error(hass):
@@ -269,20 +266,16 @@ async def test_airzone_climate_set_temp_error(hass):
     with patch(
         "homeassistant.components.airzone.AirzoneLocalApi.put_hvac",
         side_effect=AirzoneError,
-    ):
-        try:
-            await hass.services.async_call(
-                CLIMATE_DOMAIN,
-                SERVICE_SET_TEMPERATURE,
-                {
-                    ATTR_ENTITY_ID: "climate.dorm_2",
-                    ATTR_TEMPERATURE: 20.5,
-                },
-                blocking=True,
-            )
-            assert False
-        except HomeAssistantError:
-            assert True
+    ), pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {
+                ATTR_ENTITY_ID: "climate.dorm_2",
+                ATTR_TEMPERATURE: 20.5,
+            },
+            blocking=True,
+        )
 
-        state = hass.states.get("climate.dorm_2")
-        assert state.attributes.get(ATTR_TEMPERATURE) == 19.5
+    state = hass.states.get("climate.dorm_2")
+    assert state.attributes.get(ATTR_TEMPERATURE) == 19.5

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -52,8 +52,11 @@ async def test_airzone_create_climates(hass):
     assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 21.2
     assert state.attributes.get(ATTR_HVAC_ACTION) == CURRENT_HVAC_OFF
     assert state.attributes.get(ATTR_HVAC_MODES) == [
-        HVAC_MODE_HEAT,
         HVAC_MODE_OFF,
+        HVAC_MODE_FAN_ONLY,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -66,8 +69,11 @@ async def test_airzone_create_climates(hass):
     assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 20.8
     assert state.attributes.get(ATTR_HVAC_ACTION) == CURRENT_HVAC_IDLE
     assert state.attributes.get(ATTR_HVAC_MODES) == [
-        HVAC_MODE_HEAT,
         HVAC_MODE_OFF,
+        HVAC_MODE_FAN_ONLY,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -80,8 +86,11 @@ async def test_airzone_create_climates(hass):
     assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 20.5
     assert state.attributes.get(ATTR_HVAC_ACTION) == CURRENT_HVAC_OFF
     assert state.attributes.get(ATTR_HVAC_MODES) == [
-        HVAC_MODE_HEAT,
         HVAC_MODE_OFF,
+        HVAC_MODE_FAN_ONLY,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -94,8 +103,11 @@ async def test_airzone_create_climates(hass):
     assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 21.1
     assert state.attributes.get(ATTR_HVAC_ACTION) == CURRENT_HVAC_HEAT
     assert state.attributes.get(ATTR_HVAC_MODES) == [
-        HVAC_MODE_HEAT,
         HVAC_MODE_OFF,
+        HVAC_MODE_FAN_ONLY,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15


### PR DESCRIPTION
## Proposed change
HVAC modes must be updated on every coordinator update since HVAC mode should only be changed on the master zone and that change will be reflected on every slave zone after that.
This bug was introduced during the review of the Climate platform PR: https://github.com/home-assistant/core/pull/67924.

Release notes:
- https://github.com/Noltari/aioairzone/releases/tag/0.2.2
- https://github.com/Noltari/aioairzone/releases/tag/0.2.3

Git compare: https://github.com/Noltari/aioairzone/compare/0.2.1...0.2.3

## Type of change
- [x] Dependency upgrade https://github.com/Noltari/aioairzone/compare/0.2.1...0.2.3
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/68798
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
