### PR TITLE
Add ColorMode enum to light platform

### DIFF
--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -11,11 +11,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_WHITE,
-    COLOR_MODE_COLOR_TEMP,
-    COLOR_MODE_HS,
-    COLOR_MODE_RGBW,
-    COLOR_MODE_RGBWW,
-    COLOR_MODE_WHITE,
+    ColorMode,
     LightEntity,
     LightEntityFeature,
 )
@@ -33,8 +29,8 @@ LIGHT_EFFECT_LIST = ["rainbow", "none"]
 
 LIGHT_TEMPS = [240, 380]
 
-SUPPORT_DEMO = {COLOR_MODE_HS, COLOR_MODE_COLOR_TEMP}
-SUPPORT_DEMO_HS_WHITE = {COLOR_MODE_HS, COLOR_MODE_WHITE}
+SUPPORT_DEMO = {ColorMode.HS, ColorMode.COLOR_TEMP}
+SUPPORT_DEMO_HS_WHITE = {ColorMode.HS, ColorMode.WHITE}
 
 
 async def async_setup_platform(
@@ -74,7 +70,7 @@ async def async_setup_platform(
                 name="Office RGBW Lights",
                 rgbw_color=(255, 0, 0, 255),
                 state=True,
-                supported_color_modes={COLOR_MODE_RGBW},
+                supported_color_modes={ColorMode.RGBW},
                 unique_id="light_4",
             ),
             DemoLight(
@@ -82,7 +78,7 @@ async def async_setup_platform(
                 name="Living Room RGBWW Lights",
                 rgbww_color=(255, 0, 0, 255, 0),
                 state=True,
-                supported_color_modes={COLOR_MODE_RGBWW},
+                supported_color_modes={ColorMode.RGBWW},
                 unique_id="light_5",
             ),
             DemoLight(
@@ -138,13 +134,13 @@ class DemoLight(LightEntity):
         self._state = state
         self._unique_id = unique_id
         if hs_color:
-            self._color_mode = COLOR_MODE_HS
+            self._color_mode = ColorMode.HS
         elif rgbw_color:
-            self._color_mode = COLOR_MODE_RGBW
+            self._color_mode = ColorMode.RGBW
         elif rgbww_color:
-            self._color_mode = COLOR_MODE_RGBWW
+            self._color_mode = ColorMode.RGBWW
         else:
-            self._color_mode = COLOR_MODE_COLOR_TEMP
+            self._color_mode = ColorMode.COLOR_TEMP
         if not supported_color_modes:
             supported_color_modes = SUPPORT_DEMO
         self._color_modes = supported_color_modes
@@ -247,26 +243,26 @@ class DemoLight(LightEntity):
             self._brightness = kwargs[ATTR_BRIGHTNESS]
 
         if ATTR_COLOR_TEMP in kwargs:
-            self._color_mode = COLOR_MODE_COLOR_TEMP
+            self._color_mode = ColorMode.COLOR_TEMP
             self._ct = kwargs[ATTR_COLOR_TEMP]
 
         if ATTR_EFFECT in kwargs:
             self._effect = kwargs[ATTR_EFFECT]
 
         if ATTR_HS_COLOR in kwargs:
-            self._color_mode = COLOR_MODE_HS
+            self._color_mode = ColorMode.HS
             self._hs_color = kwargs[ATTR_HS_COLOR]
 
         if ATTR_RGBW_COLOR in kwargs:
-            self._color_mode = COLOR_MODE_RGBW
+            self._color_mode = ColorMode.RGBW
             self._rgbw_color = kwargs[ATTR_RGBW_COLOR]
 
         if ATTR_RGBWW_COLOR in kwargs:
-            self._color_mode = COLOR_MODE_RGBWW
+            self._color_mode = ColorMode.RGBWW
             self._rgbww_color = kwargs[ATTR_RGBWW_COLOR]
 
         if ATTR_WHITE in kwargs:
-            self._color_mode = COLOR_MODE_WHITE
+            self._color_mode = ColorMode.WHITE
             self._brightness = kwargs[ATTR_WHITE]
 
         # As we have disabled polling, we need to inform

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -12,6 +12,7 @@ from typing import cast, final
 
 import voluptuous as vol
 
+from homeassistant.backports.enum import StrEnum
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     SERVICE_TOGGLE,
@@ -64,72 +65,92 @@ SUPPORT_WHITE_VALUE = 128  # Deprecated, replaced by color modes
 ATTR_COLOR_MODE = "color_mode"
 # List of color modes supported by the light
 ATTR_SUPPORTED_COLOR_MODES = "supported_color_modes"
-# Possible color modes
-COLOR_MODE_UNKNOWN = "unknown"  # Ambiguous color mode
-COLOR_MODE_ONOFF = "onoff"  # Must be the only supported mode
-COLOR_MODE_BRIGHTNESS = "brightness"  # Must be the only supported mode
+
+
+class ColorMode(StrEnum):
+    """Possible light color modes."""
+
+    UNKNOWN = "unknown"  # Ambiguous color mode
+    ONOFF = "onoff"  # Must be the only supported mode
+    BRIGHTNESS = "brightness"  # Must be the only supported mode
+    COLOR_TEMP = "color_temp"
+    HS = "hs"
+    XY = "xy"
+    RGB = "rgb"
+    RGBW = "rgbw"
+    RGBWW = "rgbww"
+    WHITE = "white"  # Must *NOT* be the only supported mode
+
+
+# These COLOR_MODE_* constants are deprecated as of Home Assistant 2022.5.
+# Please use the LightEntityFeature enum instead.
+COLOR_MODE_UNKNOWN = "unknown"
+COLOR_MODE_ONOFF = "onoff"
+COLOR_MODE_BRIGHTNESS = "brightness"
 COLOR_MODE_COLOR_TEMP = "color_temp"
 COLOR_MODE_HS = "hs"
 COLOR_MODE_XY = "xy"
 COLOR_MODE_RGB = "rgb"
 COLOR_MODE_RGBW = "rgbw"
 COLOR_MODE_RGBWW = "rgbww"
-COLOR_MODE_WHITE = "white"  # Must *NOT* be the only supported mode
+COLOR_MODE_WHITE = "white"
 
 VALID_COLOR_MODES = {
-    COLOR_MODE_ONOFF,
-    COLOR_MODE_BRIGHTNESS,
-    COLOR_MODE_COLOR_TEMP,
-    COLOR_MODE_HS,
-    COLOR_MODE_XY,
-    COLOR_MODE_RGB,
-    COLOR_MODE_RGBW,
-    COLOR_MODE_RGBWW,
-    COLOR_MODE_WHITE,
+    ColorMode.ONOFF,
+    ColorMode.BRIGHTNESS,
+    ColorMode.COLOR_TEMP,
+    ColorMode.HS,
+    ColorMode.XY,
+    ColorMode.RGB,
+    ColorMode.RGBW,
+    ColorMode.RGBWW,
+    ColorMode.WHITE,
 }
-COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {COLOR_MODE_ONOFF}
+COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {ColorMode.ONOFF}
 COLOR_MODES_COLOR = {
-    COLOR_MODE_HS,
-    COLOR_MODE_RGB,
-    COLOR_MODE_RGBW,
-    COLOR_MODE_RGBWW,
-    COLOR_MODE_XY,
+    ColorMode.HS,
+    ColorMode.RGB,
+    ColorMode.RGBW,
+    ColorMode.RGBWW,
+    ColorMode.XY,
 }
 
 
-def valid_supported_color_modes(color_modes: Iterable[str]) -> set[str]:
+def valid_supported_color_modes(
+    color_modes: Iterable[ColorMode | str],
+) -> set[ColorMode | str]:
     """Validate the given color modes."""
     color_modes = set(color_modes)
     if (
         not color_modes
-        or COLOR_MODE_UNKNOWN in color_modes
-        or (COLOR_MODE_BRIGHTNESS in color_modes and len(color_modes) > 1)
-        or (COLOR_MODE_ONOFF in color_modes and len(color_modes) > 1)
-        or (COLOR_MODE_WHITE in color_modes and not color_supported(color_modes))
+        or ColorMode.UNKNOWN in color_modes
+        or (ColorMode.BRIGHTNESS in color_modes and len(color_modes) > 1)
+        or (ColorMode.ONOFF in color_modes and len(color_modes) > 1)
+        or (ColorMode.WHITE in color_modes and not color_supported(color_modes))
     ):
         raise vol.Error(f"Invalid supported_color_modes {sorted(color_modes)}")
     return color_modes
 
 
-def brightness_supported(color_modes: Iterable[str] | None) -> bool:
+def brightness_supported(color_modes: Iterable[ColorMode | str] | None) -> bool:
     """Test if brightness is supported."""
     if not color_modes:
         return False
     return any(mode in COLOR_MODES_BRIGHTNESS for mode in color_modes)
 
 
-def color_supported(color_modes: Iterable[str] | None) -> bool:
+def color_supported(color_modes: Iterable[ColorMode | str] | None) -> bool:
     """Test if color is supported."""
     if not color_modes:
         return False
     return any(mode in COLOR_MODES_COLOR for mode in color_modes)
 
 
-def color_temp_supported(color_modes: Iterable[str] | None) -> bool:
+def color_temp_supported(color_modes: Iterable[ColorMode | str] | None) -> bool:
     """Test if color temperature is supported."""
     if not color_modes:
         return False
-    return COLOR_MODE_COLOR_TEMP in color_modes
+    return ColorMode.COLOR_TEMP in color_modes
 
 
 def get_supported_color_modes(hass: HomeAssistant, entity_id: str) -> set | None:
@@ -311,19 +332,19 @@ def filter_turn_on_params(light, params):
     )
     if not brightness_supported(supported_color_modes):
         params.pop(ATTR_BRIGHTNESS, None)
-    if COLOR_MODE_COLOR_TEMP not in supported_color_modes:
+    if ColorMode.COLOR_TEMP not in supported_color_modes:
         params.pop(ATTR_COLOR_TEMP, None)
-    if COLOR_MODE_HS not in supported_color_modes:
+    if ColorMode.HS not in supported_color_modes:
         params.pop(ATTR_HS_COLOR, None)
-    if COLOR_MODE_RGB not in supported_color_modes:
+    if ColorMode.RGB not in supported_color_modes:
         params.pop(ATTR_RGB_COLOR, None)
-    if COLOR_MODE_RGBW not in supported_color_modes:
+    if ColorMode.RGBW not in supported_color_modes:
         params.pop(ATTR_RGBW_COLOR, None)
-    if COLOR_MODE_RGBWW not in supported_color_modes:
+    if ColorMode.RGBWW not in supported_color_modes:
         params.pop(ATTR_RGBWW_COLOR, None)
-    if COLOR_MODE_WHITE not in supported_color_modes:
+    if ColorMode.WHITE not in supported_color_modes:
         params.pop(ATTR_WHITE, None)
-    if COLOR_MODE_XY not in supported_color_modes:
+    if ColorMode.XY not in supported_color_modes:
         params.pop(ATTR_XY_COLOR, None)
 
     return params
@@ -387,7 +408,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         # for legacy lights
         if ATTR_RGBW_COLOR in params:
             if (
-                COLOR_MODE_RGBW in legacy_supported_color_modes
+                ColorMode.RGBW in legacy_supported_color_modes
                 and not supported_color_modes
             ):
                 rgbw_color = params.pop(ATTR_RGBW_COLOR)
@@ -398,15 +419,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         if ATTR_COLOR_TEMP in params:
             if (
                 supported_color_modes
-                and COLOR_MODE_COLOR_TEMP not in supported_color_modes
-                and COLOR_MODE_RGBWW in supported_color_modes
+                and ColorMode.COLOR_TEMP not in supported_color_modes
+                and ColorMode.RGBWW in supported_color_modes
             ):
                 color_temp = params.pop(ATTR_COLOR_TEMP)
                 brightness = params.get(ATTR_BRIGHTNESS, light.brightness)
                 params[ATTR_RGBWW_COLOR] = color_util.color_temperature_to_rgbww(
                     color_temp, brightness, light.min_mireds, light.max_mireds
                 )
-            elif COLOR_MODE_COLOR_TEMP not in legacy_supported_color_modes:
+            elif ColorMode.COLOR_TEMP not in legacy_supported_color_modes:
                 color_temp = params.pop(ATTR_COLOR_TEMP)
                 if color_supported(legacy_supported_color_modes):
                     temp_k = color_util.color_temperature_mired_to_kelvin(color_temp)
@@ -428,80 +449,80 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                     *rgbww_color, light.min_mireds, light.max_mireds
                 )
                 params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
-        elif ATTR_HS_COLOR in params and COLOR_MODE_HS not in supported_color_modes:
+        elif ATTR_HS_COLOR in params and ColorMode.HS not in supported_color_modes:
             hs_color = params.pop(ATTR_HS_COLOR)
-            if COLOR_MODE_RGB in supported_color_modes:
+            if ColorMode.RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = color_util.color_hs_to_RGB(*hs_color)
-            elif COLOR_MODE_RGBW in supported_color_modes:
+            elif ColorMode.RGBW in supported_color_modes:
                 rgb_color = color_util.color_hs_to_RGB(*hs_color)
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
-            elif COLOR_MODE_RGBWW in supported_color_modes:
+            elif ColorMode.RGBWW in supported_color_modes:
                 rgb_color = color_util.color_hs_to_RGB(*hs_color)
                 params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
                     *rgb_color, light.min_mireds, light.max_mireds
                 )
