### PR TITLE
Add EntityFeature enum to Cover

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
+from enum import IntEnum
 import functools as ft
 import logging
 from typing import Any, final
@@ -79,6 +80,22 @@ DEVICE_CLASS_SHADE = CoverDeviceClass.SHADE.value
 DEVICE_CLASS_SHUTTER = CoverDeviceClass.SHUTTER.value
 DEVICE_CLASS_WINDOW = CoverDeviceClass.WINDOW.value
 
+
+class CoverEntityFeature(IntEnum):
+    """Supported features of the cover entity."""
+
+    OPEN = 1
+    CLOSE = 2
+    SET_POSITION = 4
+    STOP = 8
+    OPEN_TILT = 16
+    CLOSE_TILT = 32
+    STOP_TILT = 64
+    SET_TILT_POSITION = 128
+
+
+# These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
+# Please use the CoverEntityFeature enum instead.
 SUPPORT_OPEN = 1
 SUPPORT_CLOSE = 2
 SUPPORT_SET_POSITION = 4
@@ -109,11 +126,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_OPEN_COVER, {}, "async_open_cover", [SUPPORT_OPEN]
+        SERVICE_OPEN_COVER, {}, "async_open_cover", [CoverEntityFeature.OPEN]
     )
 
     component.async_register_entity_service(
-        SERVICE_CLOSE_COVER, {}, "async_close_cover", [SUPPORT_CLOSE]
+        SERVICE_CLOSE_COVER, {}, "async_close_cover", [CoverEntityFeature.CLOSE]
     )
 
     component.async_register_entity_service(
@@ -124,27 +141,39 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
         },
         "async_set_cover_position",
-        [SUPPORT_SET_POSITION],
+        [CoverEntityFeature.SET_POSITION],
     )
 
     component.async_register_entity_service(
-        SERVICE_STOP_COVER, {}, "async_stop_cover", [SUPPORT_STOP]
+        SERVICE_STOP_COVER, {}, "async_stop_cover", [CoverEntityFeature.STOP]
     )
 
     component.async_register_entity_service(
-        SERVICE_TOGGLE, {}, "async_toggle", [SUPPORT_OPEN | SUPPORT_CLOSE]
+        SERVICE_TOGGLE,
+        {},
+        "async_toggle",
+        [CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE],
     )
 
     component.async_register_entity_service(
-        SERVICE_OPEN_COVER_TILT, {}, "async_open_cover_tilt", [SUPPORT_OPEN_TILT]
+        SERVICE_OPEN_COVER_TILT,
+        {},
+        "async_open_cover_tilt",
+        [CoverEntityFeature.OPEN_TILT],
     )
 
     component.async_register_entity_service(
-        SERVICE_CLOSE_COVER_TILT, {}, "async_close_cover_tilt", [SUPPORT_CLOSE_TILT]
+        SERVICE_CLOSE_COVER_TILT,
+        {},
+        "async_close_cover_tilt",
+        [CoverEntityFeature.CLOSE_TILT],
     )
 
     component.async_register_entity_service(
-        SERVICE_STOP_COVER_TILT, {}, "async_stop_cover_tilt", [SUPPORT_STOP_TILT]
+        SERVICE_STOP_COVER_TILT,
+        {},
+        "async_stop_cover_tilt",
+        [CoverEntityFeature.STOP_TILT],
     )
 
     component.async_register_entity_service(
@@ -155,14 +184,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
         },
         "async_set_cover_tilt_position",
-        [SUPPORT_SET_TILT_POSITION],
+        [CoverEntityFeature.SET_TILT_POSITION],
     )
 
     component.async_register_entity_service(
         SERVICE_TOGGLE_COVER_TILT,
         {},
         "async_toggle_tilt",
-        [SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT],
+        [CoverEntityFeature.OPEN_TILT | CoverEntityFeature.CLOSE_TILT],
     )
 
     return True
@@ -262,17 +291,19 @@ class CoverEntity(Entity):
         if self._attr_supported_features is not None:
             return self._attr_supported_features
 
-        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+        supported_features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+        )
 
         if self.current_cover_position is not None:
-            supported_features |= SUPPORT_SET_POSITION
+            supported_features |= CoverEntityFeature.SET_POSITION
 
         if self.current_cover_tilt_position is not None:
             supported_features |= (
-                SUPPORT_OPEN_TILT
-                | SUPPORT_CLOSE_TILT
-                | SUPPORT_STOP_TILT
-                | SUPPORT_SET_TILT_POSITION
+                CoverEntityFeature.OPEN_TILT
+                | CoverEntityFeature.CLOSE_TILT
+                | CoverEntityFeature.STOP_TILT
+                | CoverEntityFeature.SET_TILT_POSITION
             )
 
         return supported_features
@@ -395,7 +426,7 @@ class CoverEntity(Entity):
             await self.async_close_cover_tilt(**kwargs)
 
     def _get_toggle_function(self, fns):
-        if SUPPORT_STOP | self.supported_features and (
+        if CoverEntityFeature.STOP | self.supported_features and (
             self.is_closing or self.is_opening
         ):
             return fns["stop"]

--- a/homeassistant/components/demo/cover.py
+++ b/homeassistant/components/demo/cover.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
-    SUPPORT_CLOSE,
-    SUPPORT_CLOSE_TILT,
-    SUPPORT_OPEN,
-    SUPPORT_OPEN_TILT,
-    SUPPORT_SET_TILT_POSITION,
-    SUPPORT_STOP_TILT,
     CoverDeviceClass,
     CoverEntity,
+    CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -40,7 +35,7 @@ async def async_setup_platform(
                 "cover_4",
                 "Garage Door",
                 device_class=CoverDeviceClass.GARAGE,
-                supported_features=(SUPPORT_OPEN | SUPPORT_CLOSE),
+                supported_features=(CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE),
             ),
             DemoCover(
                 hass,
@@ -48,10 +43,10 @@ async def async_setup_platform(
                 "Pergola Roof",
                 tilt_position=60,
                 supported_features=(
-                    SUPPORT_OPEN_TILT
-                    | SUPPORT_STOP_TILT
-                    | SUPPORT_CLOSE_TILT
-                    | SUPPORT_SET_TILT_POSITION
+                    CoverEntityFeature.OPEN_TILT
+                    | CoverEntityFeature.STOP_TILT
+                    | CoverEntityFeature.CLOSE_TILT
+                    | CoverEntityFeature.SET_TILT_POSITION
                 ),
             ),
         ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**Developers only**: The use of the following constants has been deprecated:

- `SUPPORT_OPEN`
- `SUPPORT_CLOSE`
- `SUPPORT_SET_POSITION`
- `SUPPORT_STOP`
- `SUPPORT_OPEN_TILT`
- `SUPPORT_CLOSE_TILT`
- `SUPPORT_STOP_TILT`
- `SUPPORT_SET_TILT_POSITION`

Use the new `CoverEntityFeature` IntEnum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces the `CoverEntityFeature`, containing all the supported feature flags of a Cover.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1268

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
