### PR TITLE
Improve typing of deCONZ climate platform

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -64,6 +64,7 @@ homeassistant.components.crownstone.*
 homeassistant.components.cpuspeed.*
 homeassistant.components.deconz
 homeassistant.components.deconz.alarm_control_panel
+homeassistant.components.deconz.climate
 homeassistant.components.deconz.config_flow
 homeassistant.components.deconz.diagnostics
 homeassistant.components.deconz.gateway

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -147,24 +147,15 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         """Set up thermostat device."""
         super().__init__(device, gateway)
 
-        if not device.mode:
-            self.supported_hvac_modes = [
-                HVAC_MODE_HEAT,
-                HVAC_MODE_OFF,
-            ]
-        elif "coolsetpoint" not in device.raw["config"]:
-            self.supported_hvac_modes = [
-                HVAC_MODE_AUTO,
-                HVAC_MODE_HEAT,
-                HVAC_MODE_OFF,
-            ]
-        else:
-            self.supported_hvac_modes = [
-                HVAC_MODE_AUTO,
-                HVAC_MODE_COOL,
-                HVAC_MODE_HEAT,
-                HVAC_MODE_OFF,
-            ]
+        self.supported_hvac_modes = [
+            HVAC_MODE_HEAT,
+            HVAC_MODE_OFF,
+        ]
+        if device.mode:
+            self.supported_hvac_modes.append(HVAC_MODE_AUTO)
+
+            if "coolsetpoint" in device.raw["config"]:
+                self.supported_hvac_modes.append(HVAC_MODE_COOL)
 
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -65,7 +65,7 @@ FAN_MODE_TO_DECONZ = {
 
 DECONZ_TO_FAN_MODE = {value: key for key, value in FAN_MODE_TO_DECONZ.items()}
 
-HVAC_MODE_TO_DECONZ = {
+HVAC_MODE_TO_DECONZ: dict[str, str] = {
     HVAC_MODE_AUTO: THERMOSTAT_MODE_AUTO,
     HVAC_MODE_COOL: THERMOSTAT_MODE_COOL,
     HVAC_MODE_HEAT: THERMOSTAT_MODE_HEAT,
@@ -147,17 +147,24 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         """Set up thermostat device."""
         super().__init__(device, gateway)
 
-        self._hvac_mode_to_deconz = dict(HVAC_MODE_TO_DECONZ)
         if not device.mode:
-            self._hvac_mode_to_deconz = {
-                HVAC_MODE_HEAT: True,
-                HVAC_MODE_OFF: False,
-            }
+            self.supported_hvac_modes = [
+                HVAC_MODE_HEAT,
+                HVAC_MODE_OFF,
+            ]
         elif "coolsetpoint" not in device.raw["config"]:
-            self._hvac_mode_to_deconz.pop(HVAC_MODE_COOL)
-        self._deconz_to_hvac_mode = {
-            value: key for key, value in self._hvac_mode_to_deconz.items()
-        }
+            self.supported_hvac_modes = [
+                HVAC_MODE_AUTO,
+                HVAC_MODE_HEAT,
+                HVAC_MODE_OFF,
+            ]
+        else:
+            self.supported_hvac_modes = [
+                HVAC_MODE_AUTO,
+                HVAC_MODE_COOL,
+                HVAC_MODE_HEAT,
+                HVAC_MODE_OFF,
+            ]
 
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 
@@ -172,9 +179,9 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def fan_mode(self) -> str:
         """Return fan operation."""
-        return DECONZ_TO_FAN_MODE.get(
-            self._device.fan_mode, FAN_ON if self._device.state_on else FAN_OFF
-        )
+        if self._device.fan_mode in DECONZ_TO_FAN_MODE:
+            return DECONZ_TO_FAN_MODE[self._device.fan_mode]
+        return DECONZ_TO_FAN_MODE[FAN_ON if self._device.state_on else FAN_OFF]
 
     @property
     def fan_modes(self) -> list[str]:
@@ -196,36 +203,36 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
 
         Need to be one of HVAC_MODE_*.
         """
-        return self._deconz_to_hvac_mode.get(
-            self._device.mode,
-            HVAC_MODE_HEAT if self._device.state_on else HVAC_MODE_OFF,
-        )
+        if self._device.mode in self.supported_hvac_modes:
+            return HVAC_MODE_TO_DECONZ[self._device.mode]
+        return HVAC_MODE_HEAT if self._device.state_on else HVAC_MODE_OFF
 
     @property
     def hvac_modes(self) -> list[str]:
         """Return the list of available hvac operation modes."""
-        return list(self._hvac_mode_to_deconz)
+        return self.supported_hvac_modes
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        if hvac_mode not in self._hvac_mode_to_deconz:
+        if hvac_mode not in self.supported_hvac_modes:
             raise ValueError(f"Unsupported HVAC mode {hvac_mode}")
 
-        data = {"mode": self._hvac_mode_to_deconz[hvac_mode]}
-        if len(self._hvac_mode_to_deconz) == 2:  # Only allow turn on and off thermostat
-            data = {"on": self._hvac_mode_to_deconz[hvac_mode]}
-
-        await self._device.set_config(**data)
+        if len(self.supported_hvac_modes) == 2:  # Only allow turn on and off thermostat
+            await self._device.set_config(on=hvac_mode != HVAC_MODE_OFF)
+        else:
+            await self._device.set_config(mode=HVAC_MODE_TO_DECONZ[hvac_mode])
 
     # Preset control
 
     @property
     def preset_mode(self) -> str | None:
         """Return preset mode."""
-        return DECONZ_TO_PRESET_MODE.get(self._device.preset)
+        if self._device.preset in DECONZ_TO_PRESET_MODE:
+            return DECONZ_TO_PRESET_MODE[self._device.preset]
+        return None
 
     @property
-    def preset_modes(self) -> list:
+    def preset_modes(self) -> list[str]:
         """Return the list of available preset modes."""
         return list(PRESET_MODE_TO_DECONZ)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -506,6 +506,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.deconz.climate]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.deconz.config_flow]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -2599,9 +2610,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.binary_sensor]
-ignore_errors = true
-
-[mypy-homeassistant.components.deconz.climate]
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.cover]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -24,7 +24,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.conversation",
     "homeassistant.components.conversation.default_agent",
     "homeassistant.components.deconz.binary_sensor",
-    "homeassistant.components.deconz.climate",
     "homeassistant.components.deconz.cover",
     "homeassistant.components.deconz.fan",
     "homeassistant.components.deconz.light",

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -204,9 +204,9 @@ async def test_climate_device_without_cooling_support(
     climate_thermostat = hass.states.get("climate.thermostat")
     assert climate_thermostat.state == HVAC_MODE_AUTO
     assert climate_thermostat.attributes["hvac_modes"] == [
-        HVAC_MODE_AUTO,
         HVAC_MODE_HEAT,
         HVAC_MODE_OFF,
+        HVAC_MODE_AUTO,
     ]
     assert climate_thermostat.attributes["current_temperature"] == 22.6
     assert climate_thermostat.attributes["temperature"] == 22.0
@@ -378,10 +378,10 @@ async def test_climate_device_with_cooling_support(
     climate_thermostat = hass.states.get("climate.zen_01")
     assert climate_thermostat.state == HVAC_MODE_HEAT
     assert climate_thermostat.attributes["hvac_modes"] == [
-        HVAC_MODE_AUTO,
-        HVAC_MODE_COOL,
         HVAC_MODE_HEAT,
         HVAC_MODE_OFF,
+        HVAC_MODE_AUTO,
+        HVAC_MODE_COOL,
     ]
     assert climate_thermostat.attributes["current_temperature"] == 23.2
     assert climate_thermostat.attributes["temperature"] == 22.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Simplify how to store supported HVAC modes
- Don't use get when using a literal

```
homeassistant/components/deconz/climate.py:153: error: Dict entry 0 has incompatible type "str": "bool"; expected "str": "str"  [dict-item]
homeassistant/components/deconz/climate.py:154: error: Dict entry 1 has incompatible type "str": "bool"; expected "str": "str"  [dict-item]
homeassistant/components/deconz/climate.py:176: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[Literal['off', 'low', 'medium', 'high', 'on', 'auto', 'smart']]"; expected "str"  [arg-type]
homeassistant/components/deconz/climate.py:200: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[Literal['off', 'auto', 'cool', 'heat', 'emergency heating', 'precooling', 'fan only', 'dry', 'sleep']]"; expected "str"  [arg-type]
homeassistant/components/deconz/climate.py:218: error: Argument 1 to "set_config" of "Thermostat" has incompatible type "**Dict[str, str]"; expected "Optional[int]"  [arg-type]
homeassistant/components/deconz/climate.py:218: error: Argument 1 to "set_config" of "Thermostat" has incompatible type "**Dict[str, str]"; expected "Optional[bool]"  [arg-type]
homeassistant/components/deconz/climate.py:218: error: Argument 1 to "set_config" of "Thermostat" has incompatible type "**Dict[str, str]"; expected "Optional[List[str]]"  [arg-type]
homeassistant/components/deconz/climate.py:225: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[Literal['holiday', 'auto', 'manual', 'comfort', 'eco', 'boost', 'complex']]"; expected "str"  [arg-type]
homeassistant/components/deconz/climate.py:244: error: Unused "type: ignore" comment
homeassistant/components/deconz/climate.py:250: error: Unused "type: ignore" comment
homeassistant/components/deconz/climate.py:253: error: Unused "type: ignore" comment
```
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
