### PR TITLE
Fix opening/closing for awning in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/cover_entities/awning.py
+++ b/homeassistant/components/overkiz/cover_entities/awning.py
@@ -11,7 +11,12 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 
-from .generic_cover import COMMANDS_STOP, OverkizGenericCover
+from .generic_cover import (
+    COMMANDS_CLOSE,
+    COMMANDS_OPEN,
+    COMMANDS_STOP,
+    OverkizGenericCover,
+)
 
 
 class Awning(OverkizGenericCover):
@@ -64,3 +69,43 @@ class Awning(OverkizGenericCover):
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.executor.async_execute_command(OverkizCommand.UNDEPLOY)
+
+    @property
+    def is_opening(self) -> bool | None:
+        """Return if the cover is opening or not."""
+
+        if self.assumed_state:
+            return None
+
+        if self.is_running(COMMANDS_OPEN):
+            return True
+
+        # Check if cover is moving based on current state
+        is_moving = self.device.states.get(OverkizState.CORE_MOVING)
+        current_closure = self.device.states.get(OverkizState.CORE_DEPLOYMENT)
+        target_closure = self.device.states.get(OverkizState.CORE_TARGET_CLOSURE)
+
+        if not is_moving or not current_closure or not target_closure:
+            return None
+
+        return cast(int, current_closure.value) < cast(int, target_closure.value)
+
+    @property
+    def is_closing(self) -> bool | None:
+        """Return if the cover is closing or not."""
+
+        if self.assumed_state:
+            return None
+
+        if self.is_running(COMMANDS_CLOSE):
+            return True
+
+        # Check if cover is moving based on current state
+        is_moving = self.device.states.get(OverkizState.CORE_MOVING)
+        current_closure = self.device.states.get(OverkizState.CORE_DEPLOYMENT)
+        target_closure = self.device.states.get(OverkizState.CORE_TARGET_CLOSURE)
+
+        if not is_moving or not current_closure or not target_closure:
+            return None
+
+        return cast(int, current_closure.value) > cast(int, target_closure.value)

--- a/homeassistant/components/overkiz/cover_entities/awning.py
+++ b/homeassistant/components/overkiz/cover_entities/awning.py
@@ -73,10 +73,6 @@ class Awning(OverkizGenericCover):
     @property
     def is_opening(self) -> bool | None:
         """Return if the cover is opening or not."""
-
-        if self.assumed_state:
-            return None
-
         if self.is_running(COMMANDS_OPEN):
             return True
 
@@ -93,10 +89,6 @@ class Awning(OverkizGenericCover):
     @property
     def is_closing(self) -> bool | None:
         """Return if the cover is closing or not."""
-
-        if self.assumed_state:
-            return None
-
         if self.is_running(COMMANDS_CLOSE):
             return True
 

--- a/homeassistant/components/overkiz/cover_entities/generic_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/generic_cover.py
@@ -11,7 +11,8 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.components.overkiz.entity import OverkizEntity
+
+from ..entity import OverkizEntity
 
 ATTR_OBSTRUCTION_DETECTED = "obstruction-detected"
 
@@ -108,55 +109,13 @@ class OverkizGenericCover(OverkizEntity, CoverEntity):
         if command := self.executor.select_command(*COMMANDS_STOP_TILT):
             await self.executor.async_execute_command(command)
 
