### PR TITLE
Refresh google calendar tokens with invalid expiration times

### DIFF
--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -132,7 +132,7 @@ async def token_scopes() -> list[str]:
 
 
 @pytest.fixture
-async def token_expiry() -> datetime.datetime:
+def token_expiry() -> datetime.datetime:
     """Expiration time for credentials used in the test."""
     return utcnow() + datetime.timedelta(days=7)
 

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -138,7 +138,7 @@ def token_expiry() -> datetime.datetime:
 
 
 @pytest.fixture
-async def creds(
+def creds(
     token_scopes: list[str], token_expiry: datetime.datetime
 ) -> OAuth2Credentials:
     """Fixture that defines creds used in the test."""
@@ -163,7 +163,7 @@ async def storage() -> YieldFixture[FakeStorage]:
 
 
 @pytest.fixture
-async def config_entry_token_expiry(token_expiry: datetime.datetime) -> float:
+def config_entry_token_expiry(token_expiry: datetime.datetime) -> float:
     """Fixture for token expiration value stored in the config entry."""
     return token_expiry.timestamp()
 

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -132,9 +132,16 @@ async def token_scopes() -> list[str]:
 
 
 @pytest.fixture
-async def creds(token_scopes: list[str]) -> OAuth2Credentials:
+async def token_expiry() -> datetime.datetime:
+    """Expiration time for credentials used in the test."""
+    return utcnow() + datetime.timedelta(days=7)
+
+
+@pytest.fixture
+async def creds(
+    token_scopes: list[str], token_expiry: datetime.datetime
+) -> OAuth2Credentials:
     """Fixture that defines creds used in the test."""
-    token_expiry = utcnow() + datetime.timedelta(days=7)
     return OAuth2Credentials(
         access_token="ACCESS_TOKEN",
         client_id="client-id",
@@ -156,9 +163,16 @@ async def storage() -> YieldFixture[FakeStorage]:
 
 
 @pytest.fixture
-async def config_entry(token_scopes: list[str]) -> MockConfigEntry:
+async def config_entry_token_expiry(token_expiry: datetime.datetime) -> float:
+    """Fixture for token expiration value stored in the config entry."""
+    return token_expiry.timestamp()
+
+
+@pytest.fixture
+async def config_entry(
+    token_scopes: list[str], config_entry_token_expiry: float
+) -> MockConfigEntry:
     """Fixture to create a config entry for the integration."""
-    token_expiry = utcnow() + datetime.timedelta(days=7)
     return MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -168,7 +182,7 @@ async def config_entry(token_scopes: list[str]) -> MockConfigEntry:
                 "refresh_token": "REFRESH_TOKEN",
                 "scope": " ".join(token_scopes),
                 "token_type": "Bearer",
-                "expires_at": token_expiry.timestamp(),
+                "expires_at": config_entry_token_expiry,
             },
         },
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refresh google calendar tokens with invalid expiration times to avoid any invalid conversions later where the expiration time is not a valid date timestamp.

Note that we also need to support re-auth in this flow, but i'm considering that out of scope for a patch release since the existing google calendar did not support re-auth. However I am still investigating whether or not it is needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #69623
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
