### PR TITLE
Do not redact diagnostics empty key

### DIFF
--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -33,6 +33,10 @@ def async_redact_data(data: _T, to_redact: Iterable[Any]) -> _T:
     redacted = {**data}
 
     for key, value in redacted.items():
+        if value is None:
+            continue
+        if isinstance(value, str) and not value:
+            continue
         if key in to_redact:
             redacted[key] = REDACTED
         elif isinstance(value, Mapping):

--- a/tests/components/co2signal/test_diagnostics.py
+++ b/tests/components/co2signal/test_diagnostics.py
@@ -15,7 +15,7 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 async def test_entry_diagnostics(hass, hass_client):
     """Test config entry diagnostics."""
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_API_KEY: "", "location": ""}
+        domain=DOMAIN, data={CONF_API_KEY: "api_key", "location": ""}
     )
     config_entry.add_to_hass(hass)
     with patch("CO2Signal.get_latest", return_value=VALID_PAYLOAD):

--- a/tests/components/diagnostics/test_util.py
+++ b/tests/components/diagnostics/test_util.py
@@ -13,12 +13,18 @@ def test_redact():
             "key4_2": ["value4_2a", "value4_2b"],
             "key4_3": [["value4_3a", "value4_3b"], ["value4_3c", "value4_3d"]],
         },
+        "key5": None,
+        "key6": "",
+        "key7": False,
     }
 
     to_redact = {
         "key1",
         "key3",
         "key4_1",
+        "key5",
+        "key6",
+        "key7",
     }
 
     assert async_redact_data(data, to_redact) == {
@@ -30,4 +36,7 @@ def test_redact():
             "key4_2": ["value4_2a", "value4_2b"],
             "key4_3": [["value4_3a", "value4_3b"], ["value4_3c", "value4_3d"]],
         },
+        "key5": None,
+        "key6": "",
+        "key7": REDACTED,
     }

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -22,7 +22,7 @@ def mock_config_entry() -> MockConfigEntry:
         data={
             CONF_HOST: "192.168.1.2",
             CONF_PORT: 6053,
-            CONF_PASSWORD: "",
+            CONF_PASSWORD: "pwd",
             CONF_NOISE_PSK: "12345678123456781234567812345678",
         },
         unique_id="esphome-device",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a key value to redact with util `async_redact_data` is `None` or an empty string, does not make sense redact it and it is better to have evidence that there are no value for that key.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
