### PR TITLE
Provide NINA warnings also in one sensor

### DIFF
--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import NINADataUpdateCoordinator
 from .const import (
-    ATTR_ATTRIBUTION,
     ATTR_DESCRIPTION,
     ATTR_EXPIRES,
     ATTR_HEADLINE,
@@ -126,6 +125,7 @@ class NINASingleRegion(
         self._region: str = region
         self._attr_name: str = f"All warnings: {region_name}"
         self._attr_unique_id: str = f"{region}-warnings"
+        self._attr_attribution: str = ATTRIBUTION
         self._attr_device_class: str = BinarySensorDeviceClass.SAFETY
 
     @property
@@ -138,7 +138,7 @@ class NINASingleRegion(
         """Return extra attributes of the sensor."""
         warnings = self.coordinator.data[self._region]
 
-        data = {ATTR_ATTRIBUTION: ATTRIBUTION, ATTR_WARNING_COUNT: len(warnings)}
+        data = {ATTR_WARNING_COUNT: len(warnings)}
 
         for i, warning in enumerate(warnings, 1):
             data[f"warning_{i}_headline"] = warning[ATTR_HEADLINE]

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -124,8 +124,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None and not errors:
             user_input[CONF_REGIONS] = []
-            # user_input[CONF_SINGLE_SENSOR] = DEFAULT_SINGLE_SENSOR
-            # user_input[CONF_MULTIPLE_SENSOR] = DEFAULT_MULTIPLE_SENSOR
 
             for group in CONST_REGIONS:
                 if group_input := user_input.get(group):

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -19,6 +19,9 @@ CONF_SINGLE_SENSOR: str = "single_sensor"
 
 ATTRIBUTION: str = "Data provided by NINA"
 
+DEFAULT_SINGLE_SENSOR = False
+DEFAULT_MULTIPLE_SENSOR = True
+
 ATTR_WARNING_COUNT = "warning_count"
 ATTR_HEADLINE: str = "headline"
 ATTR_DESCRIPTION: str = "description"

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -14,7 +14,13 @@ DOMAIN: str = "nina"
 CONF_REGIONS: str = "regions"
 CONF_MESSAGE_SLOTS: str = "slots"
 CONF_FILTER_CORONA: str = "corona_filter"
+CONF_MULTIPLE_SENSOR: str = "multiple_sensor"
+CONF_SINGLE_SENSOR: str = "single_sensor"
 
+ATTRIBUTION: str = "Data provided by NINA"
+
+ATTR_WARNING_COUNT = "warning_count"
+ATTR_ATTRIBUTION: str = "attribution"
 ATTR_HEADLINE: str = "headline"
 ATTR_DESCRIPTION: str = "description"
 ATTR_SENDER: str = "sender"

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -20,7 +20,6 @@ CONF_SINGLE_SENSOR: str = "single_sensor"
 ATTRIBUTION: str = "Data provided by NINA"
 
 ATTR_WARNING_COUNT = "warning_count"
-ATTR_ATTRIBUTION: str = "attribution"
 ATTR_HEADLINE: str = "headline"
 ATTR_DESCRIPTION: str = "description"
 ATTR_SENDER: str = "sender"

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -11,7 +11,9 @@
           "_r_to_u": "City/county (R-U)",
           "_v_to_z": "City/county (V-Z)",
           "slots": "Maximum warnings per city/county",
-          "corona_filter": "Remove Corona Warnings"
+          "corona_filter": "Remove Corona Warnings",
+          "single_sensor": "Single sensor",
+          "multiple_sensor": "Multiple sensors"
         }
       }
     },
@@ -19,6 +21,7 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "error": {
+      "no_type": "Please select at least one sensor type",
       "no_selection": "Please select at least one city/county",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -11,9 +11,7 @@
           "_r_to_u": "City/county (R-U)",
           "_v_to_z": "City/county (V-Z)",
           "slots": "Maximum warnings per city/county",
-          "corona_filter": "Remove Corona Warnings",
-          "single_sensor": "Single sensor",
-          "multiple_sensor": "Multiple sensors"
+          "corona_filter": "Remove Corona Warnings"
         }
       }
     },
