### PR TITLE
Update KNX flow strings to use "data_description" and remove invalid options

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -205,6 +205,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             port = self._selected_tunnel.port
             if not self._selected_tunnel.supports_tunnelling_tcp:
                 connection_methods.remove(CONF_KNX_LABEL_TUNNELING_TCP)
+                connection_methods.remove(CONF_KNX_LABEL_TUNNELING_TCP_SECURE)
 
         fields = {
             vol.Required(CONF_KNX_TUNNELING_TYPE): vol.In(connection_methods),

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -168,7 +168,6 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 **DEFAULT_ENTRY_DATA,  # type: ignore[misc]
                 CONF_HOST: user_input[CONF_HOST],
                 CONF_PORT: user_input[CONF_PORT],
-                CONF_KNX_INDIVIDUAL_ADDRESS: user_input[CONF_KNX_INDIVIDUAL_ADDRESS],
                 CONF_KNX_ROUTE_BACK: (
                     connection_type == CONF_KNX_LABEL_TUNNELING_UDP_ROUTE_BACK
                 ),
@@ -211,9 +210,6 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_KNX_TUNNELING_TYPE): vol.In(connection_methods),
             vol.Required(CONF_HOST, default=ip_address): _IP_SELECTOR,
             vol.Required(CONF_PORT, default=port): _PORT_SELECTOR,
-            vol.Required(
-                CONF_KNX_INDIVIDUAL_ADDRESS, default=XKNX.DEFAULT_ADDRESS
-            ): _IA_SELECTOR,
         }
 
         if self.show_advanced_options:

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import selector
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from .const import (
@@ -62,6 +62,10 @@ CONF_KNX_LABEL_TUNNELING_TCP: Final = "TCP"
 CONF_KNX_LABEL_TUNNELING_TCP_SECURE: Final = "TCP with IP Secure"
 CONF_KNX_LABEL_TUNNELING_UDP: Final = "UDP"
 CONF_KNX_LABEL_TUNNELING_UDP_ROUTE_BACK: Final = "UDP with route back / NAT mode"
+
+_IA_SELECTOR = selector.selector({"text": {}})
+_IP_SELECTOR = selector.selector({"text": {}})
+_PORT_SELECTOR = selector.selector({"number": {"min": 1, "max": 65535, "mode": "box"}})
 
 
 class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -205,15 +209,15 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         fields = {
             vol.Required(CONF_KNX_TUNNELING_TYPE): vol.In(connection_methods),
-            vol.Required(CONF_HOST, default=ip_address): str,
-            vol.Required(CONF_PORT, default=port): cv.port,
+            vol.Required(CONF_HOST, default=ip_address): _IP_SELECTOR,
+            vol.Required(CONF_PORT, default=port): _PORT_SELECTOR,
             vol.Required(
                 CONF_KNX_INDIVIDUAL_ADDRESS, default=XKNX.DEFAULT_ADDRESS
-            ): str,
+            ): _IA_SELECTOR,
         }
 
         if self.show_advanced_options:
