### PR TITLE
Improve entity and device naming in Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -249,13 +249,9 @@ class SynologyDSMBaseEntity(
         self._attr_unique_id: str = (
             f"{api.information.serial}_{description.api_key}:{description.key}"
         )
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._api.information.serial)},
-            name="Synology NAS",
+            name=self._api.network.hostname,
             manufacturer="Synology",
             model=self._api.information.model,
             sw_version=self._api.information.version_string,
@@ -309,25 +305,20 @@ class SynologyDSMDeviceEntity(SynologyDSMBaseEntity):
             self._device_model = disk["model"].strip()
             self._device_firmware = disk["firm"]
             self._device_type = disk["diskType"]
-        self._name = (
-            f"{self._api.network.hostname} {self._device_name} {description.name}"
-        )
+
+        self._attr_name = f"{self._api.network.hostname} ({self._device_name} - {self._device_type}) {description.name}"
         self._attr_unique_id += f"_{self._device_id}"
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self._api.storage  # type: ignore [no-any-return]
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{self._api.information.serial}_{self._device_id}")},
-            name=f"Synology NAS ({self._device_name} - {self._device_type})",
+            name=f"{self._api.network.hostname} ({self._device_name} - {self._device_type})",
             manufacturer=self._device_manufacturer,
             model=self._device_model,
             sw_version=self._device_firmware,
             via_device=(DOMAIN, self._api.information.serial),
             configuration_url=self._api.config_url,
         )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._api.storage  # type: ignore [no-any-return]

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -306,11 +306,13 @@ class SynologyDSMDeviceEntity(SynologyDSMBaseEntity):
             self._device_firmware = disk["firm"]
             self._device_type = disk["diskType"]
 
-        self._attr_name = f"{self._api.network.hostname} ({self._device_name} - {self._device_type}) {description.name}"
+        self._attr_name = (
+            f"{self._api.network.hostname} ({self._device_name}) {description.name}"
+        )
         self._attr_unique_id += f"_{self._device_id}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{self._api.information.serial}_{self._device_id}")},
-            name=f"{self._api.network.hostname} ({self._device_name} - {self._device_type})",
+            name=f"{self._api.network.hostname} ({self._device_name})",
             manufacturer=self._device_manufacturer,
             model=self._device_model,
             sw_version=self._device_firmware,

--- a/homeassistant/components/synology_dsm/switch.py
+++ b/homeassistant/components/synology_dsm/switch.py
@@ -83,6 +83,10 @@ class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, SwitchEntity):
         super().__init__(api, coordinator, description)
         self._version = version
 
+        self._attr_name = (
+            f"{self._api.network.hostname} Surveillance Station {description.name}"
+        )
+
     @property
     def is_on(self) -> bool:
         """Return the state."""
@@ -125,7 +129,7 @@ class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, SwitchEntity):
                     f"{self._api.information.serial}_{SynoSurveillanceStation.INFO_API_KEY}",
                 )
             },
-            name="Surveillance Station",
+            name=f"{self._api.network.hostname} Surveillance Station",
             manufacturer="Synology",
             model=self._api.information.model,
             sw_version=self._version,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The naming of entities and devices has been aligned, so that the device name is now part of the entity name.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will change the naming of entities and devices, so that the device name is part of the entity name and can be shorten on the device detail view

| old | new |
|---|---|
| ![image](https://user-images.githubusercontent.com/35783820/162583386-f4e607ae-1990-4d54-8860-0a3962e4634e.png) | ![image](https://user-images.githubusercontent.com/35783820/162583306-d6f2dd22-6ce1-4cea-890d-3e60c26e4f35.png) |
| ![image](https://user-images.githubusercontent.com/35783820/162583405-f538b88c-411e-4d05-bb10-db20638a3403.png) | ![image](https://user-images.githubusercontent.com/35783820/162583319-0cdddcca-da3f-49bb-b2ff-67f2cd0bde09.png) |
| ![image](https://user-images.githubusercontent.com/35783820/162583421-7e449cfc-955c-47d8-9e8b-c220e3a31953.png) | ![image](https://user-images.githubusercontent.com/35783820/162583325-cae9b831-51bc-4df0-b0f3-0ef647b4572f.png) |
| ![image](https://user-images.githubusercontent.com/35783820/162583426-264f36c4-bfa5-41e2-ad4a-99bd60a3aee3.png) | ![image](https://user-images.githubusercontent.com/35783820/162583345-4eb7d85d-e648-4e57-9fdf-5062973e31e7.png) |


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
