### PR TITLE
Make Tibber priceInfo available as attributes of current price

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -397,8 +397,8 @@ class TibberSensorElPrice(TibberSensor):
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
-                self._attr_extra_state_attributes["raw_today"] = None
-                self._attr_extra_state_attributes["today"] = None
+                self._attr_extra_state_attributes["raw_today"] = []
+                self._attr_extra_state_attributes["today"] = []
                 _LOGGER.debug("Today priceInfo missing")
 
             # iterate through tomorrows prices and add list with only prices
@@ -419,8 +419,8 @@ class TibberSensorElPrice(TibberSensor):
                 if len(local_tomorrow) == 24 and local_tomorrow_valid:
                     self._attr_extra_state_attributes["tomorrow_valid"] = True
             else:
-                self._attr_extra_state_attributes["raw_tomorrow"] = None
-                self._attr_extra_state_attributes["tomorrow"] = None
+                self._attr_extra_state_attributes["raw_tomorrow"] = []
+                self._attr_extra_state_attributes["tomorrow"] = []
                 _LOGGER.debug("Tomorrow priceInfo missing")
 
         # tomorrows priceInfo is for today. Add tomorrows priceInfo as today
@@ -430,8 +430,8 @@ class TibberSensorElPrice(TibberSensor):
             == dt_util.now().date()
         ):
             _LOGGER.debug("Cached tomorrow priceInfo from yesterday is now today")
-            self._attr_extra_state_attributes["raw_tomorrow"] = None
-            self._attr_extra_state_attributes["tomorrow"] = None
+            self._attr_extra_state_attributes["raw_tomorrow"] = []
+            self._attr_extra_state_attributes["tomorrow"] = []
             self._attr_extra_state_attributes["tomorrow_valid"] = False
 
             # iterate through todays prices and add list with only prices
@@ -443,16 +443,16 @@ class TibberSensorElPrice(TibberSensor):
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
-                self._attr_extra_state_attributes["raw_today"] = None
-                self._attr_extra_state_attributes["today"] = None
+                self._attr_extra_state_attributes["raw_today"] = []
+                self._attr_extra_state_attributes["today"] = []
                 _LOGGER.debug("Today (tomorrow) priceInfo missing")
 
         # no cached priceInfo valid for today
         else:
-            self._attr_extra_state_attributes["today"] = None
-            self._attr_extra_state_attributes["tomorrow"] = None
-            self._attr_extra_state_attributes["raw_today"] = None
-            self._attr_extra_state_attributes["raw_tomorrow"] = None
+            self._attr_extra_state_attributes["today"] = []
+            self._attr_extra_state_attributes["tomorrow"] = []
+            self._attr_extra_state_attributes["raw_today"] = []
+            self._attr_extra_state_attributes["raw_tomorrow"] = []
             _LOGGER.debug("priceInfo missing")
 
         attrs = self._tibber_home.current_attributes()

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -403,7 +403,9 @@ class TibberSensorElPrice(TibberSensor):
 
             # iterate through tomorrows prices and add list with only prices
             if priceinfo["tomorrow"]:
-                self._attr_extra_state_attributes["raw_tomorrow"] = priceinfo["tomorrow"]
+                self._attr_extra_state_attributes["raw_tomorrow"] = priceinfo[
+                    "tomorrow"
+                ]
                 local_tomorrow = []
                 local_tomorrow_valid = True
                 for entry in priceinfo["tomorrow"]:

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -383,15 +383,13 @@ class TibberSensorElPrice(TibberSensor):
         ]
         # todays priceInfo is for today. Add todays and tomorrows priceInfo
         if (
-            dt_util.parse_datetime(priceinfo["today"][1]["startsAt"]).date()
+            priceinfo["today"]
+            and dt_util.parse_datetime(priceinfo["today"][1]["startsAt"]).date()
             == dt_util.now().date()
         ):
-            self._attr_extra_state_attributes["raw_today"] = priceinfo["today"]
-            self._attr_extra_state_attributes["raw_tomorrow"] = priceinfo["tomorrow"]
-            _LOGGER.debug("Raw priceInfo array set")
-
             # iterate through todays prices and add list with only prices
             if priceinfo["today"]:
+                self._attr_extra_state_attributes["raw_today"] = priceinfo["today"]
                 local_today = []
                 for entry in priceinfo["today"]:
                     local_today.append(entry["total"])
@@ -399,11 +397,13 @@ class TibberSensorElPrice(TibberSensor):
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
+                self._attr_extra_state_attributes["raw_today"] = None
                 self._attr_extra_state_attributes["today"] = None
                 _LOGGER.debug("Today priceInfo missing")
 
             # iterate through tomorrows prices and add list with only prices
             if priceinfo["tomorrow"]:
+                self._attr_extra_state_attributes["raw_tomorrow"] = priceinfo["tomorrow"]
                 local_tomorrow = []
                 local_tomorrow_valid = True
                 for entry in priceinfo["tomorrow"]:
