### PR TITLE
Make hassio coordinator refresh data

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -42,7 +42,7 @@ from homeassistant.helpers.device_registry import (
 )
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.loader import bind_hass
 from homeassistant.util.dt import utcnow
 
@@ -609,21 +609,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             DOMAIN, service, async_service_handler, schema=settings.schema
         )
 
-    async def update_addon_stats(slug):
-        """Update single addon stats."""
-        stats = await hassio.get_addon_stats(slug)
-        return (slug, stats)
-
-    async def update_addon_changelog(slug):
-        """Return the changelog for an add-on."""
-        changelog = await hassio.get_addon_changelog(slug)
-        return (slug, changelog)
-
-    async def update_addon_info(slug):
-        """Return the info for an add-on."""
-        info = await hassio.get_addon_info(slug)
-        return (slug, info)
-
     async def update_info_data(now):
         """Update last available supervisor information."""
 
@@ -644,28 +629,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 hassio.get_os_info(),
             )
 
-            addons = [
-                addon
-                for addon in hass.data[DATA_SUPERVISOR_INFO].get("addons", [])
-                if addon[ATTR_STATE] == ATTR_STARTED
-            ]
-            stats_data = await asyncio.gather(
-                *[update_addon_stats(addon[ATTR_SLUG]) for addon in addons]
-            )
-            hass.data[DATA_ADDONS_STATS] = dict(stats_data)
-            hass.data[DATA_ADDONS_CHANGELOGS] = dict(
-                await asyncio.gather(
-                    *[update_addon_changelog(addon[ATTR_SLUG]) for addon in addons]
-                )
-            )
-            hass.data[DATA_ADDONS_INFO] = dict(
-                await asyncio.gather(
-                    *[update_addon_info(addon[ATTR_SLUG]) for addon in addons]
-                )
-            )
-
-            if ADDONS_COORDINATOR in hass.data:
-                await hass.data[ADDONS_COORDINATOR].async_refresh()
         except HassioAPIError as err:
             _LOGGER.warning("Can't read Supervisor data: %s", err)
 
@@ -855,7 +818,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_method=self._async_update_data,
+            update_interval=HASSIO_UPDATE_INTERVAL,
         )
         self.hassio: HassIO = hass.data[DOMAIN]
         self.data = {}
@@ -865,6 +828,11 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
+        try:
+            await self.force_data_refresh()
+        except HassioAPIError as err:
+            raise UpdateFailed(f"Error on Supervisor API: {err}") from err
+
         new_data = {}
         supervisor_info = get_supervisor_info(self.hass)
         addons_info = get_addons_info(self.hass)
@@ -940,3 +908,53 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Force update of the supervisor info."""
         self.hass.data[DATA_SUPERVISOR_INFO] = await self.hassio.get_supervisor_info()
         await self.async_refresh()
+
+    async def force_data_refresh(self) -> None:
+        """Force update of the addon info."""
+        await self.hassio.refresh_updates()
+        (
+            self.hass.data[DATA_INFO],
+            self.hass.data[DATA_CORE_INFO],
+            self.hass.data[DATA_SUPERVISOR_INFO],
+            self.hass.data[DATA_OS_INFO],
+        ) = await asyncio.gather(
+            self.hassio.get_info(),
+            self.hassio.get_core_info(),
+            self.hassio.get_supervisor_info(),
+            self.hassio.get_os_info(),
+        )
+
+        addons = [
+            addon
+            for addon in self.hass.data[DATA_SUPERVISOR_INFO].get("addons", [])
+            if addon[ATTR_STATE] == ATTR_STARTED
+        ]
+        stats_data = await asyncio.gather(
+            *[self._update_addon_stats(addon[ATTR_SLUG]) for addon in addons]
+        )
+        self.hass.data[DATA_ADDONS_STATS] = dict(stats_data)
+        self.hass.data[DATA_ADDONS_CHANGELOGS] = dict(
+            await asyncio.gather(
+                *[self._update_addon_changelog(addon[ATTR_SLUG]) for addon in addons]
+            )
+        )
+        self.hass.data[DATA_ADDONS_INFO] = dict(
+            await asyncio.gather(
+                *[self._update_addon_info(addon[ATTR_SLUG]) for addon in addons]
+            )
+        )
+
+    async def _update_addon_stats(self, slug):
+        """Update single addon stats."""
+        stats = await self.hassio.get_addon_stats(slug)
+        return (slug, stats)
+
+    async def _update_addon_changelog(self, slug):
+        """Return the changelog for an add-on."""
+        changelog = await self.hassio.get_addon_changelog(slug)
+        return (slug, changelog)
+
+    async def _update_addon_info(self, slug):
+        """Return the info for an add-on."""
+        info = await self.hassio.get_addon_info(slug)
+        return (slug, info)

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -168,6 +168,14 @@ class HassIO:
         """
         return self.send_command("/homeassistant/stop")
 
