### PR TITLE
Move Local OAuth http endpoint registration to auth component

### DIFF
--- a/homeassistant/components/almond/manifest.json
+++ b/homeassistant/components/almond/manifest.json
@@ -3,7 +3,7 @@
   "name": "Almond",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/almond",
-  "dependencies": ["http", "conversation"],
+  "dependencies": ["auth", "conversation"],
   "codeowners": ["@gcampax", "@balloob"],
   "requirements": ["pyalmond==0.0.2"],
   "iot_class": "local_polling",

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -113,6 +113,12 @@ Result will be a long-lived access token:
     "result": "ABCDEFGH"
 }
 
+
+# POST /auth/external/callback
+
+This is an endpoint for OAuth2 Authorization callbacks used by integrations
+that link accounts with other cloud providers using LocalOAuth2Implementation
+as part of a config flow.
 """
 from __future__ import annotations
 
@@ -134,6 +140,7 @@ from homeassistant.components.http.ban import log_invalid_auth
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2AuthorizeCallbackView
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
@@ -195,6 +202,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.http.register_view(TokenView(retrieve_result))
     hass.http.register_view(LinkUserView(retrieve_result))
+    hass.http.register_view(OAuth2AuthorizeCallbackView())
 
     websocket_api.async_register_command(
         hass, WS_TYPE_CURRENT_USER, websocket_current_user, SCHEMA_WS_CURRENT_USER

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -2,7 +2,7 @@
   "domain": "google",
   "name": "Google Calendars",
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
   "requirements": [
     "google-api-python-client==2.38.0",

--- a/homeassistant/components/home_connect/manifest.json
+++ b/homeassistant/components/home_connect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "home_connect",
   "name": "Home Connect",
   "documentation": "https://www.home-assistant.io/integrations/home_connect",
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "codeowners": ["@DavidMStraub"],
   "requirements": ["homeconnect==0.7.0"],
   "config_flow": true,

--- a/homeassistant/components/home_plus_control/manifest.json
+++ b/homeassistant/components/home_plus_control/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/home_plus_control",
   "requirements": ["homepluscontrol==0.0.5"],
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "codeowners": ["@chemaaa"],
   "iot_class": "cloud_polling",
   "loggers": ["homepluscontrol"]

--- a/homeassistant/components/lyric/manifest.json
+++ b/homeassistant/components/lyric/manifest.json
@@ -3,7 +3,7 @@
   "name": "Honeywell Lyric",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lyric",
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "requirements": ["aiolyric==1.0.8"],
   "codeowners": ["@timmo001"],
   "quality_scale": "silver",

--- a/homeassistant/components/neato/manifest.json
+++ b/homeassistant/components/neato/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/neato",
   "requirements": ["pybotvac==0.0.23"],
   "codeowners": ["@dshokouhi", "@Santobert"],
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "iot_class": "cloud_polling",
   "loggers": ["pybotvac"]
 }

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nest",
   "name": "Nest",
   "config_flow": true,
-  "dependencies": ["ffmpeg", "http"],
+  "dependencies": ["ffmpeg", "http", "auth"],
   "after_dependencies": ["media_source"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
   "requirements": ["python-nest==4.2.0", "google-nest-sdm==1.8.0"],

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": ["pyatmo==6.2.4"],
   "after_dependencies": ["cloud", "media_source"],
-  "dependencies": ["webhook"],
+  "dependencies": ["auth", "webhook"],
   "codeowners": ["@cgtobi"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/ondilo_ico/manifest.json
+++ b/homeassistant/components/ondilo_ico/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ondilo_ico",
   "requirements": ["ondilo==0.2.0"],
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "codeowners": ["@JeromeHXP"],
   "iot_class": "cloud_polling",
   "loggers": ["ondilo"]

--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -3,7 +3,7 @@
   "name": "Smappee",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/smappee",
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "requirements": ["pysmappee==0.2.29"],
   "codeowners": ["@bsmappee"],
   "zeroconf": [

--- a/homeassistant/components/somfy/manifest.json
+++ b/homeassistant/components/somfy/manifest.json
@@ -3,7 +3,7 @@
   "name": "Somfy",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/somfy",
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "codeowners": ["@tetienne"],
   "requirements": ["pymfy==0.11.0"],
   "zeroconf": [

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/spotify",
   "requirements": ["spotipy==2.19.0"],
   "zeroconf": ["_spotify-connect._tcp.local."],
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "codeowners": ["@frenck"],
   "config_flow": true,
   "quality_scale": "silver",

--- a/homeassistant/components/toon/manifest.json
+++ b/homeassistant/components/toon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/toon",
   "requirements": ["toonapi==0.2.1"],
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "after_dependencies": ["cloud"],
   "codeowners": [],
   "dhcp": [

--- a/homeassistant/components/withings/manifest.json
+++ b/homeassistant/components/withings/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/withings",
   "requirements": ["withings-api==2.4.0"],
-  "dependencies": ["http", "webhook"],
+  "dependencies": ["auth", "http", "webhook"],
   "codeowners": ["@vangorra"],
   "iot_class": "cloud_polling",
   "loggers": ["withings_api"]

--- a/homeassistant/components/xbox/manifest.json
+++ b/homeassistant/components/xbox/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xbox",
   "requirements": ["xbox-webapi==2.0.11"],
-  "dependencies": ["http"],
+  "dependencies": ["auth"],
   "codeowners": ["@hunterjm"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -32,7 +32,6 @@ from .network import NoURLAvailableError
 _LOGGER = logging.getLogger(__name__)
 
 DATA_JWT_SECRET = "oauth2_jwt_secret"
-DATA_VIEW_REGISTERED = "oauth2_view_reg"
 DATA_IMPLEMENTATIONS = "oauth2_impl"
 DATA_PROVIDERS = "oauth2_providers"
 AUTH_CALLBACK_PATH = "/auth/external/callback"
@@ -331,12 +330,6 @@ def async_register_implementation(
     hass: HomeAssistant, domain: str, implementation: AbstractOAuth2Implementation
 ) -> None:
     """Register an OAuth2 flow implementation for an integration."""
-    if isinstance(implementation, LocalOAuth2Implementation) and not hass.data.get(
-        DATA_VIEW_REGISTERED, False
-    ):
-        hass.http.register_view(OAuth2AuthorizeCallbackView())
-        hass.data[DATA_VIEW_REGISTERED] = True
-
     implementations = hass.data.setdefault(DATA_IMPLEMENTATIONS, {})
     implementations.setdefault(domain, {})[implementation.domain] = implementation
 

--- a/script/scaffold/generate.py
+++ b/script/scaffold/generate.py
@@ -173,7 +173,7 @@ def _custom_tasks(template, info: Info) -> None:
         )
 
     elif template == "config_flow_oauth2":
-        info.update_manifest(config_flow=True, dependencies=["http"])
+        info.update_manifest(config_flow=True, dependencies=["auth"])
         info.update_strings(
             config={
                 "step": {

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -27,6 +27,7 @@ TOKEN_URL = "https://example.como/auth/token"
 async def local_impl(hass):
     """Local implementation."""
     assert await setup.async_setup_component(hass, "http", {})
+    assert await setup.async_setup_component(hass, "auth", {})
     return config_entry_oauth2_flow.LocalOAuth2Implementation(
         hass, TEST_DOMAIN, CLIENT_ID, CLIENT_SECRET, AUTHORIZE_URL, TOKEN_URL
     )

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -26,7 +26,6 @@ TOKEN_URL = "https://example.como/auth/token"
 @pytest.fixture
 async def local_impl(hass):
     """Local implementation."""
-    assert await setup.async_setup_component(hass, "http", {})
     assert await setup.async_setup_component(hass, "auth", {})
     return config_entry_oauth2_flow.LocalOAuth2Implementation(
         hass, TEST_DOMAIN, CLIENT_ID, CLIENT_SECRET, AUTHORIZE_URL, TOKEN_URL


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Breaking change for custom components: config_entry_oauth2_flow no longer
registers the local OAuth callback endpoint, and this is now done by adding
a dependency on the auth component.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move the local oauth callback http endpoint registration into the auth
component rather than registering as a side effect of invoking the
config flow registration. 

Pulled out as a pre-factor step of https://github.com/home-assistant/core/pull/69148 based on PR feedback.

Today the scaffold script adds http as a dependency which is a little non-obvious, and so now it is more
explicit as auth. All existing integrations that depend on the local oauth config flows now
have an `auth` dependency. The `http` dependency has been removed
from Integrations that do not use `http` directly and only need it for
config flow oauth.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
