### PR TITLE
Remove deprecated unit configuration option from integration integration

### DIFF
--- a/homeassistant/components/integration/const.py
+++ b/homeassistant/components/integration/const.py
@@ -4,6 +4,7 @@ DOMAIN = "integration"
 
 CONF_ROUND_DIGITS = "round"
 CONF_SOURCE_SENSOR = "source"
+CONF_UNIT_OF_MEASUREMENT = "unit"
 CONF_UNIT_PREFIX = "unit_prefix"
 CONF_UNIT_TIME = "unit_time"
 

--- a/homeassistant/components/integration/const.py
+++ b/homeassistant/components/integration/const.py
@@ -4,7 +4,6 @@ DOMAIN = "integration"
 
 CONF_ROUND_DIGITS = "round"
 CONF_SOURCE_SENSOR = "source"
-CONF_UNIT_OF_MEASUREMENT = "unit"
 CONF_UNIT_PREFIX = "unit_prefix"
 CONF_UNIT_TIME = "unit_time"
 

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -36,7 +36,6 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .const import (
     CONF_ROUND_DIGITS,
     CONF_SOURCE_SENSOR,
-    CONF_UNIT_OF_MEASUREMENT,
     CONF_UNIT_PREFIX,
     CONF_UNIT_TIME,
     INTEGRATION_METHODS,
@@ -66,22 +65,18 @@ ICON = "mdi:chart-histogram"
 
 DEFAULT_ROUND = 3
 
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_UNIT_OF_MEASUREMENT),
-    PLATFORM_SCHEMA.extend(
-        {
-            vol.Optional(CONF_NAME): cv.string,
-            vol.Optional(CONF_UNIQUE_ID): cv.string,
-            vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
-            vol.Optional(CONF_ROUND_DIGITS, default=DEFAULT_ROUND): vol.Coerce(int),
-            vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
-            vol.Optional(CONF_UNIT_TIME, default=TIME_HOURS): vol.In(UNIT_TIME),
-            vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-            vol.Optional(CONF_METHOD, default=METHOD_TRAPEZOIDAL): vol.In(
-                INTEGRATION_METHODS
-            ),
-        }
-    ),
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
+        vol.Optional(CONF_ROUND_DIGITS, default=DEFAULT_ROUND): vol.Coerce(int),
+        vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
+        vol.Optional(CONF_UNIT_TIME, default=TIME_HOURS): vol.In(UNIT_TIME),
+        vol.Optional(CONF_METHOD, default=METHOD_TRAPEZOIDAL): vol.In(
+            INTEGRATION_METHODS
+        ),
+    }
 )
 
 
@@ -107,7 +102,6 @@ async def async_setup_entry(
         round_digits=int(config_entry.options[CONF_ROUND_DIGITS]),
         source_entity=source_entity_id,
         unique_id=config_entry.entry_id,
-        unit_of_measurement=None,
         unit_prefix=unit_prefix,
         unit_time=config_entry.options[CONF_UNIT_TIME],
     )
@@ -128,7 +122,6 @@ async def async_setup_platform(
         round_digits=config[CONF_ROUND_DIGITS],
         source_entity=config[CONF_SOURCE_SENSOR],
         unique_id=config.get(CONF_UNIQUE_ID),
-        unit_of_measurement=config.get(CONF_UNIT_OF_MEASUREMENT),
         unit_prefix=config[CONF_UNIT_PREFIX],
         unit_time=config[CONF_UNIT_TIME],
     )
@@ -147,7 +140,6 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
         round_digits: int,
         source_entity: str,
         unique_id: str | None,
-        unit_of_measurement: str | None,
         unit_prefix: str | None,
         unit_time: str,
     ) -> None:
@@ -162,7 +154,7 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
         self._unit_template = (
             f"{'' if unit_prefix is None else unit_prefix}{{}}{unit_time}"
         )
-        self._unit_of_measurement = unit_of_measurement
+        self._unit_of_measurement = None
         self._unit_prefix = UNIT_PREFIXES[unit_prefix]
         self._unit_time = UNIT_TIME[unit_time]
         self._attr_state_class = SensorStateClass.TOTAL

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .const import (
     CONF_ROUND_DIGITS,
     CONF_SOURCE_SENSOR,
+    CONF_UNIT_OF_MEASUREMENT,
     CONF_UNIT_PREFIX,
     CONF_UNIT_TIME,
     INTEGRATION_METHODS,
@@ -65,18 +66,22 @@ ICON = "mdi:chart-histogram"
 
 DEFAULT_ROUND = 3
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
-        vol.Optional(CONF_ROUND_DIGITS, default=DEFAULT_ROUND): vol.Coerce(int),
-        vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
-        vol.Optional(CONF_UNIT_TIME, default=TIME_HOURS): vol.In(UNIT_TIME),
-        vol.Optional(CONF_METHOD, default=METHOD_TRAPEZOIDAL): vol.In(
-            INTEGRATION_METHODS
-        ),
-    }
+PLATFORM_SCHEMA = vol.All(
+    cv.removed(CONF_UNIT_OF_MEASUREMENT),
+    PLATFORM_SCHEMA.extend(
+        {
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_UNIQUE_ID): cv.string,
+            vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
+            vol.Optional(CONF_ROUND_DIGITS, default=DEFAULT_ROUND): vol.Coerce(int),
+            vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
+            vol.Optional(CONF_UNIT_TIME, default=TIME_HOURS): vol.In(UNIT_TIME),
+            vol.Remove(CONF_UNIT_OF_MEASUREMENT): cv.string,
+            vol.Optional(CONF_METHOD, default=METHOD_TRAPEZOIDAL): vol.In(
+                INTEGRATION_METHODS
+            ),
+        }
+    ),
 )
 
 

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -4,8 +4,10 @@ from unittest.mock import patch
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
+    POWER_KILO_WATT,
     POWER_WATT,
     STATE_UNKNOWN,
     TIME_SECONDS,
