### PR TITLE
Add outage map alerts to PECO

### DIFF
--- a/homeassistant/components/peco/__init__.py
+++ b/homeassistant/components/peco/__init__.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import timedelta
 from typing import Final
 
-from peco import BadJSONError, HttpError, OutageResults, PecoOutageApi
+from peco import AlertResults, BadJSONError, HttpError, OutageResults, PecoOutageApi
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -18,6 +18,18 @@ from .const import CONF_COUNTY, DOMAIN, LOGGER, SCAN_INTERVAL
 PLATFORMS: Final = [Platform.SENSOR]
 
 
+class PECOCoordinatorData:
+    """Something to hold the data for PECO."""
+
+    outages: OutageResults
+    alerts: AlertResults
+
+    def __init__(self, outages: OutageResults, alerts: AlertResults) -> None:
+        """Initialize the data holder for PECO."""
+        self.outages = outages
+        self.alerts = alerts
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PECO Outage Counter from a config entry."""
 
@@ -25,14 +37,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api = PecoOutageApi()
     county: str = entry.data[CONF_COUNTY]
 
-    async def async_update_data() -> OutageResults:
+    async def async_update_data() -> PECOCoordinatorData:
         """Fetch data from API."""
         try:
-            data: OutageResults = (
+            outages: OutageResults = (
                 await api.get_outage_totals(websession)
                 if county == "TOTAL"
                 else await api.get_outage_count(county, websession)
             )
+            alerts: AlertResults = await api.get_map_alerts(websession)
+            data = PECOCoordinatorData(outages, alerts)
         except HttpError as err:
             raise UpdateFailed(f"Error fetching data: {err}") from err
         except BadJSONError as err:

--- a/homeassistant/components/peco/config_flow.py
+++ b/homeassistant/components/peco/config_flow.py
@@ -37,5 +37,5 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
-            title=f"{county.capitalize()} Smart Meter", data=user_input
+            title=f"{county.capitalize()} Outage Count", data=user_input
         )

--- a/homeassistant/components/peco/config_flow.py
+++ b/homeassistant/components/peco/config_flow.py
@@ -37,5 +37,5 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
-            title=f"{county.capitalize()} Outage Count", data=user_input
+            title=f"{county.capitalize()} Smart Meter", data=user_input
         )

--- a/homeassistant/components/peco/const.py
+++ b/homeassistant/components/peco/const.py
@@ -16,3 +16,4 @@ COUNTY_LIST: Final = [
 CONFIG_FLOW_COUNTIES: Final = [{county: county.capitalize()} for county in COUNTY_LIST]
 SCAN_INTERVAL: Final = 9
 CONF_COUNTY: Final = "county"
+ATTR_CONTENT: Final = "content"

--- a/homeassistant/components/peco/manifest.json
+++ b/homeassistant/components/peco/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/peco",
   "codeowners": ["@IceBotYT"],
   "iot_class": "cloud_polling",
-  "requirements": ["peco==0.0.25"]
+  "requirements": ["peco==0.0.27"]
 }

--- a/homeassistant/components/peco/manifest.json
+++ b/homeassistant/components/peco/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/peco",
   "codeowners": ["@IceBotYT"],
   "iot_class": "cloud_polling",
-  "requirements": ["peco==0.0.27"]
+  "requirements": ["peco==0.0.28"]
 }

--- a/homeassistant/components/peco/manifest.json
+++ b/homeassistant/components/peco/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/peco",
   "codeowners": ["@IceBotYT"],
   "iot_class": "cloud_polling",
-  "requirements": ["peco==0.0.28"]
+  "requirements": ["peco==0.0.29"]
 }

--- a/homeassistant/components/peco/sensor.py
+++ b/homeassistant/components/peco/sensor.py
@@ -5,8 +5,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final
 
-from peco import OutageResults
-
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -21,14 +19,16 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import CONF_COUNTY, DOMAIN
+from . import PECOCoordinatorData
+from .const import ATTR_CONTENT, CONF_COUNTY, DOMAIN
 
 
 @dataclass
 class PECOSensorEntityDescriptionMixin:
     """Mixin for required keys."""
 
-    value_fn: Callable[[OutageResults], int]
+    value_fn: Callable[[PECOCoordinatorData], int | str]
+    attribute_fn: Callable[[PECOCoordinatorData], dict[str, str]]
 
 
 @dataclass
@@ -43,23 +43,33 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
     PECOSensorEntityDescription(
         key="customers_out",
         name="Customers Out",
-        value_fn=lambda data: int(data.customers_out),
+        value_fn=lambda data: int(data.outages.customers_out),
+        attribute_fn=lambda data: {},
     ),
     PECOSensorEntityDescription(
         key="percent_customers_out",
         name="Percent Customers Out",
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda data: int(data.percent_customers_out),
+        value_fn=lambda data: int(data.outages.percent_customers_out),
+        attribute_fn=lambda data: {},
     ),
     PECOSensorEntityDescription(
         key="outage_count",
         name="Outage Count",
-        value_fn=lambda data: int(data.outage_count),
+        value_fn=lambda data: int(data.outages.outage_count),
+        attribute_fn=lambda data: {},
     ),
     PECOSensorEntityDescription(
         key="customers_served",
         name="Customers Served",
-        value_fn=lambda data: int(data.customers_served),
+        value_fn=lambda data: int(data.outages.customers_served),
+        attribute_fn=lambda data: {},
+    ),
+    PECOSensorEntityDescription(
+        key="map_alert",
+        name="Map Alert",
+        value_fn=lambda data: str(data.alerts.alert_title),
+        attribute_fn=lambda data: {ATTR_CONTENT: data.alerts.alert_content},
     ),
 )
 
@@ -80,26 +90,36 @@ async def async_setup_entry(
     return
 
 
-class PecoSensor(CoordinatorEntity[DataUpdateCoordinator[OutageResults]], SensorEntity):
+class PecoSensor(
+    CoordinatorEntity[DataUpdateCoordinator[PECOCoordinatorData]], SensorEntity
+):
     """PECO outage counter sensor."""
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_icon: str = "mdi:power-plug-off"
     entity_description: PECOSensorEntityDescription
 
     def __init__(
         self,
         description: PECOSensorEntityDescription,
         county: str,
-        coordinator: DataUpdateCoordinator[OutageResults],
+        coordinator: DataUpdateCoordinator[PECOCoordinatorData],
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_name = f"{county.capitalize()} {description.name}"
         self._attr_unique_id = f"{county}-{description.key}"
+        self._attr_icon = (
+            "mdi:alert" if description.key == "map_alert" else "mdi:power-plug-off"
+        )
+        if description.key != "map_alert":
+            self._attr_state_class = SensorStateClass.MEASUREMENT
         self.entity_description = description
 
     @property
-    def native_value(self) -> int:
+    def native_value(self) -> int | str:
         """Return the value of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return state attributes for the sensor."""
+        return self.entity_description.attribute_fn(self.coordinator.data)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1184,7 +1184,7 @@ panasonic_viera==0.3.6
 pdunehd==1.3.2
 
 # homeassistant.components.peco
-peco==0.0.28
+peco==0.0.29
 
 # homeassistant.components.pencom
 pencompy==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1184,7 +1184,7 @@ panasonic_viera==0.3.6
 pdunehd==1.3.2
 
 # homeassistant.components.peco
-peco==0.0.25
+peco==0.0.27
 
 # homeassistant.components.pencom
 pencompy==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1184,7 +1184,7 @@ panasonic_viera==0.3.6
 pdunehd==1.3.2
 
 # homeassistant.components.peco
-peco==0.0.27
+peco==0.0.28
 
 # homeassistant.components.pencom
 pencompy==0.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -786,7 +786,7 @@ panasonic_viera==0.3.6
 pdunehd==1.3.2
 
 # homeassistant.components.peco
-peco==0.0.28
+peco==0.0.29
 
 # homeassistant.components.aruba
 # homeassistant.components.cisco_ios

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -786,7 +786,7 @@ panasonic_viera==0.3.6
 pdunehd==1.3.2
 
 # homeassistant.components.peco
-peco==0.0.27
+peco==0.0.28
 
 # homeassistant.components.aruba
 # homeassistant.components.cisco_ios

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -786,7 +786,7 @@ panasonic_viera==0.3.6
 pdunehd==1.3.2
 
 # homeassistant.components.peco
-peco==0.0.25
+peco==0.0.27
 
 # homeassistant.components.aruba
 # homeassistant.components.cisco_ios

--- a/tests/components/peco/test_sensor.py
+++ b/tests/components/peco/test_sensor.py
@@ -1,7 +1,7 @@
 """Test the PECO Outage Counter sensors."""
 from unittest.mock import patch
 
-from peco import OutageResults
+from peco import AlertResults, OutageResults
 import pytest
 
 from homeassistant.components.peco.const import DOMAIN
@@ -42,8 +42,14 @@ async def test_sensor_available(
             customers_served=789,
         ),
     ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        with patch(
+            "peco.PecoOutageApi.get_map_alerts",
+            return_value=AlertResults(
+                alert_content="Testing 1234", alert_title="Testing 4321"
+            ),
+        ):
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
     assert hass.data[DOMAIN]
 
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -69,8 +75,14 @@ async def test_sensor_available(
             customers_served=789,
         ),
     ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        with patch(
+            "peco.PecoOutageApi.get_map_alerts",
+            return_value=AlertResults(
+                alert_content="Testing 1234", alert_title="Testing 4321"
+            ),
+        ):
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new feature that allows users to view the alert that appears when you open the outage map.
Here is the GitHub diff for the versions [https://github.com/IceBotYT/peco-outage-api/compare/`9493b0c...fa53b97`](https://github.com/IceBotYT/peco-outage-api/compare/9493b0c...fa53b97)
For example, this is what appears when you open the [outage map](https://www.peco.com/Outages/CheckOutageStatus/Pages/OutageMap.aspx):
![Picture showing outage map alert](https://ipradio.app/cdn/86e83.png)

And this is what appears in Home Assistant:
![Picture showing outage map alert inside of Home Assistant](https://ipradio.app/cdn/1221c.png)

The `native_value` is the title and the attribute `content` is the content of the alert.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22331

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
