### PR TITLE
Mend incorrectly imported MQTT config entries

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -131,10 +131,11 @@ DEFAULT_PROTOCOL = PROTOCOL_311
 DEFAULT_TLS_PROTOCOL = "auto"
 
 DEFAULT_VALUES = {
-    CONF_PORT: DEFAULT_PORT,
-    CONF_WILL_MESSAGE: DEFAULT_WILL,
     CONF_BIRTH_MESSAGE: DEFAULT_BIRTH,
     CONF_DISCOVERY: DEFAULT_DISCOVERY,
+    CONF_PORT: DEFAULT_PORT,
+    CONF_TLS_VERSION: DEFAULT_TLS_PROTOCOL,
+    CONF_WILL_MESSAGE: DEFAULT_WILL,
 }
 
 ATTR_TOPIC_TEMPLATE = "topic_template"
@@ -203,9 +204,7 @@ CONFIG_SCHEMA_BASE = vol.Schema(
             CONF_CLIENT_CERT, "client_key_auth", msg=CLIENT_KEY_AUTH_MSG
         ): cv.isfile,
         vol.Optional(CONF_TLS_INSECURE): cv.boolean,
-        vol.Optional(CONF_TLS_VERSION, default=DEFAULT_TLS_PROTOCOL): vol.Any(
-            "auto", "1.0", "1.1", "1.2"
-        ),
+        vol.Optional(CONF_TLS_VERSION): vol.Any("auto", "1.0", "1.1", "1.2"),
         vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): vol.All(
             cv.string, vol.In([PROTOCOL_31, PROTOCOL_311])
         ),
@@ -219,6 +218,17 @@ CONFIG_SCHEMA_BASE = vol.Schema(
         ): valid_publish_topic,
     }
 )
+
+DEPRECATED_CONFIG_KEYS = [
+    CONF_BIRTH_MESSAGE,
+    CONF_BROKER,
+    CONF_DISCOVERY,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_TLS_VERSION,
+    CONF_USERNAME,
+    CONF_WILL_MESSAGE,
+]
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -602,28 +612,64 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass.data[DATA_MQTT_CONFIG] = conf
 
     if not bool(hass.config_entries.async_entries(DOMAIN)):
+        # Create an import flow if the user has yaml configured entities etc.
+        # but no broker configuration. Note: The intention is not for this to
+        # import broker configuration from YAML because that has been deprecated.
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-                data={},
+                data={"hello": "world"},
             )
         )
     return True
 
 
