### PR TITLE
Improve typing of deCONZ events

### DIFF
--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from pydeconz.models.event import EventType
 from pydeconz.sensor import (
     ANCILLARY_CONTROL_EMERGENCY,
     ANCILLARY_CONTROL_FIRE,
@@ -20,7 +23,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import slugify
 
 from .const import CONF_ANGLE, CONF_GESTURE, LOGGER
@@ -42,43 +44,42 @@ async def async_setup_events(gateway: DeconzGateway) -> None:
     """Set up the deCONZ events."""
 
     @callback
-    def async_add_sensor(
-        sensors: AncillaryControl | Switch | None = None,
-    ) -> None:
+    def async_add_sensor(_, sensor_id: str) -> None:
         """Create DeconzEvent."""
-        new_events = []
-        known_events = {event.unique_id for event in gateway.events}
+        new_event: DeconzAlarmEvent | DeconzEvent
+        sensor = gateway.api.sensors[sensor_id]
 
-        if sensors is None:
-            sensors = gateway.api.sensors.values()
+        if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
+            return None
 
-        for sensor in sensors:
+        if isinstance(sensor, Switch):
+            new_event = DeconzEvent(sensor, gateway)
 
-            if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
-                continue
+        elif isinstance(sensor, AncillaryControl):
+            new_event = DeconzAlarmEvent(sensor, gateway)
 
-            if sensor.unique_id in known_events:
-                continue
+        else:
+            return None
 
-            if isinstance(sensor, Switch):
-                new_events.append(DeconzEvent(sensor, gateway))
-
-            elif isinstance(sensor, AncillaryControl):
-                new_events.append(DeconzAlarmEvent(sensor, gateway))
-
-        for new_event in new_events:
-            gateway.hass.async_create_task(new_event.async_update_device_registry())
-            gateway.events.append(new_event)
+        gateway.hass.async_create_task(new_event.async_update_device_registry())
+        gateway.events.append(new_event)
 
     gateway.config_entry.async_on_unload(
-        async_dispatcher_connect(
-            gateway.hass,
-            gateway.signal_new_sensor,
+        gateway.api.sensors.ancillary_control.subscribe(
             async_add_sensor,
+            EventType.ADDED,
         )
     )
 
-    async_add_sensor()
+    gateway.config_entry.async_on_unload(
+        gateway.api.sensors.switch.subscribe(
+            async_add_sensor,
+            EventType.ADDED,
+        )
+    )
+
+    for sensor_id in gateway.api.sensors:
+        async_add_sensor(EventType.ADDED, sensor_id)
 
 
 @callback
@@ -90,7 +91,7 @@ def async_unload_events(gateway: DeconzGateway) -> None:
     gateway.events.clear()
 
 
-class DeconzEvent(DeconzBase):
+class DeconzEventBase(DeconzBase):
     """When you want signals instead of entities.
 
     Stateless sensors such as remotes are expected to generate an event
@@ -105,21 +106,44 @@ class DeconzEvent(DeconzBase):
         """Register callback that will be used for signals."""
         super().__init__(device, gateway)
 
-        self._device.register_callback(self.async_update_callback)
+        self._unsubscribe = device.subscribe(self.async_update_callback)
 
+        self.device = device
         self.device_id: str | None = None
         self.event_id = slugify(self._device.name)
         LOGGER.debug("deCONZ event created: %s", self.event_id)
 
-    @property
-    def device(self) -> AncillaryControl | Switch:
-        """Return Event device."""
-        return self._device
-
     @callback
     def async_will_remove_from_hass(self) -> None:
         """Disconnect event object when removed."""
-        self._device.remove_callback(self.async_update_callback)
+        self._unsubscribe()
+
+    @callback
+    def async_update_callback(self) -> None:
+        """Fire the event if reason is that state is updated."""
+        raise NotImplementedError
+
+    async def async_update_device_registry(self) -> None:
+        """Update device registry."""
+        if not self.device_info:
+            return
+
+        device_registry = dr.async_get(self.gateway.hass)
+
+        entry = device_registry.async_get_or_create(
+            config_entry_id=self.gateway.config_entry.entry_id, **self.device_info
+        )
+        self.device_id = entry.id
+
+
+class DeconzEvent(DeconzEventBase):
+    """When you want signals instead of entities.
+
+    Stateless sensors such as remotes are expected to generate an event
+    instead of a sensor entity in hass.
+    """
+
+    _device: Switch
 
     @callback
     def async_update_callback(self) -> None:
@@ -130,7 +154,7 @@ class DeconzEvent(DeconzBase):
         ):
             return
 
-        data = {
+        data: dict[str, Any] = {
             CONF_ID: self.event_id,
             CONF_UNIQUE_ID: self.serial,
             CONF_EVENT: self._device.button_event,
@@ -150,20 +174,8 @@ class DeconzEvent(DeconzBase):
 
         self.gateway.hass.bus.async_fire(CONF_DECONZ_EVENT, data)
 
-    async def async_update_device_registry(self) -> None:
-        """Update device registry."""
-        if not self.device_info:
-            return
 
-        device_registry = dr.async_get(self.gateway.hass)
-
-        entry = device_registry.async_get_or_create(
-            config_entry_id=self.gateway.config_entry.entry_id, **self.device_info
-        )
-        self.device_id = entry.id
-
-
-class DeconzAlarmEvent(DeconzEvent):
+class DeconzAlarmEvent(DeconzEventBase):
     """Alarm control panel companion event when user interacts with a keypad."""
 
     _device: AncillaryControl


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix the typing issues of deconz events
- Use the new way to subscribe to new events from lib
- Make subclass define what sensor type is expected
- Make subclass define the update callback

```
homeassistant/components/deconz/deconz_event.py:55: error: Incompatible types in assignment (expression has type "DeconzEvent", variable has type "Union[AncillaryControl, Switch, None]")  [assignment]
homeassistant/components/deconz/deconz_event.py:58: error: Incompatible types in assignment (expression has type "DeconzAlarmEvent", variable has type "Union[AncillaryControl, Switch, None]")  [assignment]
homeassistant/components/deconz/deconz_event.py:60: error: Item "AncillaryControl" of "Union[AncillaryControl, Switch, None]" has no attribute "async_update_device_registry"  [union-attr]
homeassistant/components/deconz/deconz_event.py:60: error: Item "Switch" of "Union[AncillaryControl, Switch, None]" has no attribute "async_update_device_registry"  [union-attr]
homeassistant/components/deconz/deconz_event.py:60: error: Item "None" of "Union[AncillaryControl, Switch, None]" has no attribute "async_update_device_registry"  [union-attr]
homeassistant/components/deconz/deconz_event.py:61: error: Argument 1 to "append" of "list" has incompatible type "Union[AncillaryControl, Switch, None]"; expected "Union[DeconzAlarmEvent, DeconzEvent]"  [arg-type]
homeassistant/components/deconz/deconz_event.py:116: error: Incompatible return value type (got "Union[Group, LightBase, SensorBase]", expected "Union[AncillaryControl, Switch]")  [return-value]
homeassistant/components/deconz/deconz_event.py:135: error: Item "Group" of "Union[Group, LightBase, SensorBase]" has no attribute "button_event"  [union-attr]
homeassistant/components/deconz/deconz_event.py:135: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "button_event"  [union-attr]
homeassistant/components/deconz/deconz_event.py:135: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "button_event"  [union-attr]
homeassistant/components/deconz/deconz_event.py:141: error: Item "Group" of "Union[Group, LightBase, SensorBase]" has no attribute "gesture"  [union-attr]
homeassistant/components/deconz/deconz_event.py:141: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "gesture"  [union-attr]
homeassistant/components/deconz/deconz_event.py:141: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "gesture"  [union-attr]
homeassistant/components/deconz/deconz_event.py:142: error: Item "Group" of "Union[Group, LightBase, SensorBase]" has no attribute "gesture"  [union-attr]
homeassistant/components/deconz/deconz_event.py:142: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "gesture"  [union-attr]
homeassistant/components/deconz/deconz_event.py:142: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "gesture"  [union-attr]
homeassistant/components/deconz/deconz_event.py:144: error: Item "Group" of "Union[Group, LightBase, SensorBase]" has no attribute "angle"  [union-attr]
homeassistant/components/deconz/deconz_event.py:144: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "angle"  [union-attr]
homeassistant/components/deconz/deconz_event.py:144: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "angle"  [union-attr]
homeassistant/components/deconz/deconz_event.py:145: error: Item "Group" of "Union[Group, LightBase, SensorBase]" has no attribute "angle"  [union-attr]
homeassistant/components/deconz/deconz_event.py:145: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "angle"  [union-attr]
homeassistant/components/deconz/deconz_event.py:145: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "angle"  [union-attr]
homeassistant/components/deconz/deconz_event.py:147: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "xy"  [union-attr]
homeassistant/components/deconz/deconz_event.py:147: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "xy"  [union-attr]
homeassistant/components/deconz/deconz_event.py:148: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "xy"  [union-attr]
homeassistant/components/deconz/deconz_event.py:148: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "xy"  [union-attr]
```
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