+    @_api_bool
+    def refresh_updates(self):
+        """Refresh available updates.
+
+        This method return a coroutine.
+        """
+        return self.send_command("/refresh_updates", timeout=None)
+
     @api_data
     def retrieve_discovery_messages(self):
         """Return all discovery data from Hass.io API.

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -127,6 +127,7 @@ def mock_all(aioclient_mock, request):
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels", json={"result": "ok", "data": {"panels": {}}}
     )
+    aioclient_mock.post("http://127.0.0.1/refresh_updates", json={"result": "ok"})
 
 
 @pytest.mark.parametrize(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components import frontend
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.hassio import ADDONS_COORDINATOR, DOMAIN, STORAGE_KEY
+from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.setup import async_setup_component
@@ -151,6 +152,7 @@ def mock_all(aioclient_mock, request):
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels", json={"result": "ok", "data": {"panels": {}}}
     )
+    aioclient_mock.post("http://127.0.0.1/refresh_updates", json={"result": "ok"})
 
 
 async def test_setup_api_ping(hass, aioclient_mock):
@@ -159,7 +161,7 @@ async def test_setup_api_ping(hass, aioclient_mock):
         result = await async_setup_component(hass, "hassio", {})
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert hass.components.hassio.get_core_info()["version_latest"] == "1.0.0"
     assert hass.components.hassio.is_hassio()
 
@@ -198,7 +200,7 @@ async def test_setup_api_push_api_data(hass, aioclient_mock):
         )
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -214,7 +216,7 @@ async def test_setup_api_push_api_data_server_host(hass, aioclient_mock):
         )
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert not aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -226,7 +228,7 @@ async def test_setup_api_push_api_data_default(hass, aioclient_mock, hass_storag
         result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     refresh_token = aioclient_mock.mock_calls[1][2]["refresh_token"]
@@ -293,7 +295,7 @@ async def test_setup_api_existing_hassio_user(hass, aioclient_mock, hass_storage
         result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     assert aioclient_mock.mock_calls[1][2]["refresh_token"] == token.token
@@ -307,7 +309,7 @@ async def test_setup_core_push_timezone(hass, aioclient_mock):
         result = await async_setup_component(hass, "hassio", {"hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert aioclient_mock.mock_calls[2][2]["timezone"] == "testzone"
 
     with patch("homeassistant.util.dt.set_default_time_zone"):
@@ -324,7 +326,7 @@ async def test_setup_hassio_no_additional_data(hass, aioclient_mock):
         result = await async_setup_component(hass, "hassio", {"hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 15
     assert aioclient_mock.mock_calls[-1][3]["X-Hassio-Key"] == "123456"
 
 
@@ -630,3 +632,27 @@ async def test_device_registry_calls(hass):
         async_fire_time_changed(hass, dt_util.now() + timedelta(hours=3))
         await hass.async_block_till_done()
         assert len(dev_reg.devices) == 5
+
+
+async def test_coordinator_updates(hass, caplog):
+    """Test coordinator."""
+    with patch.dict(os.environ, MOCK_ENVIRON), patch(
+        "homeassistant.components.hassio.HassIO.refresh_updates"
+    ) as refresh_updates_mock:
+        config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert refresh_updates_mock.call_count == 1
+
+    with patch(
+        "homeassistant.components.hassio.HassIO.refresh_updates",
+        side_effect=HassioAPIError("Unknown"),
+    ) as refresh_updates_mock:
+        async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=5))
+        await hass.async_block_till_done()
+        assert refresh_updates_mock.call_count == 1
+        assert (
+            "Error fetching hassio data: Error on Supervisor API: Unknown"
+            in caplog.text
+        )

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -120,6 +120,7 @@ def mock_all(aioclient_mock, request):
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels", json={"result": "ok", "data": {"panels": {}}}
     )
+    aioclient_mock.post("http://127.0.0.1/refresh_updates", json={"result": "ok"})
 
 
 @pytest.mark.parametrize(

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -133,6 +133,7 @@ def mock_all(aioclient_mock, request):
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels", json={"result": "ok", "data": {"panels": {}}}
     )
+    aioclient_mock.post("http://127.0.0.1/refresh_updates", json={"result": "ok"})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The coordinator used by hassio entities only used the cached data on an update.
Which made the "Check for updates" not actually check for updates for entities provided by this integration.

This PR makes it actually request updated data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