@@ -21,7 +19,6 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "error": {
-      "no_type": "Please select at least one sensor type",
       "no_selection": "Please select at least one city/county",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
@@ -39,11 +36,14 @@
           "_r_to_u": "City/county (R-U)",
           "_v_to_z": "City/county (V-Z)",
           "slots": "Maximum warnings per city/county",
-          "corona_filter": "Remove Corona Warnings"
+          "corona_filter": "Remove Corona Warnings",
+          "single_sensor": "Single sensor",
+          "multiple_sensor": "Multiple sensors"
         }
       }
     },
     "error": {
+      "no_type": "Please select at least one sensor type",
       "no_selection": "Please select at least one city/county",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/homeassistant/components/nina/translations/en.json
+++ b/homeassistant/components/nina/translations/en.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "no_selection": "Please select at least one city/county",
+            "no_type": "Please select at least one sensor type",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -18,6 +19,8 @@
                     "_r_to_u": "City/county (R-U)",
                     "_v_to_z": "City/county (V-Z)",
                     "corona_filter": "Remove Corona Warnings",
+                    "multiple_sensor": "Multiple sensors",
+                    "single_sensor": "Single sensor",
                     "slots": "Maximum warnings per city/county"
                 },
                 "title": "Select city/county"

--- a/homeassistant/components/nina/translations/en.json
+++ b/homeassistant/components/nina/translations/en.json
@@ -6,7 +6,6 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "no_selection": "Please select at least one city/county",
-            "no_type": "Please select at least one sensor type",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -19,8 +18,6 @@
                     "_r_to_u": "City/county (R-U)",
                     "_v_to_z": "City/county (V-Z)",
                     "corona_filter": "Remove Corona Warnings",
-                    "multiple_sensor": "Multiple sensors",
-                    "single_sensor": "Single sensor",
                     "slots": "Maximum warnings per city/county"
                 },
                 "title": "Select city/county"
@@ -31,6 +28,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "no_selection": "Please select at least one city/county",
+            "no_type": "Please select at least one sensor type",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -43,6 +41,8 @@
                     "_r_to_u": "City/county (R-U)",
                     "_v_to_z": "City/county (V-Z)",
                     "corona_filter": "Remove Corona Warnings",
+                    "multiple_sensor": "Multiple sensors",
+                    "single_sensor": "Single sensor",
                     "slots": "Maximum warnings per city/county"
                 },
                 "title": "Options"

--- a/tests/components/nina/test_binary_sensor.py
+++ b/tests/components/nina/test_binary_sensor.py
@@ -29,12 +29,16 @@ ENTRY_DATA: dict[str, Any] = {
     "slots": 5,
     "corona_filter": True,
     "regions": {"083350000000": "Aach, Stadt"},
+    "single_sensor": True,
+    "multiple_sensor": True,
 }
 
 ENTRY_DATA_NO_CORONA: dict[str, Any] = {
     "slots": 5,
     "corona_filter": False,
     "regions": {"083350000000": "Aach, Stadt"},
+    "single_sensor": True,
+    "multiple_sensor": True,
 }
 
 
@@ -140,6 +144,50 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
         assert entry_w5.unique_id == "083350000000-5"
         assert state_w5.attributes.get("device_class") == BinarySensorDeviceClass.SAFETY
