### PR TITLE
Improve typing of deCONZ binary_sensor platform

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -11,7 +11,7 @@ from pydeconz.sensor import (
     GenericFlag,
     OpenClose,
     Presence,
-    SensorBase as PydeconzSensor,
+    SensorResources,
     Vibration,
     Water,
 )
@@ -55,7 +55,7 @@ class DeconzBinarySensorDescriptionMixin:
 
     suffix: str
     update_key: str
-    value_fn: Callable[[PydeconzSensor], bool | None]
+    value_fn: Callable[[SensorResources], bool | None]
 
 
 @dataclass
@@ -70,7 +70,7 @@ ENTITY_DESCRIPTIONS = {
     Alarm: [
         DeconzBinarySensorDescription(
             key="alarm",
-            value_fn=lambda device: device.alarm,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.alarm if isinstance(device, Alarm) else None,
             suffix="",
             update_key="alarm",
             device_class=BinarySensorDeviceClass.SAFETY,
@@ -79,7 +79,9 @@ ENTITY_DESCRIPTIONS = {
     CarbonMonoxide: [
         DeconzBinarySensorDescription(
             key="carbon_monoxide",
-            value_fn=lambda device: device.carbon_monoxide,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.carbon_monoxide
+            if isinstance(device, CarbonMonoxide)
+            else None,
             suffix="",
             update_key="carbonmonoxide",
             device_class=BinarySensorDeviceClass.CO,
@@ -88,14 +90,16 @@ ENTITY_DESCRIPTIONS = {
     Fire: [
         DeconzBinarySensorDescription(
             key="fire",
-            value_fn=lambda device: device.fire,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.fire if isinstance(device, Fire) else None,
             suffix="",
             update_key="fire",
             device_class=BinarySensorDeviceClass.SMOKE,
         ),
         DeconzBinarySensorDescription(
             key="in_test_mode",
-            value_fn=lambda device: device.in_test_mode,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.in_test_mode
+            if isinstance(device, Fire)
+            else None,
             suffix="Test Mode",
             update_key="test",
             device_class=BinarySensorDeviceClass.SMOKE,
@@ -105,7 +109,9 @@ ENTITY_DESCRIPTIONS = {
     GenericFlag: [
         DeconzBinarySensorDescription(
             key="flag",
-            value_fn=lambda device: device.flag,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.flag
+            if isinstance(device, GenericFlag)
+            else None,
             suffix="",
             update_key="flag",
         )
@@ -113,7 +119,9 @@ ENTITY_DESCRIPTIONS = {
     OpenClose: [
         DeconzBinarySensorDescription(
             key="open",
-            value_fn=lambda device: device.open,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.open
+            if isinstance(device, OpenClose)
+            else None,
             suffix="",
             update_key="open",
             device_class=BinarySensorDeviceClass.OPENING,
@@ -122,7 +130,9 @@ ENTITY_DESCRIPTIONS = {
     Presence: [
         DeconzBinarySensorDescription(
             key="presence",
-            value_fn=lambda device: device.presence,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.presence
+            if isinstance(device, Presence)
+            else None,
             suffix="",
             update_key="presence",
             device_class=BinarySensorDeviceClass.MOTION,
@@ -131,7 +141,9 @@ ENTITY_DESCRIPTIONS = {
     Vibration: [
         DeconzBinarySensorDescription(
             key="vibration",
-            value_fn=lambda device: device.vibration,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.vibration
+            if isinstance(device, Vibration)
+            else None,
             suffix="",
             update_key="vibration",
             device_class=BinarySensorDeviceClass.VIBRATION,
@@ -140,7 +152,7 @@ ENTITY_DESCRIPTIONS = {
     Water: [
         DeconzBinarySensorDescription(
             key="water",
-            value_fn=lambda device: device.water,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.water if isinstance(device, Water) else None,
             suffix="",
             update_key="water",
             device_class=BinarySensorDeviceClass.MOISTURE,
@@ -178,7 +190,7 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_sensor(sensors: list[PydeconzSensor] | None = None) -> None:
+    def async_add_sensor(sensors: list[SensorResources] | None = None) -> None:
         """Add binary sensor from deCONZ."""
         entities: list[DeconzBinarySensor] = []
 
@@ -225,12 +237,12 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     """Representation of a deCONZ binary sensor."""
 
     TYPE = DOMAIN
-    _device: PydeconzSensor
+    _device: SensorResources
     entity_description: DeconzBinarySensorDescription
 
     def __init__(
         self,
-        device: PydeconzSensor,
+        device: SensorResources,
         gateway: DeconzGateway,
         description: DeconzBinarySensorDescription,
     ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is really ugly (and should possibly be burnt) but it works to enable strict typing. Was looking at Hue sensor platform and looked much cleaner, maybe I should consider going that route instead?

Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
