### PR TITLE
Fix zwave_js device action logic

### DIFF
--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -241,7 +241,7 @@ async def async_call_action_from_config(
     hass: HomeAssistant, config: dict, variables: dict, context: Context | None
 ) -> None:
     """Execute a device action."""
-    action_type = service = config.pop(CONF_TYPE)
+    action_type = service = config[CONF_TYPE]
     if action_type not in ACTION_TYPES:
         raise HomeAssistantError(f"Unhandled action type {action_type}")
 
@@ -249,10 +249,10 @@ async def async_call_action_from_config(
     service_data = {
         k: v
         for k, v in config.items()
-        if k not in (ATTR_DOMAIN, CONF_SUBTYPE) and v not in (None, "")
+        if k not in (ATTR_DOMAIN, CONF_TYPE, CONF_SUBTYPE) and v not in (None, "")
     }
 
-    # Entity services (including refresh value which is a fake entity service) expects
+    # Entity services (including refresh value which is a fake entity service) expect
     # just an entity ID
     if action_type in (
         SERVICE_REFRESH_VALUE,

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -177,6 +177,15 @@ async def test_actions(
         assert len(args) == 1
         assert args[0].value_id == "13-64-1-mode"
 
+    # Call action a second time to confirm that it works (this was previously a bug)
+    with patch("zwave_js_server.model.node.Node.async_poll_value") as mock_call:
+        hass.bus.async_fire("test_event_refresh_value")
+        await hass.async_block_till_done()
+        mock_call.assert_called_once()
+        args = mock_call.call_args_list[0][0]
+        assert len(args) == 1
+        assert args[0].value_id == "13-64-1-mode"
+
     with patch("zwave_js_server.model.node.Node.async_ping") as mock_call:
         hass.bus.async_fire("test_event_ping")
         await hass.async_block_till_done()
@@ -204,6 +213,51 @@ async def test_actions(
         assert args[0].node_id == 13
         assert args[1] == 1
         assert args[2] == 1
+
+
+async def test_actions_multiple_calls(
+    hass: HomeAssistant,
+    client: Client,
+    climate_radio_thermostat_ct100_plus: Node,
+    integration: ConfigEntry,
+) -> None:
+    """Test actions can be called multiple times and still work."""
+    node = climate_radio_thermostat_ct100_plus
+    device_id = get_device_id(client, node)
+    dev_reg = device_registry.async_get(hass)
+    device = dev_reg.async_get_device({device_id})
+    assert device
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event_refresh_value",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "type": "refresh_value",
+                        "device_id": device.id,
+                        "entity_id": "climate.z_wave_thermostat",
+                    },
+                },
+            ]
+        },
+    )
+
+    # Trigger automation multiple times to confirm that it works each time
+    for _ in range(5):
+        with patch("zwave_js_server.model.node.Node.async_poll_value") as mock_call:
+            hass.bus.async_fire("test_event_refresh_value")
+            await hass.async_block_till_done()
+            mock_call.assert_called_once()
+            args = mock_call.call_args_list[0][0]
+            assert len(args) == 1
+            assert args[0].value_id == "13-64-1-mode"
 
 
 async def test_lock_actions(


### PR DESCRIPTION
## Proposed change
`zwave_js` device actions have a reported behavior of only working once after start. It's because the device action logic pops the `type` key/value from the config `dict`, modifying the stored dictionary representation of the YAML configuration and therefore the logic fails the second time because `type` can't be found and is necessary for the action logic.

I tested before and after this change and this appears to resolve the issue. Also added a test for this exact scenario


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/69038 and fixes https://github.com/home-assistant/core/issues/66645
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
