### PR TITLE
Add full release notes to add-on update entities

### DIFF
--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -88,38 +88,64 @@ async def async_setup_entry(
 class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
     """Update entity to handle updates for the Supervisor add-ons."""
 
-    _attr_supported_features = UpdateEntityFeature.INSTALL | UpdateEntityFeature.BACKUP
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL
+        | UpdateEntityFeature.BACKUP
+        | UpdateEntityFeature.RELEASE_NOTES
+    )
+
+    @property
+    def _addon_data(self) -> dict:
+        """Return the add-on data."""
+        return self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug]
 
     @property
     def title(self) -> str | None:
         """Return the title of the update."""
-        return self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug][ATTR_NAME]
+        return self._addon_data[ATTR_NAME]
 
     @property
     def latest_version(self) -> str | None:
         """Latest version available for install."""
-        return self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug][
-            ATTR_VERSION_LATEST
-        ]
+        return self._addon_data[ATTR_VERSION_LATEST]
 
     @property
     def current_version(self) -> str | None:
         """Version currently in use."""
-        return self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug][ATTR_VERSION]
+        return self._addon_data[ATTR_VERSION]
 
     @property
     def release_summary(self) -> str | None:
         """Release summary for the add-on."""
-        return self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug][ATTR_CHANGELOG]
+        return self._strip_release_notes()
 
     @property
     def entity_picture(self) -> str | None:
         """Return the icon of the add-on if any."""
         if not self.available:
             return None
-        if self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug][ATTR_ICON]:
+        if self._addon_data[ATTR_ICON]:
             return f"/api/hassio/addons/{self._addon_slug}/icon"
         return None
+
+    def _strip_release_notes(self) -> str | None:
+        """Strip release notes from the changelog."""
+        if (notes := self._addon_data[ATTR_CHANGELOG]) is None:
+            return None
+
+        if f"# {self.latest_version}" in notes and f"# {self.current_version}" in notes:
+            # Split the release notes to only what is between the versions if we can
+            new_notes = notes.split(f"# {self.current_version}")[0]
+            if f"# {self.latest_version}" in new_notes:
+                # Make sure the latest version is still there.
+                # This can be False if the order of the release notes are not correct
+                # In that case we just return the whole release notes
+                return new_notes
+        return notes
+
+    async def async_release_notes(self) -> str | None:
+        """Return the release notes for the update."""
+        return self._strip_release_notes()
 
     async def async_install(
         self,

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -129,7 +129,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         return None
 
     def _strip_release_notes(self) -> str | None:
-        """Strip release notes from the changelog."""
+        """Strip the release notes to contain the needed sections."""
         if (notes := self._addon_data[ATTR_CHANGELOG]) is None:
             return None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
