### PR TITLE
Options are required in select selector if custom_value is False

### DIFF
--- a/homeassistant/components/utility_meter/config_flow.py
+++ b/homeassistant/components/utility_meter/config_flow.py
@@ -84,7 +84,7 @@ CONFIG_SCHEMA = vol.Schema(
             }
         ),
         vol.Required(CONF_TARIFFS, default=[]): selector.selector(
-            {"select": {"options": [], "custom_value": True, "multiple": True}}
+            {"select": {"custom_value": True, "multiple": True}}
         ),
         vol.Required(CONF_METER_NET_CONSUMPTION, default=False): selector.selector(
             {"boolean": {}}

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -470,7 +470,7 @@ select_option = vol.All(
 
 
 def has_options_if_no_custom_value(data: Any) -> Any:
-    """Validate that options are provided if custom_value is False."""
+    """Validate that options are included if custom_value is False."""
     if data["custom_value"]:
         return data
     if "options" not in data:

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -381,12 +381,12 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
             (0, None, ["red"]),
         ),
         (
-            {"options": [], "custom_value": True},
+            {"custom_value": True},
             ("red", "cat"),
             (0, None, ["red"]),
         ),
         (
-            {"options": [], "custom_value": True, "multiple": True},
+            {"custom_value": True, "multiple": True},
             (["red"], ["green", "blue"], []),
             (0, None, "red"),
         ),


### PR DESCRIPTION
## Proposed change
As mentioned here: https://github.com/home-assistant/core/pull/68952#discussion_r839609757

It only makes sense to not provide options when `custom_value` is `True`, and I think it's better to require that at least one option is included if `options` is specified. This preserves the original behavior when `custom_value` is `False` but allows options to not be provided when `custom_value` is `True`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22207

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