@@ -24,7 +26,6 @@ async def test_state(hass) -> None:
             "platform": "integration",
             "name": "integration",
             "source": "sensor.power",
-            "unit": ENERGY_KILO_WATT_HOUR,
             "round": 2,
         }
     }
@@ -34,7 +35,7 @@ async def test_state(hass) -> None:
         assert await async_setup_component(hass, "sensor", config)
 
         entity_id = config["sensor"]["source"]
-        hass.states.async_set(entity_id, 1, {})
+        hass.states.async_set(entity_id, 1, {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT})
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.integration")
@@ -45,7 +46,13 @@ async def test_state(hass) -> None:
     future_now = dt_util.utcnow() + timedelta(seconds=3600)
     with patch("homeassistant.util.dt.utcnow", return_value=future_now):
         hass.states.async_set(
-            entity_id, 1, {"device_class": SensorDeviceClass.POWER}, force_update=True
+            entity_id,
+            1,
+            {
+                "device_class": SensorDeviceClass.POWER,
+                ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
+            },
+            force_update=True,
         )
         await hass.async_block_till_done()
 
@@ -137,7 +144,6 @@ async def test_trapezoidal(hass):
             "platform": "integration",
             "name": "integration",
             "source": "sensor.power",
-            "unit": ENERGY_KILO_WATT_HOUR,
             "round": 2,
         }
     }
@@ -152,7 +158,12 @@ async def test_trapezoidal(hass):
     for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
         now = dt_util.utcnow() + timedelta(minutes=time)
         with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
+            hass.states.async_set(
+                entity_id,
+                value,
+                {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT},
+                force_update=True,
+            )
             await hass.async_block_till_done()
 
     state = hass.states.get("sensor.integration")
@@ -171,7 +182,6 @@ async def test_left(hass):
             "name": "integration",
             "method": "left",
             "source": "sensor.power",
-            "unit": ENERGY_KILO_WATT_HOUR,
             "round": 2,
         }
     }
@@ -179,14 +189,19 @@ async def test_left(hass):
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
+    hass.states.async_set(entity_id, 0, {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT})
     await hass.async_block_till_done()
 
     # Testing a power sensor with non-monotonic intervals and values
     for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
         now = dt_util.utcnow() + timedelta(minutes=time)
         with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
+            hass.states.async_set(
+                entity_id,
+                value,
+                {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT},
+                force_update=True,
+            )
             await hass.async_block_till_done()
 
     state = hass.states.get("sensor.integration")
@@ -205,7 +220,6 @@ async def test_right(hass):
             "name": "integration",
             "method": "right",
             "source": "sensor.power",
-            "unit": ENERGY_KILO_WATT_HOUR,
             "round": 2,
         }
     }
@@ -213,14 +227,19 @@ async def test_right(hass):
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
+    hass.states.async_set(entity_id, 0, {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT})
     await hass.async_block_till_done()
 
     # Testing a power sensor with non-monotonic intervals and values
     for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
         now = dt_util.utcnow() + timedelta(minutes=time)
         with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
+            hass.states.async_set(
+                entity_id,
+                value,
+                {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT},
+                force_update=True,
+            )
             await hass.async_block_till_done()
 
     state = hass.states.get("sensor.integration")
@@ -280,12 +299,17 @@ async def test_suffix(hass):
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 1000, {})
+    hass.states.async_set(entity_id, 1000, {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT})
     await hass.async_block_till_done()
 
     now = dt_util.utcnow() + timedelta(seconds=10)
     with patch("homeassistant.util.dt.utcnow", return_value=now):
-        hass.states.async_set(entity_id, 1000, {}, force_update=True)
+        hass.states.async_set(
+            entity_id,
+            1000,
+            {ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT},
+            force_update=True,
+        )
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Integration sensor `unit` configuration parameter was deprecated in Home Assistant Core release 2021.10 and is now removed as it did not take `unit_prefix` and `unit_time` into account.

Example:
```
sensor:
  - platform: integration
    source: sensor.current_power
    name: energy_spent
    unit_prefix: k
    unit_time: h
    unit: MWs
    round: 2
```

The configuration in the example would cause the source sensor's unit (e.g. W) tobe over ruled and the integration sensor's `unit_of_measurement` would be set to MWs (MegaWatt-Second) even though the integral calculation was performed with k (kilo) and h (hour), i.e. the value of the integration sensor is in kWh not MWs.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a late closure to https://github.com/home-assistant/core/pull/55876

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
