### PR TITLE
Continue on template error during yaml import for generic

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -136,7 +136,7 @@ async def async_test_still(hass, info) -> tuple[dict[str, str], str | None]:
     try:
         url = url.async_render(parse_result=False)
     except TemplateError as err:
-        _LOGGER.error("Error parsing template %s: %s", url, err)
+        _LOGGER.warning("Problem parsing template %s: %s", url, err)
         return {CONF_STILL_IMAGE_URL: "template_error"}, None
     verify_ssl = info.get(CONF_VERIFY_SSL)
     auth = generate_auth(info)
@@ -283,6 +283,14 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         if self.check_for_existing(import_config):
             return self.async_abort(reason="already_exists")
         errors, still_format = await async_test_still(self.hass, import_config)
+        if errors.get(CONF_STILL_IMAGE_URL) == "template_error":
+            _LOGGER.warning(
+                "Could not render template, but it could be that "
+                "referenced entities are still initialising. "
+                "Continuing assuming that imported YAML template is valid"
+            )
+            errors.pop(CONF_STILL_IMAGE_URL)
+            still_format = import_config.get(CONF_CONTENT_TYPE, "image/jpeg")
         errors = errors | await async_test_stream(self.hass, import_config)
         still_url = import_config.get(CONF_STILL_IMAGE_URL)
         stream_url = import_config.get(CONF_STREAM_SOURCE)

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -136,7 +136,7 @@ async def async_test_still(hass, info) -> tuple[dict[str, str], str | None]:
     try:
         url = url.async_render(parse_result=False)
     except TemplateError as err:
-        _LOGGER.warning("Problem parsing template %s: %s", url, err)
+        _LOGGER.warning("Problem rendering template %s: %s", url, err)
         return {CONF_STILL_IMAGE_URL: "template_error"}, None
     verify_ssl = info.get(CONF_VERIFY_SSL)
     auth = generate_auth(info)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During yaml import for generic (camera), a check is done on the still_image_url.  But the check can fail if this url contains a template referring to an entity which is not yet initialized at that point in the startup.

This change is to allow `TemplateError`s to occur during yaml import, on the assumption that the original yaml was valid.

If it turns out to be invalid after all, it is not a huge problem.  The user can still tinker with it in the configuration section of the UI, and the checks will be done (the errors are only ignored during yaml import).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69402
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
