### PR TITLE
Add missing typing to Airzone tests

### DIFF
--- a/tests/components/airzone/test_binary_sensor.py
+++ b/tests/components/airzone/test_binary_sensor.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from .util import async_init_integration
 
 
-async def test_airzone_create_binary_sensors(hass: HomeAssistant):
+async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
     """Test creation of binary sensors."""
 
     await async_init_integration(hass)

--- a/tests/components/airzone/test_binary_sensor.py
+++ b/tests/components/airzone/test_binary_sensor.py
@@ -1,11 +1,12 @@
 """The sensor tests for the Airzone platform."""
 
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
 
 
-async def test_airzone_create_binary_sensors(hass):
+async def test_airzone_create_binary_sensors(hass: HomeAssistant):
     """Test creation of binary sensors."""
 
     await async_init_integration(hass)

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -37,12 +37,13 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .util import async_init_integration
 
 
-async def test_airzone_create_climates(hass):
+async def test_airzone_create_climates(hass: HomeAssistant):
     """Test creation of climates."""
 
     await async_init_integration(hass)
@@ -133,7 +134,7 @@ async def test_airzone_create_climates(hass):
     assert state.attributes.get(ATTR_TEMPERATURE) == 19.1
 
 
-async def test_airzone_climate_set_hvac_mode(hass):
+async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant):
     """Test setting the HVAC mode."""
 
     await async_init_integration(hass)
@@ -192,7 +193,7 @@ async def test_airzone_climate_set_hvac_mode(hass):
     assert state.state == HVAC_MODE_OFF
 
 
-async def test_airzone_climate_set_hvac_slave_error(hass):
+async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant):
     """Test setting the HVAC mode for a slave zone."""
 
     HVAC_MOCK = {
@@ -225,7 +226,7 @@ async def test_airzone_climate_set_hvac_slave_error(hass):
     assert state.state == HVAC_MODE_OFF
 
 
-async def test_airzone_climate_set_temp(hass):
+async def test_airzone_climate_set_temp(hass: HomeAssistant):
     """Test setting the target temperature."""
 
     HVAC_MOCK = {
@@ -258,7 +259,7 @@ async def test_airzone_climate_set_temp(hass):
     assert state.attributes.get(ATTR_TEMPERATURE) == 20.5
 
 
-async def test_airzone_climate_set_temp_error(hass):
+async def test_airzone_climate_set_temp_error(hass: HomeAssistant):
     """Test error when setting the target temperature."""
 
     await async_init_integration(hass)

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -43,7 +43,7 @@ from homeassistant.exceptions import HomeAssistantError
 from .util import async_init_integration
 
 
-async def test_airzone_create_climates(hass: HomeAssistant):
+async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     """Test creation of climates."""
 
     await async_init_integration(hass)
@@ -134,7 +134,7 @@ async def test_airzone_create_climates(hass: HomeAssistant):
     assert state.attributes.get(ATTR_TEMPERATURE) == 19.1
 
 
-async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant):
+async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
     """Test setting the HVAC mode."""
 
     await async_init_integration(hass)
@@ -193,7 +193,7 @@ async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant):
     assert state.state == HVAC_MODE_OFF
 
 
-async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant):
+async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant) -> None:
     """Test setting the HVAC mode for a slave zone."""
 
     HVAC_MOCK = {
@@ -226,7 +226,7 @@ async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant):
     assert state.state == HVAC_MODE_OFF
 
 
-async def test_airzone_climate_set_temp(hass: HomeAssistant):
+async def test_airzone_climate_set_temp(hass: HomeAssistant) -> None:
     """Test setting the target temperature."""
 
     HVAC_MOCK = {
@@ -259,7 +259,7 @@ async def test_airzone_climate_set_temp(hass: HomeAssistant):
     assert state.attributes.get(ATTR_TEMPERATURE) == 20.5
 
 
-async def test_airzone_climate_set_temp_error(hass: HomeAssistant):
+async def test_airzone_climate_set_temp_error(hass: HomeAssistant) -> None:
     """Test error when setting the target temperature."""
 
     await async_init_integration(hass)

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -8,13 +8,14 @@ from homeassistant import data_entry_flow
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from .util import CONFIG, HVAC_MOCK
 
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant):
     """Test that the form is served with valid input."""
 
     with patch(
@@ -56,7 +57,7 @@ async def test_form(hass):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_duplicated_id(hass):
+async def test_form_duplicated_id(hass: HomeAssistant):
     """Test setting up duplicated entry."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=CONFIG)
@@ -74,7 +75,7 @@ async def test_form_duplicated_id(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_connection_error(hass):
+async def test_connection_error(hass: HomeAssistant):
     """Test connection to host error."""
 
     with patch(

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -15,7 +15,7 @@ from .util import CONFIG, HVAC_MOCK
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant):
+async def test_form(hass: HomeAssistant) -> None:
     """Test that the form is served with valid input."""
 
     with patch(
@@ -57,7 +57,7 @@ async def test_form(hass: HomeAssistant):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_duplicated_id(hass: HomeAssistant):
+async def test_form_duplicated_id(hass: HomeAssistant) -> None:
     """Test setting up duplicated entry."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=CONFIG)

--- a/tests/components/airzone/test_coordinator.py
+++ b/tests/components/airzone/test_coordinator.py
@@ -15,7 +15,7 @@ from .util import CONFIG, HVAC_MOCK
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_coordinator_client_connector_error(hass: HomeAssistant):
+async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
     """Test ClientConnectorError on coordinator update."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=CONFIG)

--- a/tests/components/airzone/test_init.py
+++ b/tests/components/airzone/test_init.py
@@ -4,13 +4,14 @@ from unittest.mock import patch
 
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from .util import CONFIG, HVAC_MOCK
 
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant):
     """Test unload."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/airzone/test_init.py
+++ b/tests/components/airzone/test_init.py
@@ -11,7 +11,7 @@ from .util import CONFIG, HVAC_MOCK
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass: HomeAssistant):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unload."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -1,9 +1,11 @@
 """The sensor tests for the Airzone platform."""
 
+from homeassistant.core import HomeAssistant
+
 from .util import async_init_integration
 
 
-async def test_airzone_create_sensors(hass):
+async def test_airzone_create_sensors(hass: HomeAssistant):
     """Test creation of sensors."""
 
     await async_init_integration(hass)

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from .util import async_init_integration
 
 
-async def test_airzone_create_sensors(hass: HomeAssistant):
+async def test_airzone_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of sensors."""
 
     await async_init_integration(hass)

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -150,7 +150,7 @@ HVAC_MOCK = {
 
 async def async_init_integration(
     hass: HomeAssistant,
-):
+) -> None:
     """Set up the Airzone integration in Home Assistant."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=CONFIG)


### PR DESCRIPTION
## Proposed change
Add missing hass typing to Airzone tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
