### PR TITLE
Add scaffold template for backup

### DIFF
--- a/script/scaffold/docs.py
+++ b/script/scaffold/docs.py
@@ -2,6 +2,10 @@
 from .model import Info
 
 DATA = {
+    "backup": {
+        "title": "Backup",
+        "docs": "https://developers.home-assistant.io/docs/core/platform/backup",
+    },
     "config_flow": {
         "title": "Config Flow",
         "docs": "https://developers.home-assistant.io/docs/en/config_entries_config_flow_handler.html",
@@ -36,12 +40,12 @@ DATA = {
     },
     "reproduce_state": {
         "title": "Reproduce State",
-        "docs": "https://developers.home-assistant.io/docs/en/reproduce_state_index.html",
+        "docs": "https://developers.home-assistant.io/docs/core/platform/reproduce_state",
         "extra": "You will now need to update the code to make sure that every attribute that can occur in the state will cause the right service to be called.",
     },
     "significant_change": {
         "title": "Significant Change",
-        "docs": "https://developers.home-assistant.io/docs/en/significant_change_index.html",
+        "docs": "https://developers.home-assistant.io/docs/core/platform/significant_change",
         "extra": "You will now need to update the code to make sure that entities with different device classes are correctly considered.",
     },
 }

--- a/script/scaffold/templates/backup/integration/backup.py
+++ b/script/scaffold/templates/backup/integration/backup.py
@@ -1,0 +1,10 @@
+"""Backup platform for the NEW_NAME integration."""
+from homeassistant.core import HomeAssistant
+
+
+async def async_pre_backup(hass: HomeAssistant) -> None:
+    """Perform operations before a backup starts."""
+
+
+async def async_post_backup(hass: HomeAssistant) -> None:
+    """Perform operations after a backup finishes."""

--- a/script/scaffold/templates/backup/tests/test_backup.py
+++ b/script/scaffold/templates/backup/tests/test_backup.py
@@ -1,0 +1,18 @@
+"""Test the NEW_NAME backup platform."""
+from homeassistant.components.NEW_DOMAIN.backup import (
+    async_post_backup,
+    async_pre_backup,
+)
+from homeassistant.core import HomeAssistant
+
+
+async def test_async_post_backup(hass: HomeAssistant) -> None:
+    """Verify async_post_backup."""
+    # TODO: verify that the async_post_backup function executes as expected
+    assert await async_post_backup(hass)
+
+
+async def test_async_pre_backup(hass: HomeAssistant) -> None:
+    """Verify async_pre_backup."""
+    # TODO: verify that the async_pre_backup function executes as expected
+    assert await async_pre_backup(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds scaffold template to make it easier to start adding backup platforms

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
