### PR TITLE
Add energyMeter sensor type in fibaro integration

### DIFF
--- a/homeassistant/components/fibaro/sensor.py
+++ b/homeassistant/components/fibaro/sensor.py
@@ -64,7 +64,12 @@ async def async_setup_entry(
     """Set up the Fibaro controller devices."""
     entities: list[SensorEntity] = []
     for device in hass.data[DOMAIN][entry.entry_id][FIBARO_DEVICES]["sensor"]:
-        entities.append(FibaroSensor(device))
+        if device.type == "com.fibaro.energyMeter":
+            entities.append(FibaroEnergySensor(device))
+            if "power" in device.interfaces:
+                entities.append(FibaroPowerSensor(device))
+        else:
+            entities.append(FibaroSensor(device))
     for device_type in ("cover", "light", "switch"):
         for device in hass.data[DOMAIN][entry.entry_id][FIBARO_DEVICES][device_type]:
             if "energy" in device.interfaces:


### PR DESCRIPTION
Possibility to see current power of energy meter was removed together with https://github.com/home-assistant/core/pull/68821
Therefore I define energyMeter sensor type explicitly and create it's _power entity if it has power interface (so assuming that sensor could have power interface).

Example sensor:

```
2022-04-07 10:28:35 DEBUG (SyncWorker_0) [homeassistant.components.fibaro] unknown_elektromer_topeni_212 (com.fibaro.energyMeter, com.fibaro.meter) -> sensor {'id': 212, 'name': 'Elektroměr topení', 'roomID': 0, 'type': 'com.fibaro.energyMeter', 'baseType': 'com.fibaro.meter', 'enabled': True, 'visible': True, 'isPlugin': False, 'parentId': 208, 'remoteGatewayId': 0, 'viewXml': False, 'configXml': False, 'interfaces': ['power', 'zwave', 'zwaveMultiChannelAssociation'], 'properties': {'pollingTimeSec': 0, 'zwaveCompany': 'Goap', 'zwaveInfo': '3,4,61', 'zwaveVersion': '1.0', 'categories': '["other"]', 'configured': True, 'dead': 'false', 'deadReason': '', 'deviceControlType': '0', 'deviceIcon': '102', 'emailNotificationID': '0', 'emailNotificationType': '0', 'endPointId': '1', 'log': '', 'logTemp': '', 'manufacturer': '', 'markAsDead': 'true', 'model': '', 'nodeId': '46', 'parametersTemplate': '847', 'power': '14.60', 'productInfo': '1,89,0,7,0,84,1,0', 'pushNotificationID': '0', 'pushNotificationType': '0', 'remoteGatewayId': '0', 'saveLogs': 'true', 'serialNumber': '', 'showEnergy': 'true', 'smsNotificationID': '0', 'smsNotificationType': '0', 'unit': 'kWh', 'useTemplate': 'true', 'userDescription': '', 'value': '9956.50'}, 'actions': {'reconfigure': 0, 'reset': 0}, 'created': 1646217913, 'modified': 1646217913, 'sortOrder': 159, 'fibaro_controller': <homeassistant.components.fibaro.FibaroController object at 0x7f5a9f06fb50>, 'room_name': 'Unknown', 'friendly_name': 'Unknown Elektroměr topení', 'ha_id': 'unknown_elektromer_topeni_212', 'mapped_type': 'sensor', 'unique_id_str': 'hcl_058984.212'}
```

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
