### PR TITLE
Add EntityFeature enum to Humidifier

### DIFF
--- a/homeassistant/components/demo/humidifier.py
+++ b/homeassistant/components/demo/humidifier.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.components.humidifier import HumidifierDeviceClass, HumidifierEntity
-from homeassistant.components.humidifier.const import SUPPORT_MODES
+from homeassistant.components.humidifier.const import HumidifierEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -71,7 +71,7 @@ class DemoHumidifier(HumidifierEntity):
         self._attr_supported_features = SUPPORT_FLAGS
         if mode is not None:
             self._attr_supported_features = (
-                self._attr_supported_features | SUPPORT_MODES
+                self._attr_supported_features | HumidifierEntityFeature.MODES
             )
         self._attr_target_humidity = target_humidity
         self._attr_mode = mode

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -41,6 +41,7 @@ from .const import (  # noqa: F401
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
     SUPPORT_MODES,
+    HumidifierEntityFeature,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_SET_MODE,
         {vol.Required(ATTR_MODE): cv.string},
         "async_set_mode",
-        [SUPPORT_MODES],
+        [HumidifierEntityFeature.MODES],
     )
     component.async_register_entity_service(
         SERVICE_SET_HUMIDITY,
@@ -142,7 +143,7 @@ class HumidifierEntity(ToggleEntity):
             ATTR_MAX_HUMIDITY: self.max_humidity,
         }
 
-        if supported_features & SUPPORT_MODES:
+        if supported_features & HumidifierEntityFeature.MODES:
             data[ATTR_AVAILABLE_MODES] = self.available_modes
 
         return data
@@ -166,7 +167,7 @@ class HumidifierEntity(ToggleEntity):
         if self.target_humidity is not None:
             data[ATTR_HUMIDITY] = self.target_humidity
 
-        if supported_features & SUPPORT_MODES:
+        if supported_features & HumidifierEntityFeature.MODES:
             data[ATTR_MODE] = self.mode
 
         return data
@@ -180,7 +181,7 @@ class HumidifierEntity(ToggleEntity):
     def mode(self) -> str | None:
         """Return the current mode, e.g., home, auto, baby.
 
-        Requires SUPPORT_MODES.
+        Requires HumidifierEntityFeature.MODES.
         """
         return self._attr_mode
 
@@ -188,7 +189,7 @@ class HumidifierEntity(ToggleEntity):
     def available_modes(self) -> list[str] | None:
         """Return a list of available modes.
 
-        Requires SUPPORT_MODES.
+        Requires HumidifierEntityFeature.MODES.
         """
         return self._attr_available_modes
 

--- a/homeassistant/components/humidifier/const.py
+++ b/homeassistant/components/humidifier/const.py
@@ -1,4 +1,6 @@
 """Provides the constants needed for component."""
+from enum import IntEnum
+
 MODE_NORMAL = "normal"
 MODE_ECO = "eco"
 MODE_AWAY = "away"
@@ -27,4 +29,13 @@ DEVICE_CLASS_DEHUMIDIFIER = "dehumidifier"
 SERVICE_SET_MODE = "set_mode"
 SERVICE_SET_HUMIDITY = "set_humidity"
 
+
+class HumidifierEntityFeature(IntEnum):
+    """Supported features of the alarm control panel entity."""
+
+    MODES = 1
+
+
+# The SUPPORT_MODES constant is deprecated as of Home Assistant 2022.5.
+# Please use the HumidifierEntityFeature enum instead.
 SUPPORT_MODES = 1

--- a/homeassistant/components/humidifier/device_action.py
+++ b/homeassistant/components/humidifier/device_action.py
@@ -66,7 +66,7 @@ async def async_get_actions(
         }
         actions.append({**base_action, CONF_TYPE: "set_humidity"})
 
-        if supported_features & const.SUPPORT_MODES:
+        if supported_features & const.HumidifierEntityFeature.MODES:
             actions.append({**base_action, CONF_TYPE: "set_mode"})
 
     return actions

--- a/homeassistant/components/humidifier/device_condition.py
+++ b/homeassistant/components/humidifier/device_condition.py
@@ -51,7 +51,7 @@ async def async_get_conditions(
 
         supported_features = get_supported_features(hass, entry.entity_id)
 
-        if supported_features & const.SUPPORT_MODES:
+        if supported_features & const.HumidifierEntityFeature.MODES:
             conditions.append(
                 {
                     CONF_CONDITION: "device",

--- a/homeassistant/components/humidifier/intent.py
+++ b/homeassistant/components/humidifier/intent.py
@@ -13,7 +13,7 @@ from . import (
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
     SERVICE_TURN_ON,
-    SUPPORT_MODES,
+    HumidifierEntityFeature,
 )
 
 INTENT_HUMIDITY = "HassHumidifierSetpoint"
@@ -90,7 +90,7 @@ class SetModeHandler(intent.IntentHandler):
 
         service_data = {ATTR_ENTITY_ID: state.entity_id}
 
-        intent.async_test_feature(state, SUPPORT_MODES, "modes")
+        intent.async_test_feature(state, HumidifierEntityFeature.MODES, "modes")
         mode = slots["mode"]["value"]
 
         if mode not in state.attributes.get(ATTR_AVAILABLE_MODES, []):

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -36,9 +36,9 @@ def entity_reg(hass):
     "set_state,features_reg,features_state,expected_action_types",
     [
         (False, 0, 0, []),
-        (False, const.SUPPORT_MODES, 0, ["set_mode"]),
+        (False, const.HumidifierEntityFeature.MODES, 0, ["set_mode"]),
         (True, 0, 0, []),
-        (True, 0, const.SUPPORT_MODES, ["set_mode"]),
+        (True, 0, const.HumidifierEntityFeature.MODES, ["set_mode"]),
     ],
 )
 async def test_get_actions(

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -42,9 +42,9 @@ def calls(hass):
     "set_state,features_reg,features_state,expected_condition_types",
     [
         (False, 0, 0, []),
-        (False, const.SUPPORT_MODES, 0, ["is_mode"]),
+        (False, const.HumidifierEntityFeature.MODES, 0, ["is_mode"]),
         (True, 0, 0, []),
-        (True, 0, const.SUPPORT_MODES, ["is_mode"]),
+        (True, 0, const.HumidifierEntityFeature.MODES, ["is_mode"]),
     ],
 )
 async def test_get_conditions(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**Developers only**: The use of the following constants has been deprecated:

- `SUPPORT_MODES`

Use the new `HumidifierEntityFeature` IntEnum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces the `HumidifierEntityFeature`, containing all the supported feature flags of a Humidifier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1270

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
