### PR TITLE
Remove deprecated temperature conversion of non temperature sensors

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -396,7 +396,10 @@ class SensorEntity(Entity):
 
         native_unit_of_measurement = self.native_unit_of_measurement
 
-        if native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
+        if (
+            self.device_class == DEVICE_CLASS_TEMPERATURE
+            and native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+        ):
             return self.hass.config.units.temperature_unit
 
         return native_unit_of_measurement
@@ -478,37 +481,6 @@ class SensorEntity(Entity):
 
                 # Round to the wanted precision
                 value = round(value_f_new) if prec == 0 else round(value_f_new, prec)
-
-        elif (
-            value is not None
-            and self.device_class != DEVICE_CLASS_TEMPERATURE
-            and native_unit_of_measurement != self.hass.config.units.temperature_unit
-            and native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT)
-        ):
-            units = self.hass.config.units
-            if not self._temperature_conversion_reported:
-                self._temperature_conversion_reported = True
-                report_issue = self._suggest_report_issue()
-                _LOGGER.warning(
-                    "Entity %s (%s) with device_class %s reports a temperature in "
-                    "%s which will be converted to %s. Temperature conversion for "
-                    "entities without correct device_class is deprecated and will"
-                    " be removed from Home Assistant Core 2022.3. Please update "
-                    "your configuration if device_class is manually configured, "
-                    "otherwise %s",
-                    self.entity_id,
-                    type(self),
-                    self.device_class,
-                    native_unit_of_measurement,
-                    units.temperature_unit,
-                    report_issue,
-                )
-            value_s = str(value)
-            prec = len(value_s) - value_s.index(".") - 1 if "." in value_s else 0
-            # Suppress ValueError (Could not convert sensor_value to float)
-            with suppress(ValueError):
-                temp = units.temperature(float(value), native_unit_of_measurement)  # type: ignore[arg-type]
-                value = round(temp) if prec == 0 else round(temp, prec)
 
         return value
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -456,7 +456,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return DEVICE_CLASS_MAP.get(self.unit_of_measurement)
+        return DEVICE_CLASS_MAP.get(self._unit_of_measurement)
 
     @property
     def state_class(self):

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -6,11 +6,16 @@ from typing import cast
 
 import pyvera as veraApi
 
-from homeassistant.components.sensor import ENTITY_ID_FORMAT, SensorEntity
+from homeassistant.components.sensor import (
+    ENTITY_ID_FORMAT,
+    SensorDeviceClass,
+    SensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
+    POWER_WATT,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     Platform,
@@ -60,6 +65,19 @@ class VeraSensor(VeraDevice[veraApi.VeraSensor], SensorEntity):
         return self.current_value
 
     @property
+    def device_class(self) -> str | None:
+        """Return the class of this entity."""
+        if self.vera_device.category == veraApi.CATEGORY_TEMPERATURE_SENSOR:
+            return SensorDeviceClass.TEMPERATURE
+        if self.vera_device.category == veraApi.CATEGORY_LIGHT_SENSOR:
+            return SensorDeviceClass.ILLUMINANCE
+        if self.vera_device.category == veraApi.CATEGORY_HUMIDITY_SENSOR:
+            return SensorDeviceClass.HUMIDITY
+        if self.vera_device.category == veraApi.CATEGORY_POWER_METER:
+            return SensorDeviceClass.POWER
+        return None
+
+    @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of this entity, if any."""
 
@@ -72,7 +90,7 @@ class VeraSensor(VeraDevice[veraApi.VeraSensor], SensorEntity):
         if self.vera_device.category == veraApi.CATEGORY_HUMIDITY_SENSOR:
             return PERCENTAGE
         if self.vera_device.category == veraApi.CATEGORY_POWER_METER:
-            return "watts"
+            return POWER_WATT
         return None
 
     def update(self) -> None:

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -15,7 +15,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
-    POWER_WATT,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     Platform,
@@ -90,7 +89,7 @@ class VeraSensor(VeraDevice[veraApi.VeraSensor], SensorEntity):
         if self.vera_device.category == veraApi.CATEGORY_HUMIDITY_SENSOR:
             return PERCENTAGE
         if self.vera_device.category == veraApi.CATEGORY_POWER_METER:
-            return POWER_WATT
+            return "watts"
         return None
 
     def update(self) -> None:

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -135,7 +135,7 @@ async def test_power_meter_sensor(
         category=pv.CATEGORY_POWER_METER,
         class_property="power",
         assert_states=(("12", "12"), ("13", "13")),
-        assert_unit_of_measurement="watts",
+        assert_unit_of_measurement="W",
     )
 
 

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -135,7 +135,7 @@ async def test_power_meter_sensor(
         category=pv.CATEGORY_POWER_METER,
         class_property="power",
         assert_states=(("12", "12"), ("13", "13")),
-        assert_unit_of_measurement="W",
+        assert_unit_of_measurement="watts",
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Sensors reporting a temperature but not setting device class to `temperature` will no longer have their values converted.
For background, refer to: https://github.com/home-assistant/core/pull/48261

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated temperature conversion of non temperature sensors, this was deprecated by https://github.com/home-assistant/core/pull/48261 and scheduled for removal in Home Assistant Core 2022.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
