### PR TITLE
Remove deprecated reject_call service from modem_callerid

### DIFF
--- a/homeassistant/components/modem_callerid/const.py
+++ b/homeassistant/components/modem_callerid/const.py
@@ -8,7 +8,6 @@ DATA_KEY_API = "api"
 DEFAULT_NAME = "Phone Modem"
 DOMAIN = "modem_callerid"
 ICON = "mdi:phone-classic"
-SERVICE_REJECT_CALL = "reject_call"
 
 EXCEPTIONS: Final = (
     FileNotFoundError,

--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_DEVICE, EVENT_HOMEASSISTANT_STOP, STATE_IDL
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 
-from .const import CID, DATA_KEY_API, DOMAIN, ICON, SERVICE_REJECT_CALL
+from .const import CID, DATA_KEY_API, DOMAIN, ICON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +42,6 @@ async def async_setup_entry(
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_on_hass_stop)
     )
-
-    platform = entity_platform.async_get_current_platform()
-    platform.async_register_entity_service(SERVICE_REJECT_CALL, {}, "async_reject_call")
 
 
 class ModemCalleridSensor(SensorEntity):
@@ -85,12 +82,3 @@ class ModemCalleridSensor(SensorEntity):
             self._attr_extra_state_attributes[CID.CID_TIME] = self.api.cid_time
         self._attr_native_value = self.api.state
         self.async_write_ha_state()
-
-    async def async_reject_call(self) -> None:
-        """Reject Incoming Call."""
-        _LOGGER.warning(
-            "Calling reject_call service is deprecated and will be removed after 2022.4; "
-            "A new button entity is now available with the same function "
-            "and replaces the existing service"
-        )
-        await self.api.reject_call(self.device)

--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -7,7 +7,7 @@ from phone_modem import PhoneModem
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE, EVENT_HOMEASSISTANT_STOP, STATE_IDLE
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_IDLE
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 
@@ -28,7 +28,6 @@ async def async_setup_entry(
             ModemCalleridSensor(
                 api,
                 entry.title,
-                entry.data[CONF_DEVICE],
                 entry.entry_id,
             )
         ]
@@ -50,11 +49,8 @@ class ModemCalleridSensor(SensorEntity):
     _attr_icon = ICON
     _attr_should_poll = False
 
-    def __init__(
-        self, api: PhoneModem, name: str, device: str, server_unique_id: str
-    ) -> None:
+    def __init__(self, api: PhoneModem, name: str, server_unique_id: str) -> None:
         """Initialize the sensor."""
-        self.device = device
         self.api = api
         self._attr_name = name
         self._attr_unique_id = server_unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated `modem_calledid.reject_call` service, has now been removed.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
