### PR TITLE
Add active alarm zones as select entity to Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -104,7 +104,6 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     ),
 ]
 
-
 SUPPORTED_STATES = {description.key: description for description in SELECT_DESCRIPTIONS}
 
 
@@ -125,8 +124,6 @@ async def async_setup_entry(
             continue
 
         for state in device.definition.states:
-            print(state.qualified_name)
-
             if description := SUPPORTED_STATES.get(state.qualified_name):
                 entities.append(
                     OverkizSelect(


### PR DESCRIPTION
## Proposed change
Follow up of https://github.com/home-assistant/core/pull/68996. Currently only a few zones are mapped, since the AlarmControlPanel entity doesn't support this. This select entity will allow a user to enable all other zones.
All available options: `(A, B, C, A,B, B,C, A,C, A,B,C)`.

This will still work together with the Alarm Control Panel entity. Zones that are not mapped will be mapped to 'custom bypass'.

**Disarmed:**
<img width="360" alt="Screen Shot 2022-03-31 at 18 25 01" src="https://user-images.githubusercontent.com/1424596/161107443-0957a7dd-9e09-4452-ae18-197f7ab6cd21.png">


**A:**
<img width="361" alt="Screen Shot 2022-03-31 at 18 25 13" src="https://user-images.githubusercontent.com/1424596/161107421-c06d7340-e0e6-4ff2-aad7-ebcecb159bb1.png">


**A,C:**
<img width="399" alt="Screen Shot 2022-03-31 at 18 44 24" src="https://user-images.githubusercontent.com/1424596/161107396-8ab51519-67a4-4423-ad68-0faaaa8c9749.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
