### PR TITLE
Relax dlna_dmr filtering when browsing media

### DIFF
--- a/homeassistant/components/dlna_dmr/config_flow.py
+++ b/homeassistant/components/dlna_dmr/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 import logging
 from pprint import pformat
-from typing import Any, Optional, Type, cast
+from typing import Any, Optional, cast
 from urllib.parse import urlparse
 
 from async_upnp_client.client import UpnpError
@@ -331,7 +331,7 @@ class DlnaDmrOptionsFlowHandler(config_entries.OptionsFlow):
 
         fields = {}
 
-        def _add_with_suggestion(key: str, validator: Callable | Type[bool]) -> None:
+        def _add_with_suggestion(key: str, validator: Callable | type[bool]) -> None:
             """Add a field to with a suggested value.
 
             For bools, use the existing value as default, or fallback to False.

--- a/homeassistant/components/dlna_dmr/const.py
+++ b/homeassistant/components/dlna_dmr/const.py
@@ -16,6 +16,7 @@ DOMAIN: Final = "dlna_dmr"
 CONF_LISTEN_PORT: Final = "listen_port"
 CONF_CALLBACK_URL_OVERRIDE: Final = "callback_url_override"
 CONF_POLL_AVAILABILITY: Final = "poll_availability"
+CONF_BROWSE_UNFILTERED: Final = "browse_unfiltered"
 
 DEFAULT_NAME: Final = "DLNA Digital Media Renderer"
 

--- a/homeassistant/components/dlna_dmr/strings.json
+++ b/homeassistant/components/dlna_dmr/strings.json
@@ -44,7 +44,8 @@
         "data": {
           "listen_port": "Event listener port (random if not set)",
           "callback_url_override": "Event listener callback URL",
-          "poll_availability": "Poll for device availability"
+          "poll_availability": "Poll for device availability",
+          "browse_unfiltered": "Show incompatible media when browsing"
         }
       }
     },

--- a/homeassistant/components/dlna_dmr/translations/en.json
+++ b/homeassistant/components/dlna_dmr/translations/en.json
@@ -47,6 +47,7 @@
         "step": {
             "init": {
                 "data": {
+                    "browse_unfiltered": "Show incompatible media when browsing",
                     "callback_url_override": "Event listener callback URL",
                     "listen_port": "Event listener port (random if not set)",
                     "poll_availability": "Poll for device availability"

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -11,6 +11,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import ssdp
 from homeassistant.components.dlna_dmr.const import (
+    CONF_BROWSE_UNFILTERED,
     CONF_CALLBACK_URL_OVERRIDE,
     CONF_LISTEN_PORT,
     CONF_POLL_AVAILABILITY,
@@ -558,6 +559,7 @@ async def test_options_flow(
         user_input={
             CONF_CALLBACK_URL_OVERRIDE: "Bad url",
             CONF_POLL_AVAILABILITY: False,
+            CONF_BROWSE_UNFILTERED: False,
         },
     )
 
@@ -572,6 +574,7 @@ async def test_options_flow(
             CONF_LISTEN_PORT: 2222,
             CONF_CALLBACK_URL_OVERRIDE: "http://override/callback",
             CONF_POLL_AVAILABILITY: True,
+            CONF_BROWSE_UNFILTERED: True,
         },
     )
 
@@ -580,4 +583,5 @@ async def test_options_flow(
         CONF_LISTEN_PORT: 2222,
         CONF_CALLBACK_URL_OVERRIDE: "http://override/callback",
         CONF_POLL_AVAILABILITY: True,
+        CONF_BROWSE_UNFILTERED: True,
     }

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -74,7 +74,7 @@ MOCK_DISCOVERY = ssdp.SsdpServiceInfo(
             ]
         },
     },
-    x_homeassistant_matching_domains=(DLNA_DOMAIN,),
+    x_homeassistant_matching_domains={DLNA_DOMAIN},
 )
 
 
@@ -390,7 +390,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
     """Test SSDP ignores devices that are missing required services."""
     # No services defined at all
     discovery = dataclasses.replace(MOCK_DISCOVERY)
-    discovery.upnp = discovery.upnp.copy()
+    discovery.upnp = dict(discovery.upnp)
     del discovery.upnp[ssdp.ATTR_UPNP_SERVICE_LIST]
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN,
@@ -402,7 +402,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
 
     # AVTransport service is missing
     discovery = dataclasses.replace(MOCK_DISCOVERY)
-    discovery.upnp = discovery.upnp.copy()
+    discovery.upnp = dict(discovery.upnp)
     discovery.upnp[ssdp.ATTR_UPNP_SERVICE_LIST] = {
         "service": [
             service
@@ -431,7 +431,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
     assert result["reason"] == "alternative_integration"
 
     discovery = dataclasses.replace(MOCK_DISCOVERY)
-    discovery.upnp = discovery.upnp.copy()
+    discovery.upnp = dict(discovery.upnp)
     discovery.upnp[
         ssdp.ATTR_UPNP_DEVICE_TYPE
     ] = "urn:schemas-upnp-org:device:ZonePlayer:1"
@@ -450,7 +450,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
         ("Royal Philips Electronics", "Philips TV DMR"),
     ]:
         discovery = dataclasses.replace(MOCK_DISCOVERY)
-        discovery.upnp = discovery.upnp.copy()
+        discovery.upnp = dict(discovery.upnp)
         discovery.upnp[ssdp.ATTR_UPNP_MANUFACTURER] = manufacturer
         discovery.upnp[ssdp.ATTR_UPNP_MODEL_NAME] = model
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -23,6 +23,7 @@ from homeassistant import const as ha_const
 from homeassistant.components import ssdp
 from homeassistant.components.dlna_dmr import media_player
 from homeassistant.components.dlna_dmr.const import (
+    CONF_BROWSE_UNFILTERED,
     CONF_CALLBACK_URL_OVERRIDE,
     CONF_LISTEN_PORT,
     CONF_POLL_AVAILABILITY,
@@ -1019,6 +1020,87 @@ async def test_browse_media(
 
     # Device does not specify what it can play
     dmr_device_mock.sink_protocol_info = []
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "media_player/browse_media",
+            "entity_id": mock_entity_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    # All files should be returned
+    assert expected_child_video in response["result"]["children"]
+    assert expected_child_audio in response["result"]["children"]
+
+
+async def test_browse_media_unfiltered(
+    hass: HomeAssistant,
+    hass_ws_client,
+    config_entry_mock: MockConfigEntry,
+    dmr_device_mock: Mock,
+    mock_entity_id: str,
+) -> None:
+    """Test the async_browse_media method with filtering turned off and on."""
+    # Based on cast's test_entity_browse_media
+    await async_setup_component(hass, MS_DOMAIN, {MS_DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    expected_child_video = {
+        "title": "Epic Sax Guy 10 Hours.mp4",
+        "media_class": "video",
+        "media_content_type": "video/mp4",
+        "media_content_id": "media-source://media_source/local/Epic Sax Guy 10 Hours.mp4",
+        "can_play": True,
+        "can_expand": False,
+        "thumbnail": None,
+        "children_media_class": None,
+    }
+    expected_child_audio = {
+        "title": "test.mp3",
+        "media_class": "music",
+        "media_content_type": "audio/mpeg",
+        "media_content_id": "media-source://media_source/local/test.mp3",
+        "can_play": True,
+        "can_expand": False,
+        "thumbnail": None,
+        "children_media_class": None,
+    }
+
+    # Device can only play MIME type audio/mpeg and audio/vorbis
+    dmr_device_mock.sink_protocol_info = [
+        "http-get:*:audio/mpeg:*",
+        "http-get:*:audio/vorbis:*",
+    ]
+
+    # Filtering turned on by default
+    assert CONF_BROWSE_UNFILTERED not in config_entry_mock.options
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "media_player/browse_media",
+            "entity_id": mock_entity_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    # Video file should not be shown
+    assert expected_child_video not in response["result"]["children"]
+    # Audio file should appear
+    assert expected_child_audio in response["result"]["children"]
+
+    # Filtering turned off via config entry
+    hass.config_entries.async_update_entry(
+        config_entry_mock,
+        options={
+            CONF_BROWSE_UNFILTERED: True,
+        },
+    )
+    await hass.async_block_till_done()
+
     client = await hass_ws_client()
     await client.send_json(
         {

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -997,6 +997,26 @@ async def test_browse_media(
     # Audio file should appear
     assert expected_child_audio in response["result"]["children"]
 
+    # Device specifies extra parameters in MIME type, uses non-standard "x-"
+    # prefix, and capitilizes things, all of which should be ignored
+    dmr_device_mock.sink_protocol_info = [
+        "http-get:*:audio/X-MPEG;codecs=mp3:*",
+    ]
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "media_player/browse_media",
+            "entity_id": mock_entity_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    # Video file should not be shown
+    assert expected_child_video not in response["result"]["children"]
+    # Audio file should appear
+    assert expected_child_audio in response["result"]["children"]
+
     # Device does not specify what it can play
     dmr_device_mock.sink_protocol_info = []
     client = await hass_ws_client()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When browsing media in the dlna_dmr integration, loosen the filtering criteria slightly by only matching on MIME type, not including any extra parameters. E.g. only match against `audio/mpeg` in `audio/mpeg;codecs=mp3`, ignoring the part after the semicolon.

For when this isn't enough (when the DMR device doesn't correctly report all media types it supports) also add an integration option to disable filtering altogether.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #67690 fixes #68691
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22287

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
