### PR TITLE
Set brand icon as entity picture on update entities

### DIFF
--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -219,7 +219,7 @@ class UpdateEntity(RestoreEntity):
             return None
 
         return (
-            f"https://brands.home-assistant.io/{self.platform.platform_name}/icon.png"
+            f"https://brands.home-assistant.io/_/{self.platform.platform_name}/icon.png"
         )
 
     @property

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -209,6 +209,20 @@ class UpdateEntity(RestoreEntity):
         return EntityCategory.DIAGNOSTIC
 
     @property
+    def entity_picture(self) -> str | None:
+        """Return the entity picture to use in the frontend.
+
+        Update entities return the brand icon based on the integration
+        domain by default.
+        """
+        if self.platform is None:
+            return None
+
+        return (
+            f"https://brands.home-assistant.io/{self.platform.platform_name}/icon.png"
+        )
+
+    @property
     def in_progress(self) -> bool | int | None:
         """Update installation progress.
 

--- a/homeassistant/components/wled/update.py
+++ b/homeassistant/components/wled/update.py
@@ -51,11 +51,6 @@ class WLEDUpdateEntity(WLEDEntity, UpdateEntity):
         return str(version)
 
     @property
-    def entity_picture(self) -> str:
-        """Return the entity picture to use in the frontend, if any."""
-        return "https://brands.home-assistant.io/wled/icon.png"
-
-    @property
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         # If we already run a pre-release, we consider being on the beta channel.

--- a/tests/components/demo/test_update.py
+++ b/tests/components/demo/test_update.py
@@ -12,7 +12,13 @@ from homeassistant.components.update.const import (
     ATTR_RELEASE_URL,
     ATTR_TITLE,
 )
-from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ATTR_ENTITY_PICTURE,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
@@ -37,6 +43,10 @@ def test_setup_params(hass: HomeAssistant) -> None:
         state.attributes[ATTR_RELEASE_SUMMARY] == "Awesome update, fixing everything!"
     )
     assert state.attributes[ATTR_RELEASE_URL] == "https://www.example.com/release/1.0.1"
+    assert (
+        state.attributes[ATTR_ENTITY_PICTURE]
+        == "https://brands.home-assistant.io/demo/icon.png"
+    )
 
     state = hass.states.get("update.demo_no_update")
     assert state
@@ -46,6 +56,10 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_LATEST_VERSION] == "1.0.0"
     assert state.attributes[ATTR_RELEASE_SUMMARY] is None
     assert state.attributes[ATTR_RELEASE_URL] is None
+    assert (
+        state.attributes[ATTR_ENTITY_PICTURE]
+        == "https://brands.home-assistant.io/demo/icon.png"
+    )
 
     state = hass.states.get("update.demo_add_on")
     assert state
@@ -57,6 +71,10 @@ def test_setup_params(hass: HomeAssistant) -> None:
         state.attributes[ATTR_RELEASE_SUMMARY] == "Awesome update, fixing everything!"
     )
     assert state.attributes[ATTR_RELEASE_URL] == "https://www.example.com/release/1.0.1"
+    assert (
+        state.attributes[ATTR_ENTITY_PICTURE]
+        == "https://brands.home-assistant.io/demo/icon.png"
+    )
 
     state = hass.states.get("update.demo_living_room_bulb_update")
     assert state
@@ -69,6 +87,10 @@ def test_setup_params(hass: HomeAssistant) -> None:
         state.attributes[ATTR_RELEASE_URL] == "https://www.example.com/release/1.93.3"
     )
     assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert (
+        state.attributes[ATTR_ENTITY_PICTURE]
+        == "https://brands.home-assistant.io/demo/icon.png"
+    )
 
     state = hass.states.get("update.demo_update_with_progress")
     assert state
@@ -81,6 +103,10 @@ def test_setup_params(hass: HomeAssistant) -> None:
         state.attributes[ATTR_RELEASE_URL] == "https://www.example.com/release/1.93.3"
     )
     assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert (
+        state.attributes[ATTR_ENTITY_PICTURE]
+        == "https://brands.home-assistant.io/demo/icon.png"
+    )
 
 
 async def test_update_with_progress(hass: HomeAssistant) -> None:

--- a/tests/components/demo/test_update.py
+++ b/tests/components/demo/test_update.py
@@ -45,7 +45,7 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_RELEASE_URL] == "https://www.example.com/release/1.0.1"
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "https://brands.home-assistant.io/demo/icon.png"
+        == "https://brands.home-assistant.io/_/demo/icon.png"
     )
 
     state = hass.states.get("update.demo_no_update")
@@ -58,7 +58,7 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_RELEASE_URL] is None
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "https://brands.home-assistant.io/demo/icon.png"
+        == "https://brands.home-assistant.io/_/demo/icon.png"
     )
 
     state = hass.states.get("update.demo_add_on")
@@ -73,7 +73,7 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_RELEASE_URL] == "https://www.example.com/release/1.0.1"
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "https://brands.home-assistant.io/demo/icon.png"
+        == "https://brands.home-assistant.io/_/demo/icon.png"
     )
 
     state = hass.states.get("update.demo_living_room_bulb_update")
@@ -89,7 +89,7 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "https://brands.home-assistant.io/demo/icon.png"
+        == "https://brands.home-assistant.io/_/demo/icon.png"
     )
 
     state = hass.states.get("update.demo_update_with_progress")
@@ -105,7 +105,7 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "https://brands.home-assistant.io/demo/icon.png"
+        == "https://brands.home-assistant.io/_/demo/icon.png"
     )
 
 

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -81,7 +81,7 @@ async def test_update(hass: HomeAssistant) -> None:
     update.platform = MockEntityPlatform(hass)
     assert (
         update.entity_picture
-        == "https://brands.home-assistant.io/test_platform/icon.png"
+        == "https://brands.home-assistant.io/_/test_platform/icon.png"
     )
 
     # Test no update available

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockEntityPlatform, mock_restore_cache
 
 
 class MockUpdateEntity(UpdateEntity):
@@ -58,6 +58,7 @@ async def test_update(hass: HomeAssistant) -> None:
     update._attr_title = "Title"
 
     assert update.entity_category is EntityCategory.DIAGNOSTIC
+    assert update.entity_picture is None
     assert update.installed_version == "1.0.0"
     assert update.latest_version == "1.0.1"
     assert update.release_summary == "Summary"
@@ -75,6 +76,13 @@ async def test_update(hass: HomeAssistant) -> None:
         ATTR_SKIPPED_VERSION: None,
         ATTR_TITLE: "Title",
     }
+
+    # Test with platform
+    update.platform = MockEntityPlatform(hass)
+    assert (
+        update.entity_picture
+        == "https://brands.home-assistant.io/test_platform/icon.png"
+    )
 
     # Test no update available
     update._attr_installed_version = "1.0.0"

--- a/tests/components/wled/test_update.py
+++ b/tests/components/wled/test_update.py
@@ -49,7 +49,7 @@ async def test_update_available(
     assert state.state == STATE_ON
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "https://brands.home-assistant.io/wled/icon.png"
+        == "https://brands.home-assistant.io/_/wled/icon.png"
     )
     assert state.attributes[ATTR_INSTALLED_VERSION] == "0.8.5"
     assert state.attributes[ATTR_LATEST_VERSION] == "0.12.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Set the brand icons for update integrations by default. This can be overridden by integrations if wanted/needed. For example: in case the integration has no brand icon, has a different source, or wants to use an MDI icon instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