@@ -417,6 +417,7 @@ class TibberSensorElPrice(TibberSensor):
                 if len(local_tomorrow) == 24 and local_tomorrow_valid:
                     self._attr_extra_state_attributes["tomorrow_valid"] = True
             else:
+                self._attr_extra_state_attributes["raw_tomorrow"] = None
                 self._attr_extra_state_attributes["tomorrow"] = None
                 _LOGGER.debug("Tomorrow priceInfo missing")
 
@@ -427,19 +428,20 @@ class TibberSensorElPrice(TibberSensor):
             == dt_util.now().date()
         ):
             _LOGGER.debug("Cached tomorrow priceInfo from yesterday is now today")
-            self._attr_extra_state_attributes["raw_today"] = priceinfo["tomorrow"]
             self._attr_extra_state_attributes["raw_tomorrow"] = None
             self._attr_extra_state_attributes["tomorrow"] = None
             self._attr_extra_state_attributes["tomorrow_valid"] = False
 
             # iterate through todays prices and add list with only prices
             if priceinfo["tomorrow"]:
+                self._attr_extra_state_attributes["raw_today"] = priceinfo["tomorrow"]
                 local_today = []
                 for entry in priceinfo["tomorrow"]:
                     local_today.append(entry["total"])
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
+                self._attr_extra_state_attributes["raw_today"] = None
                 self._attr_extra_state_attributes["today"] = None
                 _LOGGER.debug("Today (tomorrow) priceInfo missing")
 

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -394,7 +394,7 @@ class TibberSensorElPrice(TibberSensor):
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
-                self._attr_extra_state_attributes["today"] = []
+                self._attr_extra_state_attributes["today"] = None
                 _LOGGER.debug("Today priceInfo missing")
             
             # iterate through tomorrows prices and add list with only prices
@@ -405,22 +405,22 @@ class TibberSensorElPrice(TibberSensor):
                     local_tomorrow.append(entry["total"])
                     if not entry["total"]:
                         local_tomorrow_valid = False
-            
+                        
                 self._attr_extra_state_attributes["tomorrow"] = local_tomorrow
                 _LOGGER.debug("Tomorrow priceInfo array set")
                 # if no empty values and 24 entries, mark tomorrow as valid
-                if len(local_tomorrow)==24 and local_tomorrow_valid:
+                if len(local_tomorrow) == 24 and local_tomorrow_valid:
                     self._attr_extra_state_attributes["tomorrow_valid"] = True
             else:
-                self._attr_extra_state_attributes["tomorrow"] = []
+                self._attr_extra_state_attributes["tomorrow"] = None
                 _LOGGER.debug("Tomorrow priceInfo missing")
-        
+                
         # tomorrows priceInfo is for today. Add tomorrows priceInfo as today
         elif priceinfo["tomorrow"] and dt_util.parse_datetime(priceinfo["tomorrow"][1]["startsAt"]).date() == dt_util.now().date():
             _LOGGER.debug("Cached tomorrow priceInfo from yesterday is now today")
             self._attr_extra_state_attributes["raw_today"] = priceinfo["tomorrow"]
-            self._attr_extra_state_attributes["raw_tomorrow"] = []
-            self._attr_extra_state_attributes["tomorrow"] = []
+            self._attr_extra_state_attributes["raw_tomorrow"] = None
+            self._attr_extra_state_attributes["tomorrow"] = None
             self._attr_extra_state_attributes["tomorrow_valid"] = False
 
             # iterate through todays prices and add list with only prices
@@ -428,19 +428,18 @@ class TibberSensorElPrice(TibberSensor):
                 local_today = []
                 for entry in priceinfo["tomorrow"]:
                     local_today.append(entry["total"])
-            
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
-                self._attr_extra_state_attributes["today"] = []
+                self._attr_extra_state_attributes["today"] = None
                 _LOGGER.debug("Today (tomorrow) priceInfo missing")
         
         # no cached priceInfo valid for today
         else:
-            self._attr_extra_state_attributes["today"] = []
-            self._attr_extra_state_attributes["tomorrow"] = []
-            self._attr_extra_state_attributes["raw_today"] = []
-            self._attr_extra_state_attributes["raw_tomorrow"] = []
+            self._attr_extra_state_attributes["today"] = None
+            self._attr_extra_state_attributes["tomorrow"] = None
+            self._attr_extra_state_attributes["raw_today"] = None
+            self._attr_extra_state_attributes["raw_tomorrow"] = None
             _LOGGER.debug("priceInfo missing")
 
         attrs = self._tibber_home.current_attributes()

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -377,7 +377,7 @@ class TibberSensorElPrice(TibberSensor):
         res = self._tibber_home.current_price_data()
         self._attr_native_value, price_level, self._last_updated = res
         self._attr_extra_state_attributes["price_level"] = price_level
