### PR TITLE
Improve image checks for generic camera

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import contextlib
 from errno import EHOSTUNREACH, EIO
 from functools import partial
-import imghdr
+import io
 import logging
 from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
+import PIL
 from async_timeout import timeout
 import av
 from httpx import HTTPStatusError, RequestError, TimeoutException
@@ -110,9 +111,14 @@ def build_schema(
 
 def get_image_type(image):
     """Get the format of downloaded bytes that could be an image."""
-    fmt = imghdr.what(None, h=image)
+    fmt = None
+    imagefile = io.BytesIO(image)
+    with contextlib.suppress(PIL.UnidentifiedImageError):
+        img = PIL.Image.open(imagefile)
+        fmt = img.format.lower()
+
     if fmt is None:
-        # if imghdr can't figure it out, could be svg.
+        # if PIL can't figure it out, could be svg.
         with contextlib.suppress(UnicodeDecodeError):
             if image.decode("utf-8").lstrip().startswith("<svg"):
                 return "svg+xml"

--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -2,7 +2,7 @@
   "domain": "generic",
   "name": "Generic Camera",
   "config_flow": true,
-  "requirements": ["av==9.0.0"],
+  "requirements": ["av==9.0.0", "pillow==9.0.1"],
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "codeowners": ["@davet2001"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1201,6 +1201,7 @@ pi1wire==0.1.0
 pilight==0.1.1
 
 # homeassistant.components.doods
+# homeassistant.components.generic
 # homeassistant.components.image
 # homeassistant.components.proxy
 # homeassistant.components.qrcode

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -798,6 +798,7 @@ pi1wire==0.1.0
 pilight==0.1.1
 
 # homeassistant.components.doods
+# homeassistant.components.generic
 # homeassistant.components.image
 # homeassistant.components.proxy
 # homeassistant.components.qrcode


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The generic camera config flow now validates images during setup.  This has caused some problems where the still images were not identified correctly causing the user config flow or yaml import to fail, e.g. #69011

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
This PR swaps the [deprecated](https://github.com/home-assistant/core/issues/68939#issuecomment-1085052293) imghdr library for the PIL (pillow) library.  This seems to be more effective at identifying images, and works for all the test cases supplied so far that I've tested.

This PR is to quickly resolve the issue.  I plan to follow up with pytests based on the sample images people have provided.

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69011
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
