### PR TITLE
Handle expired credentials in reauth in google calendar initialization

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any
 
+import aiohttp
 from httplib2.error import ServerNotFoundError
 from oauth2client.file import Storage
 import voluptuous as vol
@@ -24,7 +25,11 @@ from homeassistant.const import (
     CONF_OFFSET,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers import config_entry_oauth2_flow
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -191,7 +196,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if session.token["expires_at"] >= datetime(2070, 1, 1).timestamp():
         session.token["expires_in"] = 0
         session.token["expires_at"] = datetime.now().timestamp()
+    try:
         await session.async_ensure_token_valid()
+    except aiohttp.client_exceptions.ClientResponseError as err:
+        if 400 <= err.status < 500:
+            raise ConfigEntryAuthFailed from err
+        raise ConfigEntryNotReady from err
+    except aiohttp.client_exceptions.ClientError as err:
+        raise ConfigEntryNotReady from err
 
     required_scope = hass.data[DOMAIN][DATA_CONFIG][CONF_CALENDAR_ACCESS].scope
     if required_scope not in session.token.get("scope", []):

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -202,7 +202,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if 400 <= err.status < 500:
             raise ConfigEntryAuthFailed from err
         raise ConfigEntryNotReady from err
-    except aiohttp.client_exceptions.ClientError as err:
+    except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err
 
     required_scope = hass.data[DOMAIN][DATA_CONFIG][CONF_CALENDAR_ACCESS].scope

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -198,7 +198,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         session.token["expires_at"] = datetime.now().timestamp()
     try:
         await session.async_ensure_token_valid()
-    except aiohttp.client_exceptions.ClientResponseError as err:
+    except aiohttp.ClientResponseError as err:
         if 400 <= err.status < 500:
             raise ConfigEntryAuthFailed from err
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -34,7 +34,7 @@ class OAuth2FlowHandler(
         return logging.getLogger(__name__)
 
     async def async_step_import(self, info: dict[str, Any]) -> FlowResult:
-        """Import existing auth from Nest."""
+        """Import existing auth into a new config entry."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
         implementations = await config_entry_oauth2_flow.async_get_implementations(

--- a/homeassistant/components/google/strings.json
+++ b/homeassistant/components/google/strings.json
@@ -6,7 +6,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Nest integration needs to re-authenticate your account"
+        "description": "The Google Calendar integration needs to re-authenticate your account"
       },
       "auth": {
         "title": "Link Google Account"

--- a/homeassistant/components/google/translations/en.json
+++ b/homeassistant/components/google/translations/en.json
@@ -3,7 +3,7 @@
         "abort": {
             "already_configured": "Account is already configured",
             "already_in_progress": "Configuration flow is already in progress",
-            "code_expired": "Authentication code expired, please try again.",
+            "code_expired": "Authentication code expired or credential setup is invalid, please try again.",
             "invalid_access_token": "Invalid access token",
             "missing_configuration": "The component is not configured. Please follow the documentation.",
             "oauth_error": "Received invalid token data.",
@@ -23,7 +23,7 @@
                 "title": "Pick Authentication Method"
             },
             "reauth_confirm": {
-                "description": "The Nest integration needs to re-authenticate your account",
+                "description": "The Google Calendar integration needs to re-authenticate your account",
                 "title": "Reauthenticate Integration"
             }
         }

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import datetime
+import http
 import time
 from typing import Any
 from unittest.mock import Mock, call, patch
@@ -31,6 +32,10 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
+
+EXPIRED_TOKEN_TIMESTAMP = (
+    datetime.datetime.now() + datetime.timedelta(minutes=-5)
+).timestamp()
 
 # Typing helpers
 HassApi = Callable[[], Awaitable[dict[str, Any]]]
@@ -507,3 +512,52 @@ async def test_invalid_token_expiry_in_config_entry(
     assert entries[0].state is ConfigEntryState.LOADED
     assert entries[0].data["token"]["access_token"] == "some-updated-token"
     assert entries[0].data["token"]["expires_in"] == expires_in
+
+
+@pytest.mark.parametrize("config_entry_token_expiry", [EXPIRED_TOKEN_TIMESTAMP])
+async def test_expired_token_refresh_internal_error(
+    hass: HomeAssistant,
+    component_setup: ComponentSetup,
+    setup_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Generic errors on reauth are treated as a retryable setup error."""
+
+    aioclient_mock.post(
+        "https://oauth2.googleapis.com/token",
+        status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
+
+    assert await component_setup()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    "config_entry_token_expiry",
+    [EXPIRED_TOKEN_TIMESTAMP],
+)
+async def test_expired_token_requires_reauth(
+    hass: HomeAssistant,
+    component_setup: ComponentSetup,
+    setup_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test case where reauth is required for token that cannot be refreshed."""
+
+    aioclient_mock.post(
+        "https://oauth2.googleapis.com/token",
+        status=http.HTTPStatus.BAD_REQUEST,
+    )
+
+    assert await component_setup()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -33,9 +33,7 @@ from .conftest import (
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
-EXPIRED_TOKEN_TIMESTAMP = (
-    datetime.datetime.now() + datetime.timedelta(minutes=-5)
-).timestamp()
+EXPIRED_TOKEN_TIMESTAMP = datetime.datetime(2022, 4, 8).timestamp()
 
 # Typing helpers
 HassApi = Callable[[], Awaitable[dict[str, Any]]]


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update google calendar init to handle expired credentials and trigger the reauth flow to refresh credentials. Also includes some text fixes that were copy/pasted from nest integration, including message shown during reauth.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #69623
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
