### PR TITLE
Change Amcrest event monitor to non-async

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+import threading
 from typing import Any
 
 import aiohttp
@@ -30,15 +31,14 @@ from homeassistant.const import (
     CONF_USERNAME,
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
-    EVENT_HOMEASSISTANT_STOP,
     HTTP_BASIC_AUTHENTICATION,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import Unauthorized, UnknownUser
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import async_extract_entity_ids
 from homeassistant.helpers.typing import ConfigType
@@ -144,10 +144,13 @@ class AmcrestChecker(ApiWrapper):
         self._hass = hass
         self._wrap_name = name
         self._wrap_errors = 0
-        self._wrap_lock = asyncio.Lock()
+        self._wrap_lock = threading.Lock()
+        self._async_wrap_lock = asyncio.Lock()
         self._wrap_login_err = False
-        self._wrap_event_flag = asyncio.Event()
+        self._wrap_event_flag = threading.Event()
         self._wrap_event_flag.set()
+        self._async_wrap_event_flag = asyncio.Event()
+        self._async_wrap_event_flag.set()
         self._unsub_recheck: Callable[[], None] | None = None
         super().__init__(
             host,
@@ -164,12 +167,18 @@ class AmcrestChecker(ApiWrapper):
         return self._wrap_errors <= MAX_ERRORS and not self._wrap_login_err
 
     @property
-    def available_flag(self) -> asyncio.Event:
+    def available_flag(self) -> threading.Event:
         """Return event flag that indicates if camera's API is responding."""
         return self._wrap_event_flag
 
+    @property
+    def async_available_flag(self) -> asyncio.Event:
+        """Return event flag that indicates if camera's API is responding."""
+        return self._async_wrap_event_flag
+
     def _start_recovery(self) -> None:
-        self._wrap_event_flag.clear()
+        self.available_flag.clear()
+        self.async_available_flag.clear()
         async_dispatcher_send(
             self._hass, service_signal(SERVICE_UPDATE, self._wrap_name)
         )
@@ -177,9 +186,22 @@ class AmcrestChecker(ApiWrapper):
             self._hass, self._wrap_test_online, RECHECK_INTERVAL
         )
 
+    def command(self, *args: Any, **kwargs: Any) -> Any:
+        """amcrest.ApiWrapper.command wrapper to catch errors."""
+        try:
+            ret = super().command(*args, **kwargs)
+        except LoginError as ex:
+            self._handle_offline(ex)
+            raise
+        except AmcrestError:
+            self._handle_error()
+            raise
+        self._set_online()
+        return ret
+
     async def async_command(self, *args: Any, **kwargs: Any) -> httpx.Response:
         """amcrest.ApiWrapper.command wrapper to catch errors."""
-        async with self._command_wrapper():
+        async with self._async_command_wrapper():
             ret = await super().async_command(*args, **kwargs)
         return ret
 
@@ -188,35 +210,47 @@ class AmcrestChecker(ApiWrapper):
         self, *args: Any, **kwargs: Any
     ) -> AsyncIterator[httpx.Response]:
         """amcrest.ApiWrapper.command wrapper to catch errors."""
-        async with self._command_wrapper():
+        async with self._async_command_wrapper():
             async with super().async_stream_command(*args, **kwargs) as ret:
                 yield ret
 
     @asynccontextmanager
-    async def _command_wrapper(self) -> AsyncIterator[None]:
+    async def _async_command_wrapper(self) -> AsyncIterator[None]:
         try:
             yield
         except LoginError as ex:
-            async with self._wrap_lock:
-                was_online = self.available
-                was_login_err = self._wrap_login_err
-                self._wrap_login_err = True
-            if not was_login_err:
-                _LOGGER.error("%s camera offline: Login error: %s", self._wrap_name, ex)
-            if was_online:
-                self._start_recovery()
+            async with self._async_wrap_lock:
+                self._handle_offline(ex)
             raise
         except AmcrestError:
-            async with self._wrap_lock:
-                was_online = self.available
-                errs = self._wrap_errors = self._wrap_errors + 1
-                offline = not self.available
-            _LOGGER.debug("%s camera errs: %i", self._wrap_name, errs)
-            if was_online and offline:
-                _LOGGER.error("%s camera offline: Too many errors", self._wrap_name)
-                self._start_recovery()
+            async with self._async_wrap_lock:
+                self._handle_error()
             raise