+
+        state_single_warning = hass.states.get("binary_sensor.all_warnings_aach_stadt")
+        entry_single_warning = entity_registry.async_get(
+            "binary_sensor.all_warnings_aach_stadt"
+        )
+
+        assert state_single_warning.state == STATE_ON
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_HEADLINE}")
+            == "Ausfall Notruf 112"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_DESCRIPTION}")
+            == "Es treten Sturmböen mit Geschwindigkeiten zwischen 70 km/h (20m/s, 38kn, Bft 8) und 85 km/h (24m/s, 47kn, Bft 9) aus westlicher Richtung auf. In Schauernähe sowie in exponierten Lagen muss mit schweren Sturmböen bis 90 km/h (25m/s, 48kn, Bft 10) gerechnet werden."
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_SENDER}")
+            == "Deutscher Wetterdienst"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_SEVERITY}") == "Minor"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_ID}")
+            == "mow.DE-NW-BN-SE030-20201014-30-000"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_SENT}")
+            == "2021-10-11T05:20:00+01:00"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_START}")
+            == "2021-11-01T05:20:00+01:00"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_EXPIRES}")
+            == "3021-11-22T05:19:00+01:00"
+        )
+
+        assert entry_single_warning.unique_id == "083350000000-warnings"
+        assert (
+            state_single_warning.attributes.get("device_class")
+            == BinarySensorDeviceClass.SAFETY
+        )
 
 
 async def test_sensors_without_corona_filter(hass: HomeAssistant) -> None:
@@ -250,3 +298,72 @@ async def test_sensors_without_corona_filter(hass: HomeAssistant) -> None:
 
         assert entry_w5.unique_id == "083350000000-5"
         assert state_w5.attributes.get("device_class") == BinarySensorDeviceClass.SAFETY
+
+        state_single_warning = hass.states.get("binary_sensor.all_warnings_aach_stadt")
+        entry_single_warning = entity_registry.async_get(
+            "binary_sensor.all_warnings_aach_stadt"
+        )
+
+        assert state_single_warning.state == STATE_ON
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_HEADLINE}")
+            == "Corona-Verordnung des Landes: Warnstufe durch Landesgesundheitsamt ausgerufen"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_DESCRIPTION}")
+            == "Die Zahl der mit dem Corona-Virus infizierten Menschen steigt gegenwärtig stark an. Es wächst daher die Gefahr einer weiteren Verbreitung der Infektion und - je nach Einzelfall - auch von schweren Erkrankungen."
+        )
+        assert state_single_warning.attributes.get(f"warning_1_{ATTR_SENDER}") == ""
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_SEVERITY}") == "Minor"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_ID}")
+            == "mow.DE-BW-S-SE018-20211102-18-001"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_1_{ATTR_SENT}")
+            == "2021-11-02T20:07:16+01:00"
+        )
+
+        assert state_single_warning.attributes.get(f"warning_1_{ATTR_START}") == ""
+
+        assert state_single_warning.attributes.get(f"warning_1_{ATTR_EXPIRES}") == ""
+
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_HEADLINE}")
+            == "Ausfall Notruf 112"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_DESCRIPTION}")
+            == "Es treten Sturmböen mit Geschwindigkeiten zwischen 70 km/h (20m/s, 38kn, Bft 8) und 85 km/h (24m/s, 47kn, Bft 9) aus westlicher Richtung auf. In Schauernähe sowie in exponierten Lagen muss mit schweren Sturmböen bis 90 km/h (25m/s, 48kn, Bft 10) gerechnet werden."
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_SENDER}")
+            == "Deutscher Wetterdienst"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_SEVERITY}") == "Minor"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_ID}")
+            == "mow.DE-NW-BN-SE030-20201014-30-000"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_SENT}")
+            == "2021-10-11T05:20:00+01:00"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_START}")
+            == "2021-11-01T05:20:00+01:00"
+        )
+        assert (
+            state_single_warning.attributes.get(f"warning_2_{ATTR_EXPIRES}")
+            == "3021-11-22T05:19:00+01:00"
+        )
+
+        assert entry_single_warning.unique_id == "083350000000-warnings"
+        assert (
+            state_single_warning.attributes.get("device_class")
+            == BinarySensorDeviceClass.SAFETY
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR allows users to access the warnings also via a single sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/22362

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