-            fields[vol.Optional(CONF_KNX_LOCAL_IP)] = str
+            fields[vol.Optional(CONF_KNX_LOCAL_IP)] = _IP_SELECTOR
 
         return self.async_show_form(
             step_id="manual_tunnel", data_schema=vol.Schema(fields), errors=errors
@@ -245,9 +249,15 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         fields = {
-            vol.Required(CONF_KNX_SECURE_USER_ID): int,
-            vol.Required(CONF_KNX_SECURE_USER_PASSWORD): str,
-            vol.Required(CONF_KNX_SECURE_DEVICE_AUTHENTICATION): str,
+            vol.Required(CONF_KNX_SECURE_USER_ID, default=2): selector.selector(
+                {"number": {"min": 1, "max": 127, "mode": "box"}}
+            ),
+            vol.Required(CONF_KNX_SECURE_USER_PASSWORD): selector.selector(
+                {"text": {"type": "password"}}
+            ),
+            vol.Required(CONF_KNX_SECURE_DEVICE_AUTHENTICATION): selector.selector(
+                {"text": {"type": "password"}}
+            ),
         }
 
         return self.async_show_form(
@@ -290,8 +300,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "file_not_found"
 
         fields = {
-            vol.Required(CONF_KNX_KNXKEY_FILENAME): str,
-            vol.Required(CONF_KNX_KNXKEY_PASSWORD): str,
+            vol.Required(CONF_KNX_KNXKEY_FILENAME): selector.selector({"text": {}}),
+            vol.Required(CONF_KNX_KNXKEY_PASSWORD): selector.selector({"text": {}}),
         }
 
         return self.async_show_form(
@@ -319,13 +329,15 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         fields = {
             vol.Required(
                 CONF_KNX_INDIVIDUAL_ADDRESS, default=XKNX.DEFAULT_ADDRESS
-            ): str,
-            vol.Required(CONF_KNX_MCAST_GRP, default=DEFAULT_MCAST_GRP): str,
-            vol.Required(CONF_KNX_MCAST_PORT, default=DEFAULT_MCAST_PORT): cv.port,
+            ): _IA_SELECTOR,
+            vol.Required(CONF_KNX_MCAST_GRP, default=DEFAULT_MCAST_GRP): _IP_SELECTOR,
+            vol.Required(
+                CONF_KNX_MCAST_PORT, default=DEFAULT_MCAST_PORT
+            ): _PORT_SELECTOR,
         }
 
         if self.show_advanced_options:
-            fields[vol.Optional(CONF_KNX_LOCAL_IP)] = str
+            fields[vol.Optional(CONF_KNX_LOCAL_IP)] = _IP_SELECTOR
 
         return self.async_show_form(
             step_id="routing", data_schema=vol.Schema(fields), errors=errors
@@ -370,17 +382,17 @@ class KNXOptionsFlowHandler(OptionsFlow):
             vol.Required(
                 CONF_KNX_INDIVIDUAL_ADDRESS,
                 default=self.current_config[CONF_KNX_INDIVIDUAL_ADDRESS],
-            ): str,
+            ): selector.selector({"text": {}}),
             vol.Required(
                 CONF_KNX_MCAST_GRP,
                 default=self.current_config.get(CONF_KNX_MCAST_GRP, DEFAULT_MCAST_GRP),
-            ): str,
+            ): _IP_SELECTOR,
             vol.Required(
                 CONF_KNX_MCAST_PORT,
                 default=self.current_config.get(
                     CONF_KNX_MCAST_PORT, DEFAULT_MCAST_PORT
                 ),
-            ): cv.port,
+            ): _PORT_SELECTOR,
         }
 
         if self.show_advanced_options:
@@ -394,7 +406,7 @@ class KNXOptionsFlowHandler(OptionsFlow):
                     CONF_KNX_LOCAL_IP,
                     default=local_ip,
                 )
-            ] = str
+            ] = _IP_SELECTOR
             data_schema[
                 vol.Required(
                     CONF_KNX_STATE_UPDATER,
@@ -403,7 +415,7 @@ class KNXOptionsFlowHandler(OptionsFlow):
                         CONF_KNX_DEFAULT_STATE_UPDATER,
                     ),
                 )
-            ] = bool
+            ] = selector.selector({"boolean": {}})
             data_schema[
                 vol.Required(
                     CONF_KNX_RATE_LIMIT,
@@ -412,7 +424,15 @@ class KNXOptionsFlowHandler(OptionsFlow):
                         CONF_KNX_DEFAULT_RATE_LIMIT,
                     ),
                 )
-            ] = vol.All(vol.Coerce(int), vol.Range(min=1, max=CONF_MAX_RATE_LIMIT))
+            ] = selector.selector(
+                {
+                    "number": {
+                        "min": 1,
+                        "max": CONF_MAX_RATE_LIMIT,
+                        "mode": "box",
+                    }
+                }
+            )
 
         return self.async_show_form(
             step_id="init",
@@ -444,10 +464,10 @@ class KNXOptionsFlowHandler(OptionsFlow):
                         ): vol.In(connection_methods),
                         vol.Required(
                             CONF_HOST, default=self.current_config.get(CONF_HOST)
-                        ): str,
+                        ): _IP_SELECTOR,
                         vol.Required(
                             CONF_PORT, default=self.current_config.get(CONF_PORT, 3671)
-                        ): cv.port,
+                        ): _PORT_SELECTOR,
                     }
                 ),
                 last_step=True,

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -19,13 +19,11 @@
           "tunneling_type": "KNX Tunneling Type",
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
-          "individual_address": "Individual address",
           "local_ip": "Local IP of Home Assistant"
         },
         "data_description": {
           "port": "Port of the KNX/IP tunneling device.",
           "host": "IP address of the KNX/IP tunneling device.",
-          "individual_address": "KNX address to be used by default, e.g. `1.0.250`. Used when the tunneling device does not assign an individual address for the connection.",
           "local_ip": "Leave blank to use auto-discovery."
         }
       },

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -69,7 +69,7 @@
           "local_ip": "Local IP of Home Assistant"
         },
         "data_description": {
-          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
           "local_ip": "Leave blank to use auto-discovery."
         }
       }
