### PR TITLE
Revert "Use recorder executor in demo"

### DIFF
--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -5,7 +5,6 @@ from random import random
 
 from homeassistant import config_entries, setup
 from homeassistant.components import persistent_notification
-from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     get_last_statistics,
@@ -246,7 +245,7 @@ async def _insert_statistics(hass):
     }
     statistic_id = f"{DOMAIN}:energy_consumption"
     sum_ = 0
-    last_stats = await get_instance(hass).async_add_executor_job(
+    last_stats = await hass.async_add_executor_job(
         get_last_statistics, hass, 1, statistic_id, True
     )
     if "domain:energy_consumption" in last_stats:


### PR DESCRIPTION
Reverts home-assistant/core#69327

Reverted so we can figure out what's going on with the failing recorder test `tests/components/demo/test_init.py::test_demo_statistics`.

See discussion in #69327