### PR TITLE
Ignore IPv6 link local address on ssdp discovery in Fritz!Smarthome

### DIFF
--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -121,7 +121,10 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         assert isinstance(host, str)
         self.context[CONF_HOST] = host
 
-        if ipaddress.ip_address(host).is_link_local:
+        if (
+            ipaddress.ip_address(host).version == 6
+            and ipaddress.ip_address(host).is_link_local
+        ):
             return self.async_abort(reason="ignore_ip6_link_local")
 
         if uuid := discovery_info.upnp.get(ssdp.ATTR_UPNP_UDN):

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for AVM FRITZ!SmartHome."""
 from __future__ import annotations
 
+import ipaddress
 from typing import Any
 from urllib.parse import urlparse
 
@@ -119,6 +120,9 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         host = urlparse(discovery_info.ssdp_location).hostname
         assert isinstance(host, str)
         self.context[CONF_HOST] = host
+
+        if ipaddress.ip_address(host).is_link_local:
+            return self.async_abort(reason="ignore_ip6_link_local")
 
         if uuid := discovery_info.upnp.get(ssdp.ATTR_UPNP_UDN):
             if uuid.startswith("uuid:"):

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -28,6 +28,7 @@
     "abort": {
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "ignore_ip6_link_local": "IPv6 link local address is not supported.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "not_supported": "Connected to AVM FRITZ!Box but it's unable to control Smart Home devices.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"

--- a/homeassistant/components/fritzbox/translations/en.json
+++ b/homeassistant/components/fritzbox/translations/en.json
@@ -3,6 +3,7 @@
         "abort": {
             "already_configured": "Device is already configured",
             "already_in_progress": "Configuration flow is already in progress",
+            "ignore_ip6_link_local": "IPv6 link local address is not supported.",
             "no_devices_found": "No devices found on the network",
             "not_supported": "Connected to AVM FRITZ!Box but it's unable to control Smart Home devices.",
             "reauth_successful": "Re-authentication was successful"

--- a/tests/components/fritzbox/const.py
+++ b/tests/components/fritzbox/const.py
@@ -6,7 +6,7 @@ MOCK_CONFIG = {
     DOMAIN: {
         CONF_DEVICES: [
             {
-                CONF_HOST: "fake_host",
+                CONF_HOST: "10.0.0.1",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
             }

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -35,12 +35,12 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     entries = hass.config_entries.async_entries()
     assert entries
     assert len(entries) == 1
-    assert entries[0].data[CONF_HOST] == "fake_host"
+    assert entries[0].data[CONF_HOST] == "10.0.0.1"
     assert entries[0].data[CONF_PASSWORD] == "fake_pass"
     assert entries[0].data[CONF_USERNAME] == "fake_user"
     assert fritz.call_count == 1
     assert fritz.call_args_list == [
-        call(host="fake_host", password="fake_pass", user="fake_user")
+        call(host="10.0.0.1", password="fake_pass", user="fake_user")
     ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will solve the issue while updating from <=2022.3.x to 2022.4.1, but unfortunately not for updating from 2022.4.0 to 2022.4.1. In this case you need to re-add the `fritzbox` integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69447
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
