### PR TITLE
Improve typing of deCONZ light platform

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -67,6 +67,7 @@ homeassistant.components.deconz.alarm_control_panel
 homeassistant.components.deconz.config_flow
 homeassistant.components.deconz.diagnostics
 homeassistant.components.deconz.gateway
+homeassistant.components.deconz.light
 homeassistant.components.deconz.services
 homeassistant.components.device_automation.*
 homeassistant.components.device_tracker.*

--- a/mypy.ini
+++ b/mypy.ini
@@ -539,6 +539,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.deconz.light]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.deconz.services]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -2608,9 +2619,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.fan]
-ignore_errors = true
-
-[mypy-homeassistant.components.deconz.light]
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.lock]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -27,7 +27,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.deconz.climate",
     "homeassistant.components.deconz.cover",
     "homeassistant.components.deconz.fan",
-    "homeassistant.components.deconz.light",
     "homeassistant.components.deconz.lock",
     "homeassistant.components.deconz.logbook",
     "homeassistant.components.deconz.number",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Create typevar to pass along what device type is used to replace specifying device as a union
- Rewrite turn_on and turn_off to use a typeddict to type the data to be sent

```
homeassistant/components/deconz/light.py:66: error: Incompatible types in assignment (expression has type "List[Union[ConfigurationTool, Cover, Fan, Light, Lock, Siren]]", variable has type "Optional[List[Light]]")  [assignment]
homeassistant/components/deconz/light.py:68: error: Item "None" of "Optional[List[Light]]" has no attribute "__iter__" (not iterable)  [union-attr]
homeassistant/components/deconz/light.py:159: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_mode"  [union-attr]
homeassistant/components/deconz/light.py:159: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_mode"  [union-attr]
homeassistant/components/deconz/light.py:161: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_mode"  [union-attr]
homeassistant/components/deconz/light.py:161: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_mode"  [union-attr]
homeassistant/components/deconz/light.py:163: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_mode"  [union-attr]
homeassistant/components/deconz/light.py:163: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_mode"  [union-attr]
homeassistant/components/deconz/light.py:165: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "brightness"  [union-attr]
homeassistant/components/deconz/light.py:165: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "brightness"  [union-attr]
homeassistant/components/deconz/light.py:174: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:174: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "brightness"  [union-attr]
homeassistant/components/deconz/light.py:174: note: Error code "union-attr" not covered by "type: ignore" comment
homeassistant/components/deconz/light.py:174: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "brightness"  [union-attr]
homeassistant/components/deconz/light.py:179: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:179: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_temp"  [union-attr]
homeassistant/components/deconz/light.py:179: note: Error code "union-attr" not covered by "type: ignore" comment
homeassistant/components/deconz/light.py:179: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "color_temp"  [union-attr]
homeassistant/components/deconz/light.py:179: error: Incompatible return value type (got "Union[int, None, Any]", expected "int")  [return-value]
homeassistant/components/deconz/light.py:179: note: Error code "return-value" not covered by "type: ignore" comment
homeassistant/components/deconz/light.py:184: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "hue"  [union-attr]
homeassistant/components/deconz/light.py:184: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "hue"  [union-attr]
homeassistant/components/deconz/light.py:184: error: Unsupported operand types for / ("None" and "int")  [operator]
homeassistant/components/deconz/light.py:184: note: Left operand is of type "Union[int, None, Any]"
homeassistant/components/deconz/light.py:184: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "saturation"  [union-attr]
homeassistant/components/deconz/light.py:184: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "saturation"  [union-attr]
homeassistant/components/deconz/light.py:189: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:189: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "xy"  [union-attr]
homeassistant/components/deconz/light.py:189: note: Error code "union-attr" not covered by "type: ignore" comment
homeassistant/components/deconz/light.py:189: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "xy"  [union-attr]
homeassistant/components/deconz/light.py:194: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:194: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "state"  [union-attr]
homeassistant/components/deconz/light.py:194: note: Error code "union-attr" not covered by "type: ignore" comment
homeassistant/components/deconz/light.py:194: error: Incompatible return value type (got "Union[bool, None, Any]", expected "bool")  [return-value]
homeassistant/components/deconz/light.py:194: note: Error code "return-value" not covered by "type: ignore" comment
homeassistant/components/deconz/light.py:228: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "set_state"  [union-attr]
homeassistant/components/deconz/light.py:228: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "set_state"  [union-attr]
homeassistant/components/deconz/light.py:228: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, float, int, str, Tuple[float, float]]]"; expected "Union[str, None, Literal['none', 'select', 'lselect']]"  [arg-type]
homeassistant/components/deconz/light.py:228: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, float, int, str, Tuple[float, float]]]"; expected "Optional[int]"  [arg-type]
homeassistant/components/deconz/light.py:228: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, float, int, str, Tuple[float, float]]]"; expected "Union[str, None, Literal['colorloop', 'none']]"  [arg-type]
homeassistant/components/deconz/light.py:228: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, float, int, str, Tuple[float, float]]]"; expected "Optional[bool]"  [arg-type]
homeassistant/components/deconz/light.py:228: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, float, int, str, Tuple[float, float]]]"; expected "Optional[Tuple[float, float]]"  [arg-type]
homeassistant/components/deconz/light.py:232: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "state"  [union-attr]
homeassistant/components/deconz/light.py:245: error: Item "LightBase" of "Union[Group, LightBase, SensorBase]" has no attribute "set_state"  [union-attr]
homeassistant/components/deconz/light.py:245: error: Item "SensorBase" of "Union[Group, LightBase, SensorBase]" has no attribute "set_state"  [union-attr]
homeassistant/components/deconz/light.py:245: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, int, str]]"; expected "Union[str, None, Literal['none', 'select', 'lselect']]"  [arg-type]
homeassistant/components/deconz/light.py:245: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, int, str]]"; expected "Optional[int]"  [arg-type]
homeassistant/components/deconz/light.py:245: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, int, str]]"; expected "Union[str, None, Literal['colorloop', 'none']]"  [arg-type]
homeassistant/components/deconz/light.py:245: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, int, str]]"; expected "Optional[bool]"  [arg-type]
homeassistant/components/deconz/light.py:245: error: Argument 1 to "set_state" of "Group" has incompatible type "**Dict[str, Union[bool, int, str]]"; expected "Optional[Tuple[float, float]]"  [arg-type]
```
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
