### PR TITLE
Reduce the number of queries needed to compile statistics

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1096,7 +1096,7 @@ def get_latest_short_term_statistics(
             for statistic_id in statistic_ids
             if statistic_id in metadata
         ]
-        most_recent_metadata_ids = (
+        most_recent_statistic_row = (
             session.query(
                 StatisticsShortTerm.id,
                 func.max(StatisticsShortTerm.start),
@@ -1106,8 +1106,8 @@ def get_latest_short_term_statistics(
         ).subquery()
         stats = execute(
             session.query(*QUERY_STATISTICS_SHORT_TERM).join(
-                most_recent_metadata_ids,
-                StatisticsShortTerm.id == most_recent_metadata_ids.c.id,
+                most_recent_statistic_row,
+                StatisticsShortTerm.id == most_recent_statistic_row.c.id,
             )
         )
         if not stats:

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1092,15 +1092,13 @@ def get_latest_short_term_statistics(
         baked_query = hass.data[STATISTICS_BAKERY](
             lambda session: session.query(
                 *QUERY_STATISTICS_SHORT_TERM,
-                func.max(StatisticsShortTerm.metadata_id, StatisticsShortTerm.start),
+                func.max(StatisticsShortTerm.start),
             )
         )
         baked_query += lambda q: q.filter(
             StatisticsShortTerm.metadata_id.in_(bindparam("metadata_ids"))
         )
-        baked_query += lambda q: q.order_by(
-            StatisticsShortTerm.metadata_id, StatisticsShortTerm.start.desc()
-        )
+        baked_query += lambda q: q.group_by(StatisticsShortTerm.metadata_id)
         metadata_ids = [
             metadata[statistic_id][0]
             for statistic_id in statistic_ids

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1084,8 +1084,8 @@ def get_latest_short_term_statistics(
     hass: HomeAssistant, statistic_ids: list[str], convert_units: bool
 ) -> dict[str, list[dict]]:
     """Return the latest short term statistics for statistic_ids."""
-    # This function doesn't use a baked query since its
-    # deprecated since version 1.4
+    # This function doesn't use a baked query, we instead rely on the
+    # "Transparent SQL Compilation Caching" feature introduced in SQLAlchemy 1.4
     with session_scope(hass=hass) as session:
         # Fetch metadata for the given statistic_id
         metadata = get_metadata_with_session(hass, session, statistic_ids=statistic_ids)

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -66,7 +66,6 @@ QUERY_STATISTICS = [
     Statistics.sum,
 ]
 
-
 QUERY_STATISTICS_SHORT_TERM = [
     StatisticsShortTerm.metadata_id,
     StatisticsShortTerm.start,

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -237,7 +237,7 @@ def _update_or_add_metadata(
     Updating metadata source is not possible.
     """
     statistic_id = new_metadata["statistic_id"]
-    if not old_metadata_dict:
+    if statistic_id not in old_metadata_dict:
         meta = StatisticsMeta.from_meta(new_metadata)
         session.add(meta)
         session.flush()  # Flush to get the metadata id assigned

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1083,7 +1083,7 @@ def get_last_short_term_statistics(
 def get_latest_short_term_statistics(
     hass: HomeAssistant, statistic_ids: list[str], convert_units: bool
 ) -> dict[str, list[dict]]:
-    """Return the latest short term statistics for statistic_ids."""
+    """Return the latest short term statistics for a list of statistic_ids."""
     # This function doesn't use a baked query, we instead rely on the
     # "Transparent SQL Compilation Caching" feature introduced in SQLAlchemy 1.4
     with session_scope(hass=hass) as session:

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1120,7 +1120,7 @@ def get_latest_short_term_statistics(
             stats,
             statistic_ids,
             metadata,
-            convert_units,
+            False,
             StatisticsShortTerm,
             None,
         )

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1087,7 +1087,7 @@ def get_latest_short_term_statistics(
     # This function doesn't use a baked query, we instead rely on the
     # "Transparent SQL Compilation Caching" feature introduced in SQLAlchemy 1.4
     with session_scope(hass=hass) as session:
-        # Fetch metadata for the given statistic_id
+        # Fetch metadata for the given statistic_ids
         metadata = get_metadata_with_session(hass, session, statistic_ids=statistic_ids)
         if not metadata:
             return {}

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1081,7 +1081,7 @@ def get_last_short_term_statistics(
 
 
 def get_latest_short_term_statistics(
-    hass: HomeAssistant, statistic_ids: list[str], convert_units: bool
+    hass: HomeAssistant, statistic_ids: list[str]
 ) -> dict[str, list[dict]]:
     """Return the latest short term statistics for a list of statistic_ids."""
     # This function doesn't use a baked query, we instead rely on the

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -473,7 +473,7 @@ def _compile_statistics(  # noqa: C901
         if "sum" in wanted_statistics[entity_id]:
             to_query.append(entity_id)
 
-    last_stats = statistics.get_latest_short_term_statistics(hass, to_query, False)
+    last_stats = statistics.get_latest_short_term_statistics(hass, to_query)
     for (  # pylint: disable=too-many-nested-blocks
         entity_id,
         unit,

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -446,12 +446,13 @@ def _compile_statistics(  # noqa: C901
         if _state.entity_id not in history_list:
             history_list[_state.entity_id] = [_state]
 
-    for _state in sensor_states:  # pylint: disable=too-many-nested-blocks
+    to_process = []
+    to_query = []
+    for _state in sensor_states:
         entity_id = _state.entity_id
         if entity_id not in history_list:
             continue
 
-        state_class = _state.attributes[ATTR_STATE_CLASS]
         device_class = _state.attributes.get(ATTR_DEVICE_CLASS)
         entity_history = history_list[entity_id]
         unit, fstates = _normalize_states(
@@ -466,6 +467,19 @@ def _compile_statistics(  # noqa: C901
         if not fstates:
             continue
 
+        state_class = _state.attributes[ATTR_STATE_CLASS]
+
+        to_process.append((entity_id, unit, state_class, fstates))
+        if "sum" in wanted_statistics[entity_id]:
+            to_query.append(entity_id)
+
+    last_stats = statistics.get_latest_short_term_statistics(hass, to_query, False)
+    for (  # pylint: disable=too-many-nested-blocks
+        entity_id,
+        unit,
+        state_class,
+        fstates,
+    ) in to_process:
         # Check metadata
         if old_metadata := old_metadatas.get(entity_id):
             if old_metadata[1]["unit_of_measurement"] != unit:
@@ -511,9 +525,6 @@ def _compile_statistics(  # noqa: C901
             last_reset = old_last_reset = None
             new_state = old_state = None
             _sum = 0.0
-            last_stats = statistics.get_last_short_term_statistics(
-                hass, 1, entity_id, False
-            )
             if entity_id in last_stats:
                 # We have compiled history for this sensor before, use that as a starting point
                 last_reset = old_last_reset = last_stats[entity_id][0]["last_reset"]

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -133,6 +133,11 @@ def test_compile_hourly_statistics(hass_recorder):
     stats = get_last_short_term_statistics(hass, 1, "sensor.test3", True)
     assert stats == {}
 
+    recorder.get_session().query(StatisticsShortTerm).delete()
+    # Should not fail there is nothing in the table
+    stats = get_latest_short_term_statistics(hass, ["sensor.test1"], True)
+    assert stats == {}
+
 
 @pytest.fixture
 def mock_sensor_statistics():

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -135,7 +135,7 @@ def test_compile_hourly_statistics(hass_recorder):
 
     recorder.get_session().query(StatisticsShortTerm).delete()
     # Should not fail there is nothing in the table
-    stats = get_latest_short_term_statistics(hass, ["sensor.test1"], True)
+    stats = get_latest_short_term_statistics(hass, ["sensor.test1"])
     assert stats == {}
 
 

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -57,7 +57,7 @@ def test_compile_hourly_statistics(hass_recorder):
     assert dict(states) == dict(hist)
 
     # Should not fail if there is nothing there yet
-    stats = get_latest_short_term_statistics(hass, ["sensor.test1"], True)
+    stats = get_latest_short_term_statistics(hass, ["sensor.test1"])
     assert stats == {}
 
     for kwargs in ({}, {"statistic_ids": ["sensor.test1"]}):

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -23,6 +23,7 @@ from homeassistant.components.recorder.statistics import (
     delete_duplicates,
     get_last_short_term_statistics,
     get_last_statistics,
+    get_latest_short_term_statistics,
     get_metadata,
     list_statistic_ids,
     statistics_during_period,
@@ -54,6 +55,10 @@ def test_compile_hourly_statistics(hass_recorder):
     zero, four, states = record_states(hass)
     hist = history.get_significant_states(hass, zero, four)
     assert dict(states) == dict(hist)
+
+    # Should not fail if there is nothing there yet
+    stats = get_latest_short_term_statistics(hass, ["sensor.test1"], True)
+    assert stats == {}
 
     for kwargs in ({}, {"statistic_ids": ["sensor.test1"]}):
         stats = statistics_during_period(hass, zero, period="5minute", **kwargs)
@@ -109,11 +114,14 @@ def test_compile_hourly_statistics(hass_recorder):
     )
     assert stats == {}
 
-    # Test get_last_short_term_statistics
+    # Test get_last_short_term_statistics and get_latest_short_term_statistics
     stats = get_last_short_term_statistics(hass, 0, "sensor.test1", True)
     assert stats == {}
 
     stats = get_last_short_term_statistics(hass, 1, "sensor.test1", True)
+    assert stats == {"sensor.test1": [{**expected_2, "statistic_id": "sensor.test1"}]}
+
+    stats = get_latest_short_term_statistics(hass, ["sensor.test1"], True)
     assert stats == {"sensor.test1": [{**expected_2, "statistic_id": "sensor.test1"}]}
 
     stats = get_last_short_term_statistics(hass, 2, "sensor.test1", True)

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -121,7 +121,7 @@ def test_compile_hourly_statistics(hass_recorder):
     stats = get_last_short_term_statistics(hass, 1, "sensor.test1", True)
     assert stats == {"sensor.test1": [{**expected_2, "statistic_id": "sensor.test1"}]}
 
-    stats = get_latest_short_term_statistics(hass, ["sensor.test1"], True)
+    stats = get_latest_short_term_statistics(hass, ["sensor.test1"])
     assert stats == {"sensor.test1": [{**expected_2, "statistic_id": "sensor.test1"}]}
 
     stats = get_last_short_term_statistics(hass, 2, "sensor.test1", True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #56987

<img width="1387" alt="Screen_Shot_2022-04-08_at_21_15_15" src="https://user-images.githubusercontent.com/663432/162561390-cf98ca80-a3f9-4f20-8fb5-24821894742a.png">

These two queries are run in a loop and take up the most time.

We were able to optimize it in these two places by combine each loop into a single query for all the ids and extract the result

1. https://github.com/home-assistant/core/blob/dev/homeassistant/components/sensor/recorder.py#L514
```
            last_stats = statistics.get_last_short_term_statistics(
                hass, 1, entity_id, False
            )
```

2. https://github.com/home-assistant/core/blob/dev/homeassistant/components/recorder/statistics.py#L240
```
    old_metadata_dict = get_metadata_with_session(
        hass, session, statistic_ids=[statistic_id]
    )
```

After. Assuming recording states takes about same amount of cpu time. Statistics queries now take roughly the same amount of time instead of almost 10x the time we spent recording states
<img width="1390" alt="Screen_Shot_2022-04-08_at_23_31_48" src="https://user-images.githubusercontent.com/663432/162566139-e35334cf-15e6-4b64-bbc5-7f6d61813f6e.png">

After the final adjustment to use the covering index its much less time.  Its approaching two orders of magnitude less time since works out to ~8x less time than the original state recording time shown in the original graph


<img width="1270" alt="Screen_Shot_2022-04-11_at_23_15_27" src="https://user-images.githubusercontent.com/663432/162926186-25c18435-aadb-4c74-a062-96d2d91c6dfc.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
