### PR TITLE
Trigger on not matching to/from states

### DIFF
--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -36,6 +36,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ENTITY_ID = "entity_id"
 CONF_FROM = "from"
 CONF_TO = "to"
+CONF_NOT_FROM = "not_from"
+CONF_NOT_TO = "not_to"
 
 BASE_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
@@ -49,15 +51,19 @@ BASE_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
 TRIGGER_STATE_SCHEMA = BASE_SCHEMA.extend(
     {
         # These are str on purpose. Want to catch YAML conversions
-        vol.Optional(CONF_FROM): vol.Any(str, [str], None),
-        vol.Optional(CONF_TO): vol.Any(str, [str], None),
+        vol.Exclusive(CONF_FROM, CONF_FROM): vol.Any(str, [str], None),
+        vol.Exclusive(CONF_NOT_FROM, CONF_FROM): vol.Any(str, [str], None),
+        vol.Exclusive(CONF_TO, CONF_TO): vol.Any(str, [str], None),
+        vol.Exclusive(CONF_NOT_TO, CONF_TO): vol.Any(str, [str], None),
     }
 )
 
 TRIGGER_ATTRIBUTE_SCHEMA = BASE_SCHEMA.extend(
     {
-        vol.Optional(CONF_FROM): cv.match_all,
-        vol.Optional(CONF_TO): cv.match_all,
+        vol.Exclusive(CONF_FROM, CONF_FROM): cv.match_all,
+        vol.Exclusive(CONF_NOT_FROM, CONF_FROM): cv.match_all,
+        vol.Exclusive(CONF_TO, CONF_TO): cv.match_all,
+        vol.Exclusive(CONF_NOT_TO, CONF_TO): cv.match_all,
     }
 )
 
@@ -94,19 +100,30 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     entity_ids = config[CONF_ENTITY_ID]
-    if (from_state := config.get(CONF_FROM)) is None:
-        from_state = MATCH_ALL
-    if (to_state := config.get(CONF_TO)) is None:
-        to_state = MATCH_ALL
+
+    if (from_state := config.get(CONF_FROM)) is not None:
+        match_from_state = process_state_match(from_state)
+    elif (not_from_state := config.get(CONF_NOT_FROM)) is not None:
+        match_from_state = process_state_match(not_from_state, invert=True)
+    else:
+        match_from_state = process_state_match(MATCH_ALL)
+
+    if (to_state := config.get(CONF_TO)) is not None:
+        match_to_state = process_state_match(to_state)
+    elif (not_to_state := config.get(CONF_NOT_TO)) is not None:
+        match_to_state = process_state_match(not_to_state, invert=True)
+    else:
+        match_to_state = process_state_match(MATCH_ALL)
+
     time_delta = config.get(CONF_FOR)
     template.attach(hass, time_delta)
     # If neither CONF_FROM or CONF_TO are specified,
     # fire on all changes to the state or an attribute
-    match_all = CONF_FROM not in config and CONF_TO not in config
+    match_all = all(
+        item not in config for item in (CONF_FROM, CONF_NOT_FROM, CONF_NOT_TO, CONF_TO)
+    )
     unsub_track_same = {}
     period: dict[str, timedelta] = {}
-    match_from_state = process_state_match(from_state)
-    match_to_state = process_state_match(to_state)
     attribute = config.get(CONF_ATTRIBUTE)
     job = HassJob(action)
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1535,17 +1535,17 @@ track_time_change = threaded_listener_factory(async_track_time_change)
 
 
 def process_state_match(
-    parameter: None | str | Iterable[str],
+    parameter: None | str | Iterable[str], invert: bool = False
 ) -> Callable[[str | None], bool]:
     """Convert parameter to function that matches input against parameter."""
     if parameter is None or parameter == MATCH_ALL:
-        return lambda _: True
+        return lambda _: not invert
 
     if isinstance(parameter, str) or not hasattr(parameter, "__iter__"):
-        return lambda state: state == parameter
+        return lambda state: invert is not (state == parameter)
 
     parameter_set = set(parameter)
-    return lambda state: state in parameter_set
+    return lambda state: invert is not (state in parameter_set)
 
 
 @callback

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -7,7 +7,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -21,7 +21,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -164,6 +164,36 @@ async def test_if_fires_on_entity_change_with_from_filter(hass, calls):
     assert len(calls) == 1
 
 
+async def test_if_fires_on_entity_change_with_not_from_filter(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test for firing on entity change inverse filter."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "not_from": "hello",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Do not fire from hello
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert not calls
+
+    hass.states.async_set("test.entity", "universum")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
 async def test_if_fires_on_entity_change_with_to_filter(hass, calls):
     """Test for firing on entity change with to filter."""
     assert await async_setup_component(
@@ -183,6 +213,36 @@ async def test_if_fires_on_entity_change_with_to_filter(hass, calls):
     await hass.async_block_till_done()
 
     hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_if_fires_on_entity_change_with_not_to_filter(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test for firing on entity change with to filter."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "not_to": "world",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Do not fire to world
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert not calls
+
+    hass.states.async_set("test.entity", "universum")
     await hass.async_block_till_done()
     assert len(calls) == 1
 
@@ -281,6 +341,100 @@ async def test_if_fires_on_entity_change_with_both_filters(hass, calls):
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+
+async def test_if_fires_on_entity_change_with_not_from_to(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test for firing if not from doesn't match and to match."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "not_from": ["hello", "galaxy"],
+                    "to": ["galaxy", "universe"],
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # We should not trigger from hello
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert not calls
+
+    # We should not trigger to != galaxy
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert not calls
+
+    # We should trigger to galaxy
+    hass.states.async_set("test.entity", "galaxy")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # We should not trigger from milky way
+    hass.states.async_set("test.entity", "milky_way")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # We should trigger to universe
+    hass.states.async_set("test.entity", "universe")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+
+async def test_if_fires_on_entity_change_with_from_not_to(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test for firing if not from doesn't match and to match."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "from": ["hello", "galaxy"],
+                    "not_to": ["galaxy", "universe"],
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # We should trigger to world from hello
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Reset back to hello, should not trigger
+    hass.states.async_set("test.entity", "hello")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # We should not trigger to galaxy
+    hass.states.async_set("test.entity", "galaxy")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # We should trigger form galaxy to milky way
+    hass.states.async_set("test.entity", "milky_way")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    # We should not trigger to universe
+    hass.states.async_set("test.entity", "universe")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
 
 
 async def test_if_not_fires_if_to_filter_not_match(hass, calls):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for triggering state changes that do not **NOT** match certain from or to states.

For example, it allows for filtering unavailable or unknown states:

```yaml
automation:
  trigger:
    - platform: state
      entity_id: light.living_room
      not_from:
        - "unavailable"
        - "unknown"
      to: "on"
```

Or, things like:

```yaml
automation:
  trigger:
    - alias: "Trigger on any alarm state, except when it is disarmed"
      platform: state
      entity_id: alarm_control_panel.home
      not_to: "disarmed"
```

- `not_to` and `to` are exclusive, you cannot use both.
- `not_from` and `from` are exclusive, you cannot use both.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22322

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