@@ -94,15 +94,15 @@
           "multicast_port": "Multicast port",
           "local_ip": "Local IP of Home Assistant",
           "state_updater": "State updater",
-          "rate_limit": "Maximum outgoing telegrams per second"
+          "rate_limit": "Rate limit"
         },
         "data_description": {
-          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
           "multicast_group": "Used for routing and discovery. Default: `224.0.23.12`",
           "multicast_port": "Used for routing and discovery. Default: `3671`",
           "local_ip": "Use `0.0.0.0` for auto-discovery.",
           "state_updater": "Globally enable or disable reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve states from the KNX Bus, `sync_state` entity options will have no effect.",
-          "rate_limit": "Recommended: 20 to 40."
+          "rate_limit": "Maximum outgoing telegrams per second.\nRecommended: 20 to 40"
         }
       },
       "tunnel": {

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -19,39 +19,58 @@
           "tunneling_type": "KNX Tunneling Type",
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
-          "individual_address": "Individual address for the connection",
-          "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)"
+          "individual_address": "Individual address",
+          "local_ip": "Local IP of Home Assistant"
+        },
+        "data_description": {
+          "port": "Port of the KNX/IP tunneling device.",
+          "host": "IP address of the KNX/IP tunneling device.",
+          "individual_address": "KNX address to be used by default, e.g. `1.0.250`. Used when the tunneling device does not assign an individual address for the connection.",
+          "local_ip": "Leave blank to use auto-discovery."
         }
       },
       "secure_tunneling": {
-        "description": "Select how you want to configure IP Secure.",
+        "description": "Select how you want to configure KNX/IP Secure.",
         "menu_options": {
-          "secure_knxkeys": "Configure a knxkeys file containing IP secure information",
-          "secure_manual": "Configure IP secure manually"
+          "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
+          "secure_manual": "Configure IP secure keys manually"
         }
       },
       "secure_knxkeys": {
-        "description": "Please enter the information for your knxkeys file.",
+        "description": "Please enter the information for your `.knxkeys` file.",
         "data": {
-          "knxkeys_filename": "The full name of your knxkeys file",
-          "knxkeys_password": "The password to decrypt the knxkeys file"
+          "knxkeys_filename": "The filename of your `.knxkeys` file (including extension)",
+          "knxkeys_password": "The password to decrypt the `.knxkeys` file"
+        },
+        "data_description": {
+          "knxkeys_filename": "The file is expected to be found in your config directory in `.storage/knx/`.\nIn Home Assistant OS this would be `/config/.storage/knx/`\nExample: `my_project.knxkeys`",
+          "knxkeys_password": "This was set when exporting the file from ETS."
         }
       },
       "secure_manual": {
-        "description": "Please enter the IP secure information.",
+        "description": "Please enter your IP secure information.",
         "data": {
           "user_id": "User ID",
           "user_password": "User password",
           "device_authentication": "Device authentication password"
+        },
+        "data_description": {
+          "user_id": "This is often tunnel number +1. So 'Tunnel 2' would have User-ID '3'.",
+          "user_password": "Password for the specific tunnel connection set in the 'Properties' panel of the tunnel in ETS.",
+          "device_authentication": "This is set in the 'IP' panel of the interface in ETS."
         }
       },
       "routing": {
         "description": "Please configure the routing options.",
         "data": {
-          "individual_address": "Individual address for the routing connection",
-          "multicast_group": "The multicast group used for routing",
-          "multicast_port": "The multicast port used for routing",
-          "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)"
+          "individual_address": "Individual address",
+          "multicast_group": "Multicast group used for routing",
+          "multicast_port": "Multicast port used for routing",
+          "local_ip": "Local IP of Home Assistant"
+        },
+        "data_description": {
+          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+          "local_ip": "Leave blank to use auto-discovery."
         }
       }
     },
