### PR TITLE
Prevent HomeKit from offering hidden entities

### DIFF
--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -466,7 +466,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         entity_filter = self.hk_options.get(CONF_FILTER, {})
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
-        all_supported_entities = _async_get_matching_entities(self.hass, domains)
+        all_supported_entities = _async_get_matching_entities(
+            self.hass, domains, include_entity_category=True
+        )
         # In accessory mode we can only have one
         default_value = next(
             iter(
@@ -505,7 +507,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         entity_filter = self.hk_options.get(CONF_FILTER, {})
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
 
-        all_supported_entities = _async_get_matching_entities(self.hass, domains)
+        all_supported_entities = _async_get_matching_entities(
+            self.hass, domains, include_entity_category=True
+        )
         if not entities:
             entities = entity_filter.get(CONF_EXCLUDE_ENTITIES, [])
         # Strip out entities that no longer exist to prevent error in the UI
@@ -559,21 +563,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         all_supported_entities = _async_get_matching_entities(self.hass, domains)
         if not entities:
             entities = entity_filter.get(CONF_EXCLUDE_ENTITIES, [])
-        ent_reg = entity_registry.async_get(self.hass)
-        excluded_entities = set()
-        for entity_id in all_supported_entities:
-            if ent_reg_ent := ent_reg.async_get(entity_id):
-                if (
-                    ent_reg_ent.entity_category is not None
-                    or ent_reg_ent.hidden_by is not None
-                ):
-                    excluded_entities.add(entity_id)
-        # Remove entity category entities since we will exclude them anyways
-        all_supported_entities = {
-            k: v
-            for k, v in all_supported_entities.items()
-            if k not in excluded_entities
-        }
+
         # Strip out entities that no longer exist to prevent error in the UI
         default_value = [
             entity_id for entity_id in entities if entity_id in all_supported_entities
@@ -652,15 +642,36 @@ async def _async_get_supported_devices(hass: HomeAssistant) -> dict[str, str]:
     return dict(sorted(unsorted.items(), key=lambda item: item[1]))
 
 
+def _exclude_by_entity_registry(
+    ent_reg: entity_registry.EntityRegistry,
+    entity_id: str,
+    include_entity_category: bool,
+) -> bool:
+    """Filter out hidden entities and ones with entity category (unless specified)."""
+    return bool(
+        (entry := ent_reg.async_get(entity_id))
+        and (
+            entry.hidden_by is not None
+            or (not include_entity_category or entry.entity_category is not None)
+        )
+    )
+
+
 def _async_get_matching_entities(
-    hass: HomeAssistant, domains: list[str] | None = None
+    hass: HomeAssistant,
+    domains: list[str] | None = None,
+    include_entity_category: bool = False,
 ) -> dict[str, str]:
     """Fetch all entities or entities in the given domains."""
+    ent_reg = entity_registry.async_get(hass)
     return {
         state.entity_id: f"{state.attributes.get(ATTR_FRIENDLY_NAME, state.entity_id)} ({state.entity_id})"
         for state in sorted(
             hass.states.async_all(domains and set(domains)),
             key=lambda item: item.entity_id,
+        )
+        if not _exclude_by_entity_registry(
+            ent_reg, state.entity_id, include_entity_category
         )
     }
 

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1481,3 +1481,81 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
             "include_entities": [],
         },
     }
+
+
+@patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+async def test_options_flow_include_mode_skips_hidden_entities(
+    port_mock, hass, mock_get_source_ip, hk_driver, mock_async_zeroconf, entity_reg
+):
+    """Ensure include mode does not offer hidden entities."""
+    config_entry = _mock_config_entry_with_options_populated()
+    await async_init_entry(hass, config_entry)
+
+    hass.states.async_set("media_player.tv", "off")
+    hass.states.async_set("media_player.sonos", "off")
+    hass.states.async_set("switch.other", "off")
+
+    sonos_hidden_switch: RegistryEntry = entity_reg.async_get_or_create(
+        "switch",
+        "sonos",
+        "config",
+        device_id="1234",
+        hidden_by=RegistryEntryHider.INTEGRATION,
+    )
+    hass.states.async_set(sonos_hidden_switch.entity_id, "off")
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id, context={"show_advanced_options": False}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+    assert result["data_schema"]({}) == {
+        "domains": [
+            "fan",
+            "humidifier",
+            "vacuum",
+            "media_player",
+            "climate",
+            "alarm_control_panel",
+        ],
+        "mode": "bridge",
+        "include_exclude_mode": "exclude",
+    }
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "domains": ["media_player", "switch"],
+            "mode": "bridge",
+            "include_exclude_mode": "include",
+        },
+    )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["step_id"] == "include"
+    assert _get_schema_default(result2["data_schema"].schema, "entities") == []
+
+    # sonos_hidden_switch.entity_id is a hidden entity
+    # so it should not be selectable since it will always be excluded
+    with pytest.raises(voluptuous.error.MultipleInvalid):
+        await hass.config_entries.options.async_configure(
+            result2["flow_id"],
+            user_input={"entities": [sonos_hidden_switch.entity_id]},
+        )
+
+    result4 = await hass.config_entries.options.async_configure(
+        result2["flow_id"],
+        user_input={"entities": ["media_player.tv", "switch.other"]},
+    )
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {
+        "mode": "bridge",
+        "filter": {
+            "exclude_domains": [],
+            "exclude_entities": [],
+            "include_domains": [],
+            "include_entities": ["media_player.tv", "switch.other"],
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent HomeKit from offering hidden entities in the UI

#68552 did it for the exclude path, but it seems like we should do it for the include path as well since its really confusing once you group a few lights and hide the entities but they still show up in HomeKit.  Since there is also an option to unhide it seems like this is the way to go.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
