### PR TITLE
Improve typing of deCONZ diagnostics

### DIFF
--- a/homeassistant/components/deconz/diagnostics.py
+++ b/homeassistant/components/deconz/diagnostics.py
@@ -25,7 +25,8 @@ async def async_get_config_entry_diagnostics(
     diag["deconz_config"] = async_redact_data(
         gateway.api.config.raw, REDACT_DECONZ_CONFIG
     )
-    diag["websocket_state"] = gateway.api.websocket.state
+    if gateway.api.websocket:
+        diag["websocket_state"] = gateway.api.websocket.state
     diag["deconz_ids"] = gateway.deconz_ids
     diag["entities"] = gateway.entities
     diag["events"] = {
@@ -37,8 +38,42 @@ async def async_get_config_entry_diagnostics(
     }
     diag["alarm_systems"] = {k: v.raw for k, v in gateway.api.alarmsystems.items()}
     diag["groups"] = {k: v.raw for k, v in gateway.api.groups.items()}
-    diag["lights"] = {k: v.raw for k, v in gateway.api.lights.items()}
+
+    lights: dict[str, Any] = {k: v.raw for k, v in gateway.api.lights.covers.items()}
+    lights |= {k: v.raw for k, v in gateway.api.lights.fans.items()}
+    lights |= {k: v.raw for k, v in gateway.api.lights.lights.items()}
+    lights |= {k: v.raw for k, v in gateway.api.lights.locks.items()}
+    lights |= {k: v.raw for k, v in gateway.api.lights.range_extender.items()}
+    lights |= {k: v.raw for k, v in gateway.api.lights.sirens.items()}
+    diag["lights"] = lights
+
     diag["scenes"] = {k: v.raw for k, v in gateway.api.scenes.items()}
-    diag["sensors"] = {k: v.raw for k, v in gateway.api.sensors.items()}
+
+    sensors: dict[str, Any] = {
+        k: v.raw for k, v in gateway.api.sensors.air_quality.items()
+    }
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.alarm.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.ancillary_control.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.battery.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.carbon_monoxide.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.consumption.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.daylight.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.door_lock.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.fire.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.generic_flag.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.generic_status.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.humidity.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.light_level.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.open_close.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.power.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.presence.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.pressure.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.switch.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.temperature.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.thermostat.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.time.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.vibration.items()}
+    sensors |= {k: v.raw for k, v in gateway.api.sensors.water.items()}
+    diag["sensors"] = sensors
 
     return diag

--- a/homeassistant/components/deconz/diagnostics.py
+++ b/homeassistant/components/deconz/diagnostics.py
@@ -25,8 +25,9 @@ async def async_get_config_entry_diagnostics(
     diag["deconz_config"] = async_redact_data(
         gateway.api.config.raw, REDACT_DECONZ_CONFIG
     )
-    if gateway.api.websocket:
-        diag["websocket_state"] = gateway.api.websocket.state
+    diag["websocket_state"] = (
+        gateway.api.websocket.state if gateway.api.websocket else "Unknown"
+    )
     diag["deconz_ids"] = gateway.deconz_ids
     diag["entities"] = gateway.entities
     diag["events"] = {
@@ -38,42 +39,8 @@ async def async_get_config_entry_diagnostics(
     }
     diag["alarm_systems"] = {k: v.raw for k, v in gateway.api.alarmsystems.items()}
     diag["groups"] = {k: v.raw for k, v in gateway.api.groups.items()}
-
-    lights: dict[str, Any] = {k: v.raw for k, v in gateway.api.lights.covers.items()}
-    lights |= {k: v.raw for k, v in gateway.api.lights.fans.items()}
-    lights |= {k: v.raw for k, v in gateway.api.lights.lights.items()}
-    lights |= {k: v.raw for k, v in gateway.api.lights.locks.items()}
-    lights |= {k: v.raw for k, v in gateway.api.lights.range_extender.items()}
-    lights |= {k: v.raw for k, v in gateway.api.lights.sirens.items()}
-    diag["lights"] = lights
-
+    diag["lights"] = {k: v.raw for k, v in gateway.api.lights.items()}  # type: ignore[has-type, misc]
     diag["scenes"] = {k: v.raw for k, v in gateway.api.scenes.items()}
-
-    sensors: dict[str, Any] = {
-        k: v.raw for k, v in gateway.api.sensors.air_quality.items()
-    }
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.alarm.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.ancillary_control.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.battery.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.carbon_monoxide.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.consumption.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.daylight.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.door_lock.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.fire.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.generic_flag.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.generic_status.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.humidity.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.light_level.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.open_close.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.power.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.presence.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.pressure.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.switch.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.temperature.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.thermostat.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.time.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.vibration.items()}
-    sensors |= {k: v.raw for k, v in gateway.api.sensors.water.items()}
-    diag["sensors"] = sensors
+    diag["sensors"] = {k: v.raw for k, v in gateway.api.sensors.items()}  # type: ignore[has-type, misc]
 
     return diag

--- a/homeassistant/components/deconz/diagnostics.py
+++ b/homeassistant/components/deconz/diagnostics.py
@@ -39,8 +39,8 @@ async def async_get_config_entry_diagnostics(
     }
     diag["alarm_systems"] = {k: v.raw for k, v in gateway.api.alarmsystems.items()}
     diag["groups"] = {k: v.raw for k, v in gateway.api.groups.items()}
-    diag["lights"] = {k: v.raw for k, v in gateway.api.lights.items()}  # type: ignore[has-type, misc]
+    diag["lights"] = {k: v.raw for k, v in gateway.api.lights.items()}
     diag["scenes"] = {k: v.raw for k, v in gateway.api.scenes.items()}
-    diag["sensors"] = {k: v.raw for k, v in gateway.api.sensors.items()}  # type: ignore[has-type, misc]
+    diag["sensors"] = {k: v.raw for k, v in gateway.api.sensors.items()}
 
     return diag


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Check web socket is initialised
```
homeassistant/components/deconz/diagnostics.py:28: error: Item "None" of "Optional[WSClient]" has no attribute "state"  [union-attr]
```
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
