### PR TITLE
Add diagnostics support for ZHA

### DIFF
--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -1,0 +1,80 @@
+"""Provides diagnostics for ZHA."""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import bellows
+import pkg_resources
+import zigpy
+from zigpy.config import CONF_NWK_EXTENDED_PAN_ID
+import zigpy_deconz
+import zigpy_xbee
+import zigpy_zigate
+import zigpy_znp
+
+from homeassistant.components.diagnostics.util import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_UNIQUE_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .core.const import ATTR_IEEE, DATA_ZHA, DATA_ZHA_CONFIG, DATA_ZHA_GATEWAY
+from .core.device import ZHADevice
+from .core.gateway import ZHAGateway
+from .core.helpers import async_get_zha_device
+
+KEYS_TO_REDACT = {
+    ATTR_IEEE,
+    CONF_UNIQUE_ID,
+    "device_reg_id",
+    "network_key",
+    CONF_NWK_EXTENDED_PAN_ID,
+}
+
+
+def shallow_asdict(obj: Any) -> dict:
+    """Return a shallow copy of a dataclass as a dict."""
+    if hasattr(obj, "__dataclass_fields__"):
+        result = {}
+
+        for field in dataclasses.fields(obj):
+            result[field.name] = shallow_asdict(getattr(obj, field.name))
+
+        return result
+    if hasattr(obj, "as_dict"):
+        return obj.as_dict()
+    return obj
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    config: dict = hass.data[DATA_ZHA][DATA_ZHA_CONFIG]
+    gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    return async_redact_data(
+        {
+            "config": config,
+            "config_entry": config_entry.as_dict(),
+            "application_state": shallow_asdict(gateway.application_controller.state),
+            "versions": {
+                "bellows": bellows.__version__,
+                "zigpy": zigpy.__version__,
+                "zigpy_deconz": zigpy_deconz.__version__,
+                "zigpy_xbee": zigpy_xbee.__version__,
+                "zigpy_znp": zigpy_znp.__version__,
+                "zigpy_zigate": zigpy_zigate.__version__,
+                "zhaquirks": pkg_resources.get_distribution("zha-quirks").version,
+            },
+        },
+        KEYS_TO_REDACT,
+    )
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: dr.DeviceEntry
+) -> dict:
+    """Return diagnostics for a device."""
+    zha_device: ZHADevice = await async_get_zha_device(hass, device.id)
+    return async_redact_data(zha_device.zha_device_info, KEYS_TO_REDACT)

--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -27,7 +27,6 @@ from .core.helpers import async_get_zha_device
 KEYS_TO_REDACT = {
     ATTR_IEEE,
     CONF_UNIQUE_ID,
-    "device_reg_id",
     "network_key",
     CONF_NWK_EXTENDED_PAN_ID,
 }

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -11,6 +11,7 @@ from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 import zigpy.device
 import zigpy.group
 import zigpy.profiles
+from zigpy.state import State
 import zigpy.types
 import zigpy.zdo.types as zdo_t
 
@@ -54,7 +55,7 @@ def zigpy_app_controller():
     app.ieee.return_value = zigpy.types.EUI64.convert("00:15:8d:00:02:32:4f:32")
     type(app).nwk = PropertyMock(return_value=zigpy.types.NWK(0x0000))
     type(app).devices = PropertyMock(return_value={})
-    type(app).state = PropertyMock(return_value={})
+    type(app).state = PropertyMock(return_value=State())
     return app
 
 

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -54,6 +54,7 @@ def zigpy_app_controller():
     app.ieee.return_value = zigpy.types.EUI64.convert("00:15:8d:00:02:32:4f:32")
     type(app).nwk = PropertyMock(return_value=zigpy.types.NWK(0x0000))
     type(app).devices = PropertyMock(return_value={})
+    type(app).state = PropertyMock(return_value={})
     return app
 
 

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -1,0 +1,86 @@
+"""Tests for the diagnostics data provided by the ESPHome integration."""
+
+
+import pytest
+import zigpy.profiles.zha as zha
+import zigpy.zcl.clusters.security as security
+
+from homeassistant.components.diagnostics.const import REDACTED
+from homeassistant.components.zha.core.device import ZHADevice
+from homeassistant.components.zha.diagnostics import KEYS_TO_REDACT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import async_get
+
+from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+
+from tests.components.diagnostics import (
+    get_diagnostics_for_config_entry,
+    get_diagnostics_for_device,
+)
+
+CONFIG_ENTRY_DIAGNOSTICS_KEYS = [
+    "config",
+    "config_entry",
+    "application_state",
+    "versions",
+]
+
+
+@pytest.fixture
+def zigpy_device(zigpy_device_mock):
+    """Device tracker zigpy device."""
+    endpoints = {
+        1: {
+            SIG_EP_INPUT: [security.IasAce.cluster_id],
+            SIG_EP_OUTPUT: [],
+            SIG_EP_TYPE: zha.DeviceType.IAS_ANCILLARY_CONTROL,
+            SIG_EP_PROFILE: zha.PROFILE_ID,
+        }
+    }
+    return zigpy_device_mock(
+        endpoints, node_descriptor=b"\x02@\x8c\x02\x10RR\x00\x00\x00R\x00\x00"
+    )
+
+
+async def test_diagnostics_for_config_entry(
+    hass: HomeAssistant,
+    hass_client,
+    config_entry,
+    zha_device_joined,
+    zigpy_device,
+):
+    """Test diagnostics for config entry."""
+    await zha_device_joined(zigpy_device)
+    diagnostics_data = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry
+    )
+    assert diagnostics_data
+    for key in CONFIG_ENTRY_DIAGNOSTICS_KEYS:
+        assert key in diagnostics_data
+        assert diagnostics_data[key] is not None
+
+
+async def test_diagnostics_for_device(
+    hass: HomeAssistant,
+    hass_client,
+    config_entry,
+    zha_device_joined,
+    zigpy_device,
+):
+    """Test diagnostics for device."""
+
+    zha_device: ZHADevice = await zha_device_joined(zigpy_device)
+    dev_reg = async_get(hass)
+    device = dev_reg.async_get_device({("zha", str(zha_device.ieee))})
+    assert device
+    diagnostics_data = await get_diagnostics_for_device(
+        hass, hass_client, config_entry, device
+    )
+    assert diagnostics_data
+    device_info: dict = zha_device.zha_device_info
+    for key, value in device_info.items():
+        assert key in diagnostics_data
+        if key not in KEYS_TO_REDACT:
+            assert key in diagnostics_data
+        else:
+            assert diagnostics_data[key] == REDACTED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostics support to ZHA

Device:
[zha-35d973aa19c87654f03f73a2afb8e2eb-LUMI lumi.plug.maus01-a27513d0f64649d4f4561b83824d6dc9.json (1).txt](https://github.com/home-assistant/core/files/8457435/zha-35d973aa19c87654f03f73a2afb8e2eb-LUMI.lumi.plug.maus01-a27513d0f64649d4f4561b83824d6dc9.json.1.txt)

Config Entry:
[config_entry-zha-35d973aa19c87654f03f73a2afb8e2eb.json (1).txt](https://github.com/home-assistant/core/files/8457436/config_entry-zha-35d973aa19c87654f03f73a2afb8e2eb.json.1.txt)


TODO:

- [x] tests
- [x] recheck redactions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
