### PR TITLE
Fix issue with turning the ambilight on after switched off

### DIFF
--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -176,7 +176,7 @@ class PhilipsTVLightEntity(
 
     def _calculate_effect_list(self):
         """Calculate an effect list based on current status."""
-        effects = []
+        effects: list[AmbilightEffect] = []
         effects.extend(
             AmbilightEffect(mode=EFFECT_AUTO, style=style, algorithm=setting)
             for style, data in self._tv.ambilight_styles.items()

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -34,16 +34,6 @@ EFFECT_EXPERT = "Expert"
 EFFECT_AUTO = "Auto"
 EFFECT_EXPERT_STYLES = {"FOLLOW_AUDIO", "FOLLOW_COLOR", "Lounge light"}
 
-STANDARD_FOLLOW_VIDEO_SETTINGS = {
-    "STANDARD",
-    "NATURAL",
-    "IMMERSIVE",
-    "VIVID",
-    "GAME",
-    "COMFORT",
-    "RELAX",
-}
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -202,11 +192,6 @@ class PhilipsTVLightEntity(
         effects.extend(
             AmbilightEffect(mode=EFFECT_MODE, style=style)
             for style in self._tv.ambilight_modes
-        )
-
-        effects.extend(
-            AmbilightEffect(mode=EFFECT_AUTO, style="FOLLOW_VIDEO", algorithm=setting)
-            for setting in STANDARD_FOLLOW_VIDEO_SETTINGS
         )
 
         filtered_effects = [

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -34,6 +34,16 @@ EFFECT_EXPERT = "Expert"
 EFFECT_AUTO = "Auto"
 EFFECT_EXPERT_STYLES = {"FOLLOW_AUDIO", "FOLLOW_COLOR", "Lounge light"}
 
+STANDARD_FOLLOW_VIDEO_SETTINGS = {
+    "STANDARD",
+    "NATURAL",
+    "IMMERSIVE",
+    "VIVID",
+    "GAME",
+    "COMFORT",
+    "RELAX",
+}
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -194,6 +204,11 @@ class PhilipsTVLightEntity(
             for style in self._tv.ambilight_modes
         )
 
+        effects.extend(
+            AmbilightEffect(mode=EFFECT_AUTO, style="FOLLOW_VIDEO", algorithm=setting)
+            for setting in STANDARD_FOLLOW_VIDEO_SETTINGS
+        )
+
         filtered_effects = [
             str(effect)
             for effect in effects
@@ -256,7 +271,7 @@ class PhilipsTVLightEntity(
                 color = settings["color"]
 
         effect = AmbilightEffect.from_str(self._attr_effect)
-        LOGGER.debug("Current effect: %s, effect")
+        LOGGER.debug("Current effect: %s", effect)
         if effect.is_on(self._tv.powerstate):
             self._last_selected_effect = effect
 

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -197,8 +197,7 @@ class PhilipsTVLightEntity(
         filtered_effects = [
             str(effect)
             for effect in effects
-            and effect.is_valid()
-            and effect.is_on(self._tv.powerstate)
+            if effect.is_valid() and effect.is_on(self._tv.powerstate)
         ]
 
         return sorted(filtered_effects)
@@ -282,7 +281,7 @@ class PhilipsTVLightEntity(
         super()._handle_coordinator_update()
 
     async def _set_ambilight_cached(
-        self, effect: AmbilightEffect, hs_color, brightness
+        self, effect: AmbilightEffect, hs_color: tuple[float, float], brightness: int
     ):
         """Set ambilight via the manual or expert mode."""
         rgb = color_hsv_to_RGB(hs_color[0], hs_color[1], brightness * 100 / 255)
@@ -301,7 +300,7 @@ class PhilipsTVLightEntity(
                 raise Exception("Failed to set ambilight mode")
 
     async def _set_ambilight_expert_config(
-        self, effect: AmbilightEffect, hs_color, brightness
+        self, effect: AmbilightEffect, hs_color: tuple[float, float], brightness: int
     ):
         """Set ambilight via current configuration."""
         config: AmbilightCurrentConfiguration = {
@@ -371,7 +370,7 @@ class PhilipsTVLightEntity(
             brightness = 255
 
         if hs_color is None:
-            hs_color = [0, 0]
+            hs_color = (0, 0)
 
         if effect.mode == EFFECT_MODE:
             await self._set_ambilight_cached(effect, hs_color, brightness)

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -197,7 +197,6 @@ class PhilipsTVLightEntity(
         filtered_effects = [
             str(effect)
             for effect in effects
-            if isinstance(effect, AmbilightEffect)
             and effect.is_valid()
             and effect.is_on(self._tv.powerstate)
         ]

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -1,6 +1,9 @@
 """Component to integrate ambilight for TVs exposing the Joint Space API."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+import logging
+
 from haphilipsjs import PhilipsTV
 from haphilipsjs.typing import AmbilightCurrentConfiguration
 
@@ -31,6 +34,8 @@ EFFECT_EXPERT = "Expert"
 EFFECT_AUTO = "Auto"
 EFFECT_EXPERT_STYLES = {"FOLLOW_AUDIO", "FOLLOW_COLOR", "Lounge light"}
 
+LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -51,44 +56,14 @@ def _get_settings(style: AmbilightCurrentConfiguration):
     return None
 
 
-def _parse_effect(effect: str):
+def _parse_effect(effect: str) -> AmbilightEffect:
     style, _, algorithm = effect.partition(EFFECT_PARTITION)
     if style == EFFECT_MODE:
-        return EFFECT_MODE, algorithm, None
+        return AmbilightEffect(mode=EFFECT_MODE, style=algorithm, algorithm=None)
     algorithm, _, expert = algorithm.partition(EFFECT_PARTITION)
     if expert:
-        return EFFECT_EXPERT, style, algorithm
-    return EFFECT_AUTO, style, algorithm
-
-
-def _get_effect(mode: str, style: str, algorithm: str | None):
-    if mode == EFFECT_MODE:
-        return f"{EFFECT_MODE}{EFFECT_PARTITION}{style}"
-    if mode == EFFECT_EXPERT:
-        return f"{style}{EFFECT_PARTITION}{algorithm}{EFFECT_PARTITION}{EFFECT_EXPERT}"
-    return f"{style}{EFFECT_PARTITION}{algorithm}"
-
-
-def _is_on(mode, style, powerstate):
-    if mode in (EFFECT_AUTO, EFFECT_EXPERT):
-        if style in ("FOLLOW_VIDEO", "FOLLOW_AUDIO"):
-            return powerstate in ("On", None)
-        if style == "OFF":
-            return False
-        return True
-
-    if mode == EFFECT_MODE:
-        if style == "internal":
-            return powerstate in ("On", None)
-        return True
-
-    return False
-
-
-def _is_valid(mode, style):
-    if mode == EFFECT_EXPERT:
-        return style in EFFECT_EXPERT_STYLES
-    return True
+        return AmbilightEffect(mode=EFFECT_EXPERT, style=style, algorithm=algorithm)
+    return AmbilightEffect(mode=EFFECT_AUTO, style=style, algorithm=algorithm)
 
 
 def _get_cache_keys(device: PhilipsTV):
@@ -137,6 +112,7 @@ class PhilipsTVLightEntity(
         self._hs = None
         self._brightness = None
         self._cache_keys = None
+        self._last_selected_effect: AmbilightEffect = None
         super().__init__(coordinator)
 
         self._attr_supported_color_modes = [COLOR_MODE_HS, COLOR_MODE_ONOFF]
@@ -162,46 +138,48 @@ class PhilipsTVLightEntity(
         """Calculate an effect list based on current status."""
         effects = []
         effects.extend(
-            _get_effect(EFFECT_AUTO, style, setting)
+            AmbilightEffect(mode=EFFECT_AUTO, style=style, algorithm=setting)
             for style, data in self._tv.ambilight_styles.items()
-            if _is_valid(EFFECT_AUTO, style)
-            and _is_on(EFFECT_AUTO, style, self._tv.powerstate)
             for setting in data.get("menuSettings", [])
         )
 
         effects.extend(
-            _get_effect(EFFECT_EXPERT, style, algorithm)
+            AmbilightEffect(mode=EFFECT_EXPERT, style=style, algorithm=algorithm)
             for style, data in self._tv.ambilight_styles.items()
-            if _is_valid(EFFECT_EXPERT, style)
-            and _is_on(EFFECT_EXPERT, style, self._tv.powerstate)
             for algorithm in data.get("algorithms", [])
         )
 
         effects.extend(
-            _get_effect(EFFECT_MODE, style, None)
+            AmbilightEffect(mode=EFFECT_MODE, style=style)
             for style in self._tv.ambilight_modes
-            if _is_valid(EFFECT_MODE, style)
-            and _is_on(EFFECT_MODE, style, self._tv.powerstate)
         )
 
-        return sorted(effects)
+        filtered_effects = [
+            str(effect)
+            for effect in effects
+            if isinstance(effect, AmbilightEffect)
+            and effect.is_valid()
+            and effect.is_on(self._tv.powerstate)
+        ]
 
-    def _calculate_effect(self):
+        return sorted(filtered_effects)
+
+    def _calculate_effect(self) -> AmbilightEffect:
         """Return the current effect."""
         current = self._tv.ambilight_current_configuration
         if current and self._tv.ambilight_mode != "manual":
             if current["isExpert"]:
                 if settings := _get_settings(current):
-                    return _get_effect(
+                    return AmbilightEffect(
                         EFFECT_EXPERT, current["styleName"], settings["algorithm"]
                     )
-                return _get_effect(EFFECT_EXPERT, current["styleName"], None)
+                return AmbilightEffect(EFFECT_EXPERT, current["styleName"], None)
 
-            return _get_effect(
+            return AmbilightEffect(
                 EFFECT_AUTO, current["styleName"], current.get("menuSetting", None)
             )
 
-        return _get_effect(EFFECT_MODE, self._tv.ambilight_mode, None)
+        return AmbilightEffect(EFFECT_MODE, self._tv.ambilight_mode, None)
 
     @property
     def color_mode(self):
@@ -219,8 +197,8 @@ class PhilipsTVLightEntity(
     def is_on(self):
         """Return if the light is turned on."""
         if self._tv.on:
-            mode, style, _ = _parse_effect(self.effect)
-            return _is_on(mode, style, self._tv.powerstate)
+            effect = _parse_effect(self.effect)
+            return effect.is_on(self._tv.powerstate)
 
         return False
 
@@ -231,21 +209,24 @@ class PhilipsTVLightEntity(
         if (cache_keys := _get_cache_keys(self._tv)) != self._cache_keys:
             self._cache_keys = cache_keys
             self._attr_effect_list = self._calculate_effect_list()
-            self._attr_effect = self._calculate_effect()
+            self._attr_effect = str(self._calculate_effect())
 
         if current and current["isExpert"]:
             if settings := _get_settings(current):
                 color = settings["color"]
 
-        mode, _, _ = _parse_effect(self._attr_effect)
+        effect = _parse_effect(self._attr_effect)
+        LOGGER.debug("Current effect: %s, effect")
+        if effect.is_on(self._tv.powerstate):
+            self._last_selected_effect = effect
 
-        if mode == EFFECT_EXPERT and color:
+        if effect.mode == EFFECT_EXPERT and color:
             self._attr_hs_color = (
                 color["hue"] * 360.0 / 255.0,
                 color["saturation"] * 100.0 / 255.0,
             )
             self._attr_brightness = color["brightness"]
-        elif mode == EFFECT_MODE and self._tv.ambilight_cached:
+        elif effect.mode == EFFECT_MODE and self._tv.ambilight_cached:
             hsv_h, hsv_s, hsv_v = color_RGB_to_hsv(
                 *_average_pixels(self._tv.ambilight_cached)
             )
@@ -261,7 +242,9 @@ class PhilipsTVLightEntity(
         self._update_from_coordinator()
         super()._handle_coordinator_update()
 
-    async def _set_ambilight_cached(self, algorithm, hs_color, brightness):
+    async def _set_ambilight_cached(
+        self, effect: AmbilightEffect, hs_color, brightness
+    ):
         """Set ambilight via the manual or expert mode."""
         rgb = color_hsv_to_RGB(hs_color[0], hs_color[1], brightness * 100 / 255)
 
@@ -274,21 +257,21 @@ class PhilipsTVLightEntity(
         if not await self._tv.setAmbilightCached(data):
             raise Exception("Failed to set ambilight color")
 
-        if algorithm != self._tv.ambilight_mode:
-            if not await self._tv.setAmbilightMode(algorithm):
+        if effect.algorithm != self._tv.ambilight_mode:
+            if not await self._tv.setAmbilightMode(effect.algorithm):
                 raise Exception("Failed to set ambilight mode")
 
     async def _set_ambilight_expert_config(
-        self, style, algorithm, hs_color, brightness
+        self, effect: AmbilightEffect, hs_color, brightness
     ):
         """Set ambilight via current configuration."""
         config: AmbilightCurrentConfiguration = {
-            "styleName": style,
+            "styleName": effect.style,
             "isExpert": True,
         }
 
         setting = {
-            "algorithm": algorithm,
+            "algorithm": effect.algorithm,
             "color": {
                 "hue": round(hs_color[0] * 255.0 / 360.0),
                 "saturation": round(hs_color[1] * 255.0 / 100.0),
@@ -301,23 +284,23 @@ class PhilipsTVLightEntity(
             },
         }
 
-        if style in ("FOLLOW_COLOR", "Lounge light"):
+        if effect.style in ("FOLLOW_COLOR", "Lounge light"):
             config["colorSettings"] = setting
             config["speed"] = 2
 
-        elif style == "FOLLOW_AUDIO":
+        elif effect.style == "FOLLOW_AUDIO":
             config["audioSettings"] = setting
             config["tuning"] = 0
 
         if not await self._tv.setAmbilightCurrentConfiguration(config):
             raise Exception("Failed to set ambilight mode")
 
-    async def _set_ambilight_config(self, style, algorithm):
+    async def _set_ambilight_config(self, effect: AmbilightEffect):
         """Set ambilight via current configuration."""
         config: AmbilightCurrentConfiguration = {
-            "styleName": style,
+            "styleName": effect.style,
             "isExpert": False,
-            "menuSetting": algorithm,
+            "menuSetting": effect.algorithm,
         }
 
         if await self._tv.setAmbilightCurrentConfiguration(config) is False:
@@ -327,20 +310,23 @@ class PhilipsTVLightEntity(
         """Turn the bulb on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness)
         hs_color = kwargs.get(ATTR_HS_COLOR, self.hs_color)
-        effect = kwargs.get(ATTR_EFFECT, self.effect)
+        attr_effect = kwargs.get(ATTR_EFFECT, self.effect)
 
         if not self._tv.on:
             raise Exception("TV is not available")
 
-        mode, style, setting = _parse_effect(effect)
+        effect = _parse_effect(attr_effect)
 
-        if not _is_on(mode, style, self._tv.powerstate):
-            mode = EFFECT_MODE
-            setting = None
-            if self._tv.powerstate in ("On", None):
-                style = "internal"
+        if not effect.is_on(self._tv.powerstate):
+            if self._last_selected_effect:
+                effect = self._last_selected_effect
             else:
-                style = "manual"
+                effect.mode = EFFECT_MODE
+                effect.algorithm = None
+                if self._tv.powerstate in ("On", None):
+                    effect.style = "internal"
+                else:
+                    effect.style = "manual"
 
         if brightness is None:
             brightness = 255
@@ -348,14 +334,12 @@ class PhilipsTVLightEntity(
         if hs_color is None:
             hs_color = [0, 0]
 
-        if mode == EFFECT_MODE:
-            await self._set_ambilight_cached(style, hs_color, brightness)
-        elif mode == EFFECT_AUTO:
-            await self._set_ambilight_config(style, setting)
-        elif mode == EFFECT_EXPERT:
-            await self._set_ambilight_expert_config(
-                style, setting, hs_color, brightness
-            )
+        if effect.mode == EFFECT_MODE:
+            await self._set_ambilight_cached(effect, hs_color, brightness)
+        elif effect.mode == EFFECT_AUTO:
+            await self._set_ambilight_config(effect)
+        elif effect.mode == EFFECT_EXPERT:
+            await self._set_ambilight_expert_config(effect, hs_color, brightness)
 
         self._update_from_coordinator()
         self.async_write_ha_state()
@@ -369,7 +353,46 @@ class PhilipsTVLightEntity(
         if await self._tv.setAmbilightMode("internal") is False:
             raise Exception("Failed to set ambilight mode")
 
-        await self._set_ambilight_config("OFF", "")
+        await self._set_ambilight_config(AmbilightEffect(EFFECT_MODE, "OFF", ""))
 
         self._update_from_coordinator()
         self.async_write_ha_state()
+
+
+@dataclass
+class AmbilightEffect:
+    """Data class describing the ambilight effect."""
+
+    mode: str
+    style: str
+    algorithm: str | None = None
+
+    def is_on(self, powerstate) -> bool:
+        """Check whether the ambilight is considered on."""
+        if self.mode in (EFFECT_AUTO, EFFECT_EXPERT):
+            if self.style in ("FOLLOW_VIDEO", "FOLLOW_AUDIO"):
+                return powerstate in ("On", None)
+            if self.style == "OFF":
+                return False
+            return True
+
+        if self.mode == EFFECT_MODE:
+            if self.style == "internal":
+                return powerstate in ("On", None)
+            return True
+
+        return False
+
+    def is_valid(self) -> bool:
+        """Validate the effect configuration."""
+        if self.mode == EFFECT_EXPERT:
+            return self.style in EFFECT_EXPERT_STYLES
+        return True
+
+    def __str__(self) -> str:
+        """Get a string representation of the effect."""
+        if self.mode == EFFECT_MODE:
+            return f"{EFFECT_MODE}{EFFECT_PARTITION}{self.style}"
+        if self.mode == EFFECT_EXPERT:
+            return f"{self.style}{EFFECT_PARTITION}{self.algorithm}{EFFECT_PARTITION}{EFFECT_EXPERT}"
+        return f"{self.style}{EFFECT_PARTITION}{self.algorithm}"


### PR DESCRIPTION
## Proposed change
When ambilight is turned off it would not turn on anymore. This was caused by the mode and style being set to `AUTO` and `OFF` respectivily, which are not a valid combination.
This PR adds a property `_last_selected_effect` which will remember the choosen effect combination after turning on or retrieving the state from the TV. After turning off and turning on again it will restore the effect from `_last_selected_effect` if any. Otherwise the old logic still applies.

Also refactored the effect parsing and data structure to make use of a dataclass to make the code better maintainable. Less passing around of lots of parameters, less parsing. And moved the effect related methods `is_on`, `is_valid` to the `AmbilightEffect` class.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68676

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
