### PR TITLE
Fix regression in zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -113,6 +113,11 @@ DATA_INVALID_SERVER_VERSION_LOGGED = "invalid_server_version_logged"
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Z-Wave JS component."""
     hass.data[DOMAIN] = {}
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if not isinstance(entry.unique_id, str):
+            hass.config_entries.async_update_entry(
+                entry, unique_id=str(entry.unique_id)
+            )
     return True
 
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -775,14 +775,3 @@ def async_ensure_addon_updated(hass: HomeAssistant) -> None:
     if addon_manager.task_in_progress():
         raise ConfigEntryNotReady
     addon_manager.async_schedule_update_addon(catch_error=True)
-
-
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
-    if isinstance(config_entry.unique_id, int):  # type: ignore[unreachable]
-        hass.config_entries.async_update_entry(  # type: ignore[unreachable]
-            config_entry,
-            unique_id=str(config_entry.unique_id),
-        )
-
-    return True

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import abstractmethod
 import asyncio
 import logging
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from async_timeout import timeout
@@ -307,6 +307,20 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
     def flow_manager(self) -> config_entries.ConfigEntriesFlowManager:
         """Return the correct flow manager."""
         return self.hass.config_entries.flow
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow start."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if not isinstance(entry.unique_id, str):
+                self.hass.config_entries.async_update_entry(
+                    entry, unique_id=str(entry.unique_id)
+                )
+
+        return cast(
+            FlowResult, await getattr(self, f"async_step_{self.source}")(user_input)
+        )
 
     @staticmethod
     @callback

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1048,6 +1048,7 @@ async def test_addon_running_already_configured(
         unique_id=1234,  # Unique ID is purposely set to int to test migration logic
     )
     entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1042,7 +1042,7 @@ async def test_addon_running_already_configured(
             "s2_unauthenticated_key": "old987",
         },
         title=TITLE,
-        unique_id="1234",
+        unique_id=1234,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -811,7 +811,10 @@ async def test_abort_usb_discovery_with_existing_flow(hass, supervisor, addon_op
 async def test_abort_usb_discovery_already_configured(hass, supervisor, addon_options):
     """Test usb discovery flow is aborted when there is an existing entry."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={"url": "ws://localhost:3000"}, title=TITLE, unique_id=1234
+        domain=DOMAIN,
+        data={"url": "ws://localhost:3000"},
+        title=TITLE,
+        unique_id="1234",
     )
     entry.add_to_hass(hass)
 
@@ -1030,6 +1033,7 @@ async def test_addon_running_already_configured(
     addon_options["s2_access_control_key"] = "new456"
     addon_options["s2_authenticated_key"] = "new789"
     addon_options["s2_unauthenticated_key"] = "new987"
+    # Unique ID is purposely set to int to test migration logic
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1560,7 +1564,7 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
 async def test_options_manual(hass, client, integration):
     """Test manual settings in options flow."""
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
 
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
@@ -1605,7 +1609,7 @@ async def test_options_manual_different_device(hass, integration):
 async def test_options_not_addon(hass, client, supervisor, integration):
     """Test options flow and opting out of add-on on Supervisor."""
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
 
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
@@ -1706,7 +1710,7 @@ async def test_options_addon_running(
     """Test options flow and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
     hass.config_entries.async_update_entry(entry, data=data)
 
@@ -1816,7 +1820,7 @@ async def test_options_addon_running_no_changes(
     """Test options flow without changes, and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
     hass.config_entries.async_update_entry(entry, data=data)
 
@@ -1929,7 +1933,7 @@ async def test_options_different_device(
     """Test options flow and configuring a different device."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
     hass.config_entries.async_update_entry(entry, data=data)
 
@@ -2079,7 +2083,7 @@ async def test_options_addon_restart_failed(
     """Test options flow and add-on restart failure."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
     hass.config_entries.async_update_entry(entry, data=data)
 
@@ -2200,7 +2204,7 @@ async def test_options_addon_running_server_info_failure(
     """Test options flow and add-on already running with server info failure."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
     hass.config_entries.async_update_entry(entry, data=data)
 
@@ -2304,7 +2308,7 @@ async def test_options_addon_not_installed(
     addon_installed.return_value["version"] = None
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = 1234
+    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
     hass.config_entries.async_update_entry(entry, data=data)
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1033,7 +1033,6 @@ async def test_addon_running_already_configured(
     addon_options["s2_access_control_key"] = "new456"
     addon_options["s2_authenticated_key"] = "new789"
     addon_options["s2_unauthenticated_key"] = "new987"
-    # Unique ID is purposely set to int to test migration logic
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1046,7 +1045,7 @@ async def test_addon_running_already_configured(
             "s2_unauthenticated_key": "old987",
         },
         title=TITLE,
-        unique_id=1234,
+        unique_id=1234,  # Unique ID is purposely set to int to test migration logic
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -8,7 +8,6 @@ from zwave_js_server.exceptions import BaseZwaveJSServerError, InvalidServerVers
 from zwave_js_server.model.node import Node
 
 from homeassistant.components.hassio.handler import HassioAPIError
-from homeassistant.components.zwave_js import async_migrate_entry
 from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
@@ -1328,12 +1327,3 @@ async def test_disabled_entity_on_value_removed(hass, zp3111, client, integratio
         | {battery_level_entity, binary_cover_entity, sensor_cover_entity}
         == new_unavailable_entities
     )
-
-
-async def test_async_migrate_entry(hass):
-    """Test async_migrate_entry."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=123456789)
-    assert isinstance(entry.unique_id, int)
-    await async_migrate_entry(hass, entry)
-    assert isinstance(entry.unique_id, str)
-    assert entry.unique_id == "123456789"


### PR DESCRIPTION
## Proposed change
https://github.com/home-assistant/core/pull/69163/ introduced a regression where a discovery flow gets kicked off using the new string format of the unique ID. The existing config entry does not get migrated before this happens, which means that it can't find the existing entry and does not abort the new flow. This change checks for both the int and str versions of the unique ID in order to properly abort regardless of order of operations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
