### PR TITLE
Fix supported_features in Ecovacs vacuum

### DIFF
--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -15,18 +15,6 @@ from . import ECOVACS_DEVICES
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_ECOVACS = (
-    VacuumEntityFeature.BATTERY
-    | VacuumEntityFeature.RETURN_HOME
-    | VacuumEntityFeature.CLEAN_SPOT
-    | VacuumEntityFeature.STOP
-    | VacuumEntityFeature.TURN_OFF
-    | VacuumEntityFeature.TURN_ON
-    | VacuumEntityFeature.LOCATE
-    | VacuumEntityFeature.STATUS
-    | VacuumEntityFeature.SEND_COMMAND
-    | VacuumEntityFeature.FAN_SPEED
-)
 
 ATTR_ERROR = "error"
 ATTR_COMPONENT_PREFIX = "component_"
@@ -48,6 +36,19 @@ def setup_platform(
 
 class EcovacsVacuum(VacuumEntity):
     """Ecovacs Vacuums such as Deebot."""
+
+    _attr_supported_features = (
+        VacuumEntityFeature.BATTERY
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.CLEAN_SPOT
+        | VacuumEntityFeature.STOP
+        | VacuumEntityFeature.TURN_OFF
+        | VacuumEntityFeature.TURN_ON
+        | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.STATUS
+        | VacuumEntityFeature.SEND_COMMAND
+        | VacuumEntityFeature.FAN_SPEED
+    )
 
     def __init__(self, device):
         """Initialize the Ecovacs Vacuum."""
@@ -112,9 +113,9 @@ class EcovacsVacuum(VacuumEntity):
         return self._name
 
     @property
-    def supported_features(self):
-        """Flag vacuum cleaner robot features that are supported."""
-        return SUPPORT_ECOVACS
+    def supported_features(self) -> int:
+        """Flag vacuum cleaner features that are supported."""
+        return self._attr_supported_features
 
     @property
     def status(self):

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -15,7 +15,6 @@ from . import ECOVACS_DEVICES
 
 _LOGGER = logging.getLogger(__name__)
 
-
 ATTR_ERROR = "error"
 ATTR_COMPONENT_PREFIX = "component_"
 

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -15,6 +15,19 @@ from . import ECOVACS_DEVICES
 
 _LOGGER = logging.getLogger(__name__)
 
+SUPPORT_ECOVACS = (
+    VacuumEntityFeature.BATTERY
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.CLEAN_SPOT
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.TURN_OFF
+    | VacuumEntityFeature.TURN_ON
+    | VacuumEntityFeature.LOCATE
+    | VacuumEntityFeature.STATUS
+    | VacuumEntityFeature.SEND_COMMAND
+    | VacuumEntityFeature.FAN_SPEED
+)
+
 ATTR_ERROR = "error"
 ATTR_COMPONENT_PREFIX = "component_"
 
@@ -35,19 +48,6 @@ def setup_platform(
 
 class EcovacsVacuum(VacuumEntity):
     """Ecovacs Vacuums such as Deebot."""
-
-    _attr_supported_features = (
-        VacuumEntityFeature.BATTERY
-        | VacuumEntityFeature.RETURN_HOME
-        | VacuumEntityFeature.CLEAN_SPOT
-        | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.TURN_OFF
-        | VacuumEntityFeature.TURN_ON
-        | VacuumEntityFeature.LOCATE
-        | VacuumEntityFeature.STATUS
-        | VacuumEntityFeature.SEND_COMMAND
-        | VacuumEntityFeature.FAN_SPEED
-    )
 
     def __init__(self, device):
         """Initialize the Ecovacs Vacuum."""
@@ -110,6 +110,11 @@ class EcovacsVacuum(VacuumEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    @property
+    def supported_features(self):
+        """Flag vacuum cleaner robot features that are supported."""
+        return SUPPORT_ECOVACS
 
     @property
     def status(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix issue introduced in #69384, as the shorthand attribute is not supported in the vacuum platform: https://github.com/home-assistant/core/blob/d8d1e98d4eea6755f62b1d01ff53ae0b27a9f91c/homeassistant/components/vacuum/__init__.py#L176-L179

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
