### PR TITLE
Add unit of measurement to `Filesize` integration

### DIFF
--- a/homeassistant/components/filesize/__init__.py
+++ b/homeassistant/components/filesize/__init__.py
@@ -1,7 +1,6 @@
 """The filesize component."""
 from __future__ import annotations
 
-import logging
 import pathlib
 
 from homeassistant.config_entries import ConfigEntry
@@ -11,8 +10,6 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import PLATFORMS
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
@@ -21,10 +18,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     get_path = await hass.async_add_executor_job(pathlib.Path, path)
 
     if not get_path.exists() and not get_path.is_file():
-        raise ConfigEntryNotReady(f"Can not access file {path}")
+        raise ConfigEntryNotReady(f"Cannot access file {path}")
 
     if not hass.config.is_allowed_path(path):
-        raise ConfigEntryNotReady(f"Filepath {path} is not valid or allowed")
+        raise ConfigEntryNotReady(f"File path {path} is not valid or allowed")
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True

--- a/homeassistant/components/filesize/config_flow.py
+++ b/homeassistant/components/filesize/config_flow.py
@@ -8,13 +8,60 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_FILE_PATH
+from homeassistant.const import (
+    CONF_FILE_PATH,
+    CONF_UNIT_OF_MEASUREMENT,
+    DATA_BYTES,
+    DATA_EXABYTES,
+    DATA_EXBIBYTES,
+    DATA_GIBIBYTES,
+    DATA_GIGABYTES,
+    DATA_KIBIBYTES,
+    DATA_KILOBYTES,
+    DATA_MEBIBYTES,
+    DATA_MEGABYTES,
+    DATA_PEBIBYTES,
+    DATA_PETABYTES,
+    DATA_TEBIBYTES,
+    DATA_TERABYTES,
+    DATA_YOBIBYTES,
+    DATA_YOTTABYTES,
+    DATA_ZEBIBYTES,
+    DATA_ZETTABYTES,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
-DATA_SCHEMA = vol.Schema({vol.Required(CONF_FILE_PATH): str})
+UNIT_OF_MEASUREMENTS = {
+    DATA_BYTES,
+    DATA_KILOBYTES,
+    DATA_MEGABYTES,
+    DATA_GIGABYTES,
+    DATA_TERABYTES,
+    DATA_PETABYTES,
+    DATA_EXABYTES,
+    DATA_ZETTABYTES,
+    DATA_YOTTABYTES,
+    DATA_KIBIBYTES,
+    DATA_MEBIBYTES,
+    DATA_GIBIBYTES,
+    DATA_TEBIBYTES,
+    DATA_PEBIBYTES,
+    DATA_EXBIBYTES,
+    DATA_ZEBIBYTES,
+    DATA_YOBIBYTES,
+}
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_FILE_PATH): str,
+        vol.Required(CONF_UNIT_OF_MEASUREMENT, default=DATA_MEGABYTES): vol.In(
+            UNIT_OF_MEASUREMENTS
+        ),
+    }
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,11 +71,11 @@ def validate_path(hass: HomeAssistant, path: str) -> pathlib.Path:
     try:
         get_path = pathlib.Path(path)
     except OSError as error:
-        _LOGGER.error("Can not access file %s, error %s", path, error)
+        _LOGGER.error("Cannot access file %s, error %s", path, error)
         raise NotValidError from error
 
     if not hass.config.is_allowed_path(path):
-        _LOGGER.error("Filepath %s is not valid or allowed", path)
+        _LOGGER.error("File path %s is not valid or allowed", path)
         raise NotAllowedError
 
     return get_path
@@ -54,13 +101,17 @@ class FilesizeConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "not_allowed"
             else:
                 fullpath = str(get_path.absolute())
