### PR TITLE
Input binary sensors are not generated for Shelly 1 Pro

### DIFF
--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -265,7 +265,9 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     if device.config.get("switch:0"):
         key = key.replace("input", "switch")
     device_name = get_rpc_device_name(device)
-    entity_name: str | None = device.config[key].get("name", device_name) if key in device.config else None
+    entity_name: str | None = None
+    if key in device.config:
+        entity_name = device.config[key].get("name", device_name)
 
     if entity_name is None:
         return f"{device_name} {key.replace(':', '_')}"

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -265,7 +265,7 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     if device.config.get("switch:0"):
         key = key.replace("input", "switch")
     device_name = get_rpc_device_name(device)
-    entity_name: str | None = device.config[key].get("name", device_name)
+    entity_name: str | None = device.config[key].get("name", device_name) if key in device.config else None
 
     if entity_name is None:
         return f"{device_name} {key.replace(':', '_')}"


### PR DESCRIPTION
## Proposed change

This PR fixes #69045.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
The PR makes sure that the key actually exists in the dictionary before using it to extract the RPC Channel Name.

- This PR fixes or closes issue: fixes #69045
- This PR is related to issue: #65604

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

