### PR TITLE
bmw_connected_drive: Fix unit conversion if value is None

### DIFF
--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -46,6 +46,17 @@ class BMWSensorEntityDescription(SensorEntityDescription):
     value: Callable = lambda x, y: x
 
 
+def convert_and_round(
+    state: tuple,
+    converter: Callable[[float | None, str], float],
+    precision: int,
+) -> float | None:
+    """Safely convert and round a value from a Tuple[value, unit]."""
+    if state[0] is None:
+        return None
+    return round(converter(state[0], UNIT_MAP.get(state[1], state[1])), precision)
+
+
 SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     # --- Generic ---
     "charging_start_time": BMWSensorEntityDescription(
@@ -78,45 +89,35 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
         icon="mdi:speedometer",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
-        value=lambda x, hass: round(
-            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1])), 2
-        ),
+        value=lambda x, hass: convert_and_round(x, hass.config.units.length, 2),
     ),
     "remaining_range_total": BMWSensorEntityDescription(
         key="remaining_range_total",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
-        value=lambda x, hass: round(
-            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1])), 2
-        ),
+        value=lambda x, hass: convert_and_round(x, hass.config.units.length, 2),
     ),
     "remaining_range_electric": BMWSensorEntityDescription(
         key="remaining_range_electric",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
-        value=lambda x, hass: round(
-            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1])), 2
-        ),
+        value=lambda x, hass: convert_and_round(x, hass.config.units.length, 2),
     ),
     "remaining_range_fuel": BMWSensorEntityDescription(
         key="remaining_range_fuel",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
-        value=lambda x, hass: round(
-            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1])), 2
-        ),
+        value=lambda x, hass: convert_and_round(x, hass.config.units.length, 2),
     ),
     "remaining_fuel": BMWSensorEntityDescription(
         key="remaining_fuel",
         icon="mdi:gas-station",
         unit_metric=VOLUME_LITERS,
         unit_imperial=VOLUME_GALLONS,
-        value=lambda x, hass: round(
-            hass.config.units.volume(x[0], UNIT_MAP.get(x[1], x[1])), 2
-        ),
+        value=lambda x, hass: convert_and_round(x, hass.config.units.volume, 2),
     ),
     "fuel_percent": BMWSensorEntityDescription(
         key="fuel_percent",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes unit conversion of sensor values if they are unavailable in the upstream API (i.e. they are `None`).

Original traceback:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/richard/home-assistant-core/homeassistant/util/unit_system.py", line 134, in length
    raise TypeError(f"{length!s} is not a numeric value.")
TypeError: None is not a numeric value.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