@@ -71,11 +90,19 @@
         "data": {
           "connection_type": "KNX Connection Type",
           "individual_address": "Default individual address",
-          "multicast_group": "Multicast group used for routing and discovery",
-          "multicast_port": "Multicast port used for routing and discovery",
-          "local_ip": "Local IP of Home Assistant (use 0.0.0.0 for automatic detection)",
-          "state_updater": "Globally enable reading states from the KNX Bus",
+          "multicast_group": "Multicast group",
+          "multicast_port": "Multicast port",
+          "local_ip": "Local IP of Home Assistant",
+          "state_updater": "State updater",
           "rate_limit": "Maximum outgoing telegrams per second"
+        },
+        "data_description": {
+          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+          "multicast_group": "Used for routing and discovery. Default: `224.0.23.12`",
+          "multicast_port": "Used for routing and discovery. Default: `3671`",
+          "local_ip": "Use `0.0.0.0` for auto-discovery.",
+          "state_updater": "Globally enable or disable reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve states from the KNX Bus, `sync_state` entity options will have no effect.",
+          "rate_limit": "Recommended: 20 to 40."
         }
       },
       "tunnel": {
@@ -83,6 +110,10 @@
           "tunneling_type": "KNX Tunneling Type",
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "port": "Port of the KNX/IP tunneling device.",
+          "host": "IP address of the KNX/IP tunneling device."
         }
       }
     }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -13,44 +13,63 @@
             "manual_tunnel": {
                 "data": {
                     "host": "Host",
-                    "individual_address": "Individual address for the connection",
-                    "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)",
+                    "individual_address": "Individual address",
+                    "local_ip": "Local IP of Home Assistant",
                     "port": "Port",
                     "tunneling_type": "KNX Tunneling Type"
+                },
+                "data_description": {
+                    "host": "IP address of the KNX/IP tunneling device.",
+                    "individual_address": "KNX address to be used by default, e.g. `1.0.250`. Used when the tunneling device does not assign an individual address for the connection.",
+                    "local_ip": "Leave blank to use auto-discovery.",
+                    "port": "Port of the KNX/IP tunneling device."
                 },
                 "description": "Please enter the connection information of your tunneling device."
             },
             "routing": {
                 "data": {
-                    "individual_address": "Individual address for the routing connection",
-                    "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)",
-                    "multicast_group": "The multicast group used for routing",
-                    "multicast_port": "The multicast port used for routing"
+                    "individual_address": "Individual address",
+                    "local_ip": "Local IP of Home Assistant",
+                    "multicast_group": "Multicast group used for routing",
+                    "multicast_port": "Multicast port used for routing"
+                },
+                "data_description": {
+                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+                    "local_ip": "Leave blank to use auto-discovery."
                 },
                 "description": "Please configure the routing options."
             },
             "secure_knxkeys": {
                 "data": {
-                    "knxkeys_filename": "The full name of your knxkeys file",
-                    "knxkeys_password": "The password to decrypt the knxkeys file."
+                    "knxkeys_filename": "The filename of your `.knxkeys` file (including extension)",
+                    "knxkeys_password": "The password to decrypt the `.knxkeys` file"
                 },
-                "description": "Please enter the information for your knxkeys file."
-            },
-            "secure_tunneling": {
-                "description": "Select how you want to configure IP Secure.",
-                "menu_options": {
-                    "secure_knxkeys": "Configure a knxkeys file containing IP secure information",
-                    "secure_manual": "Configure IP secure manually"
-                }
+                "data_description": {
+                    "knxkeys_filename": "The file is expected to be found in your config directory in `.storage/knx/`.\nIn Home Assistant OS this would be `/config/.storage/knx/`\nExample: `my_project.knxkeys`",
+                    "knxkeys_password": "This was set when exporting the file from ETS."
+                },
+                "description": "Please enter the information for your `.knxkeys` file."
             },
             "secure_manual": {
-                "description": "Please enter the IP secure information.",
                 "data": {
-                  "user_id": "User ID",
-                  "user_password": "User password",
-                  "device_authentication": "Device authentication password"
+                    "device_authentication": "Device authentication password",
+                    "user_id": "User ID",
+                    "user_password": "User password"
+                },
+                "data_description": {
+                    "device_authentication": "This is set in the 'IP' panel of the interface in ETS.",
+                    "user_id": "This is often tunnel number +1. So 'Tunnel 2' would have User-ID '3'.",
+                    "user_password": "Password for the specific tunnel connection set in the 'Properties' panel of the tunnel in ETS."
+                },
+                "description": "Please enter your IP secure information."
+            },
+            "secure_tunneling": {
+                "description": "Select how you want to configure KNX/IP Secure.",
+                "menu_options": {
+                    "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
+                    "secure_manual": "Configure IP secure keys manually"
                 }
-              },
+            },
             "tunnel": {
                 "data": {
                     "gateway": "KNX Tunnel Connection"
@@ -71,11 +90,19 @@
                 "data": {
                     "connection_type": "KNX Connection Type",
                     "individual_address": "Default individual address",
-                    "local_ip": "Local IP of Home Assistant (use 0.0.0.0 for automatic detection)",
-                    "multicast_group": "Multicast group used for routing and discovery",
-                    "multicast_port": "Multicast port used for routing and discovery",
+                    "local_ip": "Local IP of Home Assistant",
+                    "multicast_group": "Multicast group",
+                    "multicast_port": "Multicast port",
                     "rate_limit": "Maximum outgoing telegrams per second",
-                    "state_updater": "Globally enable reading states from the KNX Bus"
+                    "state_updater": "State updater"
+                },
+                "data_description": {
+                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+                    "local_ip": "Use `0.0.0.0` for auto-discovery.",
+                    "multicast_group": "Used for routing and discovery. Default: `224.0.23.12`",
+                    "multicast_port": "Used for routing and discovery. Default: `3671`",
+                    "rate_limit": "Recommended: 20 to 40.",
+                    "state_updater": "Globally enable or disable reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve states from the KNX Bus, `sync_state` entity options will have no effect."
                 }
             },
             "tunnel": {
@@ -83,6 +110,10 @@
                     "host": "Host",
                     "port": "Port",
                     "tunneling_type": "KNX Tunneling Type"
+                },
+                "data_description": {
+                    "host": "IP address of the KNX/IP tunneling device.",
+                    "port": "Port of the KNX/IP tunneling device."
                 }
             }
         }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -34,7 +34,7 @@
                     "multicast_port": "Multicast port used for routing"
                 },
                 "data_description": {
-                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
                     "local_ip": "Leave blank to use auto-discovery."
                 },
                 "description": "Please configure the routing options."
