### PR TITLE
Drop deprecated support for unit_of_measurement from sensor

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-import inspect
 import logging
 from math import floor, log10
 from typing import Any, Final, cast, final
@@ -253,27 +252,6 @@ class SensorEntityDescription(EntityDescription):
     state_class: SensorStateClass | str | None = None
     unit_of_measurement: None = None  # Type override, use native_unit_of_measurement
 
-    def __post_init__(self) -> None:
-        """Post initialisation processing."""
-        if self.unit_of_measurement:
-            caller = inspect.stack()[2]  # type: ignore[unreachable]
-            module = inspect.getmodule(caller[0])
-            if "custom_components" in module.__file__:
-                report_issue = "report it to the custom component author."
-            else:
-                report_issue = (
-                    "create a bug report at "
-                    "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
-                )
-            _LOGGER.warning(
-                "%s is setting 'unit_of_measurement' on an instance of "
-                "SensorEntityDescription, this is not valid and will be unsupported "
-                "from Home Assistant 2021.11. Please %s",
-                module.__name__,
-                report_issue,
-            )
-            self.native_unit_of_measurement = self.unit_of_measurement
-
 
 class SensorEntity(Entity):
     """Base class for sensor entities."""
@@ -386,13 +364,6 @@ class SensorEntity(Entity):
         """Return the unit of measurement of the entity, after unit conversion."""
         if self._sensor_option_unit_of_measurement:
             return self._sensor_option_unit_of_measurement
-
-        # Support for _attr_unit_of_measurement will be removed in Home Assistant 2021.11
-        if (
-            hasattr(self, "_attr_unit_of_measurement")
-            and self._attr_unit_of_measurement is not None
-        ):
-            return self._attr_unit_of_measurement  # type: ignore[unreachable]
 
         native_unit_of_measurement = self.native_unit_of_measurement
 

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 import pytest
 from pytest import approx
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     PRESSURE_HPA,
@@ -114,15 +114,6 @@ async def test_deprecated_last_reset(
 
     state = hass.states.get("sensor.test")
     assert "last_reset" not in state.attributes
-
-
-async def test_deprecated_unit_of_measurement(hass, caplog, enable_custom_integrations):
-    """Test warning on deprecated unit_of_measurement."""
-    SensorEntityDescription("catsensor", unit_of_measurement="cats")
-    assert (
-        "tests.components.sensor.test_init is setting 'unit_of_measurement' on an "
-        "instance of SensorEntityDescription"
-    ) in caplog.text
 
 
 async def test_datetime_conversion(hass, caplog, enable_custom_integrations):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Sensor implementations can no longer set `unit_of_measurement` directly via `SensorEntityDescription` or `SensorEntity._attr_unit_of_measurement`:
 - `unit_of_measurement` is now ignored if set on instances of `SensorEntityDescription`, integrations should instead set `native_unit_of_measurement` (#54867)
 - `SensorEntity._attr_unit_of_measurement` is ignored if set on instances of `SensorEntity`, integrations should instead set `_attr_native_unit_of_measurement` (#55211)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop deprecated support for unit_of_measurement from sensor, this was scheduled for removal in HA Core 2021.11:
 - `unit_of_measurement` is now ignored if set on instances of `SensorEntityDescription`, integrations should instead set `native_unit_of_measurement` (#54867)
 - `SensorEntity._attr_unit_of_measurement` is ignored if set on instances of `SensorEntity`, integrations should instead set `_attr_native_unit_of_measurement` (#55211)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
