### PR TITLE
Bugfix for overkiz.alarm_control_panel platform exception

### DIFF
--- a/homeassistant/components/overkiz/alarm_control_panel.py
+++ b/homeassistant/components/overkiz/alarm_control_panel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.enums.ui import UIWidget
@@ -55,15 +55,15 @@ class OverkizAlarmDescription(
     """Class to describe an Overkiz alarm control panel."""
 
     alarm_disarm: str | None = None
-    alarm_disarm_args: OverkizStateType | list[OverkizStateType] = []
+    alarm_disarm_args: OverkizStateType | list[OverkizStateType] = None
     alarm_arm_home: str | None = None
-    alarm_arm_home_args: OverkizStateType | list[OverkizStateType] = []
+    alarm_arm_home_args: OverkizStateType | list[OverkizStateType] = None
     alarm_arm_night: str | None = None
-    alarm_arm_night_args: OverkizStateType | list[OverkizStateType] = []
+    alarm_arm_night_args: OverkizStateType | list[OverkizStateType] = None
     alarm_arm_away: str | None = None
-    alarm_arm_away_args: OverkizStateType | list[OverkizStateType] = []
+    alarm_arm_away_args: OverkizStateType | list[OverkizStateType] = None
     alarm_trigger: str | None = None
-    alarm_trigger_args: OverkizStateType | list[OverkizStateType] = []
+    alarm_trigger_args: OverkizStateType | list[OverkizStateType] = None
 
 
 MAP_INTERNAL_STATUS_STATE: dict[str, str] = {
@@ -266,7 +266,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         assert self.entity_description.alarm_disarm
-        await self.executor.async_execute_command(
+        await self.async_execute_command(
             self.entity_description.alarm_disarm,
             self.entity_description.alarm_disarm_args,
         )
@@ -274,7 +274,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         assert self.entity_description.alarm_arm_home
-        await self.executor.async_execute_command(
+        await self.async_execute_command(
             self.entity_description.alarm_arm_home,
             self.entity_description.alarm_arm_home_args,
         )
@@ -282,7 +282,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         assert self.entity_description.alarm_arm_night
-        await self.executor.async_execute_command(
+        await self.async_execute_command(
             self.entity_description.alarm_arm_night,
             self.entity_description.alarm_arm_night_args,
         )
@@ -290,7 +290,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         assert self.entity_description.alarm_arm_away
-        await self.executor.async_execute_command(
+        await self.async_execute_command(
             self.entity_description.alarm_arm_away,
             self.entity_description.alarm_arm_away_args,
         )
@@ -298,7 +298,14 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Send alarm trigger command."""
         assert self.entity_description.alarm_trigger
-        await self.executor.async_execute_command(
+        await self.async_execute_command(
             self.entity_description.alarm_trigger,
             self.entity_description.alarm_trigger_args,
         )
+
+    async def async_execute_command(self, command_name: str, args: Any) -> None:
+        """Execute device command in async context."""
+        if args:
+            await self.executor.async_execute_command(command_name, args)
+        else:
+            await self.executor.async_execute_command(command_name)

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -76,8 +76,6 @@ class OverkizExecutor:
         ):
             args = args + (0,)
 
-        print(args)
-
         exec_id = await self.coordinator.client.execute_command(
             self.device.device_url,
             Command(command_name, list(args)),

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -76,6 +76,8 @@ class OverkizExecutor:
         ):
             args = args + (0,)
 
+        print(args)
+
         exec_id = await self.coordinator.client.execute_command(
             self.device.device_url,
             Command(command_name, list(args)),


### PR DESCRIPTION
## Proposed change
https://github.com/home-assistant/core/pull/68996 got in a bit too fast. I was now able to fully test it for multiple alarm devices, and indeed it raises an error. 

Fixes #69124. Using `[]` in a dataclass is not allowed, however using `field(default_factory=list)` didn't work as well. It still unpacks it to a tuple `([],)` and thus passes an argument to a command where it is not allowed.

As discussed in #68996, there should be changes to the `async_execute_command` function. I will make them for next release, however I don't want to make these changes last minute since every device uses this function. (and I won't have time to test everything before the upcoming release)

This would be a temporary fix, until we refactor `async_execute_command`, which should be soon.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