-        
+
         priceinfo = self._tibber_home.info["viewer"]["home"]["currentSubscription"]["priceInfo"]
         # todays priceInfo is for today. Add todays and tomorrows priceInfo
         if dt_util.parse_datetime(priceinfo["today"][1]["startsAt"]).date() == dt_util.now().date():
@@ -390,13 +390,13 @@ class TibberSensorElPrice(TibberSensor):
                 local_today = []
                 for entry in priceinfo["today"]:
                     local_today.append(entry["total"])
-            
+
                 self._attr_extra_state_attributes["today"] = local_today
                 _LOGGER.debug("Today priceInfo array set")
             else:
                 self._attr_extra_state_attributes["today"] = None
                 _LOGGER.debug("Today priceInfo missing")
-            
+
             # iterate through tomorrows prices and add list with only prices
             if priceinfo["tomorrow"]:
                 local_tomorrow = []
@@ -405,7 +405,7 @@ class TibberSensorElPrice(TibberSensor):
                     local_tomorrow.append(entry["total"])
                     if not entry["total"]:
                         local_tomorrow_valid = False
-                        
+
                 self._attr_extra_state_attributes["tomorrow"] = local_tomorrow
                 _LOGGER.debug("Tomorrow priceInfo array set")
                 # if no empty values and 24 entries, mark tomorrow as valid
@@ -414,7 +414,7 @@ class TibberSensorElPrice(TibberSensor):
             else:
                 self._attr_extra_state_attributes["tomorrow"] = None
                 _LOGGER.debug("Tomorrow priceInfo missing")
-                
+
         # tomorrows priceInfo is for today. Add tomorrows priceInfo as today
         elif priceinfo["tomorrow"] and dt_util.parse_datetime(priceinfo["tomorrow"][1]["startsAt"]).date() == dt_util.now().date():
             _LOGGER.debug("Cached tomorrow priceInfo from yesterday is now today")
@@ -433,7 +433,7 @@ class TibberSensorElPrice(TibberSensor):
             else:
                 self._attr_extra_state_attributes["today"] = None
                 _LOGGER.debug("Today (tomorrow) priceInfo missing")
-        
+
         # no cached priceInfo valid for today
         else:
             self._attr_extra_state_attributes["today"] = None

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -378,9 +378,14 @@ class TibberSensorElPrice(TibberSensor):
         self._attr_native_value, price_level, self._last_updated = res
         self._attr_extra_state_attributes["price_level"] = price_level
 
-        priceinfo = self._tibber_home.info["viewer"]["home"]["currentSubscription"]["priceInfo"]
+        priceinfo = self._tibber_home.info["viewer"]["home"]["currentSubscription"][
+            "priceInfo"
+        ]
         # todays priceInfo is for today. Add todays and tomorrows priceInfo
-        if dt_util.parse_datetime(priceinfo["today"][1]["startsAt"]).date() == dt_util.now().date():
+        if (
+            dt_util.parse_datetime(priceinfo["today"][1]["startsAt"]).date()
+            == dt_util.now().date()
+        ):
             self._attr_extra_state_attributes["raw_today"] = priceinfo["today"]
             self._attr_extra_state_attributes["raw_tomorrow"] = priceinfo["tomorrow"]
             _LOGGER.debug("Raw priceInfo array set")
@@ -416,7 +421,11 @@ class TibberSensorElPrice(TibberSensor):
                 _LOGGER.debug("Tomorrow priceInfo missing")
 
         # tomorrows priceInfo is for today. Add tomorrows priceInfo as today
-        elif priceinfo["tomorrow"] and dt_util.parse_datetime(priceinfo["tomorrow"][1]["startsAt"]).date() == dt_util.now().date():
+        elif (
+            priceinfo["tomorrow"]
+            and dt_util.parse_datetime(priceinfo["tomorrow"][1]["startsAt"]).date()
+            == dt_util.now().date()
+        ):
             _LOGGER.debug("Cached tomorrow priceInfo from yesterday is now today")
             self._attr_extra_state_attributes["raw_today"] = priceinfo["tomorrow"]
             self._attr_extra_state_attributes["raw_tomorrow"] = None


### PR DESCRIPTION
Added priceInfo for today with timestamp and price level as list in attribute raw_today
Added priceInfo for tomorrow with timestamp and price level as list in attribute raw_tomorrow
Added only prices as list for today and tomorrow as new attributes
Added tomorrow_valid as attribute if array of tomorrows prices are valid
This is the same format as the Nordpool integration, only with Tibber's api keys ("startsAt" and "total")

Adjusted valid update interval by changing hours until last timestamp from 5 to 8 and spread_load_constant from 5000 to 3600 (to reduce refresh window)
This should move update interval from 16:20-18:00 to 13:30-14:30 to make sure tomorrows prices are downloaded a bit earlier in the day

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
add extra attributes for priceInfo and update them when current price is updated.
The price info is already included in downloaded data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
