### PR TITLE
Exclude large and chatty attributes from being recorded for update entities

### DIFF
--- a/homeassistant/components/update/recorder.py
+++ b/homeassistant/components/update/recorder.py
@@ -1,0 +1,12 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, callback
+
+from . import ATTR_IN_PROGRESS
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude update in progress attribute from being recorded in the database."""
+    return {ATTR_IN_PROGRESS}

--- a/homeassistant/components/update/recorder.py
+++ b/homeassistant/components/update/recorder.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant, callback
 
-from . import ATTR_IN_PROGRESS
+from . import ATTR_IN_PROGRESS, ATTR_RELEASE_SUMMARY
 
 
 @callback
 def exclude_attributes(hass: HomeAssistant) -> set[str]:
-    """Exclude update in progress attribute from being recorded in the database."""
-    return {ATTR_IN_PROGRESS}
+    """Exclude large and chatty update attributes from being recorded in the database."""
+    return {ATTR_IN_PROGRESS, ATTR_RELEASE_SUMMARY}

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -8,6 +8,7 @@ from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.update.const import (
     ATTR_CURRENT_VERSION,
     ATTR_IN_PROGRESS,
+    ATTR_RELEASE_SUMMARY,
     DOMAIN,
 )
 from homeassistant.const import CONF_PLATFORM
@@ -50,4 +51,5 @@ async def test_exclude_attributes(
     assert len(states) > 1
     for state in states:
         assert ATTR_IN_PROGRESS not in state.attributes
+        assert ATTR_RELEASE_SUMMARY not in state.attributes
         assert ATTR_CURRENT_VERSION in state.attributes

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -38,7 +38,7 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done_without_instance(hass)
 
-    def _fetch_sun_states() -> list[State]:
+    def _fetch_states() -> list[State]:
         with session_scope(hass=hass) as session:
             native_states = []
             for db_state, db_state_attributes in session.query(States, StateAttributes):

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -1,0 +1,53 @@
+"""The tests for update recorder."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.recorder.models import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.update.const import (
+    ATTR_CURRENT_VERSION,
+    ATTR_IN_PROGRESS,
+    DOMAIN,
+)
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import HomeAssistant, State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed, async_init_recorder_component
+from tests.components.recorder.common import async_wait_recording_done_without_instance
+
+
+async def test_exclude_attributes(
+    hass: HomeAssistant, enable_custom_integrations: None
+):
+    """Test update attributes to be excluded."""
+    await async_init_recorder_component(hass)
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+    state = hass.states.get("update.update_already_in_progress")
+    assert state.attributes[ATTR_IN_PROGRESS] == 50
+    await async_setup_component(hass, DOMAIN, {})
+
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    await async_wait_recording_done_without_instance(hass)
+
+    def _fetch_sun_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(States, StateAttributes):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_sun_states)
+    assert len(states) > 1
+    for state in states:
+        assert ATTR_IN_PROGRESS not in state.attributes
+        assert ATTR_CURRENT_VERSION in state.attributes

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -47,7 +47,7 @@ async def test_exclude_attributes(
                 native_states.append(state)
             return native_states
 
-    states: list[State] = await hass.async_add_executor_job(_fetch_sun_states)
+    states: list[State] = await hass.async_add_executor_job(_fetch_states)
     assert len(states) > 1
     for state in states:
         assert ATTR_IN_PROGRESS not in state.attributes


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exclude large and chatty attributes from being recorded for update entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
