### PR TITLE
Add EntityFeature enum to Siren

### DIFF
--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -20,12 +20,17 @@ from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
+from .const import (  # noqa: F401
     ATTR_AVAILABLE_TONES,
     ATTR_DURATION,
     ATTR_TONE,
     ATTR_VOLUME_LEVEL,
     DOMAIN,
+    SUPPORT_DURATION,
+    SUPPORT_TONES,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_SET,
     SirenEntityFeature,
 )
 

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -26,11 +26,7 @@ from .const import (
     ATTR_TONE,
     ATTR_VOLUME_LEVEL,
     DOMAIN,
-    SUPPORT_DURATION,
-    SUPPORT_TONES,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_SET,
+    SirenEntityFeature,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,7 +58,7 @@ def process_turn_on_params(
     """
     supported_features = siren.supported_features or 0
 
-    if not supported_features & SUPPORT_TONES:
+    if not supported_features & SirenEntityFeature.TONES:
         params.pop(ATTR_TONE, None)
     elif (tone := params.get(ATTR_TONE)) is not None:
         # Raise an exception if the specified tone isn't available
@@ -88,9 +84,9 @@ def process_turn_on_params(
                 key for key, value in siren.available_tones.items() if value == tone
             )
 
-    if not supported_features & SUPPORT_DURATION:
+    if not supported_features & SirenEntityFeature.DURATION:
         params.pop(ATTR_DURATION, None)
-    if not supported_features & SUPPORT_VOLUME_SET:
+    if not supported_features & SirenEntityFeature.VOLUME_SET:
         params.pop(ATTR_VOLUME_LEVEL, None)
 
     return params
@@ -117,13 +113,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
 
     component.async_register_entity_service(
-        SERVICE_TURN_ON, TURN_ON_SCHEMA, async_handle_turn_on_service, [SUPPORT_TURN_ON]
+        SERVICE_TURN_ON,
+        TURN_ON_SCHEMA,
+        async_handle_turn_on_service,
+        [SirenEntityFeature.TURN_ON],
     )
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, {}, "async_turn_off", [SUPPORT_TURN_OFF]
+        SERVICE_TURN_OFF, {}, "async_turn_off", [SirenEntityFeature.TURN_OFF]
     )
     component.async_register_entity_service(
-        SERVICE_TOGGLE, {}, "async_toggle", [SUPPORT_TURN_ON & SUPPORT_TURN_OFF]
+        SERVICE_TOGGLE,
+        {},
+        "async_toggle",
+        [SirenEntityFeature.TURN_ON & SirenEntityFeature.TURN_OFF],
     )
 
     return True
@@ -158,7 +160,10 @@ class SirenEntity(ToggleEntity):
         """Return capability attributes."""
         supported_features = self.supported_features or 0
 
-        if supported_features & SUPPORT_TONES and self.available_tones is not None:
+        if (
+            supported_features & SirenEntityFeature.TONES
+            and self.available_tones is not None
+        ):
             return {ATTR_AVAILABLE_TONES: self.available_tones}
 
         return None
@@ -168,6 +173,6 @@ class SirenEntity(ToggleEntity):
         """
         Return a list of available tones.
 
-        Requires SUPPORT_TONES.
+        Requires SirenEntityFeature.TONES.
         """
         return self._attr_available_tones

--- a/homeassistant/components/siren/const.py
+++ b/homeassistant/components/siren/const.py
@@ -1,5 +1,6 @@
 """Constants for the siren component."""
 
+from enum import IntEnum
 from typing import Final
 
 DOMAIN: Final = "siren"
@@ -10,6 +11,19 @@ ATTR_AVAILABLE_TONES: Final = "available_tones"
 ATTR_DURATION: Final = "duration"
 ATTR_VOLUME_LEVEL: Final = "volume_level"
 
+
+class SirenEntityFeature(IntEnum):
+    """Supported features of the alarm control panel entity."""
+
+    TURN_ON = 1
+    TURN_OFF = 2
+    TONES = 4
+    VOLUME_SET = 8
+    DURATION = 16
+
+
+# These constants are deprecated as of Home Assistant 2022.5
+# Please use the SirenEntityFeature enum instead.
 SUPPORT_TURN_ON: Final = 1
 SUPPORT_TURN_OFF: Final = 2
 SUPPORT_TONES: Final = 4

--- a/homeassistant/components/siren/const.py
+++ b/homeassistant/components/siren/const.py
@@ -13,7 +13,7 @@ ATTR_VOLUME_LEVEL: Final = "volume_level"
 
 
 class SirenEntityFeature(IntEnum):
-    """Supported features of the alarm control panel entity."""
+    """Supported features of the siren entity."""
 
     TURN_ON = 1
     TURN_OFF = 2

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from homeassistant.components.siren import SirenEntity, process_turn_on_params
-from homeassistant.components.siren.const import SUPPORT_TONES
+from homeassistant.components.siren.const import SirenEntityFeature
 
 
 class MockSirenEntity(SirenEntity):
@@ -42,7 +42,7 @@ async def test_sync_turn_off(hass):
 
 async def test_no_available_tones(hass):
     """Test ValueError when siren advertises tones but has no available_tones."""
-    siren = MockSirenEntity(SUPPORT_TONES)
+    siren = MockSirenEntity(SirenEntityFeature.TONES)
     siren.hass = hass
     with pytest.raises(ValueError):
         process_turn_on_params(siren, {"tone": "test"})
@@ -50,14 +50,14 @@ async def test_no_available_tones(hass):
 
 async def test_available_tones_list(hass):
     """Test that valid tones from tone list will get passed in."""
-    siren = MockSirenEntity(SUPPORT_TONES, ["a", "b"])
+    siren = MockSirenEntity(SirenEntityFeature.TONES, ["a", "b"])
     siren.hass = hass
     assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": "a"}
 
 
 async def test_available_tones_dict(hass):
     """Test that valid tones from available_tones dict will get passed in."""
-    siren = MockSirenEntity(SUPPORT_TONES, {1: "a", 2: "b"})
+    siren = MockSirenEntity(SirenEntityFeature.TONES, {1: "a", 2: "b"})
     siren.hass = hass
     assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": 1}
     assert process_turn_on_params(siren, {"tone": 1}) == {"tone": 1}
@@ -65,7 +65,7 @@ async def test_available_tones_dict(hass):
 
 async def test_missing_tones_list(hass):
     """Test ValueError when setting a tone that is missing from available_tones list."""
-    siren = MockSirenEntity(SUPPORT_TONES, ["a", "b"])
+    siren = MockSirenEntity(SirenEntityFeature.TONES, ["a", "b"])
     siren.hass = hass
     with pytest.raises(ValueError):
         process_turn_on_params(siren, {"tone": "test"})
@@ -73,7 +73,7 @@ async def test_missing_tones_list(hass):
 
 async def test_missing_tones_dict(hass):
     """Test ValueError when setting a tone that is missing from available_tones dict."""
-    siren = MockSirenEntity(SUPPORT_TONES, {1: "a", 2: "b"})
+    siren = MockSirenEntity(SirenEntityFeature.TONES, {1: "a", 2: "b"})
     siren.hass = hass
     with pytest.raises(ValueError):
         process_turn_on_params(siren, {"tone": 3})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
**Developers only**: The use of the following constants has been deprecated:

- `SUPPORT_DURATION`
- `SUPPORT_TONES`
- `SUPPORT_TURN_OFF`
- `SUPPORT_TURN_ON`
- `SUPPORT_VOLUME_SET`

Use the new `SirenEntityFeature` IntEnum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces the SirenEntityFeature, containing all the supported feature flags of the Siren.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1281

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
