### PR TITLE
Exclude static and token attributes from being recorded for media_player

### DIFF
--- a/homeassistant/components/media_player/recorder.py
+++ b/homeassistant/components/media_player/recorder.py
@@ -1,0 +1,13 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.const import ATTR_ENTITY_PICTURE
+from homeassistant.core import HomeAssistant, callback
+
+from . import ATTR_INPUT_SOURCE_LIST, ATTR_SOUND_MODE_LIST
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude static and token attributes from being recorded in the database."""
+    return {ATTR_SOUND_MODE_LIST, ATTR_ENTITY_PICTURE, ATTR_INPUT_SOURCE_LIST}

--- a/tests/components/media_player/test_recorder.py
+++ b/tests/components/media_player/test_recorder.py
@@ -1,0 +1,48 @@
+"""The tests for media_player recorder."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components import media_player
+from homeassistant.components.media_player.const import (
+    ATTR_INPUT_SOURCE_LIST,
+    ATTR_SOUND_MODE_LIST,
+)
+from homeassistant.components.recorder.models import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME
+from homeassistant.core import State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed, async_init_recorder_component
+from tests.components.recorder.common import async_wait_recording_done_without_instance
+
+
+async def test_exclude_attributes(hass):
+    """Test media_player registered attributes to be excluded."""
+    await async_init_recorder_component(hass)
+    await async_setup_component(
+        hass, media_player.DOMAIN, {media_player.DOMAIN: {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    await async_wait_recording_done_without_instance(hass)
+
+    def _fetch_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(States, StateAttributes):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    assert len(states) > 1
+    for state in states:
+        assert ATTR_SOUND_MODE_LIST not in state.attributes
+        assert ATTR_ENTITY_PICTURE not in state.attributes
+        assert ATTR_INPUT_SOURCE_LIST not in state.attributes
+        assert ATTR_FRIENDLY_NAME in state.attributes


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- The input source list and sound mode list are no longer recorded in
  the database

- The entity_picture, which contains the token is no longer recorded
  in the database (similar to #68824)

- This data has little historical value since the data in the state
  machine for the entity is expected to be the same (except between versions)


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Before
`{"source_list":["A&E","ABC","Al Jazeera English","Amazon","AMC","App\u00a0Store","Arcade","Bravo","Cartoon Network","CNN","Comedy Central","Computers","discovery+","Disney+","Drawful 2","Earthlapse","EPIX","EPIX NOW","Fibbage","Fitness","Freeform","Grubhub","HBO Max","HISTORY","HomeCam","Hulu","Investigation Discovery GO","Looming","Movies","MSNBC","MTV","Music","Nat Geo TV","NBC News","Nest","Netflix","Olympic Channel","Paramount+","PBS Video","Peacock","Photos","Plane Finder","PlayStation Vue","Podcasts","Prime Video","Search","Service Browser","Settings","Showtime","Showtime Anytime","Spectrum TV","Speedtest","STARZ","SYFY","TBS","TED","The CW","TJPP6","TLC GO","Trailers","TV","TV Shows","UniFi Protect","USA","VICE","YouTube"],"media_content_id":"ad89f86e-86a0-4a1f-985a-b581dc6e5820","media_content_type":"video","media_duration":2241,"media_position":237,"media_position_updated_at":"2022-03-30T16:49:34.357527+00:00","media_title":"Have You Seen This Man? | S1 E3 - The Spy Who Scammed Me","app_id":"com.hulu.plus","app_name":"Hulu","entity_picture":"/api/media_player_proxy/media_player.master_bed_89?token=9b3f36c319de64860a1531f3588744b59bc0abc1f1e213cdbf706261330183ed&cache=ad89f86e-86a0-4a1f-985a-b581dc6e5820","friendly_name":"Master Bed 89","supported_features":450487}`

After
`{"media_content_id":"ad89f86e-86a0-4a1f-985a-b581dc6e5820","media_content_type":"video","media_duration":2241,"media_position":237,"media_position_updated_at":"2022-03-30T16:49:34.357527+00:00","media_title":"Have You Seen This Man? | S1 E3 - The Spy Who Scammed Me","app_id":"com.hulu.plus","app_name":"Hulu","friendly_name":"Master Bed 89","supported_features":450487}`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