-            elif COLOR_MODE_XY in supported_color_modes:
+            elif ColorMode.XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_hs_to_xy(*hs_color)
-        elif ATTR_RGB_COLOR in params and COLOR_MODE_RGB not in supported_color_modes:
+        elif ATTR_RGB_COLOR in params and ColorMode.RGB not in supported_color_modes:
             rgb_color = params.pop(ATTR_RGB_COLOR)
-            if COLOR_MODE_RGBW in supported_color_modes:
+            if ColorMode.RGBW in supported_color_modes:
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
-            elif COLOR_MODE_RGBWW in supported_color_modes:
+            elif ColorMode.RGBWW in supported_color_modes:
                 params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
                     *rgb_color, light.min_mireds, light.max_mireds
                 )
-            elif COLOR_MODE_HS in supported_color_modes:
+            elif ColorMode.HS in supported_color_modes:
                 params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
-            elif COLOR_MODE_XY in supported_color_modes:
+            elif ColorMode.XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
-        elif ATTR_XY_COLOR in params and COLOR_MODE_XY not in supported_color_modes:
+        elif ATTR_XY_COLOR in params and ColorMode.XY not in supported_color_modes:
             xy_color = params.pop(ATTR_XY_COLOR)
-            if COLOR_MODE_HS in supported_color_modes:
+            if ColorMode.HS in supported_color_modes:
                 params[ATTR_HS_COLOR] = color_util.color_xy_to_hs(*xy_color)
