### PR TITLE
Exclude sun attributes from being recorded in the database

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -5,11 +5,12 @@ import logging
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ELEVATION,
+    EVENT_COMPONENT_LOADED,
     EVENT_CORE_CONFIG_UPDATE,
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import event
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.sun import (
@@ -17,6 +18,7 @@ from homeassistant.helpers.sun import (
     get_location_astral_event_next,
 )
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.setup import ATTR_COMPONENT
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
@@ -124,26 +126,43 @@ class Sun(Entity):
         self._config_listener = None
         self._update_events_listener = None
         self._update_sun_position_listener = None
-
-        @callback
-        def update_location(_event):
-            location, elevation = get_astral_location(self.hass)
-            if location == self.location:
-                return
-            self.location = location
-            self.elevation = elevation
-            if self._update_events_listener:
-                self._update_events_listener()
-            self.update_events()
-
-        update_location(None)
+        self._loaded_listener = None
         self._config_listener = self.hass.bus.async_listen(
-            EVENT_CORE_CONFIG_UPDATE, update_location
+            EVENT_CORE_CONFIG_UPDATE, self.update_location
         )
+        self._loaded_listener = self.hass.bus.async_listen(
+            EVENT_COMPONENT_LOADED, self.loading_complete
+        )
+
+    @callback
+    def loading_complete(self, event_: Event) -> None:
+        """Update location when loading is complete."""
+        if event_.data[ATTR_COMPONENT] == DOMAIN:
+            self.update_location()
+            self._remove_loaded_listener()
+
+    @callback
+    def update_location(self, *_):
+        """Update location."""
+        location, elevation = get_astral_location(self.hass)
+        if location == self.location:
+            return
+        self.location = location
+        self.elevation = elevation
+        if self._update_events_listener:
+            self._update_events_listener()
+        self.update_events()
+
+    @callback
+    def _remove_loaded_listener(self):
+        """Remove the loaded listener."""
+        if self._loaded_listener:
+            self._loaded_listener()
 
     @callback
     def remove_listeners(self):
         """Remove listeners."""
+        self._remove_loaded_listener()
         if self._config_listener:
             self._config_listener()
         if self._update_events_listener:

--- a/homeassistant/components/sun/recorder.py
+++ b/homeassistant/components/sun/recorder.py
@@ -1,0 +1,32 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, callback
+
+from . import (
+    STATE_ATTR_AZIMUTH,
+    STATE_ATTR_ELEVATION,
+    STATE_ATTR_NEXT_DAWN,
+    STATE_ATTR_NEXT_DUSK,
+    STATE_ATTR_NEXT_MIDNIGHT,
+    STATE_ATTR_NEXT_NOON,
+    STATE_ATTR_NEXT_RISING,
+    STATE_ATTR_NEXT_SETTING,
+    STATE_ATTR_RISING,
+)
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude sun attributes from being recorded in the database."""
+    return {
+        STATE_ATTR_AZIMUTH,
+        STATE_ATTR_ELEVATION,
+        STATE_ATTR_RISING,
+        STATE_ATTR_NEXT_DAWN,
+        STATE_ATTR_NEXT_DUSK,
+        STATE_ATTR_NEXT_MIDNIGHT,
+        STATE_ATTR_NEXT_NOON,
+        STATE_ATTR_NEXT_RISING,
+        STATE_ATTR_NEXT_SETTING,
+    }

--- a/tests/components/sun/test_recorder.py
+++ b/tests/components/sun/test_recorder.py
@@ -27,7 +27,7 @@ from tests.components.recorder.common import async_wait_recording_done_without_i
 
 
 async def test_exclude_attributes(hass):
-    """Test camera registered attributes to be excluded."""
+    """Test sun attributes to be excluded."""
     await async_init_recorder_component(hass)
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/sun/test_recorder.py
+++ b/tests/components/sun/test_recorder.py
@@ -1,0 +1,59 @@
+"""The tests for sun recorder."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.recorder.models import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.sun import (
+    DOMAIN,
+    STATE_ATTR_AZIMUTH,
+    STATE_ATTR_ELEVATION,
+    STATE_ATTR_NEXT_DAWN,
+    STATE_ATTR_NEXT_DUSK,
+    STATE_ATTR_NEXT_MIDNIGHT,
+    STATE_ATTR_NEXT_NOON,
+    STATE_ATTR_NEXT_RISING,
+    STATE_ATTR_NEXT_SETTING,
+    STATE_ATTR_RISING,
+)
+from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed, async_init_recorder_component
+from tests.components.recorder.common import async_wait_recording_done_without_instance
+
+
+async def test_exclude_attributes(hass):
+    """Test camera registered attributes to be excluded."""
+    await async_init_recorder_component(hass)
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    await async_wait_recording_done_without_instance(hass)
+
+    def _fetch_sun_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(States, StateAttributes):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_sun_states)
+    assert len(states) > 1
+    for state in states:
+        assert STATE_ATTR_AZIMUTH not in state.attributes
+        assert STATE_ATTR_ELEVATION not in state.attributes
+        assert STATE_ATTR_NEXT_DAWN not in state.attributes
+        assert STATE_ATTR_NEXT_DUSK not in state.attributes
+        assert STATE_ATTR_NEXT_MIDNIGHT not in state.attributes
+        assert STATE_ATTR_NEXT_NOON not in state.attributes
+        assert STATE_ATTR_NEXT_RISING not in state.attributes
+        assert STATE_ATTR_NEXT_SETTING not in state.attributes
+        assert STATE_ATTR_RISING not in state.attributes
+        assert ATTR_FRIENDLY_NAME in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The attributes for the `sun.sun` entity are no longer recorded in the database.

As historical data can be derived from the `astral` library without the need to fetch it the database, it didn't seem like it needs to be copied there as well since it frequently generates new attributes rows in the database.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
