### PR TITLE
Generic fix stream thumbnail

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -349,7 +349,9 @@ class GenericOptionsFlowHandler(OptionsFlow):
         self.cached_user_input: dict[str, Any] = {}
         self.cached_title = ""
 
-    async def async_step_init(self, user_input: dict[str, Any]) -> FlowResult:
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage Generic IP Camera options."""
         errors: dict[str, str] = {}
 

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -293,11 +293,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                     # Show a conditional 2nd page to ask them the content type.
                     self.cached_user_input = user_input
                     self.cached_title = name
-                    return self.async_show_form(
-                        step_id="user2",
-                        data_schema=build_schema2({}),
-                        errors={},
-                    )
+                    return await self.async_step_user2()
         else:
             user_input = DEFAULT_DATA.copy()
 
@@ -307,12 +303,20 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_user2(self, user_input: dict[str, Any]) -> FlowResult:
+    async def async_step_user2(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the user's choice for stream content_type."""
-        user_input = self.cached_user_input | user_input
-        await self.async_set_unique_id(self.flow_id)
-        return self.async_create_entry(
-            title=self.cached_title, data={}, options=user_input
+        if user_input is not None:
+            user_input = self.cached_user_input | user_input
+            await self.async_set_unique_id(self.flow_id)
+            return self.async_create_entry(
+                title=self.cached_title, data={}, options=user_input
+            )
+        return self.async_show_form(
+            step_id="user2",
+            data_schema=build_schema2({}),
+            errors={},
         )
 
     async def async_step_import(self, import_config) -> FlowResult:

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -91,6 +91,12 @@ def build_schema(
             CONF_PASSWORD,
             description={"suggested_value": user_input.get(CONF_PASSWORD, "")},
         ): str,
+        vol.Optional(
+            CONF_CONTENT_TYPE,
+            description={
+                "suggested_value": user_input.get(CONF_CONTENT_TYPE, "image/jpeg")
+            },
+        ): str,
         vol.Required(
             CONF_FRAMERATE,
             description={"suggested_value": user_input.get(CONF_FRAMERATE, 2)},
@@ -129,7 +135,7 @@ async def async_test_still(hass, info) -> tuple[dict[str, str], str | None]:
     """Verify that the still image is valid before we create an entity."""
     fmt = None
     if not (url := info.get(CONF_STILL_IMAGE_URL)):
-        return {}, None
+        return {}, info.get(CONF_CONTENT_TYPE, "image/jpeg")
     if not isinstance(url, template_helper.Template) and url:
         url = cv.template(url)
         url.hass = hass

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -238,8 +238,8 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
     def check_for_existing(self, options):
         """Check whether an existing entry is using the same URLs."""
         return any(
-            entry.options[CONF_STILL_IMAGE_URL] == options[CONF_STILL_IMAGE_URL]
-            and entry.options[CONF_STREAM_SOURCE] == options[CONF_STREAM_SOURCE]
+            entry.options.get(CONF_STILL_IMAGE_URL) == options.get(CONF_STILL_IMAGE_URL)
+            and entry.options.get(CONF_STREAM_SOURCE) == options.get(CONF_STREAM_SOURCE)
             for entry in self._async_current_entries()
         )
 

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -30,9 +30,14 @@
           "limit_refetch_to_url_change": "Limit refetch to url change",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "content_type": "Content Type",
           "framerate": "Frame Rate (Hz)",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        }
+      },
+      "user2": {
+        "description": "Specify the content type for the stream.",
+        "data": {
+          "content_type": "Content Type"
         }
       },
       "confirm": {
@@ -51,9 +56,14 @@
           "limit_refetch_to_url_change": "[%key:component::generic::config::step::user::data::limit_refetch_to_url_change%]",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "content_type": "[%key:component::generic::config::step::user::data::content_type%]",
           "framerate": "[%key:component::generic::config::step::user::data::framerate%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        }
+      },
+      "init2": {
+        "description": "[%key:component::generic::config::step::user2::description%]",
+        "data": {
+          "content_type": "[%key:component::generic::config::step::user2::data::content_type%]"
         }
       }
     },

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -34,7 +34,7 @@
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         }
       },
