### PR TITLE
Add EntityFeature enum to Light

### DIFF
--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -16,8 +16,8 @@ from homeassistant.components.light import (
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
     COLOR_MODE_WHITE,
-    SUPPORT_EFFECT,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -149,7 +149,7 @@ class DemoLight(LightEntity):
             supported_color_modes = SUPPORT_DEMO
         self._color_modes = supported_color_modes
         if self._effect_list is not None:
-            self._features |= SUPPORT_EFFECT
+            self._features |= LightEntityFeature.EFFECT
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 import csv
 import dataclasses
 from datetime import timedelta
+from enum import IntEnum
 import logging
 import os
 from typing import cast, final
@@ -40,7 +41,17 @@ DATA_PROFILES = "light_profiles"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
-# Bitfield of features supported by the light entity
+
+class LightEntityFeature(IntEnum):
+    """Supported features of the light entity."""
+
+    EFFECT = 4
+    FLASH = 8
+    TRANSITION = 32
+
+
+# These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
+# Please use the CoverEntityFeature enum instead.
 SUPPORT_BRIGHTNESS = 1  # Deprecated, replaced by color modes
 SUPPORT_COLOR_TEMP = 2  # Deprecated, replaced by color modes
 SUPPORT_EFFECT = 4
@@ -274,9 +285,9 @@ def filter_turn_off_params(light, params):
     """Filter out params not used in turn off or not supported by the light."""
     supported_features = light.supported_features
 
-    if not supported_features & SUPPORT_FLASH:
+    if not supported_features & LightEntityFeature.FLASH:
         params.pop(ATTR_FLASH, None)
-    if not supported_features & SUPPORT_TRANSITION:
+    if not supported_features & LightEntityFeature.TRANSITION:
         params.pop(ATTR_TRANSITION, None)
 
     return {k: v for k, v in params.items() if k in (ATTR_TRANSITION, ATTR_FLASH)}
@@ -286,11 +297,11 @@ def filter_turn_on_params(light, params):
     """Filter out params not supported by the light."""
     supported_features = light.supported_features
 
-    if not supported_features & SUPPORT_EFFECT:
+    if not supported_features & LightEntityFeature.EFFECT:
         params.pop(ATTR_EFFECT, None)
-    if not supported_features & SUPPORT_FLASH:
+    if not supported_features & LightEntityFeature.FLASH:
         params.pop(ATTR_FLASH, None)
-    if not supported_features & SUPPORT_TRANSITION:
+    if not supported_features & LightEntityFeature.TRANSITION:
         params.pop(ATTR_TRANSITION, None)
     if not supported_features & SUPPORT_WHITE_VALUE:
         params.pop(ATTR_WHITE_VALUE, None)
@@ -831,7 +842,7 @@ class LightEntity(ToggleEntity):
             data[ATTR_MIN_MIREDS] = self.min_mireds
             data[ATTR_MAX_MIREDS] = self.max_mireds
 
-        if supported_features & SUPPORT_EFFECT:
+        if supported_features & LightEntityFeature.EFFECT:
             data[ATTR_EFFECT_LIST] = self.effect_list
 
         data[ATTR_SUPPORTED_COLOR_MODES] = sorted(supported_color_modes)
@@ -927,7 +938,7 @@ class LightEntity(ToggleEntity):
             if self.hs_color is not None:
                 data.update(self._light_internal_convert_color(COLOR_MODE_HS))
 
-        if supported_features & SUPPORT_EFFECT:
+        if supported_features & LightEntityFeature.EFFECT:
             data[ATTR_EFFECT] = self.effect
 
         return {key: val for key, val in data.items() if val is not None}

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -51,7 +51,7 @@ class LightEntityFeature(IntEnum):
 
 
 # These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
-# Please use the CoverEntityFeature enum instead.
+# Please use the LightEntityFeature enum instead.
 SUPPORT_BRIGHTNESS = 1  # Deprecated, replaced by color modes
 SUPPORT_COLOR_TEMP = 2  # Deprecated, replaced by color modes
 SUPPORT_EFFECT = 4

--- a/homeassistant/components/light/device_action.py
+++ b/homeassistant/components/light/device_action.py
@@ -24,9 +24,9 @@ from . import (
     ATTR_FLASH,
     DOMAIN,
     FLASH_SHORT,
-    SUPPORT_FLASH,
     VALID_BRIGHTNESS_PCT,
     VALID_FLASH,
+    LightEntityFeature,
     brightness_supported,
     get_supported_color_modes,
 )
@@ -116,7 +116,7 @@ async def async_get_actions(
                 )
             )
 
