### PR TITLE
Remove deprecated YAML configuration from MJPEG Camera

### DIFF
--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -10,13 +10,11 @@ from aiohttp import web
 import async_timeout
 import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-import voluptuous as vol
 
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.components.camera import Camera
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_AUTHENTICATION,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -24,61 +22,14 @@ from homeassistant.const import (
     HTTP_DIGEST_AUTHENTICATION,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web,
     async_get_clientsession,
 )
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, DOMAIN, LOGGER
-
-CONTENT_TYPE_HEADER = "Content-Type"
-
-DEFAULT_NAME = "Mjpeg Camera"
-DEFAULT_VERIFY_SSL = True
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_MJPEG_URL): cv.url,
-        vol.Optional(CONF_STILL_IMAGE_URL): cv.url,
-        vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION): vol.In(
-            [HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]
-        ),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PASSWORD, default=""): cv.string,
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the MJPEG IP camera from platform."""
-    LOGGER.warning(
-        "Configuration of the MJPEG IP Camera platform in YAML is deprecated "
-        "and will be removed in Home Assistant 2022.5; Your existing "
-        "configuration has been imported into the UI automatically and can be "
-        "safely removed from your configuration.yaml file"
-    )
-
-    if discovery_info:
-        config = PLATFORM_SCHEMA(discovery_info)
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/mjpeg/config_flow.py
+++ b/homeassistant/components/mjpeg/config_flow.py
@@ -174,22 +174,6 @@ class MJPEGFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Handle a flow initialized by importing a config."""
-        self._async_abort_entries_match({CONF_MJPEG_URL: config[CONF_MJPEG_URL]})
-        return self.async_create_entry(
-            title=config[CONF_NAME],
-            data={},
-            options={
-                CONF_AUTHENTICATION: config[CONF_AUTHENTICATION],
-                CONF_MJPEG_URL: config[CONF_MJPEG_URL],
-                CONF_PASSWORD: config[CONF_PASSWORD],
-                CONF_STILL_IMAGE_URL: config.get(CONF_STILL_IMAGE_URL),
-                CONF_USERNAME: config.get(CONF_USERNAME),
-                CONF_VERIFY_SSL: config[CONF_VERIFY_SSL],
-            },
-        )
-
 
 class MJPEGOptionsFlowHandler(OptionsFlow):
     """Handle MJPEG IP Camera options."""

--- a/tests/components/mjpeg/test_config_flow.py
+++ b/tests/components/mjpeg/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.components.mjpeg.const import (
     CONF_STILL_IMAGE_URL,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_NAME,
@@ -18,7 +18,6 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION,
-    HTTP_DIGEST_AUTHENTICATION,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -250,70 +249,6 @@ async def test_already_configured(
 
     assert result2.get("type") == RESULT_TYPE_ABORT
     assert result2.get("reason") == "already_configured"
-
-
-async def test_import_flow(
-    hass: HomeAssistant,
-    mock_mjpeg_requests: Mocker,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test the import configuration flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
-            CONF_MJPEG_URL: "http://example.com/mjpeg",
-            CONF_NAME: "Imported Camera",
-            CONF_PASSWORD: "omgpuppies",
-            CONF_STILL_IMAGE_URL: "http://example.com/still",
-            CONF_USERNAME: "frenck",
-            CONF_VERIFY_SSL: False,
-        },
-    )
-
-    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
-    assert result.get("title") == "Imported Camera"
-    assert result.get("data") == {}
-    assert result.get("options") == {
-        CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
-        CONF_MJPEG_URL: "http://example.com/mjpeg",
-        CONF_PASSWORD: "omgpuppies",
-        CONF_STILL_IMAGE_URL: "http://example.com/still",
-        CONF_USERNAME: "frenck",
-        CONF_VERIFY_SSL: False,
-    }
-
-    assert len(mock_setup_entry.mock_calls) == 1
-    assert mock_mjpeg_requests.call_count == 0
-
-
-async def test_import_flow_already_configured(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test the import configuration flow for an already configured entry."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
-            CONF_MJPEG_URL: "https://example.com/mjpeg",
-            CONF_NAME: "Imported Camera",
-            CONF_PASSWORD: "omgpuppies",
-            CONF_STILL_IMAGE_URL: "https://example.com/still",
-            CONF_USERNAME: "frenck",
-            CONF_VERIFY_SSL: False,
-        },
-    )
-
-    assert result.get("type") == RESULT_TYPE_ABORT
-    assert result.get("reason") == "already_configured"
-
-    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_options_flow(

--- a/tests/components/mjpeg/test_init.py
+++ b/tests/components/mjpeg/test_init.py
@@ -1,25 +1,9 @@
 """Tests for the MJPEG IP Camera integration."""
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
-from homeassistant.components.mjpeg.const import (
-    CONF_MJPEG_URL,
-    CONF_STILL_IMAGE_URL,
-    DOMAIN,
-)
+from homeassistant.components.mjpeg.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    CONF_AUTHENTICATION,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_VERIFY_SSL,
-    HTTP_BASIC_AUTHENTICATION,
-)
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -54,46 +38,3 @@ async def test_reload_config_entry(
         init_integration, options={"something": "else"}
     )
     assert len(mock_reload_entry.mock_calls) == 1
-
-
-async def test_import_config(
-    hass: HomeAssistant,
-    mock_mjpeg_requests: MagicMock,
-    mock_setup_entry: AsyncMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test MJPEG IP Camera being set up from config via import."""
-    assert await async_setup_component(
-        hass,
-        CAMERA_DOMAIN,
-        {
-            CAMERA_DOMAIN: {
-                "platform": DOMAIN,
-                CONF_MJPEG_URL: "http://example.com/mjpeg",
-                CONF_NAME: "Random Camera",
-                CONF_PASSWORD: "supersecret",
-                CONF_STILL_IMAGE_URL: "http://example.com/still",
-                CONF_USERNAME: "frenck",
-                CONF_VERIFY_SSL: False,
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(config_entries) == 1
-
-    assert "the MJPEG IP Camera platform in YAML is deprecated" in caplog.text
-
-    entry = config_entries[0]
-    assert entry.title == "Random Camera"
-    assert entry.unique_id is None
-    assert entry.data == {}
-    assert entry.options == {
-        CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
-        CONF_MJPEG_URL: "http://example.com/mjpeg",
-        CONF_PASSWORD: "supersecret",
-        CONF_STILL_IMAGE_URL: "http://example.com/still",
-        CONF_USERNAME: "frenck",
-        CONF_VERIFY_SSL: False,
-    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration of the MJPEG integration has been removed.

MJPEG is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the deprecated YAML importer from the MJPEG integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
