### PR TITLE
Fix issue with relative time-based state updates in RainMachine zones

### DIFF
--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -20,7 +20,7 @@ from .const import (
     DATA_RESTRICTIONS_UNIVERSAL,
     DOMAIN,
 )
-from .model import RainMachineSensorDescriptionMixin
+from .model import RainMachineDescriptionMixinApiCategory
 
 TYPE_FLOW_SENSOR = "flow_sensor"
 TYPE_FREEZE = "freeze"
@@ -35,7 +35,7 @@ TYPE_WEEKDAY = "weekday"
 
 @dataclass
 class RainMachineBinarySensorDescription(
-    BinarySensorEntityDescription, RainMachineSensorDescriptionMixin
+    BinarySensorEntityDescription, RainMachineDescriptionMixinApiCategory
 ):
     """Describe a RainMachine binary sensor."""
 
@@ -119,7 +119,7 @@ async def async_setup_entry(
     coordinators = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
 
     @callback
-    def async_get_sensor(api_category: str) -> partial:
+    def async_get_sensor_by_api_category(api_category: str) -> partial:
         """Generate the appropriate sensor object for an API category."""
         if api_category == DATA_PROVISION_SETTINGS:
             return partial(
@@ -143,7 +143,9 @@ async def async_setup_entry(
 
     async_add_entities(
         [
-            async_get_sensor(description.api_category)(controller, description)
+            async_get_sensor_by_api_category(description.api_category)(
+                controller, description
+            )
             for description in BINARY_SENSOR_DESCRIPTIONS
         ]
     )

--- a/homeassistant/components/rainmachine/model.py
+++ b/homeassistant/components/rainmachine/model.py
@@ -3,7 +3,14 @@ from dataclasses import dataclass
 
 
 @dataclass
-class RainMachineSensorDescriptionMixin:
+class RainMachineDescriptionMixinApiCategory:
     """Define an entity description mixin for binary and regular sensors."""
 
     api_category: str
+
+
+@dataclass
+class RainMachineDescriptionMixinUid:
+    """Define an entity description mixin for switches."""
+
+    uid: int

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -219,7 +219,7 @@ class ZoneTimeRemainingSensor(RainMachineEntity, SensorEntity):
         data = self.coordinator.data[self.entity_description.uid]
         now = utcnow()
 
-        if data["state"] != ZONE_STATE_RUNNING:
+        if ZONE_STATE_MAP.get(data["state"]) != ZONE_STATE_RUNNING:
             # If the zone isn't actively running, return immediately:
             return
 

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -146,7 +146,7 @@ async def async_setup_entry(
                 controller,
                 RainMachineSensorDescriptionUid(
                     key=f"{TYPE_ZONE_TIME_REMAINING}_{uid}",
-                    name=f"Zone Time Remaining: {zone['name']}",
+                    name=f"Zone Run Completion Time: {zone['name']}",
                     device_class=SensorDeviceClass.TIMESTAMP,
                     entity_category=EntityCategory.DIAGNOSTIC,
                     uid=uid,
@@ -211,6 +211,8 @@ class ZoneTimeRemainingSensor(RainMachineEntity, SensorEntity):
         ]
 
         if seconds_remaining == 0:
-            self._attr_native_value = None
-        else:
-            self._attr_native_value = now + timedelta(seconds=seconds_remaining)
+            # If 0 seconds remain, the zone is finished/not running, so we leave the
+            # state wherever it was:
+            return
+
+        self._attr_native_value = now + timedelta(seconds=seconds_remaining)

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -41,6 +41,15 @@ TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
 TYPE_FREEZE_TEMP = "freeze_protect_temp"
 TYPE_ZONE_RUN_COMPLETION_TIME = "zone_run_completion_time"
 
+ZONE_STATE_NOT_RUNNING = "not_running"
+ZONE_STATE_PENDING = "pending"
+ZONE_STATE_RUNNING = "running"
+ZONE_STATE_MAP = {
+    0: ZONE_STATE_NOT_RUNNING,
+    1: ZONE_STATE_RUNNING,
+    2: ZONE_STATE_PENDING,
+}
+
 
 @dataclass
 class RainMachineSensorDescriptionApiCategory(
@@ -207,17 +216,14 @@ class ZoneTimeRemainingSensor(RainMachineEntity, SensorEntity):
     @callback
     def update_from_latest_data(self) -> None:
         """Update the state."""
+        data = self.coordinator.data[self.entity_description.uid]
         now = utcnow()
-        seconds_remaining = self.coordinator.data[self.entity_description.uid][
-            "remaining"
-        ]
 
-        if seconds_remaining == 0:
-            # If 0 seconds remain, the zone is finished/not running, so we leave the
-            # state wherever it was:
+        if data["state"] != ZONE_STATE_RUNNING:
+            # If the zone isn't actively running, return immediately:
             return
 
-        new_timestamp = now + timedelta(seconds=seconds_remaining)
+        new_timestamp = now + timedelta(seconds=data["remaining"])
 
         if self._attr_native_value:
             assert isinstance(self._attr_native_value, datetime)

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -146,7 +146,7 @@ async def async_setup_entry(
                 controller,
                 RainMachineSensorDescriptionUid(
                     key=f"{TYPE_ZONE_TIME_REMAINING}_{uid}",
-                    name=f"Zone Run Completion Time: {zone['name']}",
+                    name=f"{zone['name']} Run Completion Time",
                     device_class=SensorDeviceClass.TIMESTAMP,
                     entity_category=EntityCategory.DIAGNOSTIC,
                     uid=uid,

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -31,6 +31,7 @@ from .const import (
     DEFAULT_ZONE_RUN,
     DOMAIN,
 )
+from .model import RainMachineDescriptionMixinUid
 
 ATTR_AREA = "area"
 ATTR_CS_ON = "cs_on"
@@ -110,15 +111,8 @@ VEGETATION_MAP = {
 
 
 @dataclass
-class RainMachineSwitchDescriptionMixin:
-    """Define an entity description mixin for switches."""
-
-    uid: int
-
-
-@dataclass
 class RainMachineSwitchDescription(
-    SwitchEntityDescription, RainMachineSwitchDescriptionMixin
+    SwitchEntityDescription, RainMachineDescriptionMixinUid
 ):
     """Describe a RainMachine switch."""
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Coroutine
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from regenmaschine.controller import Controller
@@ -20,7 +20,6 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util.dt import utcnow
 
 from . import RainMachineEntity, async_update_programs_and_zones
 from .const import (
@@ -50,9 +49,9 @@ ATTR_SOIL_TYPE = "soil_type"
 ATTR_SPRINKLER_TYPE = "sprinkler_head_type"
 ATTR_STATUS = "status"
 ATTR_SUN_EXPOSURE = "sun_exposure"
+ATTR_TIME_REMAINING = "time_remaining"
 ATTR_VEGETATION_TYPE = "vegetation_type"
 ATTR_ZONES = "zones"
-ATTR_ZONE_FINISHED_AT = "zone_finished_at"
 
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
@@ -382,9 +381,6 @@ class RainMachineZone(RainMachineActivitySwitch):
             self._controller.zones.stop(self.entity_description.uid)
         )
 
-        self._attr_extra_state_attributes[ATTR_ZONE_FINISHED_AT] = None
-        self.async_write_ha_state()
-
     async def async_turn_on_when_active(self, **kwargs: Any) -> None:
         """Turn the switch on when its associated activity is active."""
         await self._async_run_api_coroutine(
@@ -393,14 +389,6 @@ class RainMachineZone(RainMachineActivitySwitch):
                 kwargs.get("duration", self._entry.options[CONF_ZONE_RUN_TIME]),
             )
         )
-
-        # When the zone starts, calculate when it is expected to be done and set the
-        # appropriate attribute once:
-        data = self.coordinator.data[self.entity_description.uid]
-        self._attr_extra_state_attributes[ATTR_ZONE_FINISHED_AT] = utcnow() + timedelta(
-            seconds=data["remaining"]
-        )
-        self.async_write_ha_state()
 
     @callback
     def update_from_latest_data(self) -> None:
@@ -423,6 +411,7 @@ class RainMachineZone(RainMachineActivitySwitch):
                 ATTR_SPRINKLER_TYPE: SPRINKLER_TYPE_MAP.get(data.get("group_id")),
                 ATTR_STATUS: RUN_STATUS_MAP[data["state"]],
                 ATTR_SUN_EXPOSURE: SUN_EXPOSURE_MAP.get(data.get("sun")),
+                ATTR_TIME_REMAINING: data.get("remaining"),
                 ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(data.get("type")),
             }
         )

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -50,7 +50,6 @@ ATTR_SOIL_TYPE = "soil_type"
 ATTR_SPRINKLER_TYPE = "sprinkler_head_type"
 ATTR_STATUS = "status"
 ATTR_SUN_EXPOSURE = "sun_exposure"
-ATTR_TIME_REMAINING = "time_remaining"
 ATTR_VEGETATION_TYPE = "vegetation_type"
 ATTR_ZONES = "zones"
 
@@ -405,7 +404,6 @@ class RainMachineZone(RainMachineActivitySwitch):
                 ATTR_SPRINKLER_TYPE: SPRINKLER_TYPE_MAP.get(data.get("group_id")),
                 ATTR_STATUS: RUN_STATUS_MAP[data["state"]],
                 ATTR_SUN_EXPOSURE: SUN_EXPOSURE_MAP.get(data.get("sun")),
-                ATTR_TIME_REMAINING: data.get("remaining"),
                 ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(data.get("type")),
             }
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
RainMachine zone switches no longer have the `time_remaining` attribute; instead, each zone now has a separate sensor entity (device class of `timestamp`, entity category of `diagnostic`) that shows the datetime at which the zone will finish (or last finished if the zone isn't running).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When RainMachine zones were running, we updated a relative `time_remaining` attribute every time the controller was polled (causing a large number of state updates). This PR eliminates that attribute and replaces it with a separate `timestamp` sensor (which is a UTC timestamp that denotes when the zone will be finished). This sensor is "wobble-proof," meaning that it won't spam the state machine unless there's at least 5 seconds of difference between values from the API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/69204
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