-        if supported_features & SUPPORT_FLASH:
+        if supported_features & LightEntityFeature.FLASH:
             actions.append({**base_action, CONF_TYPE: TYPE_FLASH})
 
     return actions
@@ -144,7 +144,7 @@ async def async_get_action_capabilities(
     if brightness_supported(supported_color_modes):
         extra_fields[vol.Optional(ATTR_BRIGHTNESS_PCT)] = VALID_BRIGHTNESS_PCT
 
-    if supported_features & SUPPORT_FLASH:
+    if supported_features & LightEntityFeature.FLASH:
         extra_fields[vol.Optional(ATTR_FLASH)] = VALID_FLASH
 
     return {"extra_fields": vol.Schema(extra_fields)} if extra_fields else {}

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -9,7 +9,7 @@ from homeassistant.components.light import (
     DOMAIN,
     FLASH_LONG,
     FLASH_SHORT,
-    SUPPORT_FLASH,
+    LightEntityFeature,
 )
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
@@ -57,7 +57,7 @@ async def test_get_actions(hass, device_reg, entity_reg):
         "test",
         "5678",
         device_id=device_entry.id,
-        supported_features=SUPPORT_FLASH,
+        supported_features=LightEntityFeature.FLASH,
         capabilities={"supported_color_modes": ["brightness"]},
     )
     expected_actions = [
@@ -196,7 +196,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
         (
             False,
             {"turn_on", "toggle", "turn_off", "flash"},
-            SUPPORT_FLASH,
+            LightEntityFeature.FLASH,
             0,
             None,
             {},
@@ -215,7 +215,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
             True,
             {"turn_on", "toggle", "turn_off", "flash"},
             0,
-            SUPPORT_FLASH,
+            LightEntityFeature.FLASH,
             None,
             {},
             {

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -120,14 +120,16 @@ async def test_services(hass, mock_light_profiles, enable_custom_integrations):
     ent1, ent2, ent3 = platform.ENTITIES
     ent1.supported_color_modes = [light.COLOR_MODE_HS]
     ent3.supported_color_modes = [light.COLOR_MODE_HS]
-    ent1.supported_features = light.SUPPORT_TRANSITION
+    ent1.supported_features = light.LightEntityFeature.TRANSITION
     ent2.supported_features = (
         light.SUPPORT_COLOR
-        | light.SUPPORT_EFFECT
-        | light.SUPPORT_TRANSITION
+        | light.LightEntityFeature.EFFECT
+        | light.LightEntityFeature.TRANSITION
         | light.SUPPORT_WHITE_VALUE
     )
-    ent3.supported_features = light.SUPPORT_FLASH | light.SUPPORT_TRANSITION
+    ent3.supported_features = (
+        light.LightEntityFeature.FLASH | light.LightEntityFeature.TRANSITION
+    )
 
     # Test init
     assert light.is_on(hass, ent1.entity_id)
@@ -539,7 +541,7 @@ async def test_light_profiles(
 
     ent1, _, _ = platform.ENTITIES
     ent1.supported_color_modes = [light.COLOR_MODE_HS]
-    ent1.supported_features = light.SUPPORT_TRANSITION
+    ent1.supported_features = light.LightEntityFeature.TRANSITION
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -576,7 +578,7 @@ async def test_default_profiles_group(
 
     ent, _, _ = platform.ENTITIES
     ent.supported_color_modes = [light.COLOR_MODE_HS]
-    ent.supported_features = light.SUPPORT_TRANSITION
+    ent.supported_features = light.LightEntityFeature.TRANSITION
     await hass.services.async_call(
         light.DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ent.entity_id}, blocking=True
     )
@@ -683,7 +685,7 @@ async def test_default_profiles_light(
 
     dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES))
     dev.supported_color_modes = [light.COLOR_MODE_HS]
-    dev.supported_features = light.SUPPORT_TRANSITION
+    dev.supported_features = light.LightEntityFeature.TRANSITION
     await hass.services.async_call(
         light.DOMAIN,
         SERVICE_TURN_ON,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**Developers only**: The use of the following constants has been deprecated:

- `SUPPORT_EFFECT`
- `SUPPORT_FLASH`
- `SUPPORT_TRANSITION`

Use the new `LightEntityFeature` IntEnum instead.

Note that the following constants were already deprecated, thus `LightEntityFeature` does not provide a replacement for those.

- `SUPPORT_BRIGHTNESS`
- `SUPPORT_COLOR_TEMP`
- `SUPPORT_COLOR`
- `SUPPORT_WHITE_VALUE`

These cases should instead be migrated to the new color modes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces the `FanEntityFeature`, containing all the supported feature flags of a Fan.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1272

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
