### PR TITLE
Only fire device_registry_updated for suggested_area if the suggestion results in an area change

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -85,7 +85,6 @@ class DeviceEntry:
     model: str | None = attr.ib(default=None)
     name_by_user: str | None = attr.ib(default=None)
     name: str | None = attr.ib(default=None)
-    suggested_area: str | None = attr.ib(default=None)
     sw_version: str | None = attr.ib(default=None)
     hw_version: str | None = attr.ib(default=None)
     via_device_id: str | None = attr.ib(default=None)
@@ -492,7 +491,6 @@ class DeviceRegistry:
             ("name", name),
             ("name_by_user", name_by_user),
             ("area_id", area_id),
-            ("suggested_area", suggested_area),
             ("sw_version", sw_version),
             ("hw_version", hw_version),
             ("via_device_id", via_device_id),

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -43,6 +43,8 @@ CONNECTION_ZIGBEE = "zigbee"
 
 ORPHANED_DEVICE_KEEP_SECONDS = 86400 * 30
 
+RUNTIME_ONLY_ATTRS = {"suggested_area"}
+
 
 class _DeviceIndex(NamedTuple):
     identifiers: dict[tuple[str, str], str]
@@ -509,6 +511,10 @@ class DeviceRegistry:
 
         new = attr.evolve(old, **new_values)
         self._update_device(old, new)