-            elif COLOR_MODE_RGB in supported_color_modes:
+            elif ColorMode.RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = color_util.color_xy_to_RGB(*xy_color)
-            elif COLOR_MODE_RGBW in supported_color_modes:
+            elif ColorMode.RGBW in supported_color_modes:
                 rgb_color = color_util.color_xy_to_RGB(*xy_color)
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
-            elif COLOR_MODE_RGBWW in supported_color_modes:
+            elif ColorMode.RGBWW in supported_color_modes:
                 rgb_color = color_util.color_xy_to_RGB(*xy_color)
                 params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
                     *rgb_color, light.min_mireds, light.max_mireds
                 )
-        elif ATTR_RGBW_COLOR in params and COLOR_MODE_RGBW not in supported_color_modes:
+        elif ATTR_RGBW_COLOR in params and ColorMode.RGBW not in supported_color_modes:
             rgbw_color = params.pop(ATTR_RGBW_COLOR)
             rgb_color = color_util.color_rgbw_to_rgb(*rgbw_color)
-            if COLOR_MODE_RGB in supported_color_modes:
+            if ColorMode.RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = rgb_color
-            elif COLOR_MODE_RGBWW in supported_color_modes:
+            elif ColorMode.RGBWW in supported_color_modes:
                 params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
                     *rgb_color, light.min_mireds, light.max_mireds
                 )
-            elif COLOR_MODE_HS in supported_color_modes:
+            elif ColorMode.HS in supported_color_modes:
                 params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
-            elif COLOR_MODE_XY in supported_color_modes:
+            elif ColorMode.XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
         elif (
-            ATTR_RGBWW_COLOR in params and COLOR_MODE_RGBWW not in supported_color_modes
+            ATTR_RGBWW_COLOR in params and ColorMode.RGBWW not in supported_color_modes
         ):
             rgbww_color = params.pop(ATTR_RGBWW_COLOR)
             rgb_color = color_util.color_rgbww_to_rgb(
                 *rgbww_color, light.min_mireds, light.max_mireds
             )
-            if COLOR_MODE_RGB in supported_color_modes:
+            if ColorMode.RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = rgb_color
-            elif COLOR_MODE_RGBW in supported_color_modes:
+            elif ColorMode.RGBW in supported_color_modes:
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
-            elif COLOR_MODE_HS in supported_color_modes:
+            elif ColorMode.HS in supported_color_modes:
                 params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
-            elif COLOR_MODE_XY in supported_color_modes:
+            elif ColorMode.XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
 
         # If both white and brightness are specified, override white
         if (
             supported_color_modes
             and ATTR_WHITE in params
-            and COLOR_MODE_WHITE in supported_color_modes
+            and ColorMode.WHITE in supported_color_modes
         ):
             params[ATTR_WHITE] = params.pop(ATTR_BRIGHTNESS, params[ATTR_WHITE])
 
@@ -703,7 +724,7 @@ class LightEntity(ToggleEntity):
 
     entity_description: LightEntityDescription
     _attr_brightness: int | None = None
-    _attr_color_mode: str | None = None
+    _attr_color_mode: ColorMode | str | None = None
     _attr_color_temp: int | None = None
     _attr_effect_list: list[str] | None = None
     _attr_effect: str | None = None
@@ -713,7 +734,7 @@ class LightEntity(ToggleEntity):
     _attr_rgb_color: tuple[int, int, int] | None = None
     _attr_rgbw_color: tuple[int, int, int, int] | None = None
     _attr_rgbww_color: tuple[int, int, int, int, int] | None = None
-    _attr_supported_color_modes: set[str] | None = None
+    _attr_supported_color_modes: set[ColorMode | str] | None = None
     _attr_supported_features: int = 0
     _attr_xy_color: tuple[float, float] | None = None
 
@@ -723,7 +744,7 @@ class LightEntity(ToggleEntity):
         return self._attr_brightness
 
     @property
-    def color_mode(self) -> str | None:
+    def color_mode(self) -> ColorMode | str | None:
         """Return the color mode of the light."""
         return self._attr_color_mode
 
@@ -736,20 +757,20 @@ class LightEntity(ToggleEntity):
             supported = self._light_internal_supported_color_modes
 
             if (
-                COLOR_MODE_RGBW in supported
+                ColorMode.RGBW in supported
                 and self.white_value is not None
                 and self.hs_color is not None
             ):
-                return COLOR_MODE_RGBW
-            if COLOR_MODE_HS in supported and self.hs_color is not None:
-                return COLOR_MODE_HS
-            if COLOR_MODE_COLOR_TEMP in supported and self.color_temp is not None:
-                return COLOR_MODE_COLOR_TEMP
-            if COLOR_MODE_BRIGHTNESS in supported and self.brightness is not None:
-                return COLOR_MODE_BRIGHTNESS
-            if COLOR_MODE_ONOFF in supported:
-                return COLOR_MODE_ONOFF
-            return COLOR_MODE_UNKNOWN
+                return ColorMode.RGBW
+            if ColorMode.HS in supported and self.hs_color is not None:
+                return ColorMode.HS
+            if ColorMode.COLOR_TEMP in supported and self.color_temp is not None:
+                return ColorMode.COLOR_TEMP
+            if ColorMode.BRIGHTNESS in supported and self.brightness is not None:
+                return ColorMode.BRIGHTNESS
+            if ColorMode.ONOFF in supported:
+                return ColorMode.ONOFF
+            return ColorMode.UNKNOWN
 
         return color_mode
 