-                await self.async_set_unique_id(fullpath)
+                unique_id = f"{fullpath}_{user_input[CONF_UNIT_OF_MEASUREMENT]}"
+                await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
 
                 name = str(user_input[CONF_FILE_PATH]).rsplit("/", maxsplit=1)[-1]
                 return self.async_create_entry(
-                    title=name,
-                    data={CONF_FILE_PATH: user_input[CONF_FILE_PATH]},
+                    title=f"{name} ({user_input[CONF_UNIT_OF_MEASUREMENT]})",
+                    data={
+                        CONF_FILE_PATH: user_input[CONF_FILE_PATH],
+                        CONF_UNIT_OF_MEASUREMENT: user_input[CONF_UNIT_OF_MEASUREMENT],
+                    },
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -107,7 +107,7 @@ async def async_setup_entry(
     """Set up the platform from config entry."""
 
     path = entry.data[CONF_FILE_PATH]
-    unit_of_measurement = entry.data[CONF_UNIT_OF_MEASUREMENT]
+    unit_of_measurement = entry.data.get(CONF_UNIT_OF_MEASUREMENT, DATA_MEGABYTES)
     get_path = await hass.async_add_executor_job(pathlib.Path, path)
     fullpath = str(get_path.absolute())
 
@@ -187,7 +187,7 @@ class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
         base_name = f"{base_name} ({unit_of_measurement})"
         self._attr_name = f"{base_name} {description.name}"
         self._attr_unique_id = (
-            entry_id
+            f"{entry_id}-{unit_of_measurement}"
             if description.key == "file"
             else f"{entry_id}-{unit_of_measurement}-{description.key}"
         )

--- a/homeassistant/components/filesize/strings.json
+++ b/homeassistant/components/filesize/strings.json
@@ -3,7 +3,8 @@
     "step": {
       "user": {
         "data": {
-          "file_path": "Path to file"
+          "file_path": "Path to file",
+          "unit_of_measurement": "Unit"
         }
       }
     },

--- a/homeassistant/components/filesize/translations/en.json
+++ b/homeassistant/components/filesize/translations/en.json
@@ -3,7 +3,8 @@
       "step": {
         "user": {
           "data": {
-            "file_path": "Path to file"
+            "file_path": "Path to file",
+            "unit_of_measurement": "Unit"
           }
         }
       },
@@ -12,7 +13,7 @@
         "not_allowed": "Path is not allowed"
       },
       "abort": {
-        "already_configured": "Filepath is already configured"
+        "already_configured": "File path is already configured"
       }
     },
     "title": "Filesize"

--- a/homeassistant/components/pushbullet/notify.py
+++ b/homeassistant/components/pushbullet/notify.py
@@ -148,12 +148,12 @@ class PushBulletNotificationService(BaseNotificationService):
                 pusher.push_link(title, url, body=message, **email_kwargs)
             elif filepath:
                 if not self.hass.config.is_allowed_path(filepath):
-                    _LOGGER.error("Filepath is not valid or allowed")
+                    _LOGGER.error("File path is not valid or allowed")
                     return
                 with open(filepath, "rb") as fileh:
                     filedata = self.pushbullet.upload_file(fileh, filepath)
                     if filedata.get("file_type") == "application/x-empty":
-                        _LOGGER.error("Can not send an empty file")
+                        _LOGGER.error("Cannot send an empty file")
                         return
                     filedata.update(email_kwargs)
                     pusher.push_file(title=title, body=message, **filedata)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -734,6 +734,7 @@ SPEED: Final = "speed"
 WIND_SPEED: Final = "wind_speed"
 ILLUMINANCE: Final = "illuminance"
 ACCUMULATED_PRECIPITATION: Final = "accumulated_precipitation"
+DATA_SIZE: Final = "data_size"
 
 WEEKDAYS: Final[list[str]] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 

