### PR TITLE
Fix config_flow error from dlna_dmr for UPnP discovery info containing a single service

### DIFF
--- a/homeassistant/components/dlna_dmr/config_flow.py
+++ b/homeassistant/components/dlna_dmr/config_flow.py
@@ -134,10 +134,16 @@ class DlnaDmrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         discovery_service_list = discovery_info.upnp.get(ssdp.ATTR_UPNP_SERVICE_LIST)
         if not discovery_service_list:
             return self.async_abort(reason="not_dmr")
-        discovery_service_ids = {
-            service.get("serviceId")
-            for service in discovery_service_list.get("service") or []
-        }
+
+        services = discovery_service_list.get("service")
+        if not services:
+            discovery_service_ids: set[str] = set()
+        elif isinstance(services, list):
+            discovery_service_ids = {service.get("serviceId") for service in services}
+        else:
+            # Only one service defined (etree_to_dict failed to make a list)
+            discovery_service_ids = {services.get("serviceId")}
+
         if not DmrDevice.SERVICE_IDS.issubset(discovery_service_ids):
             return self.async_abort(reason="not_dmr")
 

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -388,10 +388,22 @@ async def test_ssdp_flow_upnp_udn(
 
 async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
     """Test SSDP ignores devices that are missing required services."""
-    # No services defined at all
+    # No service list at all
     discovery = dataclasses.replace(MOCK_DISCOVERY)
     discovery.upnp = discovery.upnp.copy()
     del discovery.upnp[ssdp.ATTR_UPNP_SERVICE_LIST]
+    result = await hass.config_entries.flow.async_init(
+        DLNA_DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=discovery,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "not_dmr"
+
+    # Service list does not contain services
+    discovery = dataclasses.replace(MOCK_DISCOVERY)
+    discovery.upnp = discovery.upnp.copy()
+    discovery.upnp[ssdp.ATTR_UPNP_SERVICE_LIST] = {"bad_key": "bad_value"}
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
@@ -412,6 +424,28 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
     }
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=discovery
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "not_dmr"
+
+
+async def test_ssdp_single_service(hass: HomeAssistant) -> None:
+    """Test SSDP discovery info with only one service defined.
+
+    THe etree_to_dict function turns multiple services into a list of dicts, but
+    a single service into only a dict.
+    """
+    discovery = dataclasses.replace(MOCK_DISCOVERY)
+    discovery.upnp = discovery.upnp.copy()
+    service_list = discovery.upnp[ssdp.ATTR_UPNP_SERVICE_LIST].copy()
+    # Turn mock's list of service dicts into a single dict
+    service_list["service"] = service_list["service"][0]
+    discovery.upnp[ssdp.ATTR_UPNP_SERVICE_LIST] = service_list
+
+    result = await hass.config_entries.flow.async_init(
+        DLNA_DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=discovery,
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "not_dmr"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The SSDP config flow handler for `dlna_dmr` crashes when a device only defines a single service in its UPnP description. This is a fix for that case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #67521
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
