### PR TITLE
Add `diagnostics` platform for Airly integration

### DIFF
--- a/homeassistant/components/airly/diagnostics.py
+++ b/homeassistant/components/airly/diagnostics.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_UNIQUE_ID,
+)
 from homeassistant.core import HomeAssistant
 
 from . import AirlyDataUpdateCoordinator
 from .const import DOMAIN
 
-TO_REDACT = {CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE}
+TO_REDACT = {CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_UNIQUE_ID}
 
 
 async def async_get_config_entry_diagnostics(
@@ -19,7 +24,7 @@ async def async_get_config_entry_diagnostics(
     coordinator: AirlyDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     diagnostics_data = {
-        "config_entry_data": async_redact_data(dict(config_entry.as_dict(), TO_REDACT),
+        "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT),
         "coordinator_data": coordinator.data,
     }
 

--- a/homeassistant/components/airly/diagnostics.py
+++ b/homeassistant/components/airly/diagnostics.py
@@ -1,0 +1,26 @@
+"""Diagnostics support for Airly."""
+from __future__ import annotations
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
+
+from . import AirlyDataUpdateCoordinator
+from .const import DOMAIN
+
+TO_REDACT = {CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    coordinator: AirlyDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    diagnostics_data = {
+        "config_entry_data": async_redact_data(dict(config_entry.data), TO_REDACT),
+        "coordinator_data": coordinator.data,
+    }
+
+    return diagnostics_data

--- a/homeassistant/components/airly/diagnostics.py
+++ b/homeassistant/components/airly/diagnostics.py
@@ -19,7 +19,7 @@ async def async_get_config_entry_diagnostics(
     coordinator: AirlyDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     diagnostics_data = {
-        "config_entry_data": async_redact_data(dict(config_entry.data), TO_REDACT),
+        "config_entry_data": async_redact_data(dict(config_entry.as_dict(), TO_REDACT),
         "coordinator_data": coordinator.data,
     }
 

--- a/tests/components/airly/fixtures/diagnostics_data.json
+++ b/tests/components/airly/fixtures/diagnostics_data.json
@@ -1,0 +1,16 @@
+{
+  "PM1": 9.8,
+  "PM25": 14.98,
+  "PM10": 18.47,
+  "PRESSURE": 1018.06,
+  "HUMIDITY": 63.6,
+  "TEMPERATURE": 6.78,
+  "PM25_LIMIT": 25.0,
+  "PM25_PERCENT": 59.94,
+  "PM10_LIMIT": 50.0,
+  "PM10_PERCENT": 36.93,
+  "CAQI": 24.97,
+  "LEVEL": "very low",
+  "DESCRIPTION": "Great air here today!",
+  "ADVICE": "It couldn't be better ;)"
+}

--- a/tests/components/airly/fixtures/diagnostics_data.json
+++ b/tests/components/airly/fixtures/diagnostics_data.json
@@ -1,16 +1,16 @@
 {
-  "PM1": 9.8,
-  "PM25": 14.98,
-  "PM10": 18.47,
-  "PRESSURE": 1018.06,
-  "HUMIDITY": 63.6,
-  "TEMPERATURE": 6.78,
+  "PM1": 9.23,
+  "PM25": 13.71,
+  "PM10": 18.58,
+  "PRESSURE": 1000.87,
+  "HUMIDITY": 92.84,
+  "TEMPERATURE": 14.23,
   "PM25_LIMIT": 25.0,
-  "PM25_PERCENT": 59.94,
+  "PM25_PERCENT": 54.84,
   "PM10_LIMIT": 50.0,
-  "PM10_PERCENT": 36.93,
-  "CAQI": 24.97,
+  "PM10_PERCENT": 37.17,
+  "CAQI": 22.85,
   "LEVEL": "very low",
   "DESCRIPTION": "Great air here today!",
-  "ADVICE": "It couldn't be better ;)"
+  "ADVICE": "Great air!"
 }

--- a/tests/components/airly/test_diagnostics.py
+++ b/tests/components/airly/test_diagnostics.py
@@ -6,9 +6,9 @@ from tests.components.airly import init_integration
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_entry_diagnostics(hass, hass_client):
+async def test_entry_diagnostics(hass, aioclient_mock, hass_client):
     """Test config entry diagnostics."""
-    entry = await init_integration(hass)
+    entry = await init_integration(hass, aioclient_mock)
 
     coordinator_data = json.loads(load_fixture("diagnostics_data.json", "airly"))
 

--- a/tests/components/airly/test_diagnostics.py
+++ b/tests/components/airly/test_diagnostics.py
@@ -1,6 +1,8 @@
 """Test Airly diagnostics."""
 import json
 
+from homeassistant.components.diagnostics import REDACTED
+
 from tests.common import load_fixture
 from tests.components.airly import init_integration
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -14,10 +16,22 @@ async def test_entry_diagnostics(hass, aioclient_mock, hass_client):
 
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 
-    assert result["config_entry_data"] == {
-        "api_key": "**REDACTED**",
-        "latitude": "**REDACTED**",
-        "longitude": "**REDACTED**",
-        "name": "Home",
+    assert result["config_entry"] == {
+        "entry_id": entry.entry_id,
+        "version": 1,
+        "domain": "airly",
+        "title": "Dom",
+        "data": {
+            "latitude": REDACTED,
+            "longitude": REDACTED,
+            "name": "Home",
+            "api_key": REDACTED,
+        },
+        "options": {},
+        "pref_disable_new_entities": False,
+        "pref_disable_polling": False,
+        "source": "user",
+        "unique_id": REDACTED,
+        "disabled_by": None,
     }
     assert result["coordinator_data"] == coordinator_data

--- a/tests/components/airly/test_diagnostics.py
+++ b/tests/components/airly/test_diagnostics.py
@@ -1,0 +1,23 @@
+"""Test Airly diagnostics."""
+import json
+
+from tests.common import load_fixture
+from tests.components.airly import init_integration
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_entry_diagnostics(hass, hass_client):
+    """Test config entry diagnostics."""
+    entry = await init_integration(hass)
+
+    coordinator_data = json.loads(load_fixture("diagnostics_data.json", "airly"))
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert result["config_entry_data"] == {
+        "api_key": "**REDACTED**",
+        "latitude": "**REDACTED**",
+        "longitude": "**REDACTED**",
+        "name": "Home",
+    }
+    assert result["coordinator_data"] == coordinator_data

--- a/tests/components/airly/test_diagnostics.py
+++ b/tests/components/airly/test_diagnostics.py
@@ -20,7 +20,7 @@ async def test_entry_diagnostics(hass, aioclient_mock, hass_client):
         "entry_id": entry.entry_id,
         "version": 1,
         "domain": "airly",
-        "title": "Dom",
+        "title": "Home",
         "data": {
             "latitude": REDACTED,
             "longitude": REDACTED,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds `diagnostics` platform for Airly integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
