### PR TITLE
Fix Protexial alarm in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/alarm_control_panel.py
+++ b/homeassistant/components/overkiz/alarm_control_panel.py
@@ -55,15 +55,15 @@ class OverkizAlarmDescription(
     """Class to describe an Overkiz alarm control panel."""
 
     alarm_disarm: str | None = None
-    alarm_disarm_args: OverkizStateType | list[OverkizStateType] | None = None
+    alarm_disarm_args: OverkizStateType | list[OverkizStateType] = []
     alarm_arm_home: str | None = None
-    alarm_arm_home_args: OverkizStateType | list[OverkizStateType] | None = None
+    alarm_arm_home_args: OverkizStateType | list[OverkizStateType] = []
     alarm_arm_night: str | None = None
-    alarm_arm_night_args: OverkizStateType | list[OverkizStateType] | None = None
+    alarm_arm_night_args: OverkizStateType | list[OverkizStateType] = []
     alarm_arm_away: str | None = None
-    alarm_arm_away_args: OverkizStateType | list[OverkizStateType] | None = None
+    alarm_arm_away_args: OverkizStateType | list[OverkizStateType] = []
     alarm_trigger: str | None = None
-    alarm_trigger_args: OverkizStateType | list[OverkizStateType] | None = None
+    alarm_trigger_args: OverkizStateType | list[OverkizStateType] = []
 
 
 MAP_INTERNAL_STATUS_STATE: dict[str, str] = {

--- a/homeassistant/components/overkiz/alarm_control_panel.py
+++ b/homeassistant/components/overkiz/alarm_control_panel.py
@@ -22,6 +22,7 @@ from homeassistant.components.alarm_control_panel.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
@@ -91,23 +92,25 @@ def _state_tsk_alarm_controller(select_state: Callable[[str], OverkizStateType])
     ]
 
 
+MAP_CORE_ACTIVE_ZONES: dict[str, str] = {
+    OverkizCommandParam.A: STATE_ALARM_ARMED_HOME,
+    f"{OverkizCommandParam.A},{OverkizCommandParam.B}": STATE_ALARM_ARMED_NIGHT,
+    f"{OverkizCommandParam.A},{OverkizCommandParam.B},{OverkizCommandParam.C}": STATE_ALARM_ARMED_AWAY,
+}
+
+
 def _state_stateful_alarm_controller(
     select_state: Callable[[str], OverkizStateType]
 ) -> str:
     """Return the state of the device."""
-    if state := cast(list, select_state(OverkizState.CORE_ACTIVE_ZONES)):
-        if [
-            OverkizCommandParam.A,
-            OverkizCommandParam.B,
-            OverkizCommandParam.C,
-        ] in state:
-            return STATE_ALARM_ARMED_AWAY
+    if state := cast(str, select_state(OverkizState.CORE_ACTIVE_ZONES)):
+        # The Stateful Alarm Controller has 3 zones with the following options:
+        # (A, B, C, A,B, B,C, A,C, A,B,C). Since it is not possible to map this to AlarmControlPanel entity,
+        # only the most important zones are mapped, other zones can only be disarmed.
+        if state in MAP_CORE_ACTIVE_ZONES:
+            return MAP_CORE_ACTIVE_ZONES[state]
 
-        if [OverkizCommandParam.A, OverkizCommandParam.B] in state:
-            return STATE_ALARM_ARMED_NIGHT
-
-        if OverkizCommandParam.A in state:
-            return STATE_ALARM_ARMED_HOME
+        return STATE_ALARM_ARMED_CUSTOM_BYPASS
 
     return STATE_ALARM_DISARMED
 
@@ -181,17 +184,13 @@ ALARM_DESCRIPTIONS: list[OverkizAlarmDescription] = [
             SUPPORT_ALARM_ARM_AWAY | SUPPORT_ALARM_ARM_HOME | SUPPORT_ALARM_ARM_NIGHT
         ),
         fn_state=_state_stateful_alarm_controller,
-        alarm_disarm=OverkizCommand.DISARM,
+        alarm_disarm=OverkizCommand.ALARM_OFF,
         alarm_arm_home=OverkizCommand.ALARM_ZONE_ON,
-        alarm_arm_home_args=[OverkizCommandParam.A],
+        alarm_arm_home_args=OverkizCommandParam.A,
         alarm_arm_night=OverkizCommand.ALARM_ZONE_ON,
-        alarm_arm_night_args=[OverkizCommandParam.A, OverkizCommandParam.B],
+        alarm_arm_night_args=f"{OverkizCommandParam.A}, {OverkizCommandParam.B}",
         alarm_arm_away=OverkizCommand.ALARM_ZONE_ON,
-        alarm_arm_away_args=[
-            OverkizCommandParam.A,
-            OverkizCommandParam.B,
-            OverkizCommandParam.C,
-        ],
+        alarm_arm_away_args=f"{OverkizCommandParam.A},{OverkizCommandParam.B},{OverkizCommandParam.C}",
     ),
     # MyFoxAlarmController
     OverkizAlarmDescription(

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -76,12 +76,9 @@ class OverkizExecutor:
         ):
             args = args + (0,)
 
-        if all(arg is None for arg in args):
-            args = ()
-
         exec_id = await self.coordinator.client.execute_command(
             self.device.device_url,
-            Command(command_name, list(args) if args else None),
+            Command(command_name, list(args)),
             "Home Assistant",
         )
 

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -76,9 +76,12 @@ class OverkizExecutor:
         ):
             args = args + (0,)
 
+        if all(arg is None for arg in args):
+            args = ()
+
         exec_id = await self.coordinator.client.execute_command(
             self.device.device_url,
-            Command(command_name, list(args)),
+            Command(command_name, list(args) if args else None),
             "Home Assistant",
         )
 


### PR DESCRIPTION
## Proposed change
The latest beta includes Alarm Control Panel (#67164); however this doesn't work for the Protexial alarm. Working with a user via Discord, I found the culprit and was able to fix this.

Apparently Overkiz expects a string, instead of a list... And for disarm, when `None` is passed in the args, it will make a list with None, and thus commands without parameters will throw an error. Also fixes https://github.com/home-assistant/core/issues/68733.

I am not a huge fan of the current code; thus all feedback is appreciated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
