### PR TITLE
Make zwave_js config entry unique ID a string

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -770,3 +770,14 @@ def async_ensure_addon_updated(hass: HomeAssistant) -> None:
     if addon_manager.task_in_progress():
         raise ConfigEntryNotReady
     addon_manager.async_schedule_update_addon(catch_error=True)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    if isinstance(config_entry.unique_id, int):  # type: ignore[unreachable]
+        hass.config_entries.async_update_entry(  # type: ignore[unreachable]
+            config_entry,
+            unique_id=str(config_entry.unique_id),
+        )
+
+    return True

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -411,7 +411,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         else:
             await self.async_set_unique_id(
-                version_info.home_id, raise_on_progress=False
+                str(version_info.home_id), raise_on_progress=False
             )
             # Make sure we disable any add-on handling
             # if the controller is reconfigured in a manual step.
@@ -445,7 +445,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         except CannotConnect:
             return self.async_abort(reason="cannot_connect")
 
-        await self.async_set_unique_id(version_info.home_id)
+        await self.async_set_unique_id(str(version_info.home_id))
         self._abort_if_unique_id_configured(updates={CONF_URL: self.ws_address})
 
         return await self.async_step_hassio_confirm()
@@ -579,7 +579,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
                     raise AbortFlow("cannot_connect") from err
 
             await self.async_set_unique_id(
-                self.version_info.home_id, raise_on_progress=False
+                str(self.version_info.home_id), raise_on_progress=False
             )
 
         self._abort_if_unique_id_configured(

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -169,7 +169,7 @@ async def test_manual(hass):
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-    assert result2["result"].unique_id == 1234
+    assert result2["result"].unique_id == "1234"
 
 
 async def slow_server_version(*args):
@@ -243,7 +243,7 @@ async def test_manual_already_configured(hass):
             "integration_created_addon": True,
         },
         title=TITLE,
-        unique_id=1234,
+        unique_id="1234",
     )
     entry.add_to_hass(hass)
 
@@ -401,7 +401,10 @@ async def test_abort_discovery_with_existing_entry(
     """Test discovery flow is aborted if an entry already exists."""
 
     entry = MockConfigEntry(
-        domain=DOMAIN, data={"url": "ws://localhost:3000"}, title=TITLE, unique_id=1234
+        domain=DOMAIN,
+        data={"url": "ws://localhost:3000"},
+        title=TITLE,
+        unique_id="1234",
     )
     entry.add_to_hass(hass)
 
@@ -1039,7 +1042,7 @@ async def test_addon_running_already_configured(
             "s2_unauthenticated_key": "old987",
         },
         title=TITLE,
-        unique_id=1234,
+        unique_id="1234",
     )
     entry.add_to_hass(hass)
 
@@ -1370,7 +1373,7 @@ async def test_addon_installed_already_configured(
             "s2_unauthenticated_key": "old987",
         },
         title=TITLE,
-        unique_id=1234,
+        unique_id="1234",
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -8,6 +8,7 @@ from zwave_js_server.exceptions import BaseZwaveJSServerError, InvalidServerVers
 from zwave_js_server.model.node import Node
 
 from homeassistant.components.hassio.handler import HassioAPIError
+from homeassistant.components.zwave_js import async_migrate_entry
 from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
@@ -1327,3 +1328,12 @@ async def test_disabled_entity_on_value_removed(hass, zp3111, client, integratio
         | {battery_level_entity, binary_cover_entity, sensor_cover_entity}
         == new_unavailable_entities
     )
+
+
+async def test_async_migrate_entry(hass):
+    """Test async_migrate_entry."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=123456789)
+    assert isinstance(entry.unique_id, int)
+    await async_migrate_entry(hass, entry)
+    assert isinstance(entry.unique_id, str)
+    assert entry.unique_id == "123456789"


### PR DESCRIPTION
## Proposed change
We currently set the config entry `unitue_id` to an `int` which causes typing issues with `ConfigEntry`. This change updates all existing config entries to use a string reference and updates the config flow to set it as a string for new entries


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