+
+        if RUNTIME_ONLY_ATTRS.issuperset(new_values):
+            return new
+
         self.async_schedule_save()
 
         data: dict[str, Any] = {

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -85,6 +85,7 @@ class DeviceEntry:
     model: str | None = attr.ib(default=None)
     name_by_user: str | None = attr.ib(default=None)
     name: str | None = attr.ib(default=None)
+    suggested_area: str | None = attr.ib(default=None)
     sw_version: str | None = attr.ib(default=None)
     hw_version: str | None = attr.ib(default=None)
     via_device_id: str | None = attr.ib(default=None)
@@ -491,6 +492,7 @@ class DeviceRegistry:
             ("name", name),
             ("name_by_user", name_by_user),
             ("area_id", area_id),
+            ("suggested_area", suggested_area),
             ("sw_version", sw_version),
             ("hw_version", hw_version),
             ("via_device_id", via_device_id),

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -512,6 +512,9 @@ class DeviceRegistry:
         new = attr.evolve(old, **new_values)
         self._update_device(old, new)
 
+        # If its only run time attributes (suggested_area)
+        # that do not get saved we do not want to write
+        # to disk or fire an event
         if RUNTIME_ONLY_ATTRS.issuperset(new_values):
             return new
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -514,7 +514,9 @@ class DeviceRegistry:
 
         # If its only run time attributes (suggested_area)
         # that do not get saved we do not want to write
-        # to disk or fire an event
+        # to disk or fire an event as we would end up
+        # firing events for data we have nothing to compare
+        # against since its never saved on disk
         if RUNTIME_ONLY_ATTRS.issuperset(new_values):
             return new
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1128,6 +1128,16 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
     assert update_events[1]["device_id"] == entry.id
     assert update_events[1]["changes"] == {"area_id": None, "suggested_area": None}
 
+    # Do not save or fire the event if the suggested
+    # area does not result in a change of area
+    # but still update the actual entry
+    with patch.object(registry, "async_schedule_save") as mock_save_2:
+        updated_entry = registry.async_update_device(entry.id, suggested_area="Other")
+    assert len(update_events) == 2
+    assert mock_save_2.call_count == 0
+    assert updated_entry != entry
+    assert updated_entry.suggested_area == "Other"
+
 
 async def test_cleanup_device_registry(hass, registry):
     """Test cleanup works."""

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -87,7 +87,6 @@ async def test_get_or_create_returns_same_entry(
     assert entry3.model == "model"
     assert entry3.name == "name"
     assert entry3.sw_version == "sw-version"
-    assert entry3.suggested_area == "Game Room"
     assert entry3.area_id == game_room_area.id
 
     await hass.async_block_till_done()
@@ -847,13 +846,11 @@ async def test_loading_saving_data(hass, registry, area_registry):
 
     # Ensure a save/load cycle does not keep suggested area
     new_kitchen_light = registry2.async_get_device({("hue", "999")})
-    assert orig_kitchen_light.suggested_area == "Kitchen"
 
-    orig_kitchen_light_witout_suggested_area = registry.async_update_device(
+    orig_kitchen_light_without_suggested_area = registry.async_update_device(
         orig_kitchen_light.id, suggested_area=None
     )
-    assert orig_kitchen_light_witout_suggested_area.suggested_area is None
-    assert orig_kitchen_light_witout_suggested_area == new_kitchen_light
+    assert orig_kitchen_light_without_suggested_area == new_kitchen_light
 
 
 async def test_no_unnecessary_changes(registry):
@@ -1099,7 +1096,6 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bla", "123")},
     )
-    assert not entry.suggested_area
     assert entry.area_id is None
 
     suggested_area = "Pool"
@@ -1111,7 +1107,6 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
 
     assert mock_save.call_count == 1
     assert updated_entry != entry
-    assert updated_entry.suggested_area == suggested_area
 
     pool_area = area_registry.async_get_area_by_name("Pool")
     assert pool_area is not None
@@ -1126,7 +1121,7 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
     assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry.id
-    assert update_events[1]["changes"] == {"area_id": None, "suggested_area": None}
+    assert update_events[1]["changes"] == {"area_id": None}
 
 
 async def test_cleanup_device_registry(hass, registry):

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -87,6 +87,7 @@ async def test_get_or_create_returns_same_entry(
     assert entry3.model == "model"
     assert entry3.name == "name"
     assert entry3.sw_version == "sw-version"
+    assert entry3.suggested_area == "Game Room"
     assert entry3.area_id == game_room_area.id
 
     await hass.async_block_till_done()
@@ -846,11 +847,13 @@ async def test_loading_saving_data(hass, registry, area_registry):
 
     # Ensure a save/load cycle does not keep suggested area
     new_kitchen_light = registry2.async_get_device({("hue", "999")})
+    assert orig_kitchen_light.suggested_area == "Kitchen"
 
-    orig_kitchen_light_without_suggested_area = registry.async_update_device(
+    orig_kitchen_light_witout_suggested_area = registry.async_update_device(
         orig_kitchen_light.id, suggested_area=None
     )
-    assert orig_kitchen_light_without_suggested_area == new_kitchen_light
+    assert orig_kitchen_light_witout_suggested_area.suggested_area is None
+    assert orig_kitchen_light_witout_suggested_area == new_kitchen_light
 
 
 async def test_no_unnecessary_changes(registry):
@@ -1096,6 +1099,7 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bla", "123")},
     )
+    assert not entry.suggested_area
     assert entry.area_id is None
 
     suggested_area = "Pool"
@@ -1107,6 +1111,7 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
 
     assert mock_save.call_count == 1
     assert updated_entry != entry
+    assert updated_entry.suggested_area == suggested_area
 
     pool_area = area_registry.async_get_area_by_name("Pool")
     assert pool_area is not None
@@ -1121,7 +1126,7 @@ async def test_update_suggested_area(hass, registry, area_registry, update_event
     assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry.id
-    assert update_events[1]["changes"] == {"area_id": None}
+    assert update_events[1]["changes"] == {"area_id": None, "suggested_area": None}
 
 
 async def test_cleanup_device_registry(hass, registry):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Found this while doing an audit of non state change events in the db with `select * from events where event_type!='state_changed';`


- We do not store the suggested_area, which means it causes many
  device_registry_updated events to fire as it is changed at startup

- If the suggested area results in a change of area id, we will
   still get a `device_registry_updated` event

Fixes numerous device_registry_updated events being fired at startup (this is only a subset of what my production instance does):
```
1753398|device_registry_updated|{"action":"update","device_id":"3214631fc7224697bac6e1c01f96c52f","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.371745|8ef987dfa973ebe0ea44e2a7ed7692eb||
1753400|device_registry_updated|{"action":"update","device_id":"5401b9e74ade4e089ad2e3ce82d1c449","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.372446|6803c44f85589e0511bb832008f8f655||
1753402|device_registry_updated|{"action":"update","device_id":"3ec1dc94d2014987936f94aeaf23cfd2","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.373086|96770bbe69b0d9fff85564f7f9e302c3||
1753404|device_registry_updated|{"action":"update","device_id":"6e7cfdb8d4a64844978fdef9db5c334f","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.373604|13903bcb428d8680184d6e9a04b58a5e||
1753406|device_registry_updated|{"action":"update","device_id":"04d81a827188406da06670c557d2fe6a","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.374096|8e13c2f370950de985aa05a55bd6a0a0||
1753408|device_registry_updated|{"action":"update","device_id":"3b90f48be2664b6ab4d9c8c9925f618b","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.374608|506408422229c5cdb08549f98f89d5c7||
1753410|device_registry_updated|{"action":"update","device_id":"f62065291bfa4e0db8cee50b5df1ce89","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.375078|827a33f4441aaaa4d4947097110b8faf||
1753412|device_registry_updated|{"action":"update","device_id":"2818c7b209674035b1eabc78af340fc7","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.375567|a30936ee8e2f9e6327bf8694c224f4d2||
1753414|device_registry_updated|{"action":"update","device_id":"15357139477a33bca9d69db0876e8131","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.376031|7394d0ddcfffb3b786dbd6dd8ddf91c1||
1753416|device_registry_updated|{"action":"update","device_id":"ab670f205a634b27aa266c2136e4736d","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.376675|9aadd91d5641ddb673e6138a53759bc3||
1753436|device_registry_updated|{"action":"update","device_id":"ecafc8f5c6354e3cab52ae16826efb1e","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.383949|587bc9bbccf1e8efba496eab601c88c8||
1753438|device_registry_updated|{"action":"update","device_id":"26e4811300ad4ac39db0fb9d13545487","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.384540|22f1fe09c0440dc03cc523016d1e4822||
1753439|device_registry_updated|{"action":"update","device_id":"ebdd341539fe496dac8cca7395b44adb","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.384932|5641bdf79a4353503e91925733b727c2||
1753440|device_registry_updated|{"action":"update","device_id":"c7630b629004dd51ef5668ec69b11251","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.385281|ed53292d9b554217721ed34965a743aa||
1753441|device_registry_updated|{"action":"update","device_id":"5c5d709a9b5b4cdc838a1d17a0988d64","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.385655|ffea09aabfaf9452a8a8aba4027fd3f1||
1753442|device_registry_updated|{"action":"update","device_id":"617d9b72d14d4669a1199de8b63b6b44","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.386005|7c3d9b182fee5a3a601b346bd489e6ba||
1753443|device_registry_updated|{"action":"update","device_id":"d1fd340b41bb422982f7ee9033503301","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.386358|1945813acccb6ba8a5518848de52e4d6||
1753444|device_registry_updated|{"action":"update","device_id":"e142fc88b42740cba572e88d22cae5e4","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.386714|a7d035f3139cbc860b9aee516ac8eda3||
1753445|device_registry_updated|{"action":"update","device_id":"c826ad2184c247f2ac84d86c0a9d39c4","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.387068|56f9cbd73f388af278fba421e3df852a||
1753446|device_registry_updated|{"action":"update","device_id":"4bcacdce46fc43aaa14626638b79152d","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.387577|505ba57e2550a021a6e726ba4180fe36||
1753447|device_registry_updated|{"action":"update","device_id":"9ca77eaa3228091dcf38e203ef93d95a","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.387945|7b3c234ca853acff78264bf329fd04b6||
1753448|device_registry_updated|{"action":"update","device_id":"29387c677ec44d4bafac79c909d1e3a8","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.388321|22a5cf8eb358041e69a4b4ef9478f50a||
1753449|device_registry_updated|{"action":"update","device_id":"6f7790072a3f4a728a253ce73de2c211","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.388693|5243c8c0a7b339d1f65d19724c3e136a||
1753450|device_registry_updated|{"action":"update","device_id":"312d5fc10e64469f93a75e522fbfa72b","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.389056|01553940a7362081e52912add8cef13f||
1753451|device_registry_updated|{"action":"update","device_id":"d1d181b229cf48aea4f268f120b519c2","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.389444|6e5187f526a637e65b9b5ab2a167b3e2||
1753452|device_registry_updated|{"action":"update","device_id":"47c20c45b9964b5594053a8ad7cf1e48","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.389783|a0d9f6d33de5ef8c653e88c5fb53ff85||
1753453|device_registry_updated|{"action":"update","device_id":"ace7a92d29d34e72bc1811ae1c718abd","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.390119|fb55c30b9f61871cc7583e97888e2d7c||
1753454|device_registry_updated|{"action":"update","device_id":"bf4ba62c747c421792e13802f3b31dc2","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.390505|e981668b2a975376bd8e9b710b4334ca||
1753455|device_registry_updated|{"action":"update","device_id":"e82b63080ca94709bcbe1bc6c1cb9a23","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.390848|d12844d2d1e2e6a3869298edc9ddfc5e||
1753456|device_registry_updated|{"action":"update","device_id":"ec05b16a060e439089837b370ceca596","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.391202|ad351c915f91ad18a6bf2c10e8e97ebe||
1753457|device_registry_updated|{"action":"update","device_id":"f3fb9f215c3e4558b98b5858768733ad","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.391578|d5e6f016fde2a221248e1743afbb8fca||
1753458|device_registry_updated|{"action":"update","device_id":"79eb125847c04eed84a836986a08e926","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.391997|ac82eba9b14eb870f2c658d4d27e0a8e||
1753459|device_registry_updated|{"action":"update","device_id":"17c781d4971647d8b657097dd8753911","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.392334|b51c899e68836442f656bbd5f15d5e07||
1753460|device_registry_updated|{"action":"update","device_id":"4df1710dbbb143ad9c96501ba76d1101","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.392712|445efa403f9f9e510ff48a5f04cb1817||
1753461|device_registry_updated|{"action":"update","device_id":"352a0019f79848e79259515398aa7f4a","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.393061|7acd1e6e13ba48c40fc69d55c014a6f6||
1753462|device_registry_updated|{"action":"update","device_id":"6e1f6c90907442f1a72278dd47adef67","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.393428|894cb0d3a82bf40ed5cb780d06f6e4bf||
1753463|device_registry_updated|{"action":"update","device_id":"4f11f8199927458c90d7fc6a4a76460c","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.393791|7ba91ac6c4af57452e61b5651d7014b3||
1753464|device_registry_updated|{"action":"update","device_id":"b93486c8c471466f95c32b4e72d5ead4","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.394124|bb299ccc601b91b446a8ecdfd004d823||
1753465|device_registry_updated|{"action":"update","device_id":"394adfe643ce42949200cd46ba1e738d","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.394497|fdd68a7579e87ce6d473c383b13f81ad||
1753466|device_registry_updated|{"action":"update","device_id":"b3608e40ff8d9a9f225adfeb71cc0136","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.394827|94f5923f50c1006966f048a8efbad4fe||
1753467|device_registry_updated|{"action":"update","device_id":"0a1734e5ce154e7d06ef163ab8136497","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.395185|bcb2960556c847d3e14991a03e9606b2||
1753468|device_registry_updated|{"action":"update","device_id":"bfb2da358b664036b024788163a96bc8","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.395577|4ac0f92cacd8166dd82384cf8564f073||
1753469|device_registry_updated|{"action":"update","device_id":"b0400218024149dab80ea206050474ed","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.395913|1db7ed29cf34c9eb1c24ba6c83e319a2||
1753470|device_registry_updated|{"action":"update","device_id":"c7dba270f75a453c95fe07c4bc45ece8","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.396243|401521a935456ff97c8c2845f285b04f||
1753471|device_registry_updated|{"action":"update","device_id":"b5c3b727a3254c188b226248771cdd2f","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.396706|e68db04dcf06c0b2ddee56d6a56d04f8||
1753472|device_registry_updated|{"action":"update","device_id":"dbc8544916c841b09f11bd10df30e9bc","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.397039|762bb85527cfec4ecee7a7cdd39fbf1d||
1753473|device_registry_updated|{"action":"update","device_id":"45261baa6b734cf7b4df3521d15d7c39","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.397401|0ceed67f3b7016bf084488467a10c8a3||
1753474|device_registry_updated|{"action":"update","device_id":"33b0d18cd7a14968b0b06bfa1f222a27","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.397778|62771de0ca5dbc5ffea5ae9a50aa6863||
1753475|device_registry_updated|{"action":"update","device_id":"7605af57e87e400d820c8a43aaf8eac2","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.398110|f2b32d23aca5e0ac9cc07b1711ffa3bc||
1753476|device_registry_updated|{"action":"update","device_id":"6898da082afd4542a17463c47e2939e4","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.398514|9dc0a3ca363b43f6530c71e831daf6c8||
1753477|device_registry_updated|{"action":"update","device_id":"efb4ee8ceead46ae8e236fafaaa41d32","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.398873|15ba8b184b7596ec2b6b07d0e2c69b6d||
1753478|device_registry_updated|{"action":"update","device_id":"6c952bd74f9545b7ad86c1ff306623bc","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.399253|f988d7221d8b8dc1db317c7e1960bb89||
1753479|device_registry_updated|{"action":"update","device_id":"36f1bcd92d55ae65ae1d84e149c9066e","changes":{"suggested_area":null}}|LOCAL|2022-04-03 18:42:31.399640|bbfa1789caf692e805a7a62c080a6755||
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
