### PR TITLE
Exclude static light attributes from being recorded in the database

### DIFF
--- a/homeassistant/components/light/recorder.py
+++ b/homeassistant/components/light/recorder.py
@@ -1,0 +1,12 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, callback
+
+from . import ATTR_EFFECT_LIST, ATTR_SUPPORTED_COLOR_MODES
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude static attributes from being recorded in the database."""
+    return {ATTR_SUPPORTED_COLOR_MODES, ATTR_EFFECT_LIST}

--- a/homeassistant/components/light/recorder.py
+++ b/homeassistant/components/light/recorder.py
@@ -3,10 +3,20 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant, callback
 
-from . import ATTR_EFFECT_LIST, ATTR_SUPPORTED_COLOR_MODES
+from . import (
+    ATTR_EFFECT_LIST,
+    ATTR_MAX_MIREDS,
+    ATTR_MIN_MIREDS,
+    ATTR_SUPPORTED_COLOR_MODES,
+)
 
 
 @callback
 def exclude_attributes(hass: HomeAssistant) -> set[str]:
     """Exclude static attributes from being recorded in the database."""
-    return {ATTR_SUPPORTED_COLOR_MODES, ATTR_EFFECT_LIST}
+    return {
+        ATTR_SUPPORTED_COLOR_MODES,
+        ATTR_EFFECT_LIST,
+        ATTR_MIN_MIREDS,
+        ATTR_MAX_MIREDS,
+    }

--- a/tests/components/light/test_recorder.py
+++ b/tests/components/light/test_recorder.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components import light
-from homeassistant.components.light import ATTR_EFFECT, ATTR_SUPPORTED_COLOR_MODES
+from homeassistant.components.light import (
+    ATTR_EFFECT,
+    ATTR_MAX_MIREDS,
+    ATTR_MIN_MIREDS,
+    ATTR_SUPPORTED_COLOR_MODES,
+)
 from homeassistant.components.recorder.models import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_FRIENDLY_NAME
@@ -39,6 +44,8 @@ async def test_exclude_attributes(hass):
     states: list[State] = await hass.async_add_executor_job(_fetch_states)
     assert len(states) > 1
     for state in states:
+        assert ATTR_MIN_MIREDS not in state.attributes
+        assert ATTR_MAX_MIREDS not in state.attributes
         assert ATTR_SUPPORTED_COLOR_MODES not in state.attributes
         assert ATTR_EFFECT not in state.attributes
         assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/light/test_recorder.py
+++ b/tests/components/light/test_recorder.py
@@ -1,0 +1,44 @@
+"""The tests for light recorder."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components import light
+from homeassistant.components.light import ATTR_EFFECT, ATTR_SUPPORTED_COLOR_MODES
+from homeassistant.components.recorder.models import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed, async_init_recorder_component
+from tests.components.recorder.common import async_wait_recording_done_without_instance
+
+
+async def test_exclude_attributes(hass):
+    """Test light registered attributes to be excluded."""
+    await async_init_recorder_component(hass)
+    await async_setup_component(
+        hass, light.DOMAIN, {light.DOMAIN: {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    await async_wait_recording_done_without_instance(hass)
+
+    def _fetch_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(States, StateAttributes):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    assert len(states) > 1
+    for state in states:
+        assert ATTR_SUPPORTED_COLOR_MODES not in state.attributes
+        assert ATTR_EFFECT not in state.attributes
+        assert ATTR_FRIENDLY_NAME in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- The supported color modes, min mireds, max mireds, and effect list are no longer recorded in the
  database.

- This data has little historical value since the data in the state
  machine for the entity is expected to be the same (except between versions)
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before
`{"effect_list":["RBM 1","RBM 2","RBM 3","RBM 4","RBM 5","RBM 6","RBM 7","RBM 8","RBM 9","RBM 10","RBM 11","RBM 12","RBM 13","RBM 14","RBM 15","RBM 16","RBM 17","RBM 18","RBM 19","RBM 20","RBM 21","RBM 22","RBM 23","RBM 24","RBM 25","RBM 26","RBM 27","RBM 28","RBM 29","RBM 30","RBM 31","RBM 32","RBM 33","RBM 34","RBM 35","RBM 36","RBM 37","RBM 38","RBM 39","RBM 40","RBM 41","RBM 42","RBM 43","RBM 44","RBM 45","RBM 46","RBM 47","RBM 48","RBM 49","RBM 50","RBM 51","RBM 52","RBM 53","RBM 54","RBM 55","RBM 56","RBM 57","RBM 58","RBM 59","RBM 60","RBM 61","RBM 62","RBM 63","RBM 64","RBM 65","RBM 66","RBM 67","RBM 68","RBM 69","RBM 70","RBM 71","RBM 72","RBM 73","RBM 74","RBM 75","RBM 76","RBM 77","RBM 78","RBM 79","RBM 80","RBM 81","RBM 82","RBM 83","RBM 84","RBM 85","RBM 86","RBM 87","RBM 88","RBM 89","RBM 90","RBM 91","RBM 92","RBM 93","RBM 94","RBM 95","RBM 96","RBM 97","RBM 98","RBM 99","RBM 100","RBM 101","RBM 102","Circulate all modes","random","music"],"supported_color_modes":["rgb"],"friendly_name":"Corner Lamp","supported_features":36}`

After

`{"friendly_name":"Corner Lamp","supported_features":36}`



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
