### PR TITLE
Limit autogenerated entity_id string length

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -289,7 +289,7 @@ class EntityRegistry:
         if len(domain) > MAX_LENGTH_STATE_DOMAIN:
             raise MaxLengthExceeded(domain, "domain", MAX_LENGTH_STATE_DOMAIN)
 
-        test_string = preferred_string
+        test_string = preferred_string[:MAX_LENGTH_STATE_ENTITY_ID]
         if not known_object_ids:
             known_object_ids = {}
 
@@ -300,11 +300,9 @@ class EntityRegistry:
             or not self.hass.states.async_available(test_string)
         ):
             tries += 1
-            test_string = f"{preferred_string}_{tries}"
-
-        if len(test_string) > MAX_LENGTH_STATE_ENTITY_ID:
-            raise MaxLengthExceeded(
-                test_string, "generated_entity_id", MAX_LENGTH_STATE_ENTITY_ID
+            len_suffix = len(str(tries)) + 1
+            test_string = (
+                f"{preferred_string[:MAX_LENGTH_STATE_ENTITY_ID-len_suffix]}_{tries}"
             )
 
         return test_string

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1133,6 +1133,24 @@ async def test_entity_max_length_exceeded(hass, registry):
     assert exc_info.value.max_length == 64
     assert exc_info.value.value == long_domain_name
 
+    # Try again but force a number to get added to the entity ID
+    long_entity_id_name = (
+        "1234567890123456789012345678901234567890123456789012345678901234567890"
+        "1234567890123456789012345678901234567890123456789012345678901234567890"
+        "1234567890123456789012345678901234567890123456789012345678901234567890"
+        "1234567890123456789012345678901234567"
+    )
+
+    known = []
+    new_id = registry.async_generate_entity_id("sensor", long_entity_id_name, known)
+    assert new_id == "sensor." + long_entity_id_name[: 255 - 7]
+    known.append(new_id)
+    new_id = registry.async_generate_entity_id("sensor", long_entity_id_name, known)
+    assert new_id == "sensor." + long_entity_id_name[: 255 - 7 - 2] + "_2"
+    known.append(new_id)
+    new_id = registry.async_generate_entity_id("sensor", long_entity_id_name, known)
+    assert new_id == "sensor." + long_entity_id_name[: 255 - 7 - 2] + "_3"
+
 
 async def test_resolve_entity_ids(hass, registry):
     """Test resolving entity IDs."""

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1119,45 +1119,19 @@ async def test_disabled_entities_excluded_from_entity_list(hass, registry):
 async def test_entity_max_length_exceeded(hass, registry):
     """Test that an exception is raised when the max character length is exceeded."""
 
-    long_entity_id_name = (
+    long_domain_name = (
         "1234567890123456789012345678901234567890123456789012345678901234567890"
         "1234567890123456789012345678901234567890123456789012345678901234567890"
         "1234567890123456789012345678901234567890123456789012345678901234567890"
         "1234567890123456789012345678901234567890123456789012345678901234567890"
     )
 
-    with pytest.raises(MaxLengthExceeded) as exc_info:
-        registry.async_generate_entity_id("sensor", long_entity_id_name)
-
-    assert exc_info.value.property_name == "generated_entity_id"
-    assert exc_info.value.max_length == 255
-    assert exc_info.value.value == f"sensor.{long_entity_id_name}"
-
-    # Try again but against the domain
-    long_domain_name = long_entity_id_name
     with pytest.raises(MaxLengthExceeded) as exc_info:
         registry.async_generate_entity_id(long_domain_name, "sensor")
 
     assert exc_info.value.property_name == "domain"
     assert exc_info.value.max_length == 64
     assert exc_info.value.value == long_domain_name
-
-    # Try again but force a number to get added to the entity ID
-    long_entity_id_name = (
-        "1234567890123456789012345678901234567890123456789012345678901234567890"
-        "1234567890123456789012345678901234567890123456789012345678901234567890"
-        "1234567890123456789012345678901234567890123456789012345678901234567890"
-        "1234567890123456789012345678901234567"
-    )
-
-    with pytest.raises(MaxLengthExceeded) as exc_info:
-        registry.async_generate_entity_id(
-            "sensor", long_entity_id_name, [f"sensor.{long_entity_id_name}"]
-        )
-
-    assert exc_info.value.property_name == "generated_entity_id"
-    assert exc_info.value.max_length == 255
-    assert exc_info.value.value == f"sensor.{long_entity_id_name}_2"
 
 
 async def test_resolve_entity_ids(hass, registry):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an integration uses `async_generate_entity_id()` to create a new entity id, it passes a `suggested_object_id` (string).

If this string too long, a `MaxLengthExceeded` exception is raised.  This is all ok. However if a `suggested_object_id` comes from user content (e.g. from a slugified URL or some other long unique identifier), it could be very long.  It's also possible that the incrementing suffix to avoid duplicates could tip it over the edge.

Rather than limit the length at all of the sources, I thought that it *might* be better to auto-truncate strings in `async_generate_entity_id()`

This PR does this and fixes the related issue I found.  But I would value a 2nd opinion as this is not the only way to solve it.

For example are there any scenarios where it would be more helpful to raise an exception?  If that is the case `auto_truncate` could maybe be added as an optional parameter.  But only if that complexity is worth it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69273
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
