### PR TITLE
Use CONF_NAME consistently in utility meter sensors with and without tariffs

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -138,13 +138,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         if not conf[CONF_TARIFFS]:
             # only one entity is required
-            name = conf.get(CONF_NAME, meter)
             hass.async_create_task(
                 discovery.async_load_platform(
                     hass,
                     SENSOR_DOMAIN,
                     DOMAIN,
-                    {name: {CONF_METER: meter, CONF_NAME: name}},
+                    {meter: {CONF_METER: meter}},
                     config,
                 )
             )
@@ -170,7 +169,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 name = f"{meter} {tariff}"
                 tariff_confs[name] = {
                     CONF_METER: meter,
-                    CONF_NAME: name,
                     CONF_TARIFF: tariff,
                 }
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -196,11 +196,16 @@ async def async_setup_platform(
             else None
         )
         conf_meter_name = hass.data[DATA_UTILITY][meter].get(CONF_NAME, meter)
-        conf_sensor_name = (
-            f"{conf_meter_name} {conf_sensor_tariff}"
-            if conf_sensor_tariff
-            else conf_meter_name
-        )
+        conf_sensor_tariff = conf.get(CONF_TARIFF)
+
+        suggested_entity_id = None
+        if conf_sensor_tariff:
+            conf_sensor_name = f"{conf_meter_name} {conf_sensor_tariff}"
+            slug = slugify(f"{meter} {conf_sensor_tariff}")
+            suggested_entity_id = f"sensor.{slug}"
+        else:
+            conf_sensor_name = conf_meter_name
+
         conf_meter_type = hass.data[DATA_UTILITY][meter].get(CONF_METER_TYPE)
         conf_meter_offset = hass.data[DATA_UTILITY][meter][CONF_METER_OFFSET]
         conf_meter_delta_values = hass.data[DATA_UTILITY][meter][
@@ -225,7 +230,7 @@ async def async_setup_platform(
             tariff_entity=conf_meter_tariff_entity,
             tariff=conf_sensor_tariff,
             unique_id=conf_sensor_unique_id,
-            legacy_meter_name=conf_meter_name,
+            suggested_entity_id=suggested_entity_id,
         )
         meters.append(meter_sensor)
 
@@ -259,17 +264,11 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         tariff_entity,
         tariff,
         unique_id,
-        legacy_meter_name=None,
+        suggested_entity_id=None,
     ):
         """Initialize the Utility Meter sensor."""
         self._attr_unique_id = unique_id
-        if legacy_meter_name:
-            slug = (
-                slugify(f"{parent_meter} {tariff}")
-                if tariff
-                else slugify(f"{legacy_meter_name}")
-            )
-            self.entity_id = f"sensor.{slug}"
+        self.entity_id = suggested_entity_id
         self._parent_meter = parent_meter
         self._sensor_source_id = source_entity
         self._state = None

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -194,6 +194,10 @@ async def async_setup_platform(
             if conf_meter_unique_id
             else None
         )
+        conf_meter_name = hass.data[DATA_UTILITY][meter].get(CONF_NAME, meter)
+        conf_sensor_name = (
+            f"{meter} {conf_sensor_tariff}" if conf_sensor_tariff else conf_meter_name
+        )
         conf_meter_type = hass.data[DATA_UTILITY][meter].get(CONF_METER_TYPE)
         conf_meter_offset = hass.data[DATA_UTILITY][meter][CONF_METER_OFFSET]
         conf_meter_delta_values = hass.data[DATA_UTILITY][meter][
@@ -211,7 +215,7 @@ async def async_setup_platform(
             delta_values=conf_meter_delta_values,
             meter_offset=conf_meter_offset,
             meter_type=conf_meter_type,
-            name=conf.get(CONF_NAME),
+            name=conf_sensor_name,
             net_consumption=conf_meter_net_consumption,
             parent_meter=meter,
             source_entity=conf_meter_source,

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -343,6 +343,61 @@ async def test_unique_id(hass):
 
 
 @pytest.mark.parametrize(
+    "yaml_config,entity_id, name",
+    (
+        (
+            {
+                "utility_meter": {
+                    "energy_bill": {
+                        "name": "dog",
+                        "source": "sensor.energy",
+                        "tariffs": ["onpeak", "midpeak", "offpeak"],
+                    }
+                }
+            },
+            "sensor.energy_bill_onpeak",
+            "dog onpeak",
+        ),
+        (
+            {
+                "utility_meter": {
+                    "energy_bill": {
+                        "name": "dog",
+                        "source": "sensor.energy",
+                    }
+                }
+            },
+            "sensor.dog",
+            "dog",
+        ),
+        (
+            {
+                "utility_meter": {
+                    "energy_bill": {
+                        "source": "sensor.energy",
+                    }
+                }
+            },
+            "sensor.energy_bill",
+            "energy_bill",
+        ),
+    ),
+)
+async def test_entity_name(hass, yaml_config, entity_id, name):
+    """Test utility sensor state initializtion."""
+    assert await async_setup_component(hass, DOMAIN, yaml_config)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.name == name
+
+
+@pytest.mark.parametrize(
     "yaml_config,config_entry_configs",
     (
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This addresses comment https://github.com/home-assistant/core/issues/68508#issuecomment-1076331414

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68508
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
