### PR TITLE
use `_attr_` form for mullvad and add _unique_id

### DIFF
--- a/homeassistant/components/mullvad/binary_sensor.py
+++ b/homeassistant/components/mullvad/binary_sensor.py
@@ -40,7 +40,12 @@ class MullvadBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, coordinator, sensor, config_entry):
         """Initialize the Mullvad binary sensor."""
         super().__init__(coordinator)
+        self._sensor = sensor
         self._attr_device_class = sensor[CONF_DEVICE_CLASS]
-        self._attr_is_on = self.coordinator.data[sensor[CONF_ID]]
         self._attr_name = sensor[CONF_NAME]
         self._attr_unique_id = f"{config_entry.entry_id}_{sensor[CONF_ID]}"
+
+    @property
+    def is_on(self):
+        """Return the state for this binary sensor."""
+        return self.coordinator.data[self._sensor[CONF_ID]]

--- a/homeassistant/components/mullvad/binary_sensor.py
+++ b/homeassistant/components/mullvad/binary_sensor.py
@@ -29,17 +29,18 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN]
 
     async_add_entities(
-        MullvadBinarySensor(coordinator, sensor) for sensor in BINARY_SENSORS
+        MullvadBinarySensor(coordinator, sensor, config_entry)
+        for sensor in BINARY_SENSORS
     )
 
 
 class MullvadBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Represents a Mullvad binary sensor."""
 
-    def __init__(self, coordinator, sensor):
+    def __init__(self, coordinator, sensor, config_entry):
         """Initialize the Mullvad binary sensor."""
         super().__init__(coordinator)
         self._attr_device_class = sensor[CONF_DEVICE_CLASS]
         self._attr_is_on = self.coordinator.data[sensor[CONF_ID]]
         self._attr_name = sensor[CONF_NAME]
-        self._attr_unique_id = DOMAIN
+        self._attr_unique_id = f"{config_entry.entry_id}_{sensor[CONF_ID]}"

--- a/homeassistant/components/mullvad/binary_sensor.py
+++ b/homeassistant/components/mullvad/binary_sensor.py
@@ -42,4 +42,4 @@ class MullvadBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_device_class = sensor[CONF_DEVICE_CLASS]
         self._attr_is_on = self.coordinator.data[sensor[CONF_ID]]
         self._attr_name = sensor[CONF_NAME]
-        self._attr_unique_id = DOMAIN
+        self._attr_unique_id = f"{sensor[CONF_NAME]}_{sensor[CONF_ID]}"

--- a/homeassistant/components/mullvad/binary_sensor.py
+++ b/homeassistant/components/mullvad/binary_sensor.py
@@ -39,21 +39,7 @@ class MullvadBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, coordinator, sensor):
         """Initialize the Mullvad binary sensor."""
         super().__init__(coordinator)
-        self.id = sensor[CONF_ID]
-        self._name = sensor[CONF_NAME]
-        self._device_class = sensor[CONF_DEVICE_CLASS]
-
-    @property
-    def device_class(self):
-        """Return the device class for this binary sensor."""
-        return self._device_class
-
-    @property
-    def name(self):
-        """Return the name for this binary sensor."""
-        return self._name
-
-    @property
-    def is_on(self):
-        """Return the state for this binary sensor."""
-        return self.coordinator.data[self.id]
+        self._attr_device_class = sensor[CONF_DEVICE_CLASS]
+        self._attr_is_on = self.coordinator.data[sensor[CONF_ID]]
+        self._attr_name = sensor[CONF_NAME]
+        self._attr_unique_id = DOMAIN


### PR DESCRIPTION


## Proposed change
Update Mullvad integration to use `_attr_` form and add `_unique_id` to properly show entity on integrations screen:
Currently no entities are shown even though one is created:
![image](https://user-images.githubusercontent.com/10717998/160968299-aa455941-d17f-45e9-8b19-df850e998d28.png)



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.