@@ -838,7 +859,7 @@ class LightEntity(ToggleEntity):
         supported_features = self.supported_features
         supported_color_modes = self._light_internal_supported_color_modes
 
-        if COLOR_MODE_COLOR_TEMP in supported_color_modes:
+        if ColorMode.COLOR_TEMP in supported_color_modes:
             data[ATTR_MIN_MIREDS] = self.min_mireds
             data[ATTR_MAX_MIREDS] = self.max_mireds
 
@@ -849,31 +870,31 @@ class LightEntity(ToggleEntity):
 
         return data
 
-    def _light_internal_convert_color(self, color_mode: str) -> dict:
+    def _light_internal_convert_color(self, color_mode: ColorMode | str) -> dict:
         data: dict[str, tuple] = {}
-        if color_mode == COLOR_MODE_HS and self.hs_color:
+        if color_mode == ColorMode.HS and self.hs_color:
             hs_color = self.hs_color
             data[ATTR_HS_COLOR] = (round(hs_color[0], 3), round(hs_color[1], 3))
             data[ATTR_RGB_COLOR] = color_util.color_hs_to_RGB(*hs_color)
             data[ATTR_XY_COLOR] = color_util.color_hs_to_xy(*hs_color)
-        elif color_mode == COLOR_MODE_XY and self.xy_color:
+        elif color_mode == ColorMode.XY and self.xy_color:
             xy_color = self.xy_color
             data[ATTR_HS_COLOR] = color_util.color_xy_to_hs(*xy_color)
             data[ATTR_RGB_COLOR] = color_util.color_xy_to_RGB(*xy_color)
             data[ATTR_XY_COLOR] = (round(xy_color[0], 6), round(xy_color[1], 6))
