### PR TITLE
Keep sum energy sensors always available

### DIFF
--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from goodwe import Inverter, Sensor, SensorKind
 
@@ -55,7 +55,7 @@ _MAIN_SENSORS = (
     "e_bat_discharge_total",
 )
 
-_ICONS = {
+_ICONS: dict[SensorKind, str] = {
     SensorKind.PV: "mdi:solar-power",
     SensorKind.AC: "mdi:power-plug-outline",
     SensorKind.UPS: "mdi:power-plug-off-outline",
@@ -68,10 +68,13 @@ _ICONS = {
 class GoodweSensorEntityDescription(SensorEntityDescription):
     """Class describing Goodwe sensor entities."""
 
-    value: Callable[[str, Any, Any], Any] = lambda sensor, prev, val: val
+    value: Callable[[Any, Any], Any] = lambda prev, val: val
+    available: Callable[
+        [CoordinatorEntity], bool
+    ] = lambda entity: entity.coordinator.last_update_success
 
 
-_DESCRIPTIONS = {
+_DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
     "A": GoodweSensorEntityDescription(
         key="A",
         device_class=DEVICE_CLASS_CURRENT,
@@ -95,7 +98,8 @@ _DESCRIPTIONS = {
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-        value=lambda sensor, prev, val: prev if "total" in sensor and not val else val,
+        value=lambda prev, val: prev if not val else val,
+        available=lambda entity: entity.coordinator.data is not None,
     ),
     "C": GoodweSensorEntityDescription(
         key="C",
@@ -173,10 +177,22 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the value reported by the sensor."""
-        value = self.entity_description.value(
-            self._sensor.id_,
+        value = cast(GoodweSensorEntityDescription, self.entity_description).value(
             self._previous_value,
             self.coordinator.data.get(self._sensor.id_, self._previous_value),
         )
         self._previous_value = value
         return value
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available.
+
+        We delegate the behavior to entity description lambda, since
+        some sensors (like energy produced today) should report themselves
+        as available even when the (non-battery) pv inverter is off-line during night
+        and most of the sensors are actually unavailable.
+        """
+        return cast(GoodweSensorEntityDescription, self.entity_description).available(
+            self
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Present some of the inverter sensors as available even in case the inverter device is not reachable overnight.

Non-hybrid inverters (those without battery) are usually powered by sun and after the panels stop producing energy,
the inverters go to sleep mode and stop responding to any network communication.
This state is properly handled by the integration and all (measurement) sensors are presented as unavailable.
However there are also types of (total_increasing) sensors which could/should be presented as available and report last known state. The best example is sensor reporting amount of energy produced (today or total).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66596
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