-        async with self._wrap_lock:
+        async with self._async_wrap_lock:
+            self._set_online()
+
+    def _handle_offline(self, ex: Exception) -> None:
+        with self._wrap_lock:
+            was_online = self.available
+            was_login_err = self._wrap_login_err
+            self._wrap_login_err = True
+        if not was_login_err:
+            _LOGGER.error("%s camera offline: Login error: %s", self._wrap_name, ex)
+        if was_online:
+            self._start_recovery()
+
+    def _handle_error(self) -> None:
+        with self._wrap_lock:
+            was_online = self.available
+            errs = self._wrap_errors = self._wrap_errors + 1
+            offline = not self.available
+        _LOGGER.debug("%s camera errs: %i", self._wrap_name, errs)
+        if was_online and offline:
+            _LOGGER.error("%s camera offline: Too many errors", self._wrap_name)
+            self._start_recovery()
+
+    def _set_online(self) -> None:
+        with self._wrap_lock:
             was_offline = not self.available
             self._wrap_errors = 0
             self._wrap_login_err = False
@@ -225,7 +259,8 @@ class AmcrestChecker(ApiWrapper):
             self._unsub_recheck()
             self._unsub_recheck = None
             _LOGGER.error("%s camera back online", self._wrap_name)
-            self._wrap_event_flag.set()
+            self.available_flag.set()
+            self.async_available_flag.set()
             async_dispatcher_send(
                 self._hass, service_signal(SERVICE_UPDATE, self._wrap_name)
             )
@@ -237,18 +272,18 @@ class AmcrestChecker(ApiWrapper):
             await self.async_current_time
 
 
-async def _monitor_events(
+def _monitor_events(
     hass: HomeAssistant,
     name: str,
     api: AmcrestChecker,
     event_codes: set[str],
 ) -> None:
     while True:
-        await api.available_flag.wait()
+        api.available_flag.wait()
         try:
-            async for code, payload in api.async_event_actions("All"):
+            for code, payload in api.event_actions("All"):
                 event_data = {"camera": name, "event": code, "payload": payload}
-                hass.bus.async_fire("amcrest", event_data)
+                hass.bus.fire("amcrest", event_data)
                 if code in event_codes:
                     signal = service_signal(SERVICE_EVENT, name, code)
                     start = any(
@@ -256,18 +291,32 @@ async def _monitor_events(
                         for key, val in payload.items()
                     )
                     _LOGGER.debug("Sending signal: '%s': %s", signal, start)
-                    async_dispatcher_send(hass, signal, start)
+                    dispatcher_send(hass, signal, start)
         except AmcrestError as error:
             _LOGGER.warning(
                 "Error while processing events from %s camera: %r", name, error
             )
 
 
+def _start_event_monitor(
+    hass: HomeAssistant,
+    name: str,
+    api: AmcrestChecker,
+    event_codes: set[str],
+) -> None:
+    thread = threading.Thread(
+        target=_monitor_events,
+        name=f"Amcrest {name}",
+        args=(hass, name, api, event_codes),
+        daemon=True,
+    )
+    thread.start()
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Amcrest IP Camera component."""
     hass.data.setdefault(DATA_AMCREST, {DEVICES: {}, CAMERAS: []})
 
-    monitor_tasks = []
     for device in config[DOMAIN]:
         name: str = device[CONF_NAME]
         username: str = device[CONF_USERNAME]
@@ -328,9 +377,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 and sensor.event_code is not None
             }
 
-        monitor_tasks.append(
-            asyncio.create_task(_monitor_events(hass, name, api, event_codes))
-        )
+        _start_event_monitor(hass, name, api, event_codes)
 
         if sensors:
             hass.async_create_task(
@@ -353,13 +400,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     config,
                 )
             )
-
-    @callback
-    def cancel_monitors(event: Event) -> None:
-        for monitor_task in monitor_tasks:
-            monitor_task.cancel()
-
-    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, cancel_monitors)
 
     if not hass.data[DATA_AMCREST][DEVICES]:
         return False


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Several problems have come up since using the async-based event monitor in the Amcrest component that stem from the differences between `requests` (which is used for synchronous http requests) and `httpx` (which is used for asynchronous http requests) and the workarounds that have been put in place to try to handle these differences. The underlying issue is that `httpx` will not drop a streaming connection when the resource is no longer available (eg the camera goes offline) when the read timeout is set to be infinite, while `requests` will drop such a connection. Adding a timeout to `httpx` leads to the issues linked below. `httpx` is the only http library I know of with async support for digest authentication, which is needed to communicate with Amcrest cameras. This change reverts back to using the non-async `requests`-based event stream method to get stable behavior back for the integration. I have tested this by running locally and ensuring the event handling works correctly and does not cause any of the error messages that have been reported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68272, fixes #68244
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