--- a/homeassistant/util/data_size.py
+++ b/homeassistant/util/data_size.py
@@ -1,0 +1,89 @@
+"""Data size util functions."""
+import numbers
+
+from homeassistant.const import (
+    DATA_BYTES,
+    DATA_EXABYTES,
+    DATA_EXBIBYTES,
+    DATA_GIBIBYTES,
+    DATA_GIGABYTES,
+    DATA_KIBIBYTES,
+    DATA_KILOBYTES,
+    DATA_MEBIBYTES,
+    DATA_MEGABYTES,
+    DATA_PEBIBYTES,
+    DATA_PETABYTES,
+    DATA_SIZE,
+    DATA_TEBIBYTES,
+    DATA_TERABYTES,
+    DATA_YOBIBYTES,
+    DATA_YOTTABYTES,
+    DATA_ZEBIBYTES,
+    DATA_ZETTABYTES,
+    UNIT_NOT_RECOGNIZED_TEMPLATE,
+)
+
+VALID_UNITS_SI = [
+    DATA_BYTES,
+    DATA_KILOBYTES,
+    DATA_MEGABYTES,
+    DATA_GIGABYTES,
+    DATA_TERABYTES,
+    DATA_PETABYTES,
+    DATA_EXABYTES,
+    DATA_ZETTABYTES,
+    DATA_YOTTABYTES,
+]
+
+VALID_UNITS_IEC = [
+    DATA_BYTES,
+    DATA_KIBIBYTES,
+    DATA_MEBIBYTES,
+    DATA_GIBIBYTES,
+    DATA_TEBIBYTES,
+    DATA_PEBIBYTES,
+    DATA_EXBIBYTES,
+    DATA_ZEBIBYTES,
+    DATA_YOBIBYTES,
+]
+
+
+def convert(value: float, unit_input: str, unit_output: str) -> float:
+    """Convert one unit of measurement to another."""
+
+    # Check if provided units are valid in this context
+    if unit_input not in VALID_UNITS_SI and unit_input not in VALID_UNITS_IEC:
+        raise ValueError(UNIT_NOT_RECOGNIZED_TEMPLATE.format(unit_input, DATA_SIZE))
+    if unit_output not in VALID_UNITS_SI and unit_output not in VALID_UNITS_IEC:
+        raise ValueError(UNIT_NOT_RECOGNIZED_TEMPLATE.format(unit_output, DATA_SIZE))
+
+    if not isinstance(value, numbers.Number):
+        raise TypeError(f"{value} is not of numeric type")
+
+    if unit_input == unit_output:
+        return value
+
+    result = value
+
+    # First convert the input down until we are at bytes
+    if unit_input in VALID_UNITS_SI:
+        index = VALID_UNITS_SI.index(unit_input)
+        factor = pow(1000, index)
+    else:
+        index = VALID_UNITS_IEC.index(unit_input)
+        factor = pow(1024, index)
+
+    result *= factor
+
+    # Now convert the bytes up to the target unit, unless target is bytes
+    if unit_output != DATA_BYTES:
+        if unit_output in VALID_UNITS_SI:
+            index = VALID_UNITS_SI.index(unit_output)
+            factor = pow(1000, index)
+        else:
+            index = VALID_UNITS_IEC.index(unit_output)
+            factor = pow(1024, index)
+
+        result /= factor
+
+    return result

