### PR TITLE
Add deprecation warning for statistics integration default buffer_size

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -92,7 +92,7 @@ DEPRECATION_WARNING_CHARACTERISTIC = (
     "https://www.home-assistant.io/integrations/statistics/"
 )
 DEPRECATION_WARNING_SIZE = (
-    "The configuration of either 'sampling_size' or 'max_age' will become "
+    "The configuration of 'sampling_size', 'max_age', or both will become "
     "mandatory in Home Assistant Core 2022.12 for the statistics integration. "
     "Please add 'sampling_size: 20' to the configuration of sensor '%s' to keep "
     "the current behavior. Read the documentation for further details: "

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -91,6 +91,13 @@ DEPRECATION_WARNING_CHARACTERISTIC = (
     "for further details: "
     "https://www.home-assistant.io/integrations/statistics/"
 )
+DEPRECATION_WARNING_SIZE = (
+    "The configuration of either 'sampling_size' or 'max_age' will become "
+    "mandatory in a future release of the statistics integration. Please "
+    "add 'sampling_size: %s' to the configuration of sensor '%s' to keep "
+    "the current behavior. Read the documentation for further details: "
+    "https://www.home-assistant.io/integrations/statistics/"
+)
 
 # Statistics supported by a sensor source (numeric)
 STATS_NUMERIC_SUPPORT = {
@@ -210,15 +217,27 @@ def valid_state_characteristic_configuration(config: dict[str, Any]) -> dict[str
     return config
 
 
+def valid_boundary_configuration(config: dict[str, Any]) -> dict[str, Any]:
+    """Validate that either sampling_size or max_age are provided."""
+
+    if config.get(CONF_SAMPLES_MAX_BUFFER_SIZE) is None:
+        config[CONF_SAMPLES_MAX_BUFFER_SIZE] = DEFAULT_BUFFER_SIZE
+        if config.get(CONF_MAX_AGE) is None:
+            _LOGGER.warning(
+                DEPRECATION_WARNING_SIZE,
+                str(DEFAULT_BUFFER_SIZE),
+                config[CONF_NAME],
+            )
+    return config
+
+
 _PLATFORM_SCHEMA_BASE = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Optional(CONF_STATE_CHARACTERISTIC): cv.string,
-        vol.Optional(
-            CONF_SAMPLES_MAX_BUFFER_SIZE, default=DEFAULT_BUFFER_SIZE
-        ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(CONF_SAMPLES_MAX_BUFFER_SIZE): vol.Coerce(int),
         vol.Optional(CONF_MAX_AGE): cv.time_period,
         vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): vol.Coerce(int),
         vol.Optional(
@@ -232,6 +251,7 @@ _PLATFORM_SCHEMA_BASE = PLATFORM_SCHEMA.extend(
 PLATFORM_SCHEMA = vol.All(
     _PLATFORM_SCHEMA_BASE,
     valid_state_characteristic_configuration,
+    valid_boundary_configuration,
 )
 
 

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -85,7 +85,7 @@ STAT_VARIANCE = "variance"
 
 DEPRECATION_WARNING_CHARACTERISTIC = (
     "The configuration parameter 'state_characteristic' will become "
-    "mandatory in a future release of the statistics integration. "
+    "mandatory in Home Assistant Core 2022.12 for the statistics integration. "
     "Please add 'state_characteristic: %s' to the configuration of "
     "sensor '%s' to keep the current behavior. Read the documentation "
     "for further details: "
@@ -93,8 +93,8 @@ DEPRECATION_WARNING_CHARACTERISTIC = (
 )
 DEPRECATION_WARNING_SIZE = (
     "The configuration of either 'sampling_size' or 'max_age' will become "
-    "mandatory in a future release of the statistics integration. Please "
-    "add 'sampling_size: %s' to the configuration of sensor '%s' to keep "
+    "mandatory in Home Assistant Core 2022.12 for the statistics integration. "
+    "Please add 'sampling_size: 20' to the configuration of sensor '%s' to keep "
     "the current behavior. Read the documentation for further details: "
     "https://www.home-assistant.io/integrations/statistics/"
 )
@@ -186,7 +186,6 @@ CONF_QUANTILE_INTERVALS = "quantile_intervals"
 CONF_QUANTILE_METHOD = "quantile_method"
 
 DEFAULT_NAME = "Stats"
-DEFAULT_BUFFER_SIZE = 20
 DEFAULT_PRECISION = 2
 DEFAULT_QUANTILE_INTERVALS = 4
 DEFAULT_QUANTILE_METHOD = "exclusive"
@@ -221,13 +220,11 @@ def valid_boundary_configuration(config: dict[str, Any]) -> dict[str, Any]:
     """Validate that either sampling_size or max_age are provided."""
 
     if config.get(CONF_SAMPLES_MAX_BUFFER_SIZE) is None:
-        config[CONF_SAMPLES_MAX_BUFFER_SIZE] = DEFAULT_BUFFER_SIZE
-        if config.get(CONF_MAX_AGE) is None:
-            _LOGGER.warning(
-                DEPRECATION_WARNING_SIZE,
-                str(DEFAULT_BUFFER_SIZE),
-                config[CONF_NAME],
-            )
+        config[CONF_SAMPLES_MAX_BUFFER_SIZE] = 20
+        _LOGGER.warning(
+            DEPRECATION_WARNING_SIZE,
+            config[CONF_NAME],
+        )
     return config
 
 

--- a/homeassistant/components/statistics/strings.json
+++ b/homeassistant/components/statistics/strings.json
@@ -1,0 +1,12 @@
+{
+  "issues": {
+    "deprecation_warning_characteristic": {
+      "title": "Mandatory setting assumed for a Statistics entity",
+      "description": "The configuration parameter `state_characteristic` of the statistics integration will become mandatory. Please add `state_characteristic: {characteristic}` to the configuration of sensor `{entity}` to keep the current behavior. Read the documentation for further details: https://www.home-assistant.io/integrations/statistics/"
+    },
+    "deprecation_warning_size": {
+      "title": "Mandatory setting assumed for a Statistics entity",
+      "description": "The configuration parameter `sampling_size` of the statistics integration defaulted to the value 20 so far, which will change. Please check the configuration for sensor `{entity}` and add suited boundaries, e.g., `sampling_size: 20` to keep the current behavior. The configuration of the statistics integration will become more flexible and accept either `sampling_size` or `max_age`, or both settings. Read the documentation for further details: https://www.home-assistant.io/integrations/statistics/"
+    }
+  }
+}

--- a/homeassistant/components/statistics/strings.json
+++ b/homeassistant/components/statistics/strings.json
@@ -1,12 +1,12 @@
 {
   "issues": {
     "deprecation_warning_characteristic": {
-      "title": "Mandatory setting assumed for a Statistics entity",
-      "description": "The configuration parameter `state_characteristic` of the statistics integration will become mandatory. Please add `state_characteristic: {characteristic}` to the configuration of sensor `{entity}` to keep the current behavior. Read the documentation for further details: https://www.home-assistant.io/integrations/statistics/"
+      "title": "Mandatory 'state_characteristic' assumed for a Statistics entity",
+      "description": "The configuration parameter `state_characteristic` of the statistics integration will become mandatory.\n\nPlease add `state_characteristic: {characteristic}` to the configuration of sensor `{entity}` to keep the current behavior.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/"
     },
     "deprecation_warning_size": {
-      "title": "Mandatory setting assumed for a Statistics entity",
-      "description": "The configuration parameter `sampling_size` of the statistics integration defaulted to the value 20 so far, which will change. Please check the configuration for sensor `{entity}` and add suited boundaries, e.g., `sampling_size: 20` to keep the current behavior. The configuration of the statistics integration will become more flexible and accept either `sampling_size` or `max_age`, or both settings. Read the documentation for further details: https://www.home-assistant.io/integrations/statistics/"
+      "title": "Implicit 'sampling_size' assumed for a Statistics entity",
+      "description": "The configuration parameter `sampling_size` of the statistics integration defaulted to the value 20 so far, which will change.\n\nPlease check the configuration for sensor `{entity}` and add suited boundaries, e.g., `sampling_size: 20` to keep the current behavior. The configuration of the statistics integration will become more flexible with version 2022.12.0 and accept either `sampling_size` or `max_age`, or both settings. The request above prepares your configuration for this otherwise breaking change.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/"
     }
   }
 }

--- a/homeassistant/components/statistics/strings.json
+++ b/homeassistant/components/statistics/strings.json
@@ -1,12 +1,12 @@
 {
   "issues": {
     "deprecation_warning_characteristic": {
-      "title": "Mandatory 'state_characteristic' assumed for a Statistics entity",
-      "description": "The configuration parameter `state_characteristic` of the statistics integration will become mandatory.\n\nPlease add `state_characteristic: {characteristic}` to the configuration of sensor `{entity}` to keep the current behavior.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/"
+      "description": "The configuration parameter `state_characteristic` of the statistics integration will become mandatory.\n\nPlease add `state_characteristic: {characteristic}` to the configuration of sensor `{entity}` to keep the current behavior.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/",
+      "title": "Mandatory 'state_characteristic' assumed for a Statistics entity"
     },
     "deprecation_warning_size": {
-      "title": "Implicit 'sampling_size' assumed for a Statistics entity",
-      "description": "The configuration parameter `sampling_size` of the statistics integration defaulted to the value 20 so far, which will change.\n\nPlease check the configuration for sensor `{entity}` and add suited boundaries, e.g., `sampling_size: 20` to keep the current behavior. The configuration of the statistics integration will become more flexible with version 2022.12.0 and accept either `sampling_size` or `max_age`, or both settings. The request above prepares your configuration for this otherwise breaking change.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/"
+      "description": "The configuration parameter `sampling_size` of the statistics integration defaulted to the value 20 so far, which will change.\n\nPlease check the configuration for sensor `{entity}` and add suited boundaries, e.g., `sampling_size: 20` to keep the current behavior. The configuration of the statistics integration will become more flexible with version 2022.12.0 and accept either `sampling_size` or `max_age`, or both settings. The request above prepares your configuration for this otherwise breaking change.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/",
+      "title": "Implicit 'sampling_size' assumed for a Statistics entity"
     }
   }
 }

--- a/homeassistant/components/statistics/translations/en.json
+++ b/homeassistant/components/statistics/translations/en.json
@@ -1,0 +1,12 @@
+{
+    "issues": {
+        "deprecation_warning_characteristic": {
+            "description": "The configuration parameter `state_characteristic` of the statistics integration will become mandatory.\n\nPlease add `state_characteristic: {characteristic}` to the configuration of sensor `{entity}` to keep the current behavior.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/",
+            "title": "Mandatory 'state_characteristic' assumed for a Statistics entity"
+        },
+        "deprecation_warning_size": {
+            "description": "The configuration parameter `sampling_size` of the statistics integration defaulted to the value 20 so far, which will change.\n\nPlease check the configuration for sensor `{entity}` and add suited boundaries, e.g., `sampling_size: 20` to keep the current behavior. The configuration of the statistics integration will become more flexible with version 2022.12.0 and accept either `sampling_size` or `max_age`, or both settings. The request above prepares your configuration for this otherwise breaking change.\n\nRead the documentation of the statistics integration for further details: https://www.home-assistant.io/integrations/statistics/",
+            "title": "Implicit 'sampling_size' assumed for a Statistics entity"
+        }
+    }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Adds non-destructive deprecation message for `sampling_size` default. The implicit 20 behind this variable has confused users in the past (community and false bug reports in [tickets](https://github.com/home-assistant/core/issues/50837#issuecomment-984156732)) and there is just no reasonable default here. I'd rather have the user define either `sampling size` or `max_age` (or both) explicitly. The message is only shown if a user doesn't have any boundary defined. If I had to bet, probably not more than a dozen users in this world will be affected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: Not needed!
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