-        elif color_mode == COLOR_MODE_RGB and self.rgb_color:
+        elif color_mode == ColorMode.RGB and self.rgb_color:
             rgb_color = self.rgb_color
             data[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
             data[ATTR_RGB_COLOR] = tuple(int(x) for x in rgb_color[0:3])
             data[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
-        elif color_mode == COLOR_MODE_RGBW and self._light_internal_rgbw_color:
+        elif color_mode == ColorMode.RGBW and self._light_internal_rgbw_color:
             rgbw_color = self._light_internal_rgbw_color
             rgb_color = color_util.color_rgbw_to_rgb(*rgbw_color)
             data[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
             data[ATTR_RGB_COLOR] = tuple(int(x) for x in rgb_color[0:3])
             data[ATTR_RGBW_COLOR] = tuple(int(x) for x in rgbw_color[0:4])
             data[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
-        elif color_mode == COLOR_MODE_RGBWW and self.rgbww_color:
+        elif color_mode == ColorMode.RGBWW and self.rgbww_color:
             rgbww_color = self.rgbww_color
             rgb_color = color_util.color_rgbww_to_rgb(
                 *rgbww_color, self.min_mireds, self.max_mireds
@@ -882,7 +903,7 @@ class LightEntity(ToggleEntity):
             data[ATTR_RGB_COLOR] = tuple(int(x) for x in rgb_color[0:3])
             data[ATTR_RGBWW_COLOR] = tuple(int(x) for x in rgbww_color[0:5])
             data[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
-        elif color_mode == COLOR_MODE_COLOR_TEMP and self.color_temp:
+        elif color_mode == ColorMode.COLOR_TEMP and self.color_temp:
             hs_color = color_util.color_temperature_to_hs(
                 color_util.color_temperature_mired_to_kelvin(self.color_temp)
             )
@@ -920,10 +941,10 @@ class LightEntity(ToggleEntity):
             # Add warning in 2021.6, remove in 2021.10
             data[ATTR_BRIGHTNESS] = self.brightness
 
-        if color_mode == COLOR_MODE_COLOR_TEMP:
+        if color_mode == ColorMode.COLOR_TEMP:
             data[ATTR_COLOR_TEMP] = self.color_temp
 
-        if color_mode in COLOR_MODES_COLOR or color_mode == COLOR_MODE_COLOR_TEMP:
+        if color_mode in COLOR_MODES_COLOR or color_mode == ColorMode.COLOR_TEMP:
             data.update(self._light_internal_convert_color(color_mode))
 
         if supported_features & SUPPORT_COLOR_TEMP and not self.supported_color_modes:
@@ -936,7 +957,7 @@ class LightEntity(ToggleEntity):
             # Add warning in 2021.6, remove in 2021.10
             data[ATTR_WHITE_VALUE] = self.white_value
             if self.hs_color is not None:
-                data.update(self._light_internal_convert_color(COLOR_MODE_HS))
+                data.update(self._light_internal_convert_color(ColorMode.HS))
 
         if supported_features & LightEntityFeature.EFFECT:
             data[ATTR_EFFECT] = self.effect
@@ -955,21 +976,21 @@ class LightEntity(ToggleEntity):
             supported_color_modes = set()
 
             if supported_features & SUPPORT_COLOR_TEMP:
-                supported_color_modes.add(COLOR_MODE_COLOR_TEMP)
+                supported_color_modes.add(ColorMode.COLOR_TEMP)
             if supported_features & SUPPORT_COLOR:
-                supported_color_modes.add(COLOR_MODE_HS)
+                supported_color_modes.add(ColorMode.HS)
             if supported_features & SUPPORT_WHITE_VALUE:
-                supported_color_modes.add(COLOR_MODE_RGBW)
+                supported_color_modes.add(ColorMode.RGBW)
             if supported_features & SUPPORT_BRIGHTNESS and not supported_color_modes:
-                supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+                supported_color_modes = {ColorMode.BRIGHTNESS}
 
             if not supported_color_modes:
-                supported_color_modes = {COLOR_MODE_ONOFF}
+                supported_color_modes = {ColorMode.ONOFF}
 
         return supported_color_modes
 
     @property
-    def supported_color_modes(self) -> set[str] | None:
+    def supported_color_modes(self) -> set[ColorMode | str] | None:
         """Flag supported color modes."""
         return self._attr_supported_color_modes
 
@@ -990,7 +1011,7 @@ def legacy_supported_features(
         supported_features |= SUPPORT_COLOR
     if any(mode in supported_color_modes for mode in COLOR_MODES_BRIGHTNESS):
         supported_features |= SUPPORT_BRIGHTNESS
-    if COLOR_MODE_COLOR_TEMP in supported_color_modes:
+    if ColorMode.COLOR_TEMP in supported_color_modes:
         supported_features |= SUPPORT_COLOR_TEMP
 
     return supported_features

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -33,15 +33,8 @@ from . import (
     ATTR_WHITE,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
-    COLOR_MODE_COLOR_TEMP,
-    COLOR_MODE_HS,
-    COLOR_MODE_RGB,
-    COLOR_MODE_RGBW,
-    COLOR_MODE_RGBWW,
-    COLOR_MODE_UNKNOWN,
-    COLOR_MODE_WHITE,
-    COLOR_MODE_XY,
     DOMAIN,
+    ColorMode,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,13 +72,13 @@ class ColorModeAttr(NamedTuple):
 
 
 COLOR_MODE_TO_ATTRIBUTE = {
-    COLOR_MODE_COLOR_TEMP: ColorModeAttr(ATTR_COLOR_TEMP, ATTR_COLOR_TEMP),
-    COLOR_MODE_HS: ColorModeAttr(ATTR_HS_COLOR, ATTR_HS_COLOR),
-    COLOR_MODE_RGB: ColorModeAttr(ATTR_RGB_COLOR, ATTR_RGB_COLOR),
-    COLOR_MODE_RGBW: ColorModeAttr(ATTR_RGBW_COLOR, ATTR_RGBW_COLOR),
-    COLOR_MODE_RGBWW: ColorModeAttr(ATTR_RGBWW_COLOR, ATTR_RGBWW_COLOR),
-    COLOR_MODE_WHITE: ColorModeAttr(ATTR_WHITE, ATTR_BRIGHTNESS),
-    COLOR_MODE_XY: ColorModeAttr(ATTR_XY_COLOR, ATTR_XY_COLOR),
+    ColorMode.COLOR_TEMP: ColorModeAttr(ATTR_COLOR_TEMP, ATTR_COLOR_TEMP),
+    ColorMode.HS: ColorModeAttr(ATTR_HS_COLOR, ATTR_HS_COLOR),
+    ColorMode.RGB: ColorModeAttr(ATTR_RGB_COLOR, ATTR_RGB_COLOR),
+    ColorMode.RGBW: ColorModeAttr(ATTR_RGBW_COLOR, ATTR_RGBW_COLOR),
+    ColorMode.RGBWW: ColorModeAttr(ATTR_RGBWW_COLOR, ATTR_RGBWW_COLOR),
+    ColorMode.WHITE: ColorModeAttr(ATTR_WHITE, ATTR_BRIGHTNESS),
+    ColorMode.XY: ColorModeAttr(ATTR_XY_COLOR, ATTR_XY_COLOR),
 }
 
 DEPRECATED_GROUP = [
@@ -105,11 +98,11 @@ DEPRECATION_WARNING = (
 
 def _color_mode_same(cur_state: State, state: State) -> bool:
     """Test if color_mode is same."""
-    cur_color_mode = cur_state.attributes.get(ATTR_COLOR_MODE, COLOR_MODE_UNKNOWN)
-    saved_color_mode = state.attributes.get(ATTR_COLOR_MODE, COLOR_MODE_UNKNOWN)
+    cur_color_mode = cur_state.attributes.get(ATTR_COLOR_MODE, ColorMode.UNKNOWN)
+    saved_color_mode = state.attributes.get(ATTR_COLOR_MODE, ColorMode.UNKNOWN)
 
     # Guard for scenes etc. which where created before color modes were introduced
-    if saved_color_mode == COLOR_MODE_UNKNOWN:
+    if saved_color_mode == ColorMode.UNKNOWN:
         return True
     return cast(bool, cur_color_mode == saved_color_mode)
 
@@ -161,8 +154,8 @@ async def _async_reproduce_state(
                 service_data[attr] = state.attributes[attr]
 
         if (
-            state.attributes.get(ATTR_COLOR_MODE, COLOR_MODE_UNKNOWN)
-            != COLOR_MODE_UNKNOWN
+            state.attributes.get(ATTR_COLOR_MODE, ColorMode.UNKNOWN)
+            != ColorMode.UNKNOWN
         ):
             # Remove deprecated white value if we got a valid color mode
             service_data.pop(ATTR_WHITE_VALUE, None)

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -5,10 +5,10 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
-    COLOR_MODE_BRIGHTNESS,
     DOMAIN,
     FLASH_LONG,
     FLASH_SHORT,
+    ColorMode,
     LightEntityFeature,
 )
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
@@ -154,7 +154,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
             },
             0,
             0,
-            {ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_BRIGHTNESS]},
+            {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS]},
             {},
             {
                 "turn_on": [
@@ -180,7 +180,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
             0,
             0,
             None,
-            {ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_BRIGHTNESS]},
+            {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS]},
             {
                 "turn_on": [
                     {

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -118,8 +118,8 @@ async def test_services(hass, mock_light_profiles, enable_custom_integrations):
     await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
-    ent1.supported_color_modes = [light.COLOR_MODE_HS]
-    ent3.supported_color_modes = [light.COLOR_MODE_HS]
+    ent1.supported_color_modes = [light.ColorMode.HS]
+    ent3.supported_color_modes = [light.ColorMode.HS]
     ent1.supported_features = light.LightEntityFeature.TRANSITION
     ent2.supported_features = (
         light.SUPPORT_COLOR
@@ -540,7 +540,7 @@ async def test_light_profiles(
     await hass.async_block_till_done()
 
     ent1, _, _ = platform.ENTITIES
-    ent1.supported_color_modes = [light.COLOR_MODE_HS]
+    ent1.supported_color_modes = [light.ColorMode.HS]
     ent1.supported_features = light.LightEntityFeature.TRANSITION
 
     await hass.services.async_call(
@@ -577,7 +577,7 @@ async def test_default_profiles_group(
     mock_light_profiles[profile.name] = profile
 
     ent, _, _ = platform.ENTITIES
-    ent.supported_color_modes = [light.COLOR_MODE_HS]
+    ent.supported_color_modes = [light.ColorMode.HS]
     ent.supported_features = light.LightEntityFeature.TRANSITION
     await hass.services.async_call(
         light.DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ent.entity_id}, blocking=True
@@ -684,7 +684,7 @@ async def test_default_profiles_light(
     mock_light_profiles[profile.name] = profile
 
     dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES))
-    dev.supported_color_modes = [light.COLOR_MODE_HS]
+    dev.supported_color_modes = [light.ColorMode.HS]
     dev.supported_features = light.LightEntityFeature.TRANSITION
     await hass.services.async_call(
         light.DOMAIN,
@@ -1038,63 +1038,63 @@ async def test_light_backwards_compatibility_supported_color_modes(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_ONOFF]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.ONOFF]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_ONOFF
+        assert state.attributes["color_mode"] == light.ColorMode.ONOFF
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_BRIGHTNESS]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.BRIGHTNESS]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
     state = hass.states.get(entity2.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_COLOR_TEMP]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.COLOR_TEMP]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
     state = hass.states.get(entity3.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
     state = hass.states.get(entity4.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGBW,
+        light.ColorMode.HS,
+        light.ColorMode.RGBW,
     ]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
     state = hass.states.get(entity5.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_HS,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
     ]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
     state = hass.states.get(entity6.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGBW,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
+        light.ColorMode.RGBW,
     ]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
 
 async def test_light_backwards_compatibility_color_mode(
@@ -1144,38 +1144,38 @@ async def test_light_backwards_compatibility_color_mode(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_ONOFF]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_ONOFF
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.ONOFF]
+    assert state.attributes["color_mode"] == light.ColorMode.ONOFF
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_BRIGHTNESS]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.BRIGHTNESS]
+    assert state.attributes["color_mode"] == light.ColorMode.BRIGHTNESS
 
     state = hass.states.get(entity2.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_COLOR_TEMP]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_COLOR_TEMP
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.COLOR_TEMP]
+    assert state.attributes["color_mode"] == light.ColorMode.COLOR_TEMP
     assert state.attributes["rgb_color"] == (201, 218, 255)
     assert state.attributes["hs_color"] == (221.575, 20.9)
     assert state.attributes["xy_color"] == (0.277, 0.287)
 
     state = hass.states.get(entity3.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
+    assert state.attributes["color_mode"] == light.ColorMode.HS
 
     state = hass.states.get(entity4.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGBW,
+        light.ColorMode.HS,
+        light.ColorMode.RGBW,
     ]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_RGBW
+    assert state.attributes["color_mode"] == light.ColorMode.RGBW
 
     state = hass.states.get(entity5.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_HS,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
     ]
-    # hs color prioritized over color_temp, light should report mode COLOR_MODE_HS
-    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+    # hs color prioritized over color_temp, light should report mode ColorMode.HS
+    assert state.attributes["color_mode"] == light.ColorMode.HS
 
 
 async def test_light_service_call_rgbw(hass, enable_custom_integrations):
@@ -1192,19 +1192,19 @@ async def test_light_service_call_rgbw(hass, enable_custom_integrations):
     )
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_RGBW}
+    entity1.supported_color_modes = {light.ColorMode.RGBW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGBW,
+        light.ColorMode.HS,
+        light.ColorMode.RGBW,
     ]
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBW]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBW]
 
     await hass.services.async_call(
         "light",
@@ -1243,8 +1243,8 @@ async def test_light_state_rgbw(hass, enable_custom_integrations):
     entity0.xy_color = "Invalid"  # Should be ignored
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_RGBW}
-    entity1.color_mode = light.COLOR_MODE_RGBW
+    entity1.supported_color_modes = {light.ColorMode.RGBW}
+    entity1.color_mode = light.ColorMode.RGBW
     entity1.hs_color = "Invalid"  # Should be ignored
     entity1.rgb_color = "Invalid"  # Should be ignored
     entity1.rgbw_color = (1, 2, 3, 4)
@@ -1257,9 +1257,9 @@ async def test_light_state_rgbw(hass, enable_custom_integrations):
 
     state = hass.states.get(entity0.entity_id)
     assert state.attributes == {
-        "color_mode": light.COLOR_MODE_RGBW,
+        "color_mode": light.ColorMode.RGBW,
         "friendly_name": "Test_legacy_white_value",
-        "supported_color_modes": [light.COLOR_MODE_HS, light.COLOR_MODE_RGBW],
+        "supported_color_modes": [light.ColorMode.HS, light.ColorMode.RGBW],
         "supported_features": legacy_supported_features,
         "hs_color": (210.0, 66.667),
         "rgb_color": (84, 169, 255),
@@ -1270,9 +1270,9 @@ async def test_light_state_rgbw(hass, enable_custom_integrations):
 
     state = hass.states.get(entity1.entity_id)
     assert state.attributes == {
-        "color_mode": light.COLOR_MODE_RGBW,
+        "color_mode": light.ColorMode.RGBW,
         "friendly_name": "Test_rgbw",
-        "supported_color_modes": [light.COLOR_MODE_RGBW],
+        "supported_color_modes": [light.ColorMode.RGBW],
         "supported_features": 0,
         "hs_color": (240.0, 25.0),
         "rgb_color": (3, 3, 4),
@@ -1289,8 +1289,8 @@ async def test_light_state_rgbww(hass, enable_custom_integrations):
     platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
 
     entity0 = platform.ENTITIES[0]
-    entity0.supported_color_modes = {light.COLOR_MODE_RGBWW}
-    entity0.color_mode = light.COLOR_MODE_RGBWW
+    entity0.supported_color_modes = {light.ColorMode.RGBWW}
+    entity0.color_mode = light.ColorMode.RGBWW
     entity0.hs_color = "Invalid"  # Should be ignored
     entity0.rgb_color = "Invalid"  # Should be ignored
     entity0.rgbw_color = "Invalid"  # Should be ignored
@@ -1303,9 +1303,9 @@ async def test_light_state_rgbww(hass, enable_custom_integrations):
 
     state = hass.states.get(entity0.entity_id)
     assert dict(state.attributes) == {
-        "color_mode": light.COLOR_MODE_RGBWW,
+        "color_mode": light.ColorMode.RGBWW,
         "friendly_name": "Test_rgbww",
-        "supported_color_modes": [light.COLOR_MODE_RGBWW],
+        "supported_color_modes": [light.ColorMode.RGBWW],
         "supported_features": 0,
         "hs_color": (60.0, 20.0),
         "rgb_color": (5, 5, 4),
@@ -1328,57 +1328,57 @@ async def test_light_service_call_color_conversion(hass, enable_custom_integrati
     platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
 
     entity0 = platform.ENTITIES[0]
-    entity0.supported_color_modes = {light.COLOR_MODE_HS}
+    entity0.supported_color_modes = {light.ColorMode.HS}
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_RGB}
+    entity1.supported_color_modes = {light.ColorMode.RGB}
 
     entity2 = platform.ENTITIES[2]
-    entity2.supported_color_modes = {light.COLOR_MODE_XY}
+    entity2.supported_color_modes = {light.ColorMode.XY}
 
     entity3 = platform.ENTITIES[3]
     entity3.supported_color_modes = {
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGB,
-        light.COLOR_MODE_XY,
+        light.ColorMode.HS,
+        light.ColorMode.RGB,
+        light.ColorMode.XY,
     }
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = light.SUPPORT_COLOR
 
     entity5 = platform.ENTITIES[5]
-    entity5.supported_color_modes = {light.COLOR_MODE_RGBW}
+    entity5.supported_color_modes = {light.ColorMode.RGBW}
 
     entity6 = platform.ENTITIES[6]
-    entity6.supported_color_modes = {light.COLOR_MODE_RGBWW}
+    entity6.supported_color_modes = {light.ColorMode.RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGB]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGB]
 
     state = hass.states.get(entity2.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_XY]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.XY]
 
     state = hass.states.get(entity3.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGB,
-        light.COLOR_MODE_XY,
+        light.ColorMode.HS,
+        light.ColorMode.RGB,
+        light.ColorMode.XY,
     ]
 
     state = hass.states.get(entity4.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
 
     state = hass.states.get(entity5.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBW]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBW]
 
     state = hass.states.get(entity6.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBWW]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBWW]
 
     await hass.services.async_call(
         "light",
@@ -1733,29 +1733,29 @@ async def test_light_service_call_color_conversion_named_tuple(
     platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
 
     entity0 = platform.ENTITIES[0]
-    entity0.supported_color_modes = {light.COLOR_MODE_HS}
+    entity0.supported_color_modes = {light.ColorMode.HS}
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_RGB}
+    entity1.supported_color_modes = {light.ColorMode.RGB}
 
     entity2 = platform.ENTITIES[2]
-    entity2.supported_color_modes = {light.COLOR_MODE_XY}
+    entity2.supported_color_modes = {light.ColorMode.XY}
 
     entity3 = platform.ENTITIES[3]
     entity3.supported_color_modes = {
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_RGB,
-        light.COLOR_MODE_XY,
+        light.ColorMode.HS,
+        light.ColorMode.RGB,
+        light.ColorMode.XY,
     }
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = light.SUPPORT_COLOR
 
     entity5 = platform.ENTITIES[5]
-    entity5.supported_color_modes = {light.COLOR_MODE_RGBW}
+    entity5.supported_color_modes = {light.ColorMode.RGBW}
 
     entity6 = platform.ENTITIES[6]
-    entity6.supported_color_modes = {light.COLOR_MODE_RGBWW}
+    entity6.supported_color_modes = {light.ColorMode.RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1806,30 +1806,30 @@ async def test_light_service_call_color_temp_emulation(
     platform.ENTITIES.append(platform.MockLight("Test_hs_white", STATE_ON))
 
     entity0 = platform.ENTITIES[0]
-    entity0.supported_color_modes = {light.COLOR_MODE_COLOR_TEMP, light.COLOR_MODE_HS}
+    entity0.supported_color_modes = {light.ColorMode.COLOR_TEMP, light.ColorMode.HS}
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_HS}
+    entity1.supported_color_modes = {light.ColorMode.HS}
 
     entity2 = platform.ENTITIES[2]
-    entity2.supported_color_modes = {light.COLOR_MODE_HS, light.COLOR_MODE_WHITE}
+    entity2.supported_color_modes = {light.ColorMode.HS, light.ColorMode.WHITE}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_HS,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
     ]
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
 
     state = hass.states.get(entity2.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_WHITE,
+        light.ColorMode.HS,
+        light.ColorMode.WHITE,
     ]
 
     await hass.services.async_call(
@@ -1866,24 +1866,24 @@ async def test_light_service_call_color_temp_conversion(
 
     entity0 = platform.ENTITIES[0]
     entity0.supported_color_modes = {
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_RGBWW,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.RGBWW,
     }
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_RGBWW}
+    entity1.supported_color_modes = {light.ColorMode.RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_RGBWW,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.RGBWW,
     ]
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBWW]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBWW]
 
     await hass.services.async_call(
         "light",
@@ -1986,15 +1986,15 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
 
     platform.ENTITIES.append(platform.MockLight("Test_white", STATE_ON))
     entity0 = platform.ENTITIES[0]
-    entity0.supported_color_modes = {light.COLOR_MODE_HS, light.COLOR_MODE_WHITE}
+    entity0.supported_color_modes = {light.ColorMode.HS, light.ColorMode.WHITE}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
     assert state.attributes["supported_color_modes"] == [
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_WHITE,
+        light.ColorMode.HS,
+        light.ColorMode.WHITE,
     ]
 
     await hass.services.async_call(
@@ -2072,22 +2072,22 @@ async def test_light_state_color_conversion(hass, enable_custom_integrations):
     platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
 
     entity0 = platform.ENTITIES[0]
-    entity0.supported_color_modes = {light.COLOR_MODE_HS}
-    entity0.color_mode = light.COLOR_MODE_HS
+    entity0.supported_color_modes = {light.ColorMode.HS}
+    entity0.color_mode = light.ColorMode.HS
     entity0.hs_color = (240, 100)
     entity0.rgb_color = "Invalid"  # Should be ignored
     entity0.xy_color = "Invalid"  # Should be ignored
 
     entity1 = platform.ENTITIES[1]
-    entity1.supported_color_modes = {light.COLOR_MODE_RGB}
-    entity1.color_mode = light.COLOR_MODE_RGB
+    entity1.supported_color_modes = {light.ColorMode.RGB}
+    entity1.color_mode = light.ColorMode.RGB
     entity1.hs_color = "Invalid"  # Should be ignored
     entity1.rgb_color = (128, 0, 0)
     entity1.xy_color = "Invalid"  # Should be ignored
 
     entity2 = platform.ENTITIES[2]
-    entity2.supported_color_modes = {light.COLOR_MODE_XY}
-    entity2.color_mode = light.COLOR_MODE_XY
+    entity2.supported_color_modes = {light.ColorMode.XY}
+    entity2.color_mode = light.ColorMode.XY
     entity2.hs_color = "Invalid"  # Should be ignored
     entity2.rgb_color = "Invalid"  # Should be ignored
     entity2.xy_color = (0.1, 0.8)
@@ -2100,25 +2100,25 @@ async def test_light_state_color_conversion(hass, enable_custom_integrations):
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+    assert state.attributes["color_mode"] == light.ColorMode.HS
     assert state.attributes["hs_color"] == (240, 100)
     assert state.attributes["rgb_color"] == (0, 0, 255)
     assert state.attributes["xy_color"] == (0.136, 0.04)
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["color_mode"] == light.COLOR_MODE_RGB
+    assert state.attributes["color_mode"] == light.ColorMode.RGB
     assert state.attributes["hs_color"] == (0.0, 100.0)
     assert state.attributes["rgb_color"] == (128, 0, 0)
     assert state.attributes["xy_color"] == (0.701, 0.299)
 
     state = hass.states.get(entity2.entity_id)
-    assert state.attributes["color_mode"] == light.COLOR_MODE_XY
+    assert state.attributes["color_mode"] == light.ColorMode.XY
     assert state.attributes["hs_color"] == (125.176, 100.0)
     assert state.attributes["rgb_color"] == (0, 255, 22)
     assert state.attributes["xy_color"] == (0.1, 0.8)
 
     state = hass.states.get(entity3.entity_id)
-    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+    assert state.attributes["color_mode"] == light.ColorMode.HS
     assert state.attributes["hs_color"] == (240, 100)
     assert state.attributes["rgb_color"] == (0, 0, 255)
     assert state.attributes["xy_color"] == (0.136, 0.04)
@@ -2280,7 +2280,7 @@ async def test_services_filter_parameters(
 
 def test_valid_supported_color_modes():
     """Test valid_supported_color_modes."""
-    supported = {light.COLOR_MODE_HS}
+    supported = {light.ColorMode.HS}
     assert light.valid_supported_color_modes(supported) == supported
 
     # Supported color modes must not be empty
@@ -2288,30 +2288,30 @@ def test_valid_supported_color_modes():
     with pytest.raises(vol.Error):
         light.valid_supported_color_modes(supported)
 
-    # COLOR_MODE_WHITE must be combined with a color mode supporting color
-    supported = {light.COLOR_MODE_WHITE}
+    # ColorMode.WHITE must be combined with a color mode supporting color
+    supported = {light.ColorMode.WHITE}
     with pytest.raises(vol.Error):
         light.valid_supported_color_modes(supported)
 
-    supported = {light.COLOR_MODE_WHITE, light.COLOR_MODE_COLOR_TEMP}
+    supported = {light.ColorMode.WHITE, light.ColorMode.COLOR_TEMP}
     with pytest.raises(vol.Error):
         light.valid_supported_color_modes(supported)
 
-    supported = {light.COLOR_MODE_WHITE, light.COLOR_MODE_HS}
+    supported = {light.ColorMode.WHITE, light.ColorMode.HS}
     assert light.valid_supported_color_modes(supported) == supported
 
-    # COLOR_MODE_ONOFF must be the only supported mode
-    supported = {light.COLOR_MODE_ONOFF}
+    # ColorMode.ONOFF must be the only supported mode
+    supported = {light.ColorMode.ONOFF}
     assert light.valid_supported_color_modes(supported) == supported
 
-    supported = {light.COLOR_MODE_ONOFF, light.COLOR_MODE_COLOR_TEMP}
+    supported = {light.ColorMode.ONOFF, light.ColorMode.COLOR_TEMP}
     with pytest.raises(vol.Error):
         light.valid_supported_color_modes(supported)
 
-    # COLOR_MODE_BRIGHTNESS must be the only supported mode
-    supported = {light.COLOR_MODE_BRIGHTNESS}
+    # ColorMode.BRIGHTNESS must be the only supported mode
+    supported = {light.ColorMode.BRIGHTNESS}
     assert light.valid_supported_color_modes(supported) == supported
 
-    supported = {light.COLOR_MODE_BRIGHTNESS, light.COLOR_MODE_COLOR_TEMP}
+    supported = {light.ColorMode.BRIGHTNESS, light.ColorMode.COLOR_TEMP}
     with pytest.raises(vol.Error):
         light.valid_supported_color_modes(supported)

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -1,10 +1,6 @@
 """Tests for the light intents."""
 from homeassistant.components import light
-from homeassistant.components.light import (
-    ATTR_SUPPORTED_COLOR_MODES,
-    COLOR_MODE_HS,
-    intent,
-)
+from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.helpers.intent import IntentHandleError
 
@@ -14,7 +10,7 @@ from tests.common import async_mock_service
 async def test_intent_set_color(hass):
     """Test the set color intent."""
     hass.states.async_set(
-        "light.hello_2", "off", {ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS]}
+        "light.hello_2", "off", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS]}
     )
     hass.states.async_set("switch.hello", "off")
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
@@ -59,7 +55,7 @@ async def test_intent_set_color_tests_feature(hass):
 async def test_intent_set_color_and_brightness(hass):
     """Test the set color intent."""
     hass.states.async_set(
-        "light.hello_2", "off", {ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS]}
+        "light.hello_2", "off", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS]}
     )
     hass.states.async_set("switch.hello", "off")
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -165,16 +165,16 @@ async def test_reproducing_states(hass, caplog):
 @pytest.mark.parametrize(
     "color_mode",
     (
-        light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_BRIGHTNESS,
-        light.COLOR_MODE_HS,
-        light.COLOR_MODE_ONOFF,
-        light.COLOR_MODE_RGB,
-        light.COLOR_MODE_RGBW,
-        light.COLOR_MODE_RGBWW,
-        light.COLOR_MODE_UNKNOWN,
-        light.COLOR_MODE_WHITE,
-        light.COLOR_MODE_XY,
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.BRIGHTNESS,
+        light.ColorMode.HS,
+        light.ColorMode.ONOFF,
+        light.ColorMode.RGB,
+        light.ColorMode.RGBW,
+        light.ColorMode.RGBWW,
+        light.ColorMode.UNKNOWN,
+        light.ColorMode.WHITE,
+        light.ColorMode.XY,
     ),
 )
 async def test_filter_color_modes(hass, caplog, color_mode):
@@ -200,23 +200,23 @@ async def test_filter_color_modes(hass, caplog, color_mode):
     )
 
     expected_map = {
-        light.COLOR_MODE_COLOR_TEMP: {**VALID_BRIGHTNESS, **VALID_COLOR_TEMP},
-        light.COLOR_MODE_BRIGHTNESS: VALID_BRIGHTNESS,
-        light.COLOR_MODE_HS: {**VALID_BRIGHTNESS, **VALID_HS_COLOR},
-        light.COLOR_MODE_ONOFF: {**VALID_BRIGHTNESS},
-        light.COLOR_MODE_RGB: {**VALID_BRIGHTNESS, **VALID_RGB_COLOR},
-        light.COLOR_MODE_RGBW: {**VALID_BRIGHTNESS, **VALID_RGBW_COLOR},
-        light.COLOR_MODE_RGBWW: {**VALID_BRIGHTNESS, **VALID_RGBWW_COLOR},
-        light.COLOR_MODE_UNKNOWN: {
+        light.ColorMode.COLOR_TEMP: {**VALID_BRIGHTNESS, **VALID_COLOR_TEMP},
+        light.ColorMode.BRIGHTNESS: VALID_BRIGHTNESS,
+        light.ColorMode.HS: {**VALID_BRIGHTNESS, **VALID_HS_COLOR},
+        light.ColorMode.ONOFF: {**VALID_BRIGHTNESS},
+        light.ColorMode.RGB: {**VALID_BRIGHTNESS, **VALID_RGB_COLOR},
+        light.ColorMode.RGBW: {**VALID_BRIGHTNESS, **VALID_RGBW_COLOR},
+        light.ColorMode.RGBWW: {**VALID_BRIGHTNESS, **VALID_RGBWW_COLOR},
+        light.ColorMode.UNKNOWN: {
             **VALID_BRIGHTNESS,
             **VALID_HS_COLOR,
             **VALID_WHITE_VALUE,
         },
-        light.COLOR_MODE_WHITE: {
+        light.ColorMode.WHITE: {
             **VALID_BRIGHTNESS,
             light.ATTR_WHITE: VALID_BRIGHTNESS[light.ATTR_BRIGHTNESS],
         },
-        light.COLOR_MODE_XY: {**VALID_BRIGHTNESS, **VALID_XY_COLOR},
+        light.ColorMode.XY: {**VALID_BRIGHTNESS, **VALID_XY_COLOR},
     }
     expected = expected_map[color_mode]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**Developers only**: All `COLOR_MODE_*` constants have been deprecated and replaced by a `ColorMode` enum.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1284

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
