### PR TITLE
Add EntityFeature enum to Vacuum

### DIFF
--- a/homeassistant/components/demo/vacuum.py
+++ b/homeassistant/components/demo/vacuum.py
@@ -8,21 +8,9 @@ from homeassistant.components.vacuum import (
     STATE_IDLE,
     STATE_PAUSED,
     STATE_RETURNING,
-    SUPPORT_BATTERY,
-    SUPPORT_CLEAN_SPOT,
-    SUPPORT_FAN_SPEED,
-    SUPPORT_LOCATE,
-    SUPPORT_PAUSE,
-    SUPPORT_RETURN_HOME,
-    SUPPORT_SEND_COMMAND,
-    SUPPORT_START,
-    SUPPORT_STATE,
-    SUPPORT_STATUS,
-    SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
     StateVacuumEntity,
     VacuumEntity,
+    VacuumEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -30,44 +18,47 @@ from homeassistant.helpers import event
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-SUPPORT_MINIMAL_SERVICES = SUPPORT_TURN_ON | SUPPORT_TURN_OFF
+SUPPORT_MINIMAL_SERVICES = VacuumEntityFeature.TURN_ON | VacuumEntityFeature.TURN_OFF
 
 SUPPORT_BASIC_SERVICES = (
-    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_STATUS | SUPPORT_BATTERY
+    VacuumEntityFeature.TURN_ON
+    | VacuumEntityFeature.TURN_OFF
+    | VacuumEntityFeature.STATUS
+    | VacuumEntityFeature.BATTERY
 )
 
 SUPPORT_MOST_SERVICES = (
-    SUPPORT_TURN_ON
-    | SUPPORT_TURN_OFF
-    | SUPPORT_STOP
-    | SUPPORT_RETURN_HOME
-    | SUPPORT_STATUS
-    | SUPPORT_BATTERY
+    VacuumEntityFeature.TURN_ON
+    | VacuumEntityFeature.TURN_OFF
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.STATUS
+    | VacuumEntityFeature.BATTERY
 )
 
 SUPPORT_ALL_SERVICES = (
-    SUPPORT_TURN_ON
-    | SUPPORT_TURN_OFF
-    | SUPPORT_PAUSE
-    | SUPPORT_STOP
-    | SUPPORT_RETURN_HOME
-    | SUPPORT_FAN_SPEED
-    | SUPPORT_SEND_COMMAND
-    | SUPPORT_LOCATE
-    | SUPPORT_STATUS
-    | SUPPORT_BATTERY
-    | SUPPORT_CLEAN_SPOT
+    VacuumEntityFeature.TURN_ON
+    | VacuumEntityFeature.TURN_OFF
+    | VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.FAN_SPEED
+    | VacuumEntityFeature.SEND_COMMAND
+    | VacuumEntityFeature.LOCATE
+    | VacuumEntityFeature.STATUS
+    | VacuumEntityFeature.BATTERY
+    | VacuumEntityFeature.CLEAN_SPOT
 )
 
 SUPPORT_STATE_SERVICES = (
-    SUPPORT_STATE
-    | SUPPORT_PAUSE
-    | SUPPORT_STOP
-    | SUPPORT_RETURN_HOME
-    | SUPPORT_FAN_SPEED
-    | SUPPORT_BATTERY
-    | SUPPORT_CLEAN_SPOT
-    | SUPPORT_START
+    VacuumEntityFeature.STATE
+    | VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.FAN_SPEED
+    | VacuumEntityFeature.BATTERY
+    | VacuumEntityFeature.CLEAN_SPOT
+    | VacuumEntityFeature.START
 )
 
 FAN_SPEEDS = ["min", "medium", "high", "max"]
@@ -167,7 +158,7 @@ class DemoVacuum(VacuumEntity):
 
     def turn_on(self, **kwargs):
         """Turn the vacuum on."""
-        if self.supported_features & SUPPORT_TURN_ON == 0:
+        if self.supported_features & VacuumEntityFeature.TURN_ON == 0:
             return
 
         self._state = True
@@ -178,7 +169,7 @@ class DemoVacuum(VacuumEntity):
 
     def turn_off(self, **kwargs):
         """Turn the vacuum off."""
-        if self.supported_features & SUPPORT_TURN_OFF == 0:
+        if self.supported_features & VacuumEntityFeature.TURN_OFF == 0:
             return
 
         self._state = False
@@ -187,7 +178,7 @@ class DemoVacuum(VacuumEntity):
 
     def stop(self, **kwargs):
         """Stop the vacuum."""
-        if self.supported_features & SUPPORT_STOP == 0:
+        if self.supported_features & VacuumEntityFeature.STOP == 0:
             return
 
         self._state = False
@@ -196,7 +187,7 @@ class DemoVacuum(VacuumEntity):
 
     def clean_spot(self, **kwargs):
         """Perform a spot clean-up."""
-        if self.supported_features & SUPPORT_CLEAN_SPOT == 0:
+        if self.supported_features & VacuumEntityFeature.CLEAN_SPOT == 0:
             return
 
         self._state = True
@@ -207,7 +198,7 @@ class DemoVacuum(VacuumEntity):
 
     def locate(self, **kwargs):
         """Locate the vacuum (usually by playing a song)."""
-        if self.supported_features & SUPPORT_LOCATE == 0:
+        if self.supported_features & VacuumEntityFeature.LOCATE == 0:
             return
 
         self._status = "Hi, I'm over here!"
@@ -215,7 +206,7 @@ class DemoVacuum(VacuumEntity):
 
     def start_pause(self, **kwargs):
         """Start, pause or resume the cleaning task."""
-        if self.supported_features & SUPPORT_PAUSE == 0:
+        if self.supported_features & VacuumEntityFeature.PAUSE == 0:
             return
 
         self._state = not self._state
@@ -229,7 +220,7 @@ class DemoVacuum(VacuumEntity):
 
     def set_fan_speed(self, fan_speed, **kwargs):
         """Set the vacuum's fan speed."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
+        if self.supported_features & VacuumEntityFeature.FAN_SPEED == 0:
             return
 
         if fan_speed in self.fan_speed_list:
@@ -238,7 +229,7 @@ class DemoVacuum(VacuumEntity):
 
     def return_to_base(self, **kwargs):
         """Tell the vacuum to return to its dock."""
-        if self.supported_features & SUPPORT_RETURN_HOME == 0:
+        if self.supported_features & VacuumEntityFeature.RETURN_HOME == 0:
             return
 
         self._state = False
@@ -248,7 +239,7 @@ class DemoVacuum(VacuumEntity):
 
     def send_command(self, command, params=None, **kwargs):
         """Send a command to the vacuum."""
-        if self.supported_features & SUPPORT_SEND_COMMAND == 0:
+        if self.supported_features & VacuumEntityFeature.SEND_COMMAND == 0:
             return
 
         self._status = f"Executing {command}({params})"
@@ -310,7 +301,7 @@ class StateDemoVacuum(StateVacuumEntity):
 
     def start(self):
         """Start or resume the cleaning task."""
-        if self.supported_features & SUPPORT_START == 0:
+        if self.supported_features & VacuumEntityFeature.START == 0:
             return
 
         if self._state != STATE_CLEANING:
@@ -321,7 +312,7 @@ class StateDemoVacuum(StateVacuumEntity):
 
     def pause(self):
         """Pause the cleaning task."""
-        if self.supported_features & SUPPORT_PAUSE == 0:
+        if self.supported_features & VacuumEntityFeature.PAUSE == 0:
             return
 
         if self._state == STATE_CLEANING:
@@ -330,7 +321,7 @@ class StateDemoVacuum(StateVacuumEntity):
 
     def stop(self, **kwargs):
         """Stop the cleaning task, do not return to dock."""
-        if self.supported_features & SUPPORT_STOP == 0:
+        if self.supported_features & VacuumEntityFeature.STOP == 0:
             return
 
         self._state = STATE_IDLE
@@ -338,7 +329,7 @@ class StateDemoVacuum(StateVacuumEntity):
 
     def return_to_base(self, **kwargs):
         """Return dock to charging base."""
-        if self.supported_features & SUPPORT_RETURN_HOME == 0:
+        if self.supported_features & VacuumEntityFeature.RETURN_HOME == 0:
             return
 
         self._state = STATE_RETURNING
@@ -348,7 +339,7 @@ class StateDemoVacuum(StateVacuumEntity):
 
     def clean_spot(self, **kwargs):
         """Perform a spot clean-up."""
-        if self.supported_features & SUPPORT_CLEAN_SPOT == 0:
+        if self.supported_features & VacuumEntityFeature.CLEAN_SPOT == 0:
             return
 
         self._state = STATE_CLEANING
@@ -358,7 +349,7 @@ class StateDemoVacuum(StateVacuumEntity):
 
     def set_fan_speed(self, fan_speed, **kwargs):
         """Set the vacuum's fan speed."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
+        if self.supported_features & VacuumEntityFeature.FAN_SPEED == 0:
             return
 
         if fan_speed in self.fan_speed_list:

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -93,7 +93,7 @@ class VacuumEntityFeature(IntEnum):
 
 
 # These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
-# Please use the FanEntityFeature enum instead.
+# Please use the VacuumEntityFeature enum instead.
 SUPPORT_TURN_ON = 1
 SUPPORT_TURN_OFF = 2
 SUPPORT_PAUSE = 4

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -1,6 +1,7 @@
 """Support for vacuum cleaner robots (botvacs)."""
 from dataclasses import dataclass
 from datetime import timedelta
+from enum import IntEnum
 from functools import partial
 import logging
 from typing import final
@@ -71,6 +72,28 @@ STATES = [STATE_CLEANING, STATE_DOCKED, STATE_RETURNING, STATE_ERROR]
 
 DEFAULT_NAME = "Vacuum cleaner robot"
 
+
+class VacuumEntityFeature(IntEnum):
+    """Supported features of the vacuum entity."""
+
+    TURN_ON = 1
+    TURN_OFF = 2
+    PAUSE = 4
+    STOP = 8
+    RETURN_HOME = 16
+    FAN_SPEED = 32
+    BATTERY = 64
+    STATUS = 128
+    SEND_COMMAND = 256
+    LOCATE = 512
+    CLEAN_SPOT = 1024
+    MAP = 2048
+    STATE = 4096
+    START = 8192
+
+
+# These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
+# Please use the FanEntityFeature enum instead.
 SUPPORT_TURN_ON = 1
 SUPPORT_TURN_OFF = 2
 SUPPORT_PAUSE = 4
@@ -178,7 +201,7 @@ class _BaseVacuum(Entity):
     @property
     def capability_attributes(self):
         """Return capability attributes."""
-        if self.supported_features & SUPPORT_FAN_SPEED:
+        if self.supported_features & VacuumEntityFeature.FAN_SPEED:
             return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
 
     @property
@@ -186,11 +209,11 @@ class _BaseVacuum(Entity):
         """Return the state attributes of the vacuum cleaner."""
         data = {}
 
-        if self.supported_features & SUPPORT_BATTERY:
+        if self.supported_features & VacuumEntityFeature.BATTERY:
             data[ATTR_BATTERY_LEVEL] = self.battery_level
             data[ATTR_BATTERY_ICON] = self.battery_icon
 
-        if self.supported_features & SUPPORT_FAN_SPEED:
+        if self.supported_features & VacuumEntityFeature.FAN_SPEED:
             data[ATTR_FAN_SPEED] = self.fan_speed
 
         return data
@@ -297,7 +320,7 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
         """Return the state attributes of the vacuum cleaner."""
         data = super().state_attributes
 
-        if self.supported_features & SUPPORT_STATUS:
+        if self.supported_features & VacuumEntityFeature.STATUS:
             data[ATTR_STATUS] = self.status
 
         return data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**Developers only**: The use of the following constants has been deprecated:

- `SUPPORT_TURN_ON`
- `SUPPORT_TURN_OFF`
- `SUPPORT_PAUSE`
- `SUPPORT_STOP`
- `SUPPORT_RETURN_HOME`
- `SUPPORT_FAN_SPEED`
- `SUPPORT_BATTERY`
- `SUPPORT_STATUS`
- `SUPPORT_SEND_COMMAND`
- `SUPPORT_LOCATE`
- `SUPPORT_CLEAN_SPOT`
- `SUPPORT_MAP`
- `SUPPORT_STATE`
- `SUPPORT_START`

Use the new `VacuumEntityFeature` IntEnum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces the `VacuumEntityFeature`, containing all the supported feature flags of a vacuum cleaner.

Not much to change otherwise as in this PR, as this is not used or tested in the remote component or demo integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1276

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
