### PR TITLE
Add support for new select selector properties

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -478,7 +478,7 @@ class SelectSelector(Selector):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required("options"): vol.All(
-                vol.Any([str], [select_option]), vol.Length(min=1)
+                vol.Any([str], [select_option])
             ),
             vol.Optional("multiple", default=False): cv.boolean,
             vol.Optional("custom_value", default=False): cv.boolean,

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -482,7 +482,7 @@ class SelectSelector(Selector):
             ),
             vol.Optional("multiple", default=False): cv.boolean,
             vol.Optional("custom_value", default=False): cv.boolean,
-            vol.Optional("mode"): vol.In(("list", "dropbox")),
+            vol.Optional("mode"): vol.In(("list", "dropdown")),
         }
     )
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -477,9 +477,7 @@ class SelectSelector(Selector):
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Required("options"): vol.All(
-                vol.Any([str], [select_option])
-            ),
+            vol.Required("options"): vol.All(vol.Any([str], [select_option])),
             vol.Optional("multiple", default=False): cv.boolean,
             vol.Optional("custom_value", default=False): cv.boolean,
             vol.Optional("mode"): vol.In(("list", "dropdown")),
@@ -488,10 +486,12 @@ class SelectSelector(Selector):
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-        if isinstance(self.config["options"][0], str):
-            options = self.config["options"]
-        else:
-            options = [option["value"] for option in self.config["options"]]
+        options = []
+        if self.config["options"]:
+            if isinstance(self.config["options"][0], str):
+                options = self.config["options"]
+            else:
+                options = [option["value"] for option in self.config["options"]]
 
         parent_schema = vol.In(options)
         if self.config["custom_value"]:

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -363,7 +363,7 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
         ),
         (
             {"options": ["red", "green", "blue"], "multiple": True},
-            (["red"], ["green", "blue"]),
+            (["red"], ["green", "blue"], []),
             ("cat", 0, None, "red"),
         ),
         (
@@ -372,12 +372,22 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
                 "multiple": True,
                 "custom_value": True,
             },
-            (["red"], ["green", "blue"], ["red", "cat"]),
+            (["red"], ["green", "blue"], ["red", "cat"], []),
             ("cat", 0, None, "red"),
         ),
         (
             {"options": ["red", "green", "blue"], "custom_value": True},
             ("red", "green", "blue", "cat"),
+            (0, None, ["red"]),
+        ),
+        (
+            {"options": [], "custom_value": True},
+            ("red", "cat"),
+            (0, None, ["red"]),
+        ),
+        (
+            {"options": [], "custom_value": True, "multiple": True},
+            (["red"], ["green", "blue"], []),
             (0, None, ["red"]),
         ),
     ),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -246,7 +246,7 @@ def test_number_selector_schema(schema, valid_selections, invalid_selections):
     ),
 )
 def test_number_selector_schema_error(schema):
-    """Test select selector."""
+    """Test number selector."""
     with pytest.raises(vol.Invalid):
         selector.validate_selector({"number": schema})
 
@@ -349,7 +349,7 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
         (
             {"options": ["red", "green", "blue"]},
             ("red", "green", "blue"),
-            ("cat", 0, None),
+            ("cat", 0, None, ["red"]),
         ),
         (
             {
@@ -359,7 +359,26 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
                 ]
             },
             ("red", "green"),
-            ("cat", 0, None),
+            ("cat", 0, None, ["red"]),
+        ),
+        (
+            {"options": ["red", "green", "blue"], "multiple": True},
+            (["red"], ["green", "blue"]),
+            ("cat", 0, None, "red"),
+        ),
+        (
+            {
+                "options": ["red", "green", "blue"],
+                "multiple": True,
+                "custom_value": True,
+            },
+            (["red"], ["green", "blue"], ["red", "cat"]),
+            ("cat", 0, None, "red"),
+        ),
+        (
+            {"options": ["red", "green", "blue"], "custom_value": True},
+            ("red", "green", "blue", "cat"),
+            (0, None, ["red"]),
         ),
     ),
 )

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -388,7 +388,7 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
         (
             {"options": [], "custom_value": True, "multiple": True},
             (["red"], ["green", "blue"], []),
-            (0, None, ["red"]),
+            (0, None, "red"),
         ),
     ),
 )
@@ -402,7 +402,6 @@ def test_select_selector_schema(schema, valid_selections, invalid_selections):
     (
         {},  # Must have options
         {"options": {"hello": "World"}},  # Options must be a list
-        {"options": []},  # Must have at least option
         # Options must be strings or value / label pairs
         {"options": [{"hello": "World"}]},
         # Options must all be of the same type


### PR DESCRIPTION
## Proposed change
Implemented the following new config options for the `select` selector from https://github.com/home-assistant/frontend/pull/12099 :
- `multiple`: Allows the user to select multiple items from the list
- `mode`: `list` forces a radio button list, `dropdown` forces a dropdown, nothing lets the frontend decide
- `custom_value`: Allows users to enter custom values into the selector


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22207

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