-      "user2": {
+      "content_type": {
         "description": "Specify the content type for the stream.",
         "data": {
           "content_type": "Content Type"
@@ -60,10 +60,10 @@
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         }
       },
-      "init2": {
-        "description": "[%key:component::generic::config::step::user2::description%]",
+      "content_type": {
+        "description": "[%key:component::generic::config::step::content_type::description%]",
         "data": {
-          "content_type": "[%key:component::generic::config::step::user2::data::content_type%]"
+          "content_type": "[%key:component::generic::config::step::content_type::data::content_type%]"
         }
       }
     },

--- a/homeassistant/components/generic/translations/en.json
+++ b/homeassistant/components/generic/translations/en.json
@@ -26,7 +26,6 @@
             "user": {
                 "data": {
                     "authentication": "Authentication",
-                    "content_type": "Content Type",
                     "framerate": "Frame Rate (Hz)",
                     "limit_refetch_to_url_change": "Limit refetch to url change",
                     "password": "Password",
@@ -37,6 +36,12 @@
                     "verify_ssl": "Verify SSL certificate"
                 },
                 "description": "Enter the settings to connect to the camera."
+            },
+            "user2": {
+                "data": {
+                    "content_type": "Content Type"
+                },
+                "description": "Specify the content type for the stream."
             }
         }
     },
@@ -60,7 +65,6 @@
             "init": {
                 "data": {
                     "authentication": "Authentication",
-                    "content_type": "Content Type",
                     "framerate": "Frame Rate (Hz)",
                     "limit_refetch_to_url_change": "Limit refetch to url change",
                     "password": "Password",
@@ -70,6 +74,12 @@
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
                 }
+            },
+            "init2": {
+                "data": {
+                    "content_type": "Content Type"
+                },
+                "description": "Specify the content type for the stream."
             }
         }
     }

--- a/homeassistant/components/generic/translations/en.json
+++ b/homeassistant/components/generic/translations/en.json
@@ -23,6 +23,12 @@
             "confirm": {
                 "description": "Do you want to start set up?"
             },
+            "content_type": {
+                "data": {
+                    "content_type": "Content Type"
+                },
+                "description": "Specify the content type for the stream."
+            },
             "user": {
                 "data": {
                     "authentication": "Authentication",
@@ -36,12 +42,6 @@
                     "verify_ssl": "Verify SSL certificate"
                 },
                 "description": "Enter the settings to connect to the camera."
-            },
-            "user2": {
-                "data": {
-                    "content_type": "Content Type"
-                },
-                "description": "Specify the content type for the stream."
             }
         }
     },
@@ -62,6 +62,12 @@
             "unknown": "Unexpected error"
         },
         "step": {
+            "content_type": {
+                "data": {
+                    "content_type": "Content Type"
+                },
+                "description": "Specify the content type for the stream."
+            },
             "init": {
                 "data": {
                     "authentication": "Authentication",
@@ -74,12 +80,6 @@
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
                 }
-            },
-            "init2": {
-                "data": {
-                    "content_type": "Content Type"
-                },
-                "description": "Specify the content type for the stream."
             }
         }
     }

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -205,9 +205,15 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
             result["flow_id"],
             data,
         )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "127_0_0_1_testurl_2"
-    assert result2["options"] == {
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {CONF_CONTENT_TYPE: "image/jpeg"},
+    )
+
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["title"] == "127_0_0_1_testurl_2"
+    assert result3["options"] == {
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
         CONF_STREAM_SOURCE: "http://127.0.0.1/testurl/2",
         CONF_RTSP_TRANSPORT: "tcp",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The new generic camera config flow autodetects image type for still images.  But it is not automatic for streams.  So if a camera only had a `stream_url` and no `still_image_url`, the content_type would be undefined.  This caused the thumbnail to fail for a stream #69128.

This PR fixes this by reinstating the `content_type` field, and defaulting to the user value if the autodetect is skipped.

It also enables the value to be read from YAML.

A small fix is made to the duplicate checking code which was triggering log errors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69128
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