-def _merge_config(entry, conf):
-    """Merge configuration.yaml config with config entry."""
-    # Base config on default values
-    conf = {**DEFAULT_VALUES, **conf}
+def _merge_basic_config(
+    hass: HomeAssistant, entry: ConfigEntry, yaml_config: dict[str, Any]
+) -> None:
+    """Merge basic options in configuration.yaml config with config entry.
+
+    This mends incomplete migration from old version of HA Core.
+    """
+
+    entry_updated = False
+    entry_config = {**entry.data}
+    for key in DEPRECATED_CONFIG_KEYS:
+        if key in yaml_config and key not in entry_config:
+            entry_config[key] = yaml_config[key]
+            entry_updated = True
+
+    for key, default_value in DEFAULT_VALUES.items():
+        if key not in entry_config:
+            entry_config[key] = default_value
+            entry_updated = True
+
+    if entry_updated:
+        hass.config_entries.async_update_entry(entry, data=entry_config)
+
+
+def _merge_extended_config(entry, conf):
+    """Merge advanced options in configuration.yaml config with config entry."""
     return {**conf, **entry.data}
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Load a config entry."""
-    # If user didn't have configuration.yaml config, generate defaults
+    # Merge basic configuration, and add missing defaults for basic options
+    _merge_basic_config(hass, entry, hass.data.get(DATA_MQTT_CONFIG, {}))
+
+    # Bail out if broker setting is missing
+    if CONF_BROKER not in entry.data:
+        _LOGGER.error("MQTT broker is not configured, please configure it")
+        return False
+
+    # If user doesn't have configuration.yaml config, generate default values
+    # for options not in config entry data
     if (conf := hass.data.get(DATA_MQTT_CONFIG)) is None:
         conf = CONFIG_SCHEMA_BASE(dict(entry.data))
+
+    # User has configuration.yaml config, warn about config entry overrides
     elif any(key in conf for key in entry.data):
         shared_keys = conf.keys() & entry.data.keys()
         override = {k: entry.data[k] for k in shared_keys}
@@ -635,8 +681,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             override,
         )
 
-    # Merge the configuration values from configuration.yaml
-    conf = _merge_config(entry, conf)
+    # Merge advanced configuration values from configuration.yaml
+    conf = _merge_extended_config(entry, conf)
 
     hass.data[DATA_MQTT] = MQTT(
         hass,
@@ -870,7 +916,7 @@ class MQTT:
         if (conf := hass.data.get(DATA_MQTT_CONFIG)) is None:
             conf = CONFIG_SCHEMA_BASE(dict(entry.data))
 
-        self.conf = _merge_config(entry, conf)
+        self.conf = _merge_extended_config(entry, conf)
         await self.async_disconnect()
         self.init_client()
         await self.async_connect()

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -138,6 +138,8 @@ DEFAULT_VALUES = {
     CONF_WILL_MESSAGE: DEFAULT_WILL,
 }
 
+MANDATORY_DEFAULT_VALUES = (CONF_PORT,)
+
 ATTR_TOPIC_TEMPLATE = "topic_template"
 ATTR_PAYLOAD_TEMPLATE = "payload_template"
 
@@ -640,9 +642,9 @@ def _merge_basic_config(
             entry_config[key] = yaml_config[key]
             entry_updated = True
 
-    for key, default_value in DEFAULT_VALUES.items():
+    for key in MANDATORY_DEFAULT_VALUES:
         if key not in entry_config:
-            entry_config[key] = default_value
+            entry_config[key] = DEFAULT_VALUES[key]
             entry_updated = True
 
     if entry_updated:
@@ -651,6 +653,8 @@ def _merge_basic_config(
 
 def _merge_extended_config(entry, conf):
     """Merge advanced options in configuration.yaml config with config entry."""
+    # Add default values
+    conf = {**DEFAULT_VALUES, **conf}
     return {**conf, **entry.data}
 
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -619,7 +619,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-                data={"hello": "world"},
+                data={},
             )
         )
     return True

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1642,10 +1642,6 @@ async def test_update_incomplete_entry(
     assert entry.data == {
         "port": 1234,
         "broker": "yaml_broker",
-        "birth_message": mqtt.DEFAULT_BIRTH,
-        "discovery": True,
-        "tls_version": "auto",
-        "will_message": mqtt.DEFAULT_WILL,
     }
     # Warnings about broker deprecated, but not about other keys with default values
     assert (

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 import homeassistant.core as ha
-from homeassistant.core import CoreState, callback
+from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, template
 from homeassistant.helpers.entity import Entity
@@ -1618,6 +1618,61 @@ async def test_setup_entry_with_config_override(hass, device_reg, mqtt_client_mo
 
     device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
+
+
+async def test_update_incomplete_entry(
+    hass: HomeAssistant, device_reg, mqtt_client_mock, caplog
+):
+    """Test if the MQTT component loads when config entry data is incomplete."""
+    data = (
+        '{ "device":{"identifiers":["0AFFD2"]},'
+        '  "state_topic": "foobar/sensor",'
+        '  "unique_id": "unique" }'
+    )
+
+    # Config entry data is incomplete
+    entry = MockConfigEntry(domain=mqtt.DOMAIN, data={"port": 1234})
+    entry.add_to_hass(hass)
+    # Mqtt present in yaml config
+    config = {"broker": "yaml_broker"}
+    await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
+    await hass.async_block_till_done()
+
+    # Config entry data should now be updated
+    assert entry.data == {
+        "port": 1234,
+        "broker": "yaml_broker",
+        "birth_message": mqtt.DEFAULT_BIRTH,
+        "discovery": True,
+        "tls_version": "auto",
+        "will_message": mqtt.DEFAULT_WILL,
+    }
+    # Warnings about broker deprecated, but not about other keys with default values
+    assert (
+        "The 'broker' option is deprecated, please remove it from your configuration"
+        in caplog.text
+    )
+    assert (
+        "Deprecated configuration settings found in configuration.yaml. These settings "
+        "from your configuration entry will override: {'broker': 'yaml_broker'}"
+        in caplog.text
+    )
+
+    # Discover a device to verify the entry was setup correctly
+    async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
+    await hass.async_block_till_done()
+
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    assert device_entry is not None
+
+
+async def test_fail_no_broker(hass, device_reg, mqtt_client_mock, caplog):
+    """Test if the MQTT component loads when broker configuration is missing."""
+    # Config entry data is incomplete
+    entry = MockConfigEntry(domain=mqtt.DOMAIN, data={})
+    entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    assert "MQTT broker is not configured, please configure it" in caplog.text
 
 
 @pytest.mark.no_fail_on_log_exception


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mend incorrectly imported MQTT config entries

Background:
Starting with Home Assistant 2022.3 we ask users to remove basic MQTT broker configuration from `configuration.yaml`. However, in some cases the data imported from `configuration.yaml` may be incomplete.
This makes sure the config entry data has all the needed keys by importing deprecated configuration keys found in `configuration.yaml` but not in the config entry data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/67792
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
