### PR TITLE
Add AUTO_UPDATE to UpdateEntityFeature

### DIFF
--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -93,7 +93,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(
         SERVICE_SKIP,
         {},
-        UpdateEntity.async_skip.__name__,
+        async_skip,
     )
     websocket_api.async_register_command(hass, websocket_release_notes)
 
@@ -142,6 +142,13 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
         )
 
     await entity.async_install_with_progress(version, backup)
+
+
+async def async_skip(entity: UpdateEntity, service_call: ServiceCall) -> None:
+    """Service call wrapper to validate the call."""
+    if entity.supported_features & UpdateEntityFeature.AUTO_UPDATE:
+        raise HomeAssistantError(f"Skipping update is not supported for {entity.name}")
+    await entity.async_skip()
 
 
 @dataclass

--- a/homeassistant/components/update/const.py
+++ b/homeassistant/components/update/const.py
@@ -15,6 +15,7 @@ class UpdateEntityFeature(IntEnum):
     PROGRESS = 4
     BACKUP = 8
     RELEASE_NOTES = 16
+    AUTO_UPDATE = 32
 
 
 SERVICE_INSTALL: Final = "install"

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -334,6 +334,46 @@ async def test_entity_with_unknown_version(
         )
 
 
+async def test_entity_with_auto_update(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test update entity that has auto update feature."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("update.update_with_auto_update")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_CURRENT_VERSION] == "1.0.0"
+    assert state.attributes[ATTR_LATEST_VERSION] == "1.0.1"
+    assert state.attributes[ATTR_SKIPPED_VERSION] is None
+
+    # Should be able to manually install an update even if it can auto update
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: "update.update_with_auto_update"},
+        blocking=True,
+    )
+
+    # Should not be to skip the update
+    with pytest.raises(
+        HomeAssistantError,
+        match="Skipping update is not supported for Update with auto update",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SKIP,
+            {ATTR_ENTITY_ID: "update.update_with_auto_update"},
+            blocking=True,
+        )
+
+
 async def test_entity_with_specific_version(
     hass: HomeAssistant,
     enable_custom_integrations: None,

--- a/tests/testing_config/custom_components/test/update.py
+++ b/tests/testing_config/custom_components/test/update.py
@@ -135,6 +135,14 @@ def init(empty=False):
                 latest_version="1.0.1",
                 supported_features=UpdateEntityFeature.RELEASE_NOTES,
             ),
+            MockUpdateEntity(
+                name="Update with auto update",
+                unique_id="with_auto_update",
+                current_version="1.0.0",
+                latest_version="1.0.1",
+                supported_features=UpdateEntityFeature.AUTO_UPDATE
+                | UpdateEntityFeature.INSTALL,
+            ),
         ]
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Intended to be used for entities that represent services/devices that have auto-update features.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1261

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
