### PR TITLE
Add entity registry helper to update entity platform

### DIFF
--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -162,7 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 f"{entry.data[CONF_API_KEY]}_"
                 f"{'_'.join(entity_entry.unique_id.split('_')[1:])}"
             )
-            ent_reg.async_migrate_entity_to_new_platform(
+            ent_reg.async_update_entity_platform(
                 entity_entry.entity_id,
                 DOMAIN,
                 new_unique_id=new_unique_id,

--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -155,24 +155,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for entity_entry in er.async_entries_for_config_entry(
             ent_reg, old_config_entry_id
         ):
-            _LOGGER.debug(
-                "Removing %s and recreating it for the new config entry",
-                entity_entry.entity_id,
-            )
+            old_platform = entity_entry.platform
             # In case the API key has changed due to a V3 -> V4 change, we need to
             # generate the new entity's unique ID
             new_unique_id = (
                 f"{entry.data[CONF_API_KEY]}_"
                 f"{'_'.join(entity_entry.unique_id.split('_')[1:])}"
             )
-            new_entity_entry = ent_reg.async_migrate_entity_to_new_platform(
+            ent_reg.async_migrate_entity_to_new_platform(
                 entity_entry.entity_id,
                 DOMAIN,
                 new_unique_id=new_unique_id,
-                new_config_entry=entry,
+                new_config_entry_id=entry.entry_id,
+                new_device_id=device.id,
             )
-            assert new_entity_entry
-            _LOGGER.debug("Re-created %s", new_entity_entry.entity_id)
+            assert entity_entry
+            _LOGGER.debug(
+                "Migrated %s from %s to %s",
+                entity_entry.entity_id,
+                old_platform,
+                DOMAIN,
+            )
 
         # We only have one device in the registry but we will do a loop just in case
         for old_device in dr.async_entries_for_config_entry(

--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -155,36 +155,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for entity_entry in er.async_entries_for_config_entry(
             ent_reg, old_config_entry_id
         ):
-            _LOGGER.debug("Removing %s", entity_entry.entity_id)
-            ent_reg.async_remove(entity_entry.entity_id)
+            _LOGGER.debug(
+                "Removing %s and recreating it for the new config entry",
+                entity_entry.entity_id,
+            )
             # In case the API key has changed due to a V3 -> V4 change, we need to
             # generate the new entity's unique ID
             new_unique_id = (
                 f"{entry.data[CONF_API_KEY]}_"
                 f"{'_'.join(entity_entry.unique_id.split('_')[1:])}"
             )
-            _LOGGER.debug(
-                "Re-creating %s for the new config entry", entity_entry.entity_id
-            )
-            # We will precreate the entity so that any customizations can be preserved
-            new_entity_entry = ent_reg.async_get_or_create(
-                entity_entry.domain,
+            new_entity_entry = ent_reg.async_migrate_entity_to_new_platform(
+                entity_entry.entity_id,
                 DOMAIN,
-                new_unique_id,
-                suggested_object_id=entity_entry.entity_id.split(".")[1],
-                disabled_by=entity_entry.disabled_by,
-                config_entry=entry,
-                original_name=entity_entry.original_name,
-                original_icon=entity_entry.original_icon,
+                new_unique_id=new_unique_id,
+                new_config_entry=entry,
             )
+            assert new_entity_entry
             _LOGGER.debug("Re-created %s", new_entity_entry.entity_id)
-            # If there are customizations on the old entity, apply them to the new one
-            if entity_entry.name or entity_entry.icon:
-                ent_reg.async_update_entity(
-                    new_entity_entry.entity_id,
-                    name=entity_entry.name,
-                    icon=entity_entry.icon,
-                )
 
         # We only have one device in the registry but we will do a loop just in case
         for old_device in dr.async_entries_for_config_entry(

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -646,7 +646,7 @@ class EntityRegistry:
         )
 
     @callback
-    def async_migrate_entity_to_new_platform(
+    def async_update_entity_platform(
         self,
         entity_id: str,
         new_platform: str,
@@ -661,8 +661,6 @@ class EntityRegistry:
         This should only be used when an entity needs to be migrated between
         integrations.
         """
-        if not self.async_get(entity_id):
-            raise ValueError(f"Entity {entity_id} is not in the entity registry")
         if (
             state := self.hass.states.get(entity_id)
         ) is not None and state.state != STATE_UNKNOWN:

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -656,7 +656,7 @@ class EntityRegistry:
         new_device_id: str | None | UndefinedType = UNDEFINED,
     ) -> RegistryEntry:
         """
-        Migrate entity to new platform.
+        Update entity platform.
 
         This should only be used when an entity needs to be migrated between
         integrations.

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -625,6 +625,7 @@ class EntityRegistry:
         *,
         new_unique_id: str | None = None,
         new_config_entry: ConfigEntry | None = None,
+        new_device_id: str | None = None,
     ) -> RegistryEntry | None:
         """
         Migrate entity to new platform.
@@ -633,7 +634,7 @@ class EntityRegistry:
         integrations.
         """
         if not (entry := self.async_get(entity_id)):
-            return None
+            raise ValueError(f"Entity {entity_id} if not in the entity registry")
         if (
             state := self.hass.states.get(entity_id)
         ) is not None and state.state != STATE_UNKNOWN:
@@ -644,20 +645,31 @@ class EntityRegistry:
             entry.domain,
             new_platform,
             new_unique_id or entry.unique_id,
+            area_id=entry.area_id,
+            device_id=new_device_id or entry.device_id,
             suggested_object_id=entity_id.split(".")[1],
             disabled_by=entry.disabled_by,
+            hidden_by=entry.hidden_by,
             config_entry=new_config_entry,
             original_name=entry.original_name,
             original_icon=entry.original_icon,
+            capabilities=entry.capabilities,
+            entity_category=entry.entity_category,
+            supported_features=entry.supported_features,
+            unit_of_measurement=entry.unit_of_measurement,
         )
 
         # Apply any customizations from the old entity to the new one
-        if entry.name or entry.icon:
+        if entry.name or entry.icon or entry.device_class:
             self.async_update_entity(
                 entity_id,
                 name=entry.name,
                 icon=entry.icon,
+                device_class=entry.device_class,
             )
+        if entry.options:
+            for domain, options in entry.options.items():
+                self.async_update_entity_options(entity_id, domain, dict(options))
 
         return new_entry
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -623,8 +623,8 @@ class EntityRegistry:
         entity_id: str,
         new_platform: str,
         *,
+        new_config_entry_id: str | UndefinedType = UNDEFINED,
         new_unique_id: str | UndefinedType = UNDEFINED,
-        new_config_entry_id: str | None | UndefinedType = UNDEFINED,
         new_device_id: str | None | UndefinedType = UNDEFINED,
     ) -> RegistryEntry:
         """
@@ -641,6 +641,12 @@ class EntityRegistry:
             raise ValueError("Only entities that haven't been loaded can be migrated")
 
         old = self.entities[entity_id]
+        if new_config_entry_id == UNDEFINED and old.config_entry_id is not None:
+            raise ValueError(
+                f"new_config_entry_id required because {entity_id} is already linked "
+                "to a config entry"
+            )
+
         new = self.entities[entity_id] = attr.evolve(old, platform=new_platform)
         return self.async_update_entity(
             new.entity_id,

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1276,7 +1276,7 @@ def test_migrate_entity_to_new_platform(hass, registry):
     new_config_entry = MockConfigEntry(domain="light")
     new_unique_id = "1234"
 
-    assert registry.async_migrate_entity_to_new_platform(
+    assert registry.async_update_entity_platform(
         "light.light",
         "hue2",
         new_unique_id=new_unique_id,
@@ -1294,8 +1294,8 @@ def test_migrate_entity_to_new_platform(hass, registry):
     assert new_entry.platform == "hue2"
 
     # Test nonexisting entity
-    with pytest.raises(ValueError):
-        registry.async_migrate_entity_to_new_platform(
+    with pytest.raises(KeyError):
+        registry.async_update_entity_platform(
             "light.not_a_real_light",
             "hue2",
             new_unique_id=new_unique_id,
@@ -1304,7 +1304,7 @@ def test_migrate_entity_to_new_platform(hass, registry):
 
     # Test migrate entity without new config entry ID
     with pytest.raises(ValueError):
-        registry.async_migrate_entity_to_new_platform(
+        registry.async_update_entity_platform(
             "light.light",
             "hue3",
         )
@@ -1312,7 +1312,7 @@ def test_migrate_entity_to_new_platform(hass, registry):
     # Test entity with a state
     hass.states.async_set("light.light", "on")
     with pytest.raises(ValueError):
-        registry.async_migrate_entity_to_new_platform(
+        registry.async_update_entity_platform(
             "light.light",
             "hue2",
             new_unique_id=new_unique_id,

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1291,6 +1291,7 @@ def test_migrate_entity_to_new_platform(hass, registry):
     assert new_entry.unique_id == new_unique_id
     assert new_entry.name == "new_name"
     assert new_entry.icon == "new_icon"
+    assert new_entry.platform == "hue2"
 
     assert (
         registry.async_migrate_entity_to_new_platform(

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1293,6 +1293,7 @@ def test_migrate_entity_to_new_platform(hass, registry):
     assert new_entry.icon == "new_icon"
     assert new_entry.platform == "hue2"
 
+    # Test nonexisting entity
     with pytest.raises(ValueError):
         registry.async_migrate_entity_to_new_platform(
             "light.not_a_real_light",
@@ -1301,6 +1302,14 @@ def test_migrate_entity_to_new_platform(hass, registry):
             new_config_entry_id=new_config_entry.entry_id,
         )
 
+    # Test migrate entity without new config entry ID
+    with pytest.raises(ValueError):
+        registry.async_migrate_entity_to_new_platform(
+            "light.light",
+            "hue3",
+        )
+
+    # Test entity with a state
     hass.states.async_set("light.light", "on")
     with pytest.raises(ValueError):
         registry.async_migrate_entity_to_new_platform(

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1280,7 +1280,7 @@ def test_migrate_entity_to_new_platform(hass, registry):
         "light.light",
         "hue2",
         new_unique_id=new_unique_id,
-        new_config_entry=new_config_entry,
+        new_config_entry_id=new_config_entry.entry_id,
     )
 
     assert not registry.async_get_entity_id("light", "hue", orig_unique_id)
@@ -1293,15 +1293,13 @@ def test_migrate_entity_to_new_platform(hass, registry):
     assert new_entry.icon == "new_icon"
     assert new_entry.platform == "hue2"
 
-    assert (
+    with pytest.raises(ValueError):
         registry.async_migrate_entity_to_new_platform(
             "light.not_a_real_light",
             "hue2",
             new_unique_id=new_unique_id,
-            new_config_entry=new_config_entry,
+            new_config_entry_id=new_config_entry.entry_id,
         )
-        is None
-    )
 
     hass.states.async_set("light.light", "on")
     with pytest.raises(ValueError):
@@ -1309,5 +1307,5 @@ def test_migrate_entity_to_new_platform(hass, registry):
             "light.light",
             "hue2",
             new_unique_id=new_unique_id,
-            new_config_entry=new_config_entry,
+            new_config_entry_id=new_config_entry.entry_id,
         )


### PR DESCRIPTION
## Proposed change
When I introduced the `tomorrowio` integration which `climacell` config entries will automatically migrate to, I needed a way to migrate existing entity registry entries to a new platform so that the user didn't lose any customizations they made on the entity. I wrote the logic in the `tomorrowio` integration but I realized that this logic may be useful in other places, e.g. if we want to migrate `switch.light` platform entries to `switch_as_x` config entries.

If this gets merged I may do something similar for the device registry. Both of these helpers could pave the way for a built in migration of integrations between domains due to rebrands and such

CC @bdraco 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
