### PR TITLE
Improve typing of deCONZ config flow

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -11,6 +11,7 @@ import async_timeout
 from pydeconz.errors import RequestError, ResponseError
 from pydeconz.gateway import DeconzSession
 from pydeconz.utils import (
+    DiscoveredBridge,
     discovery as deconz_discovery,
     get_bridge_id as deconz_get_bridge_id,
     normalize_bridge_id,
@@ -58,6 +59,11 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
 
     _hassio_discovery: dict[str, Any]
 
+    bridges: list[DiscoveredBridge]
+    host: str
+    port: int
+    api_key: str
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
@@ -67,8 +73,6 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the deCONZ config flow."""
         self.bridge_id = ""
-        self.bridges: list[dict[str, int | str]] = []
-        self.deconz_config: dict[str, int | str] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -85,11 +89,9 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
 
             for bridge in self.bridges:
                 if bridge[CONF_HOST] == user_input[CONF_HOST]:
-                    self.bridge_id = cast(str, bridge["id"])
-                    self.deconz_config = {
-                        CONF_HOST: bridge[CONF_HOST],
-                        CONF_PORT: bridge[CONF_PORT],
-                    }
+                    self.bridge_id = bridge["id"]
+                    self.host = bridge[CONF_HOST]
+                    self.port = bridge[CONF_PORT]
                     return await self.async_step_link()
 
         session = aiohttp_client.async_get_clientsession(self.hass)
@@ -123,7 +125,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Manual configuration."""
         if user_input:
-            self.deconz_config = user_input
+            self.host = user_input[CONF_HOST]
+            self.port = user_input[CONF_PORT]
             return await self.async_step_link()
 
         return self.async_show_form(
@@ -143,16 +146,12 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         LOGGER.debug(
-            "Preparing linking with deCONZ gateway %s", pformat(self.deconz_config)
+            "Preparing linking with deCONZ gateway %s %d", self.host, self.port
         )
 
         if user_input is not None:
             session = aiohttp_client.async_get_clientsession(self.hass)
-            deconz_session = DeconzSession(
-                session,
-                host=self.deconz_config[CONF_HOST],
-                port=self.deconz_config[CONF_PORT],
-            )
+            deconz_session = DeconzSession(session, self.host, self.port)
 
             try:
                 async with async_timeout.timeout(10):
@@ -162,7 +161,7 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_key"
 
             else:
-                self.deconz_config[CONF_API_KEY] = api_key
+                self.api_key = api_key
                 return await self._create_entry()
 
         return self.async_show_form(step_id="link", errors=errors)
@@ -175,31 +174,36 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
             try:
                 async with async_timeout.timeout(10):
                     self.bridge_id = await deconz_get_bridge_id(
-                        session, **self.deconz_config
+                        session, self.host, self.port, self.api_key
                     )
                     await self.async_set_unique_id(self.bridge_id)
 
                     self._abort_if_unique_id_configured(
                         updates={
-                            CONF_HOST: self.deconz_config[CONF_HOST],
-                            CONF_PORT: self.deconz_config[CONF_PORT],
-                            CONF_API_KEY: self.deconz_config[CONF_API_KEY],
+                            CONF_HOST: self.host,
+                            CONF_PORT: self.port,
+                            CONF_API_KEY: self.api_key,
                         }
                     )
 
             except asyncio.TimeoutError:
                 return self.async_abort(reason="no_bridges")
 
-        return self.async_create_entry(title=self.bridge_id, data=self.deconz_config)
+        return self.async_create_entry(
+            title=self.bridge_id,
+            data={
+                CONF_HOST: self.host,
+                CONF_PORT: self.port,
+                CONF_API_KEY: self.api_key,
+            },
+        )
 
     async def async_step_reauth(self, config: dict[str, Any]) -> FlowResult:
         """Trigger a reauthentication flow."""
         self.context["title_placeholders"] = {CONF_HOST: config[CONF_HOST]}
 
-        self.deconz_config = {
-            CONF_HOST: config[CONF_HOST],
-            CONF_PORT: config[CONF_PORT],
-        }
+        self.host = config[CONF_HOST]
+        self.port = config[CONF_PORT]
 
         return await self.async_step_link()
 
@@ -220,21 +224,22 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
         if entry and entry.source == config_entries.SOURCE_HASSIO:
             return self.async_abort(reason="already_configured")
 
-        hostname = cast(str, parsed_url.hostname)
-        port = cast(int, parsed_url.port)
+        self.host = cast(str, parsed_url.hostname)
+        self.port = cast(int, parsed_url.port)
 
         self._abort_if_unique_id_configured(
-            updates={CONF_HOST: hostname, CONF_PORT: port}
+            updates={
+                CONF_HOST: self.host,
+                CONF_PORT: self.port,
+            }
         )
 
         self.context.update(
             {
-                "title_placeholders": {"host": hostname},
-                "configuration_url": f"http://{hostname}:{port}",
+                "title_placeholders": {"host": self.host},
+                "configuration_url": f"http://{self.host}:{self.port}",
             }
         )
-
-        self.deconz_config = {CONF_HOST: hostname, CONF_PORT: port}
 
         return await self.async_step_link()
 
@@ -248,16 +253,19 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
         self.bridge_id = normalize_bridge_id(discovery_info.config[CONF_SERIAL])
         await self.async_set_unique_id(self.bridge_id)
 
+        self.host = discovery_info.config[CONF_HOST]
+        self.port = discovery_info.config[CONF_PORT]
+        self.api_key = discovery_info.config[CONF_API_KEY]
+
         self._abort_if_unique_id_configured(
             updates={
-                CONF_HOST: discovery_info.config[CONF_HOST],
-                CONF_PORT: discovery_info.config[CONF_PORT],
-                CONF_API_KEY: discovery_info.config[CONF_API_KEY],
+                CONF_HOST: self.host,
+                CONF_PORT: self.port,
+                CONF_API_KEY: self.api_key,
             }
         )
 
         self.context["configuration_url"] = HASSIO_CONFIGURATION_URL
-
         self._hassio_discovery = discovery_info.config
 
         return await self.async_step_hassio_confirm()
@@ -268,12 +276,6 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
         """Confirm a Hass.io discovery."""
 
         if user_input is not None:
-            self.deconz_config = {
-                CONF_HOST: self._hassio_discovery[CONF_HOST],
-                CONF_PORT: self._hassio_discovery[CONF_PORT],
-                CONF_API_KEY: self._hassio_discovery[CONF_API_KEY],
-            }
-
             return await self._create_entry()
 
         return self.async_show_form(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- When marking pydeconz as typed additional type errors pop up
- This PR changes how host, port and api_key are stored from being part of a dict to standalone attributes

```
homeassistant/components/deconz/config_flow.py:99: error: Incompatible types in assignment (expression has type "List[DiscoveredBridge]", variable has type "List[Dict[str, Union[int, str]]]")  [assignment]
homeassistant/components/deconz/config_flow.py:153: error: Argument "host" to "DeconzSession" has incompatible type "Union[int, str]"; expected "str"  [arg-type]
homeassistant/components/deconz/config_flow.py:154: error: Argument "port" to "DeconzSession" has incompatible type "Union[int, str]"; expected "int"  [arg-type]
homeassistant/components/deconz/config_flow.py:178: error: Argument 2 to "get_bridge_id" has incompatible type "**Dict[str, Union[int, str]]"; expected "str"  [arg-type]
homeassistant/components/deconz/config_flow.py:178: error: Argument 2 to "get_bridge_id" has incompatible type "**Dict[str, Union[int, str]]"; expected "int"  [arg-type]
```
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
