### PR TITLE
Fix network starting with no configured IPv4 addresses

### DIFF
--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -6,11 +6,16 @@ import logging
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import UNDEFINED, ConfigType, UndefinedType
 from homeassistant.loader import bind_hass
 
 from . import util
-from .const import IPV4_BROADCAST_ADDR, PUBLIC_TARGET_IP
+from .const import (
+    IPV4_BROADCAST_ADDR,
+    LOOPBACK_TARGET_IP,
+    MDNS_TARGET_IP,
+    PUBLIC_TARGET_IP,
+)
 from .models import Adapter
 from .network import Network, async_get_network
 
@@ -26,7 +31,7 @@ async def async_get_adapters(hass: HomeAssistant) -> list[Adapter]:
 
 @bind_hass
 async def async_get_source_ip(
-    hass: HomeAssistant, target_ip: str = PUBLIC_TARGET_IP
+    hass: HomeAssistant, target_ip: str | UndefinedType = UNDEFINED
 ) -> str:
     """Get the source ip for a target ip."""
     adapters = await async_get_adapters(hass)
@@ -35,7 +40,15 @@ async def async_get_source_ip(
         if adapter["enabled"] and (ipv4s := adapter["ipv4"]):
             all_ipv4s.extend([ipv4["address"] for ipv4 in ipv4s])
 
-    source_ip = util.async_get_source_ip(target_ip)
+    if target_ip is UNDEFINED:
+        source_ip = (
+            util.async_get_source_ip(PUBLIC_TARGET_IP)
+            or util.async_get_source_ip(MDNS_TARGET_IP)
+            or util.async_get_source_ip(LOOPBACK_TARGET_IP)
+        )
+    else:
+        source_ip = util.async_get_source_ip(target_ip)
+
     if not all_ipv4s:
         _LOGGER.warning(
             "Because the system does not have any enabled IPv4 addresses, source address detection may be inaccurate"

--- a/homeassistant/components/network/const.py
+++ b/homeassistant/components/network/const.py
@@ -17,6 +17,7 @@ ATTR_ADAPTERS: Final = "adapters"
 ATTR_CONFIGURED_ADAPTERS: Final = "configured_adapters"
 DEFAULT_CONFIGURED_ADAPTERS: list[str] = []
 
+LOOPBACK_TARGET_IP: Final = "127.0.0.1"
 MDNS_TARGET_IP: Final = "224.0.0.251"
 PUBLIC_TARGET_IP: Final = "8.8.8.8"
 IPV4_BROADCAST_ADDR: Final = "255.255.255.255"

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -27,6 +27,21 @@ def _mock_socket(sockname):
     return mock_socket
 
 
+def _mock_cond_socket(sockname):
+    class CondMockSock(MagicMock):
+        def connect(self, addr):
+            """Mock connect that stores addr."""
+            self._addr = addr[0]
+
+        def getsockname(self):
+            """Return addr iif it matches the mock sockname."""
+            if self._addr == sockname:
+                return [sockname]
+            raise AttributeError()
+
+    return CondMockSock()
+
+
 def _mock_socket_exception(exc):
     mock_socket = MagicMock()
     mock_socket.getsockname = Mock(side_effect=exc)
@@ -650,3 +665,24 @@ async def test_async_get_source_ip_cannot_be_determined_and_no_enabled_addresses
         await hass.async_block_till_done()
         with pytest.raises(HomeAssistantError):
             await network.async_get_source_ip(hass, MDNS_TARGET_IP)
+
+
+async def test_async_get_source_ip_no_ip_loopback(hass, hass_storage, caplog):
+    """Test getting the source ip address when all adapters are disabled no target is specified."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "key": STORAGE_KEY,
+        "data": {ATTR_CONFIGURED_ADAPTERS: ["eth1"]},
+    }
+
+    with patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=[],
+    ), patch(
+        "homeassistant.components.network.util.socket.socket",
+        return_value=_mock_cond_socket(_LOOPBACK_IPADDR),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+
+        assert await network.async_get_source_ip(hass) == "127.0.0.1"

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -34,7 +34,7 @@ def _mock_cond_socket(sockname):
             self._addr = addr[0]
 
         def getsockname(self):
-            """Return addr iif it matches the mock sockname."""
+            """Return addr if it matches the mock sockname."""
             if self._addr == sockname:
                 return [sockname]
             raise AttributeError()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
A previous fix for a bug that happens when no IPv4 addresses are available on the system added an explicit error when this happens. However, Home Assistant can run just fine in a suitably configured IPv6-only environment, and this error can also happen if homeassistant is started before the system IP configuration has finished. Fix the error by falling back to the loopback address if async_get_source_ip() is called without an explicit target IP argument, as suggested by @bdraco.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61635
- This PR is related to issue: #63416
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