-    @property
-    def is_opening(self) -> bool | None:
-        """Return if the cover is opening or not."""
-
-        if self.assumed_state:
-            return None
-
-        # Check if cover movement execution is currently running
-        if any(
+    def is_running(self, commands: list[OverkizCommand]) -> bool:
+        """Return if the given commands are currently running."""
+        return any(
             execution.get("device_url") == self.device.device_url
-            and execution.get("command_name") in COMMANDS_OPEN + COMMANDS_OPEN_TILT
+            and execution.get("command_name") in commands
             for execution in self.coordinator.executions.values()
-        ):
-            return True
-
-        # Check if cover is moving based on current state
-        is_moving = self.device.states.get(OverkizState.CORE_MOVING)
-        current_closure = self.device.states.get(OverkizState.CORE_CLOSURE)
-        target_closure = self.device.states.get(OverkizState.CORE_TARGET_CLOSURE)
-
-        if not is_moving or not current_closure or not target_closure:
-            return None
-
-        return cast(int, current_closure.value) > cast(int, target_closure.value)
-
-    @property
-    def is_closing(self) -> bool | None:
-        """Return if the cover is closing or not."""
-
-        if self.assumed_state:
-            return None
-
-        # Check if cover movement execution is currently running
-        if any(
-            execution.get("device_url") == self.device.device_url
-            and execution.get("command_name") in COMMANDS_CLOSE + COMMANDS_CLOSE_TILT
-            for execution in self.coordinator.executions.values()
-        ):
-            return True
-
-        # Check if cover is moving based on current state
-        is_moving = self.device.states.get(OverkizState.CORE_MOVING)
-        current_closure = self.device.states.get(OverkizState.CORE_CLOSURE)
-        target_closure = self.device.states.get(OverkizState.CORE_TARGET_CLOSURE)
-
-        if not is_moving or not current_closure or not target_closure:
-            return None
-
-        return cast(int, current_closure.value) < cast(int, target_closure.value)
+        )
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -112,10 +112,6 @@ class VerticalCover(OverkizGenericCover):
     @property
     def is_opening(self) -> bool | None:
         """Return if the cover is opening or not."""
-
-        if self.assumed_state:
-            return None
-
         if self.is_running(COMMANDS_OPEN + COMMANDS_OPEN_TILT):
             return True
 
@@ -132,10 +128,6 @@ class VerticalCover(OverkizGenericCover):
     @property
     def is_closing(self) -> bool | None:
         """Return if the cover is closing or not."""
-
-        if self.assumed_state:
-            return None
-
         if self.is_running(COMMANDS_CLOSE + COMMANDS_CLOSE_TILT):
             return True
 

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -16,9 +16,14 @@ from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntityFeature,
 )
-from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
 
-from .generic_cover import COMMANDS_STOP, OverkizGenericCover
+from ..coordinator import OverkizDataUpdateCoordinator
+from .generic_cover import (
+    COMMANDS_CLOSE_TILT,
+    COMMANDS_OPEN_TILT,
+    COMMANDS_STOP,
+    OverkizGenericCover,
+)
 
 COMMANDS_OPEN = [OverkizCommand.OPEN, OverkizCommand.UP, OverkizCommand.CYCLE]
 COMMANDS_CLOSE = [OverkizCommand.CLOSE, OverkizCommand.DOWN, OverkizCommand.CYCLE]
@@ -103,6 +108,46 @@ class VerticalCover(OverkizGenericCover):
         """Close the cover."""
         if command := self.executor.select_command(*COMMANDS_CLOSE):
             await self.executor.async_execute_command(command)
+
+    @property
+    def is_opening(self) -> bool | None:
+        """Return if the cover is opening or not."""
+
+        if self.assumed_state:
+            return None
+
+        if self.is_running(COMMANDS_OPEN + COMMANDS_OPEN_TILT):
+            return True
+
+        # Check if cover is moving based on current state
+        is_moving = self.device.states.get(OverkizState.CORE_MOVING)
+        current_closure = self.device.states.get(OverkizState.CORE_CLOSURE)
+        target_closure = self.device.states.get(OverkizState.CORE_TARGET_CLOSURE)
+
+        if not is_moving or not current_closure or not target_closure:
+            return None
+
+        return cast(int, current_closure.value) > cast(int, target_closure.value)
+
+    @property
+    def is_closing(self) -> bool | None:
+        """Return if the cover is closing or not."""
+
+        if self.assumed_state:
+            return None
+
+        if self.is_running(COMMANDS_CLOSE + COMMANDS_CLOSE_TILT):
+            return True
+
+        # Check if cover is moving based on current state
+        is_moving = self.device.states.get(OverkizState.CORE_MOVING)
+        current_closure = self.device.states.get(OverkizState.CORE_CLOSURE)
+        target_closure = self.device.states.get(OverkizState.CORE_TARGET_CLOSURE)
+
+        if not is_moving or not current_closure or not target_closure:
+            return None
+
+        return cast(int, current_closure.value) < cast(int, target_closure.value)
 
 
 class LowSpeedCover(VerticalCover):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`is_opening` and `is_closing` does work for awning devices. Indeed, the current code is based on the ClosureState which is returned only or Vertical cover. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/iMicknl/ha-tahoma/issues/730
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
