### PR TITLE
Rename sensor state class TOTAL_INCREASING to TOTAL_AUTO_CYCLE

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -186,7 +186,14 @@ class SensorStateClass(StrEnum):
     # The state represents a total amount, e.g. net energy consumption
     TOTAL = "total"
 
-    # The state represents a monotonically increasing total, e.g. an amount of consumed gas
+    # The state represents a total amount which is periodically reset to 0
+    # according to some cycle, e.g. an amount of consumed gas starting from 0
+    # the 1st of every month.
+    # This will be converted to a monotonically increasing total. Use with care,
+    # `TOTAL` should be used if the sensor does not peridocially reset.
+    TOTAL_AUTO_CYCLE = "total_auto_cycle"
+
+    # Deprecated, replaced by TOTAL_AUTO_CYCLE
     TOTAL_INCREASING = "total_increasing"
 
 

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -789,7 +789,7 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
         ),
     ],
 )
-@pytest.mark.parametrize("state_class", ["total_increasing"])
+@pytest.mark.parametrize("state_class", ["total_auto_cycle", "total_increasing"])
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,factor",
     [
@@ -879,7 +879,7 @@ def test_compile_hourly_sum_statistics_negative_state(
     state = states[entity_id][offending_state].state
     last_updated = states[entity_id][offending_state].last_updated.isoformat()
     assert (
-        f"Entity {entity_id} {warning_1}has state class total_increasing, but its state "
+        f"Entity {entity_id} {warning_1}has state class total_auto_cycle, but its state "
         f"is negative. Triggered by state {state} with last_updated set to {last_updated}."
         in caplog.text
     )
@@ -991,8 +991,9 @@ def test_compile_hourly_sum_statistics_total_no_reset(
         ("gas", "ft³", "m³", 0.0283168466),
     ],
 )
-def test_compile_hourly_sum_statistics_total_increasing(
-    hass_recorder, caplog, device_class, unit, native_unit, factor
+@pytest.mark.parametrize("state_class", ["total_auto_cycle", "total_increasing"])
+def test_compile_hourly_sum_statistics_total_auto_cycle(
+    hass_recorder, caplog, device_class, unit, native_unit, factor, state_class
 ):
     """Test compiling hourly statistics."""
     period0 = dt_util.utcnow()
@@ -1004,7 +1005,7 @@ def test_compile_hourly_sum_statistics_total_increasing(
     setup_component(hass, "sensor", {})
     attributes = {
         "device_class": device_class,
-        "state_class": "total_increasing",
+        "state_class": state_class,
         "unit_of_measurement": unit,
     }
     seq = [10, 15, 20, 10, 30, 40, 50, 60, 70]
@@ -1083,8 +1084,9 @@ def test_compile_hourly_sum_statistics_total_increasing(
     "device_class,unit,native_unit,factor",
     [("energy", "kWh", "kWh", 1)],
 )
-def test_compile_hourly_sum_statistics_total_increasing_small_dip(
-    hass_recorder, caplog, device_class, unit, native_unit, factor
+@pytest.mark.parametrize("state_class", ["total_auto_cycle", "total_increasing"])
+def test_compile_hourly_sum_statistics_total_auto_cycle_small_dip(
+    hass_recorder, caplog, device_class, unit, native_unit, factor, state_class
 ):
     """Test small dips in sensor readings do not trigger a reset."""
     period0 = dt_util.utcnow()
@@ -1096,7 +1098,7 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     setup_component(hass, "sensor", {})
     attributes = {
         "device_class": device_class,
-        "state_class": "total_increasing",
+        "state_class": state_class,
         "unit_of_measurement": unit,
     }
     seq = [10, 15, 20, 19, 30, 40, 39, 60, 70]
@@ -1115,7 +1117,7 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     recorder.do_adhoc_statistics(start=period1)
     wait_recording_done(hass)
     assert (
-        "Entity sensor.test1 has state class total_increasing, but its state is not "
+        "Entity sensor.test1 has state class total_auto_cycle, but its state is not "
         "strictly increasing."
     ) not in caplog.text
     recorder.do_adhoc_statistics(start=period2)
@@ -1124,7 +1126,7 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     previous_state = float(states["sensor.test1"][5].state)
     last_updated = states["sensor.test1"][6].last_updated.isoformat()
     assert (
-        "Entity sensor.test1 has state class total_increasing, but its state is not "
+        "Entity sensor.test1 has state class total_auto_cycle, but its state is not "
         f"strictly increasing. Triggered by state {state} ({previous_state}) with "
         f"last_updated set to {last_updated}. Please create a bug report at "
         "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
@@ -2173,8 +2175,9 @@ def test_compile_hourly_statistics_changing_device_class_2(
         (None, None, None, 13.050847, -10, 30),
     ],
 )
+@pytest.mark.parametrize("state_class", ["total_auto_cycle", "total_increasing"])
 def test_compile_hourly_statistics_changing_statistics(
-    hass_recorder, caplog, device_class, unit, native_unit, mean, min, max
+    hass_recorder, caplog, device_class, unit, native_unit, mean, min, max, state_class
 ):
     """Test compiling hourly statistics where units change during an hour."""
     period0 = dt_util.utcnow()
@@ -2190,7 +2193,7 @@ def test_compile_hourly_statistics_changing_statistics(
     }
     attributes_2 = {
         "device_class": device_class,
-        "state_class": "total_increasing",
+        "state_class": state_class,
         "unit_of_measurement": unit,
     }
     four, states = record_states(hass, period0, "sensor.test1", attributes_1)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Sensor state class `TOTAL_INCREASING` is renamed to `TOTAL_AUTO_CYCLE`
State class `TOTAL_INCREASING` is deprecated and will stop working in Home Assistant 2022.11.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename sensor state class `TOTAL_INCREASING` to `TOTAL_AUTO_CYCLE`

Integrations will be updated in follow-up PRs

Background:
The sensor state class "total_increasing" should be used for sensors representing an amount which is periodically reset to 0 according to some cycle, e.g. an amount of consumed gas starting from 0 the 1st of every month.

The name of the state class is poorly chosen, because it reflects how Home Assistant core converts the value when calculating statistics, not what the sensor value represents.

TODO: dev blog + developer documentation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
