### PR TITLE
Improve typing of deCONZ alarm control panel

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -63,6 +63,7 @@ homeassistant.components.cover.*
 homeassistant.components.crownstone.*
 homeassistant.components.cpuspeed.*
 homeassistant.components.deconz
+homeassistant.components.deconz.alarm_control_panel
 homeassistant.components.deconz.config_flow
 homeassistant.components.deconz.diagnostics
 homeassistant.components.deconz.gateway

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -150,20 +150,24 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the control panel."""
-        return DECONZ_TO_ALARM_STATE.get(self._device.panel)
+        return DECONZ_TO_ALARM_STATE.get(str(self._device.panel))
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        await self.alarm_system.arm_away(code)
+        if code:
+            await self.alarm_system.arm_away(code)
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        await self.alarm_system.arm_stay(code)
+        if code:
+            await self.alarm_system.arm_stay(code)
 
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
-        await self.alarm_system.arm_night(code)
+        if code:
+            await self.alarm_system.arm_night(code)
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        await self.alarm_system.disarm(code)
+        if code:
+            await self.alarm_system.disarm(code)

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -150,7 +150,9 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the control panel."""
-        return DECONZ_TO_ALARM_STATE.get(str(self._device.panel))
+        if self._device.panel in DECONZ_TO_ALARM_STATE:
+            return DECONZ_TO_ALARM_STATE[self._device.panel]
+        return None
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -495,6 +495,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.deconz.alarm_control_panel]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.deconz.config_flow]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -2585,9 +2596,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.conversation.default_agent]
-ignore_errors = true
-
-[mypy-homeassistant.components.deconz.alarm_control_panel]
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.binary_sensor]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -23,7 +23,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.cloud.http_api",
     "homeassistant.components.conversation",
     "homeassistant.components.conversation.default_agent",
-    "homeassistant.components.deconz.alarm_control_panel",
     "homeassistant.components.deconz.binary_sensor",
     "homeassistant.components.deconz.climate",
     "homeassistant.components.deconz.cover",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix mapping not accepting literals but only string
- Fix alarm_system methods only accept string
```
homeassistant/components/deconz/alarm_control_panel.py:153: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[Literal['armed_away', 'armed_night', 'armed_stay', 'arming_away', 'arming_night', 'arming_stay', 'disarmed', 'entry_delay', 'exit_delay', 'in_alarm', 'not_ready']]"; expected "str"  [arg-type]
homeassistant/components/deconz/alarm_control_panel.py:157: error: Argument 1 to "arm_away" of "AlarmSystem" has incompatible type "Optional[str]"; expected "str"  [arg-type]
homeassistant/components/deconz/alarm_control_panel.py:161: error: Argument 1 to "arm_stay" of "AlarmSystem" has incompatible type "Optional[str]"; expected "str"  [arg-type]
homeassistant/components/deconz/alarm_control_panel.py:165: error: Argument 1 to "arm_night" of "AlarmSystem" has incompatible type "Optional[str]"; expected "str"  [arg-type]
homeassistant/components/deconz/alarm_control_panel.py:169: error: Argument 1 to "disarm" of "AlarmSystem" has incompatible type "Optional[str]"; expected "str"  [arg-type]
```
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
