### PR TITLE
Update pylint to 2.13.5

### DIFF
--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -112,7 +112,6 @@ class MutexPool(StaticPool):  # type: ignore[misc]
 
         if DEBUG_MUTEX_POOL:
             _LOGGER.debug("%s wait conn%s", threading.current_thread().name, trace_msg)
-        # pylint: disable-next=consider-using-with
         got_lock = MutexPool.pool_lock.acquire(timeout=1)
         if not got_lock:
             raise SQLAlchemyError

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -260,9 +260,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         except asyncio.TimeoutError as err:
             # No need to try again
             self._app_list_event.set()
-            LOGGER.debug(
-                "Failed to load app list from %s: %s", self._host, err.__repr__()
-            )
+            LOGGER.debug("Failed to load app list from %s: %r", self._host, err)
 
     async def _async_startup_dmr(self) -> None:
         assert self._ssdp_rendering_control_location is not None
@@ -375,9 +373,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         try:
             await dmr_device.async_set_volume_level(volume)
         except UpnpActionResponseError as err:
-            LOGGER.warning(
-                "Unable to set volume level on %s: %s", self._host, err.__repr__()
-            )
+            LOGGER.warning("Unable to set volume level on %s: %r", self._host, err)
 
     async def async_volume_up(self) -> None:
         """Volume up the media player."""

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -121,11 +121,13 @@ def setup_platform(
             ]
 
         master = next(
-            [
-                device
-                for device in hass.data[DATA_SOUNDTOUCH]
-                if device.entity_id == master_device_id
-            ].__iter__(),
+            iter(
+                [
+                    device
+                    for device in hass.data[DATA_SOUNDTOUCH]
+                    if device.entity_id == master_device_id
+                ]
+            ),
             None,
         )
 
@@ -357,9 +359,9 @@ class SoundTouchDevice(MediaPlayerEntity):
             # Preset
             presets = self._device.presets()
             preset = next(
-                [
-                    preset for preset in presets if preset.preset_id == str(media_id)
-                ].__iter__(),
+                iter(
+                    [preset for preset in presets if preset.preset_id == str(media_id)]
+                ),
                 None,
             )
             if preset is not None:

--- a/homeassistant/components/tailscale/diagnostics.py
+++ b/homeassistant/components/tailscale/diagnostics.py
@@ -23,7 +23,6 @@ TO_REDACT = {
     "name",
     "node_key",
     "user",
-    "user",
 }
 
 

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -377,7 +377,7 @@ def entity_selector_without_own_entities(
     entity_registry = er.async_get(handler.hass)
     entities = er.async_entries_for_config_entry(
         entity_registry,
-        handler.config_entry.entry_id,  # pylint: disable=protected-access
+        handler.config_entry.entry_id,
     )
     entity_ids = [ent.entity_id for ent in entities]
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -821,7 +821,7 @@ class TemplateState(State):
 
     def __repr__(self) -> str:
         """Representation of Template State."""
-        return f"<template TemplateState({self._state.__repr__()})>"
+        return f"<template TemplateState({self._state!r})>"
 
 
 def _collect_state(hass: HomeAssistant, entity_id: str) -> None:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.2.1
 mock-open==1.4.0
 mypy==0.942
 pre-commit==2.17.0
-pylint==2.13.3
+pylint==2.13.5
 pipdeptree==2.2.1
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Proposed change
Update pylint to `2.13.5` and minor code updates for future pylint releases.

https://github.com/PyCQA/pylint/releases/tag/v2.13.4
https://github.com/PyCQA/pylint/releases/tag/v2.13.5
Compare view: https://github.com/PyCQA/pylint/compare/v2.13.3...v2.13.5

This PR also includes small changes for two new pylint checkers which will be added in `2.14.0`:
* `duplicate-value`: detect duplicate values inside sets
* `unnecessary-dunder-call`: call to dunder method outside of dunder function. I.e. `[...].__iter__()` instead of `iter([...])`.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
