### PR TITLE
Fix unifiprotect with 2.x versions

### DIFF
--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -3,7 +3,7 @@
   "name": "UniFi Protect",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
-  "requirements": ["pyunifiprotect==3.2.0", "unifi-discovery==1.1.2"],
+  "requirements": ["pyunifiprotect==3.3.0", "unifi-discovery==1.1.2"],
   "dependencies": ["http"],
   "codeowners": ["@briis", "@AngellusMortis", "@bdraco"],
   "quality_scale": "platinum",

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -137,7 +137,7 @@ CAMERA_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
         name="Detections: Person",
         icon="mdi:walk",
         entity_category=EntityCategory.CONFIG,
-        ufp_required_field="feature_flags.has_smart_detect",
+        ufp_required_field="can_detect_person",
         ufp_value="is_person_detection_on",
         ufp_set_method="set_person_detection",
     ),
@@ -146,9 +146,18 @@ CAMERA_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
         name="Detections: Vehicle",
         icon="mdi:car",
         entity_category=EntityCategory.CONFIG,
-        ufp_required_field="feature_flags.has_smart_detect",
+        ufp_required_field="can_detect_vehicle",
         ufp_value="is_vehicle_detection_on",
         ufp_set_method="set_vehicle_detection",
+    ),
+    ProtectSwitchEntityDescription(
+        key="smart_face",
+        name="Detections: Face",
+        icon="mdi:human-greeting",
+        entity_category=EntityCategory.CONFIG,
+        ufp_required_field="can_detect_face",
+        ufp_value="is_face_detection_on",
+        ufp_set_method="set_face_detection",
     ),
 )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1974,7 +1974,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==3.2.0
+pyunifiprotect==3.3.0
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1288,7 +1288,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==3.2.0
+pyunifiprotect==3.3.0
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from pyunifiprotect.data import Camera, Light
-from pyunifiprotect.data.types import RecordingMode, VideoMode
+from pyunifiprotect.data.types import RecordingMode, SmartDetectObjectType, VideoMode
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.switch import (
@@ -25,6 +25,11 @@ from .conftest import (
     enable_entity,
     ids_from_device_description,
 )
+
+CAMERA_SWITCHES_NO_FACE = [d for d in CAMERA_SWITCHES if d.name != "Detections: Face"]
+CAMERA_SWITCHES_NO_EXTRA = [
+    d for d in CAMERA_SWITCHES_NO_FACE if d.name not in ("High FPS", "Privacy Mode")
+]
 
 
 @pytest.fixture(name="light")
@@ -79,6 +84,10 @@ async def camera_fixture(
     camera_obj.feature_flags.has_privacy_mask = True
     camera_obj.feature_flags.has_speaker = True
     camera_obj.feature_flags.has_smart_detect = True
+    camera_obj.feature_flags.smart_detect_types = [
+        SmartDetectObjectType.PERSON,
+        SmartDetectObjectType.VEHICLE,
+    ]
     camera_obj.is_ssh_enabled = False
     camera_obj.led_settings.is_enabled = False
     camera_obj.hdr_mode = False
@@ -244,7 +253,7 @@ async def test_switch_setup_camera_all(
 
     entity_registry = er.async_get(hass)
 
-    for description in CAMERA_SWITCHES:
+    for description in CAMERA_SWITCHES_NO_FACE:
         unique_id, entity_id = ids_from_device_description(
             Platform.SWITCH, camera, description
         )
@@ -375,14 +384,11 @@ async def test_switch_camera_ssh(
     camera.set_ssh.assert_called_with(False)
 
 
-@pytest.mark.parametrize("description", CAMERA_SWITCHES)
+@pytest.mark.parametrize("description", CAMERA_SWITCHES_NO_EXTRA)
 async def test_switch_camera_simple(
     hass: HomeAssistant, camera: Camera, description: ProtectSwitchEntityDescription
 ):
     """Tests all simple switches for cameras."""
-
-    if description.name in ("High FPS", "Privacy Mode"):
-        return
 
     assert description.ufp_set_method is not None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes for latest UniFi Protect beta (2.0.0-beta2). 2.0.0 added a new Smart Detection type for AI series cameras only (AI Bullet / AI 360). So, there is also a bit of refactor to verify each camera can detect the specific smart detection type since G4 cameras can only do Person and Vehicle and the AI series cameras can do Person, Vehicle and Face.

There are two more additional smart detection types, Pet and License Plate, but they are not yet exposed in the UI of UniFi Protect so I am not exposing them in Home Assistant.

* Updates `pyunifiprotect` to 3.3.0 (Changelog: https://github.com/briis/pyunifiprotect/releases/tag/v3.3.0)
* Use new properties to check if a camera can detect Person / Vehicle smart detections
* Adds new switch for Face smart detection toggle

**NOTE**: It would be great to include this in the 2022.4.2 release if possible as the integration will not load without these changes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
