### PR TITLE
PhilipsTV - Add Ambilight + Hue switch entity

### DIFF
--- a/homeassistant/components/philips_js/manifest.json
+++ b/homeassistant/components/philips_js/manifest.json
@@ -2,7 +2,7 @@
   "domain": "philips_js",
   "name": "Philips TV",
   "documentation": "https://www.home-assistant.io/integrations/philips_js",
-  "requirements": ["ha-philipsjs==2.7.6"],
+  "requirements": ["ha-philipsjs==2.9.0"],
   "codeowners": ["@elupus"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -5,13 +5,16 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import PhilipsTVDataUpdateCoordinator
 from .const import DOMAIN
+
+HUE_POWER_OFF = "Off"
+HUE_POWER_ON = "On"
 
 
 async def async_setup_entry(
@@ -25,6 +28,9 @@ async def async_setup_entry(
     ]
 
     async_add_entities([PhilipsTVScreenSwitch(coordinator)])
+
+    if coordinator.api.json_feature_supported("ambilight", "Hue"):
+        async_add_entities([PhilipsTVAmbilightHueSwitch(coordinator)])
 
 
 class PhilipsTVScreenSwitch(
@@ -70,3 +76,54 @@ class PhilipsTVScreenSwitch(
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.setScreenState("Off")
+
+
+class PhilipsTVAmbilightHueSwitch(
+    CoordinatorEntity[PhilipsTVDataUpdateCoordinator], SwitchEntity
+):
+    """A Philips TV Ambi+Hue switch."""
+
+    def __init__(
+        self,
+        coordinator: PhilipsTVDataUpdateCoordinator,
+    ) -> None:
+        """Initialize entity."""
+
+        super().__init__(coordinator)
+
+        self._attr_name = f"{coordinator.system['name']} Ambilight+Hue"
+        self._attr_icon = "mdi:television-ambient-light"
+        self._attr_unique_id = f"{coordinator.unique_id}_ambi_hue"
+        self._attr_is_on = self.coordinator.api.huelamp_power == HUE_POWER_ON
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, coordinator.unique_id),
+            }
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return true if entity is available."""
+        if not super().available:
+            return False
+        if not self.coordinator.api.on:
+            return False
+        return self.coordinator.api.powerstate == "On"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.coordinator.api.setHueLampPower(HUE_POWER_ON)
+        self._attr_is_on = True
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.coordinator.api.setHueLampPower(HUE_POWER_OFF)
+        self._attr_is_on = False
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = self.coordinator.api.huelamp_power == HUE_POWER_ON
+        super()._handle_coordinator_update()

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -123,4 +123,3 @@ class PhilipsTVAmbilightHueSwitch(
         """Turn the entity off."""
         await self.coordinator.api.setHueLampPower(HUE_POWER_OFF)
         self.async_write_ha_state()
-

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -110,17 +110,20 @@ class PhilipsTVAmbilightHueSwitch(
             return False
         return self.coordinator.api.powerstate == "On"
 
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self.coordinator.api.huelamp_power == HUE_POWER_ON
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.coordinator.api.setHueLampPower(HUE_POWER_ON)
-        self._attr_is_on = True
-        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.setHueLampPower(HUE_POWER_OFF)
-        self._attr_is_on = False
-        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -124,8 +124,3 @@ class PhilipsTVAmbilightHueSwitch(
         await self.coordinator.api.setHueLampPower(HUE_POWER_OFF)
         self.async_write_ha_state()
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._attr_is_on = self.coordinator.api.huelamp_power == HUE_POWER_ON
-        super()._handle_coordinator_update()

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -94,7 +94,6 @@ class PhilipsTVAmbilightHueSwitch(
         self._attr_name = f"{coordinator.system['name']} Ambilight+Hue"
         self._attr_icon = "mdi:television-ambient-light"
         self._attr_unique_id = f"{coordinator.unique_id}_ambi_hue"
-        self._attr_is_on = self.coordinator.api.huelamp_power == HUE_POWER_ON
         self._attr_device_info = DeviceInfo(
             identifiers={
                 (DOMAIN, coordinator.unique_id),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -770,7 +770,7 @@ guppy3==3.1.2
 ha-ffmpeg==3.0.2
 
 # homeassistant.components.philips_js
-ha-philipsjs==2.7.6
+ha-philipsjs==2.9.0
 
 # homeassistant.components.habitica
 habitipy==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -537,7 +537,7 @@ guppy3==3.1.2
 ha-ffmpeg==3.0.2
 
 # homeassistant.components.philips_js
-ha-philipsjs==2.7.6
+ha-philipsjs==2.9.0
 
 # homeassistant.components.habitica
 habitipy==0.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new entity "Ambilight+Hue" which allow you to toggle the syncing of the calculated ambilight colors to your Hue lights. Some TV's support this. 
I have added a conditional check to only create the switch when your TV supports it (by looking at the featuring in system data).

Also updated underlying ha-philipsjs library to 2.9.0, which adds the necessary calls to the API.
https://github.com/danielperna84/ha-philipsjs/releases/tag/2.9.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22244

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
