### PR TITLE
Don't test config on yaml import for generic camera

### DIFF
--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -43,12 +43,12 @@ async def test_fetching_url(hass, hass_client, fakeimgbytes_png, mock_av_open):
     resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == HTTPStatus.OK
-    assert respx.calls.call_count == 2
+    assert respx.calls.call_count == 1
     body = await resp.read()
     assert body == fakeimgbytes_png
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert respx.calls.call_count == 3
+    assert respx.calls.call_count == 2
 
 
 @respx.mock
@@ -143,19 +143,19 @@ async def test_limit_refetch(hass, hass_client, fakeimgbytes_png, fakeimgbytes_j
     ):
         resp = await client.get("/api/camera_proxy/camera.config_test")
 
-    assert respx.calls.call_count == 2
+    assert respx.calls.call_count == 1
     assert resp.status == HTTPStatus.OK
 
     hass.states.async_set("sensor.temp", "10")
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert respx.calls.call_count == 3
+    assert respx.calls.call_count == 2
     assert resp.status == HTTPStatus.OK
     body = await resp.read()
     assert body == fakeimgbytes_png
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert respx.calls.call_count == 3
+    assert respx.calls.call_count == 2
     assert resp.status == HTTPStatus.OK
     body = await resp.read()
     assert body == fakeimgbytes_png
@@ -164,7 +164,7 @@ async def test_limit_refetch(hass, hass_client, fakeimgbytes_png, fakeimgbytes_j
 
     # Url change = fetch new image
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert respx.calls.call_count == 4
+    assert respx.calls.call_count == 3
     assert resp.status == HTTPStatus.OK
     body = await resp.read()
     assert body == fakeimgbytes_jpg
@@ -172,7 +172,7 @@ async def test_limit_refetch(hass, hass_client, fakeimgbytes_png, fakeimgbytes_j
     # Cause a template render error
     hass.states.async_remove("sensor.temp")
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert respx.calls.call_count == 4
+    assert respx.calls.call_count == 3
     assert resp.status == HTTPStatus.OK
     body = await resp.read()
     assert body == fakeimgbytes_jpg
@@ -392,14 +392,14 @@ async def test_camera_content_type(
     client = await hass_client()
 
     resp_1 = await client.get("/api/camera_proxy/camera.config_test_svg")
-    assert respx.calls.call_count == 3
+    assert respx.calls.call_count == 1
     assert resp_1.status == HTTPStatus.OK
     assert resp_1.content_type == "image/svg+xml"
     body = await resp_1.read()
     assert body == fakeimgbytes_svg
 
     resp_2 = await client.get("/api/camera_proxy/camera.config_test_jpg")
-    assert respx.calls.call_count == 4
+    assert respx.calls.call_count == 2
     assert resp_2.status == HTTPStatus.OK
     assert resp_2.content_type == "image/jpeg"
     body = await resp_2.read()
@@ -432,7 +432,7 @@ async def test_timeout_cancelled(hass, hass_client, fakeimgbytes_png, fakeimgbyt
     resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == HTTPStatus.OK
-    assert respx.calls.call_count == 2
+    assert respx.calls.call_count == 1
     assert await resp.read() == fakeimgbytes_png
 
     respx.get("http://example.com").respond(stream=fakeimgbytes_jpg)
@@ -442,7 +442,7 @@ async def test_timeout_cancelled(hass, hass_client, fakeimgbytes_png, fakeimgbyt
         side_effect=asyncio.CancelledError(),
     ):
         resp = await client.get("/api/camera_proxy/camera.config_test")
-        assert respx.calls.call_count == 2
+        assert respx.calls.call_count == 1
         assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
 
     respx.get("http://example.com").side_effect = [
@@ -450,7 +450,7 @@ async def test_timeout_cancelled(hass, hass_client, fakeimgbytes_png, fakeimgbyt
         httpx.TimeoutException,
     ]
 
-    for total_calls in range(3, 5):
+    for total_calls in range(2, 4):
         resp = await client.get("/api/camera_proxy/camera.config_test")
         assert respx.calls.call_count == total_calls
         assert resp.status == HTTPStatus.OK

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -167,8 +167,9 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
 async def test_form_rtsp_mode(hass, fakeimg_png, mock_av_open, user_flow):
     """Test we complete ok if the user enters a stream url."""
     with mock_av_open as mock_setup:
-        data = TESTDATA
+        data = TESTDATA.copy()
         data[CONF_RTSP_TRANSPORT] = "tcp"
+        data[CONF_STREAM_SOURCE] = "rtsp://127.0.0.1/testurl/2"
         result2 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"], data
         )
@@ -178,7 +179,7 @@ async def test_form_rtsp_mode(hass, fakeimg_png, mock_av_open, user_flow):
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
-        CONF_STREAM_SOURCE: "http://127.0.0.1/testurl/2",
+        CONF_STREAM_SOURCE: "rtsp://127.0.0.1/testurl/2",
         CONF_RTSP_TRANSPORT: "tcp",
         CONF_USERNAME: "fred_flintstone",
         CONF_PASSWORD: "bambam",
@@ -216,7 +217,6 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
     assert result3["options"] == {
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
         CONF_STREAM_SOURCE: "http://127.0.0.1/testurl/2",
-        CONF_RTSP_TRANSPORT: "tcp",
         CONF_USERNAME: "fred_flintstone",
         CONF_PASSWORD: "bambam",
         CONF_LIMIT_REFETCH_TO_URL_CHANGE: False,
@@ -549,31 +549,6 @@ async def test_import(hass, fakeimg_png, mock_av_open):
     # Any name defined in yaml should end up as the entity id.
     assert hass.states.get("camera.yaml_defined_name")
     assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
-
-
-@respx.mock
-async def test_import_invalid_still_image(hass, mock_av_open):
-    """Test configuration.yaml import used during migration."""
-    respx.get("http://127.0.0.1/testurl/1").respond(stream=b"invalid")
-    with mock_av_open:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TESTDATA_YAML
-        )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "unknown"
-
-
-@respx.mock
-async def test_import_other_error(hass, fakeimgbytes_png):
-    """Test that non-specific import errors are raised."""
-    respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
-    with patch(
-        "homeassistant.components.generic.config_flow.av.open",
-        side_effect=OSError("other error"),
-    ), pytest.raises(OSError):
-        await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TESTDATA_YAML
-        )
 
 
 # These above can be deleted after deprecation period is finished.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The generic camera config flow includes tests for the still and stream URLs to help the user only enter valid settings.  However, running these checks during yaml import has caused several problems:
- Templates not being renderable on startup #69402
- The migration highlighting underlying errors in their yaml e.g. #69461
- Authentication failures blocking yaml import #69684
The overall main problem is that all of these leave the user with nothing imported.  It looks like no import was done at all, and they have nothing to try to 'fix'.
So my conclusion is that it is best just to assume the yaml was valid and import it, then let the user fix it later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #69685, #69461
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