--- a/tests/util/test_data_size.py
+++ b/tests/util/test_data_size.py
@@ -1,0 +1,74 @@
+"""Test Home Assistant data_size utility functions."""
+
+import pytest
+
+from homeassistant.const import (
+    DATA_BYTES,
+    DATA_GIBIBYTES,
+    DATA_GIGABYTES,
+    DATA_KIBIBYTES,
+    DATA_KILOBYTES,
+    DATA_MEBIBYTES,
+    DATA_MEGABYTES,
+    DATA_TEBIBYTES,
+    DATA_TERABYTES,
+)
+import homeassistant.util.data_size as data_size_util
+
+INVALID_SYMBOL = "bob"
+VALID_SYMBOL = DATA_BYTES
+
+
+def test_convert_same_unit():
+    """Test conversion from any unit to same unit."""
+    assert data_size_util.convert(1, DATA_KILOBYTES, DATA_KILOBYTES) == 1
+    assert data_size_util.convert(1.5, DATA_KILOBYTES, DATA_KILOBYTES) == 1.5
+    assert data_size_util.convert(1.2345, DATA_KILOBYTES, DATA_KILOBYTES) == 1.2345
+
+
+def test_convert_invalid_unit():
+    """Test exception is thrown for invalid units."""
+    with pytest.raises(ValueError):
+        data_size_util.convert(5, INVALID_SYMBOL, VALID_SYMBOL)
+
+    with pytest.raises(ValueError):
+        data_size_util.convert(5, VALID_SYMBOL, INVALID_SYMBOL)
+
+
+def test_convert_nonnumeric_value():
+    """Test exception is thrown for non-numeric type."""
+    with pytest.raises(TypeError):
+        data_size_util.convert("a", DATA_MEGABYTES, DATA_KILOBYTES)
+
+
+def test_convert_si():
+    """Test conversion within SI units."""
+    assert data_size_util.convert(1, DATA_KILOBYTES, DATA_BYTES) == 1000
+    assert data_size_util.convert(1000, DATA_BYTES, DATA_KILOBYTES) == 1
+    assert data_size_util.convert(1024, DATA_BYTES, DATA_KILOBYTES) == 1.024
+    assert data_size_util.convert(1000, DATA_MEGABYTES, DATA_GIGABYTES) == 1
+    assert data_size_util.convert(1, DATA_GIGABYTES, DATA_KILOBYTES) == 1000000
+
+
+def test_convert_iec():
+    """Test conversion within IEC units."""
+    assert data_size_util.convert(1, DATA_KIBIBYTES, DATA_BYTES) == 1024
+    assert data_size_util.convert(1024, DATA_BYTES, DATA_KIBIBYTES) == 1
+    assert data_size_util.convert(1000, DATA_BYTES, DATA_KIBIBYTES) == 0.9765625
+    assert data_size_util.convert(1024, DATA_MEBIBYTES, DATA_GIBIBYTES) == 1
+    assert data_size_util.convert(1, DATA_GIBIBYTES, DATA_MEBIBYTES) == 1024
+    assert data_size_util.convert(1, DATA_GIBIBYTES, DATA_KIBIBYTES) == 1048576
+
+
+def test_convert_si_iec():
+    """Test conversion from SI to IEC units and vice versa."""
+    assert data_size_util.convert(1, DATA_KILOBYTES, DATA_KIBIBYTES) == 0.9765625
+    assert data_size_util.convert(1, DATA_KIBIBYTES, DATA_KILOBYTES) == 1.024
+    assert data_size_util.convert(0.9765625, DATA_KIBIBYTES, DATA_KILOBYTES) == 1
+    assert data_size_util.convert(1.024, DATA_KILOBYTES, DATA_KIBIBYTES) == 1
+    assert (
+        data_size_util.convert(0.9765625, DATA_KILOBYTES, DATA_KIBIBYTES)
+        == 0.95367431640625
+    )
+    assert data_size_util.convert(1, DATA_TERABYTES, DATA_KIBIBYTES) == 976562500
+    assert data_size_util.convert(1, DATA_TEBIBYTES, DATA_GIGABYTES) == 1099.511627776


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change

Successor of my abandoned https://github.com/home-assistant/core/pull/36755 (now that someone else already implemented a config flow for the integration).

This PR adds an optional parameter to define the unit of measurement for the file size. By default "MB" is used which so far was the enforced only option in the past. A file can be added multiple times to the integration for different unit of measurements (each ending up as their own device/service). To ensure uniqueness the chosen unit is now part of the unique/entity ID.

**Open issues:**
- [ ] The existing integration instance remains (fine) but gets duplicate entities with the new entity IDs containing the unit of measurement (not fine). My initial attempts at migrating those failed so far...


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36712
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
