### PR TITLE
Fix reloading the sun integration

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -131,9 +131,6 @@ class Sun(Entity):
         )
         self._loaded_listener = None
         if DOMAIN in hass.config.components:
-            # If the import flow has not finished
-            # its possible the EVENT_COMPONENT_LOADED
-            # event already fired
             self.update_location()
         else:
             self._loaded_listener = self.hass.bus.async_listen(

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -126,10 +126,10 @@ class Sun(Entity):
         self._config_listener = None
         self._update_events_listener = None
         self._update_sun_position_listener = None
+        self._loaded_listener = None
         self._config_listener = self.hass.bus.async_listen(
             EVENT_CORE_CONFIG_UPDATE, self.update_location
         )
-        self._loaded_listener = None
         if DOMAIN in hass.config.components:
             self.update_location()
         else:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8,8 +8,12 @@ import pytest
 
 from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.components.hassio import HassioServiceInfo
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import CoreState, callback
+from homeassistant.const import (
+    EVENT_COMPONENT_LOADED,
+    EVENT_HOMEASSISTANT_STARTED,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import CoreState, Event, callback
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, BaseServiceInfo
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -2297,6 +2301,72 @@ async def test_async_setup_init_entry(hass):
         entries = hass.config_entries.async_entries("comp")
         assert len(entries) == 1
         assert entries[0].state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_async_setup_init_entry_completes_before_loaded_event_fires(hass):
+    """Test a config entry being initialized during integration setup before the loaded event fires."""
+
+    @callback
+    def _record_load(event: Event) -> None:
+        nonlocal load_events
+        load_events.append(event)
+
+    listener = hass.bus.async_listen(EVENT_COMPONENT_LOADED, _record_load)
+    load_events: list[Event] = []
+
+    async def mock_async_setup(hass, config):
+        """Mock setup."""
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                "comp",
+                context={"source": config_entries.SOURCE_IMPORT},
+                data={},
+            )
+        )
+        return True
+
+    async_setup_entry = AsyncMock(return_value=True)
+    mock_integration(
+        hass,
+        MockModule(
+            "comp", async_setup=mock_async_setup, async_setup_entry=async_setup_entry
+        ),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_three(self, user_input=None):
+            """Test import step creating entry."""
+            return self.async_create_entry(title="title", data={})
+
+        async def async_step_two(self, user_input=None):
+            """Test import step creating entry."""
+            return await self.async_step_three()
+
+        async def async_step_one(self, user_input=None):
+            """Test import step creating entry."""
+            return await self.async_step_two()
+
+        async def async_step_import(self, user_input=None):
+            """Test import step creating entry."""
+            return await self.async_step_one()
+
+    # This test must not use hass.async_block_till_done()
+    # as its explicitly testing what happens without it
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        assert await async_setup_component(hass, "comp", {})
+        assert len(async_setup_entry.mock_calls) == 1
+        assert load_events[0].event_type == EVENT_COMPONENT_LOADED
+        assert load_events[0].data == {"component": "comp"}
+        entries = hass.config_entries.async_entries("comp")
+        assert len(entries) == 1
+        assert entries[0].state is config_entries.ConfigEntryState.LOADED
+
+    listener()
 
 
 async def test_async_setup_update_entry(hass):


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes
```
2022-04-06 22:15:52 ERROR (MainThread) [homeassistant.core] Unable to remove unknown job listener _FilterableJob(job=<Job HassJobType.Callback <bound method Sun.loading_complete of <Entity Sun: above_horizon>>>, event_filter=None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/core.py", line 986, in _async_remove_listener
    self._listeners[event_type].remove(filterable_job)
ValueError: list.remove(x): x not in list
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io