### PR TITLE
Fix climate HVAC device condition

### DIFF
--- a/homeassistant/components/climate/device_condition.py
+++ b/homeassistant/components/climate/device_condition.py
@@ -75,15 +75,19 @@ def async_condition_from_config(
     hass: HomeAssistant, config: ConfigType
 ) -> condition.ConditionCheckerType:
     """Create a function to test a device condition."""
-    if config[CONF_TYPE] == "is_hvac_mode":
-        attribute = const.ATTR_HVAC_MODE
-    else:
-        attribute = const.ATTR_PRESET_MODE
 
     def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
         """Test if an entity is a certain state."""
-        state = hass.states.get(config[ATTR_ENTITY_ID])
-        return state.attributes.get(attribute) == config[attribute] if state else False
+        if (state := hass.states.get(config[ATTR_ENTITY_ID])) is None:
+            return False
+
+        if config[CONF_TYPE] == "is_hvac_mode":
+            return state.state == config[const.ATTR_HVAC_MODE]
+
+        return (
+            state.attributes.get(const.ATTR_PRESET_MODE)
+            == config[const.ATTR_PRESET_MODE]
+        )
 
     return test_is_state
 

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -106,7 +106,6 @@ async def test_if_state(hass, calls):
         "climate.entity",
         const.HVAC_MODE_COOL,
         {
-            const.ATTR_HVAC_MODE: const.HVAC_MODE_COOL,
             const.ATTR_PRESET_MODE: const.PRESET_AWAY,
         },
     )

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -102,14 +102,6 @@ async def test_get_conditions(
 
 async def test_if_state(hass, calls):
     """Test for turn_on and turn_off conditions."""
-    hass.states.async_set(
-        "climate.entity",
-        const.HVAC_MODE_COOL,
-        {
-            const.ATTR_PRESET_MODE: const.PRESET_AWAY,
-        },
-    )
-
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -156,6 +148,20 @@ async def test_if_state(hass, calls):
             ]
         },
     )
+
+    # Should not fire, entity doesn't exist yet
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(
+        "climate.entity",
+        const.HVAC_MODE_COOL,
+        {
+            const.ATTR_PRESET_MODE: const.PRESET_AWAY,
+        },
+    )
+
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -165,7 +171,6 @@ async def test_if_state(hass, calls):
         "climate.entity",
         const.HVAC_MODE_AUTO,
         {
-            const.ATTR_HVAC_MODE: const.HVAC_MODE_AUTO,
             const.ATTR_PRESET_MODE: const.PRESET_AWAY,
         },
     )
@@ -185,7 +190,6 @@ async def test_if_state(hass, calls):
         "climate.entity",
         const.HVAC_MODE_AUTO,
         {
-            const.ATTR_HVAC_MODE: const.HVAC_MODE_AUTO,
             const.ATTR_PRESET_MODE: const.PRESET_HOME,
         },
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The climate device condition for checking HVAC mode didn't work (as reported by @jesserockz).

It checked for a state attribute, however, `hvac_mode` isn't a state attribute, it's the state of a climate entity. The tests didn't catch it, as it contained the same issue in the test entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
