### PR TITLE
Exclude more media player attributes from recorder

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -70,6 +70,7 @@ from .browse_media import BrowseMedia, async_process_play_media_url  # noqa: F40
 from .const import (  # noqa: F401
     ATTR_APP_ID,
     ATTR_APP_NAME,
+    ATTR_ENTITY_PICTURE_LOCAL,
     ATTR_GROUP_MEMBERS,
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
@@ -954,7 +955,7 @@ class MediaPlayerEntity(Entity):
                 state_attr[attr] = value
 
         if self.media_image_remotely_accessible:
-            state_attr["entity_picture_local"] = self.media_image_local
+            state_attr[ATTR_ENTITY_PICTURE_LOCAL] = self.media_image_local
 
         return state_attr
 

--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -6,6 +6,7 @@ CONTENT_AUTH_EXPIRY_TIME = 3600 * 24
 
 ATTR_APP_ID = "app_id"
 ATTR_APP_NAME = "app_name"
+ATTR_ENTITY_PICTURE_LOCAL = "entity_picture_local"
 ATTR_GROUP_MEMBERS = "group_members"
 ATTR_INPUT_SOURCE = "source"
 ATTR_INPUT_SOURCE_LIST = "source_list"

--- a/homeassistant/components/media_player/recorder.py
+++ b/homeassistant/components/media_player/recorder.py
@@ -4,10 +4,23 @@ from __future__ import annotations
 from homeassistant.const import ATTR_ENTITY_PICTURE
 from homeassistant.core import HomeAssistant, callback
 
-from . import ATTR_INPUT_SOURCE_LIST, ATTR_SOUND_MODE_LIST
+from . import (
+    ATTR_ENTITY_PICTURE_LOCAL,
+    ATTR_INPUT_SOURCE_LIST,
+    ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION_UPDATED_AT,
+    ATTR_SOUND_MODE_LIST,
+)
 
 
 @callback
 def exclude_attributes(hass: HomeAssistant) -> set[str]:
     """Exclude static and token attributes from being recorded in the database."""
-    return {ATTR_SOUND_MODE_LIST, ATTR_ENTITY_PICTURE, ATTR_INPUT_SOURCE_LIST}
+    return {
+        ATTR_ENTITY_PICTURE_LOCAL,
+        ATTR_ENTITY_PICTURE,
+        ATTR_INPUT_SOURCE_LIST,
+        ATTR_MEDIA_POSITION_UPDATED_AT,
+        ATTR_MEDIA_POSITION,
+        ATTR_SOUND_MODE_LIST,
+    }

--- a/tests/components/media_player/test_recorder.py
+++ b/tests/components/media_player/test_recorder.py
@@ -5,7 +5,10 @@ from datetime import timedelta
 
 from homeassistant.components import media_player
 from homeassistant.components.media_player.const import (
+    ATTR_ENTITY_PICTURE_LOCAL,
     ATTR_INPUT_SOURCE_LIST,
+    ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_SOUND_MODE_LIST,
 )
 from homeassistant.components.recorder.models import StateAttributes, States
@@ -42,7 +45,10 @@ async def test_exclude_attributes(hass):
     states: list[State] = await hass.async_add_executor_job(_fetch_states)
     assert len(states) > 1
     for state in states:
-        assert ATTR_SOUND_MODE_LIST not in state.attributes
         assert ATTR_ENTITY_PICTURE not in state.attributes
-        assert ATTR_INPUT_SOURCE_LIST not in state.attributes
+        assert ATTR_ENTITY_PICTURE_LOCAL not in state.attributes
         assert ATTR_FRIENDLY_NAME in state.attributes
+        assert ATTR_INPUT_SOURCE_LIST not in state.attributes
+        assert ATTR_MEDIA_POSITION not in state.attributes
+        assert ATTR_MEDIA_POSITION_UPDATED_AT not in state.attributes
+        assert ATTR_SOUND_MODE_LIST not in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The "entity_picture_local", "media_position" and "media_position_updated_at" attributes of a media player, are no longer recorded in the state history database.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As entity picture was already excluded, it makes sense to exclude "entity_picture_local" as well.

Additionally added media player position attributes to be excluded, as it creates a lot of data while playing (depending on the integration, it can be quite a lot).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