@@ -93,15 +93,15 @@
                     "local_ip": "Local IP of Home Assistant",
                     "multicast_group": "Multicast group",
                     "multicast_port": "Multicast port",
-                    "rate_limit": "Maximum outgoing telegrams per second",
+                    "rate_limit": "Rate limit",
                     "state_updater": "State updater"
                 },
                 "data_description": {
-                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`.",
+                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
                     "local_ip": "Use `0.0.0.0` for auto-discovery.",
                     "multicast_group": "Used for routing and discovery. Default: `224.0.23.12`",
                     "multicast_port": "Used for routing and discovery. Default: `3671`",
-                    "rate_limit": "Recommended: 20 to 40.",
+                    "rate_limit": "Maximum outgoing telegrams per second.\nRecommended: 20 to 40",
                     "state_updater": "Globally enable or disable reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve states from the KNX Bus, `sync_state` entity options will have no effect."
                 }
             },

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -13,14 +13,12 @@
             "manual_tunnel": {
                 "data": {
                     "host": "Host",
-                    "individual_address": "Individual address",
                     "local_ip": "Local IP of Home Assistant",
                     "port": "Port",
                     "tunneling_type": "KNX Tunneling Type"
                 },
                 "data_description": {
                     "host": "IP address of the KNX/IP tunneling device.",
-                    "individual_address": "KNX address to be used by default, e.g. `1.0.250`. Used when the tunneling device does not assign an individual address for the connection.",
                     "local_ip": "Leave blank to use auto-discovery.",
                     "port": "Port of the KNX/IP tunneling device."
                 },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update KNX flow strings to use "data_description"
- `individual_address` has no effect for tunneling. The address is always assigned by the tunnelling server. So the option is removed
- Tunneling V1 devices can't support IP Secure so we don't show the option if such is selected (same has been the case for TCP)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
