### PR TITLE
Upgrade frontier_silicon library to AFSAPI 0.2.4

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -403,6 +403,7 @@ omit =
     homeassistant/components/fritzbox_callmonitor/const.py
     homeassistant/components/fritzbox_callmonitor/base.py
     homeassistant/components/fritzbox_callmonitor/sensor.py
+    homeassistant/components/frontier_silicon/const.py
     homeassistant/components/frontier_silicon/media_player.py
     homeassistant/components/futurenow/light.py
     homeassistant/components/garadget/cover.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -359,6 +359,7 @@ build.json @home-assistant/supervisor
 /tests/components/fronius/ @nielstron @farmio
 /homeassistant/components/frontend/ @home-assistant/frontend
 /tests/components/frontend/ @home-assistant/frontend
+/homeassistant/components/frontier_silicon/ @wlcrs
 /homeassistant/components/garages_amsterdam/ @klaasnicolaas
 /tests/components/garages_amsterdam/ @klaasnicolaas
 /homeassistant/components/gdacs/ @exxamalte

--- a/homeassistant/components/frontier_silicon/const.py
+++ b/homeassistant/components/frontier_silicon/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Frontier Silicon Media Player integration."""
+
+DOMAIN = "frontier_silicon"
+
+DEFAULT_PIN = "1234"
+DEFAULT_PORT = 80

--- a/homeassistant/components/frontier_silicon/manifest.json
+++ b/homeassistant/components/frontier_silicon/manifest.json
@@ -2,7 +2,7 @@
   "domain": "frontier_silicon",
   "name": "Frontier Silicon",
   "documentation": "https://www.home-assistant.io/integrations/frontier_silicon",
-  "requirements": ["afsapi==0.0.4"],
-  "codeowners": [],
-  "iot_class": "local_push"
+  "requirements": ["afsapi==0.2.4"],
+  "codeowners": ["@wlcrs"],
+  "iot_class": "local_polling"
 }

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 import logging
 
-from afsapi import AFSAPI
-import requests
+from afsapi import (
+    AFSAPI,
+    ConnectionError as FSConnectionError,
+    FSApiException,
+    PlayState,
+)
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -20,25 +24,27 @@ from homeassistant.const import (
     CONF_PORT,
     STATE_IDLE,
     STATE_OFF,
+    STATE_OPENING,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DEFAULT_PIN, DEFAULT_PORT, DOMAIN
 
-DEFAULT_PORT = 80
-DEFAULT_PASSWORD = "1234"
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Optional(CONF_PASSWORD, default=DEFAULT_PIN): cv.string,
         vol.Optional(CONF_NAME): cv.string,
     }
 )
@@ -52,8 +58,13 @@ async def async_setup_platform(
 ) -> None:
     """Set up the Frontier Silicon platform."""
     if discovery_info is not None:
+        webfsapi_url = await AFSAPI.get_webfsapi_endpoint(
+            discovery_info["ssdp_description"]
+        )
+        afsapi = AFSAPI(webfsapi_url, DEFAULT_PIN)
+
         async_add_entities(
-            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD, None)],
+            [AFSAPIDevice(None, afsapi)],
             True,
         )
         return
@@ -64,11 +75,12 @@ async def async_setup_platform(
     name = config.get(CONF_NAME)
 
     try:
-        async_add_entities(
-            [AFSAPIDevice(f"http://{host}:{port}/device", password, name)], True
+        webfsapi_url = await AFSAPI.get_webfsapi_endpoint(
+            f"http://{host}:{port}/device"
         )
-        _LOGGER.debug("FSAPI device %s:%s -> %s", host, port, password)
-    except requests.exceptions.RequestException:
+        afsapi = AFSAPI(webfsapi_url, password)
+        async_add_entities([AFSAPIDevice(name, afsapi)], True)
+    except FSConnectionError:
         _LOGGER.error(
             "Could not add the FSAPI device at %s:%s -> %s", host, port, password
         )
@@ -93,10 +105,17 @@ class AFSAPIDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
-    def __init__(self, device_url, password, name):
+    def __init__(self, name: str | None, afsapi: AFSAPI) -> None:
         """Initialize the Frontier Silicon API device."""
-        self._device_url = device_url
-        self._password = password
+        self.fs_device = afsapi
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, afsapi.webfsapi_endpoint)},
+            name=name,
+        )
+        self._attr_available = True
+        self._attr_unique_id = None
+
         self._state = None
 
         self._name = name
@@ -110,17 +129,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         self._max_volume = None
         self._volume_level = None
 
-    # Properties
-    @property
-    def fs_device(self):
-        """
-        Create a fresh fsapi session.
-
-        A new session is created for each request in case someone else
-        connected to the device in between the updates and invalidated the
-        existing session (i.e UNDOK).
-        """
-        return AFSAPI(self._device_url, self._password)
+        self.__modes_by_label = None
 
     @property
     def name(self):
@@ -175,43 +184,67 @@ class AFSAPIDevice(MediaPlayerEntity):
 
     async def async_update(self):
         """Get the latest date and update device state."""
-        fs_device = self.fs_device
-
-        if not self._name:
-            self._name = await fs_device.get_friendly_name()
-
-        if not self._source_list:
-            self._source_list = await fs_device.get_mode_list()
-
-        # The API seems to include 'zero' in the number of steps (e.g. if the range is
-        # 0-40 then get_volume_steps returns 41) subtract one to get the max volume.
-        # If call to get_volume fails set to 0 and try again next time.
-        if not self._max_volume:
-            self._max_volume = int(await fs_device.get_volume_steps() or 1) - 1
-
-        if await fs_device.get_power():
-            status = await fs_device.get_play_status()
-            self._state = {
-                "playing": STATE_PLAYING,
-                "paused": STATE_PAUSED,
-                "stopped": STATE_IDLE,
-                "unknown": STATE_UNKNOWN,
-                None: STATE_IDLE,
-            }.get(status, STATE_UNKNOWN)
+        afsapi = self.fs_device
+        try:
+            if await afsapi.get_power():
+                status = await afsapi.get_play_status()
+                self._state = {
+                    PlayState.PLAYING: STATE_PLAYING,
+                    PlayState.PAUSED: STATE_PAUSED,
+                    PlayState.STOPPED: STATE_IDLE,
+                    PlayState.LOADING: STATE_OPENING,
+                    None: STATE_IDLE,
+                }.get(status, STATE_UNKNOWN)
+            else:
+                self._state = STATE_OFF
+        except FSConnectionError:
+            if self._attr_available:
+                _LOGGER.warning(
+                    "Could not connect to %s. Did it go offline?",
+                    self._name or afsapi.webfsapi_endpoint,
+                )
+                self._state = STATE_UNAVAILABLE
+                self._attr_available = False
         else:
-            self._state = STATE_OFF
+            if not self._attr_available:
+                _LOGGER.info(
+                    "Reconnected to %s",
+                    self._name or afsapi.webfsapi_endpoint,
+                )
 
-        if self._state != STATE_OFF:
-            info_name = await fs_device.get_play_name()
-            info_text = await fs_device.get_play_text()
+                self._attr_available = True
+            if not self._name:
+                self._name = await afsapi.get_friendly_name()
+
+            if not self._attr_unique_id:
+                try:
+                    self._attr_unique_id = await afsapi.get_radio_id()
+                except FSApiException:
+                    self._attr_unique_id = self._attr_name
+
+            if not self._source_list:
+                self.__modes_by_label = {
+                    mode.label: mode.key for mode in await afsapi.get_modes()
+                }
+                self._source_list = list(self.__modes_by_label.keys())
+
+            # The API seems to include 'zero' in the number of steps (e.g. if the range is
+            # 0-40 then get_volume_steps returns 41) subtract one to get the max volume.
+            # If call to get_volume fails set to 0 and try again next time.
+            if not self._max_volume:
+                self._max_volume = int(await afsapi.get_volume_steps() or 1) - 1
+
+        if self._state not in [STATE_OFF, STATE_UNAVAILABLE]:
+            info_name = await afsapi.get_play_name()
+            info_text = await afsapi.get_play_text()
 
             self._title = " - ".join(filter(None, [info_name, info_text]))
-            self._artist = await fs_device.get_play_artist()
-            self._album_name = await fs_device.get_play_album()
+            self._artist = await afsapi.get_play_artist()
+            self._album_name = await afsapi.get_play_album()
 
-            self._source = await fs_device.get_mode()
-            self._mute = await fs_device.get_mute()
-            self._media_image_url = await fs_device.get_play_graphic()
+            self._source = (await afsapi.get_mode()).label
+            self._mute = await afsapi.get_mute()
+            self._media_image_url = await afsapi.get_play_graphic()
 
             volume = await self.fs_device.get_volume()
 

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -329,4 +329,5 @@ class AFSAPIDevice(MediaPlayerEntity):
 
     async def async_select_source(self, source):
         """Select input source."""
-        await self.fs_device.set_mode(source)
+        await self.fs_device.set_power(True)
+        await self.fs_device.set_mode(self.__modes_by_label.get(source))

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from afsapi import (
-    AFSAPI,
-    ConnectionError as FSConnectionError,
-    FSApiException,
-    PlayState,
-)
+from afsapi import AFSAPI, ConnectionError as FSConnectionError, PlayState
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -113,8 +108,6 @@ class AFSAPIDevice(MediaPlayerEntity):
             identifiers={(DOMAIN, afsapi.webfsapi_endpoint)},
             name=name,
         )
-        self._attr_available = True
-        self._attr_unique_id = None
 
         self._state = None
 
@@ -215,12 +208,6 @@ class AFSAPIDevice(MediaPlayerEntity):
                 self._attr_available = True
             if not self._name:
                 self._name = await afsapi.get_friendly_name()
-
-            if not self._attr_unique_id:
-                try:
-                    self._attr_unique_id = await afsapi.get_radio_id()
-                except FSApiException:
-                    self._attr_unique_id = self._attr_name
 
             if not self._source_list:
                 self.__modes_by_label = {

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -58,8 +58,9 @@ async def async_setup_platform(
         )
         afsapi = AFSAPI(webfsapi_url, DEFAULT_PIN)
 
+        name = await afsapi.get_friendly_name()
         async_add_entities(
-            [AFSAPIDevice(None, afsapi)],
+            [AFSAPIDevice(name, afsapi)],
             True,
         )
         return

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -89,7 +89,7 @@ adguardhome==0.5.1
 advantage_air==0.3.1
 
 # homeassistant.components.frontier_silicon
-afsapi==0.0.4
+afsapi==0.2.4
 
 # homeassistant.components.agent_dvr
 agent-py==0.0.23


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update to FSAPI 0.2.4, which is a large overhaul of the previous implementation. (cfr: https://github.com/zhelev/python-afsapi/compare/0.0.4...0.2.4 )

It does no longer interfere with the use of the UNDOK application to control the radio (in recent models).

This PR splits out the library upgrade from adding config flow (PR #64365). I'll mark the config_flow PR as a draft while this smaller PR is pending.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
