### PR TITLE
Reduce precision of over-precise RainMachine switch attributes

### DIFF
--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, TypeVar, cast
+from typing import Any
 
 from regenmaschine.controller import Controller
 from regenmaschine.errors import RequestError
@@ -114,17 +114,6 @@ class RainMachineSwitchDescription(
     SwitchEntityDescription, RainMachineDescriptionMixinUid
 ):
     """Describe a RainMachine switch."""
-
-
-_T = TypeVar("_T")
-
-
-@callback
-def async_limit_precision(value: _T) -> _T:
-    """Reduce a value's decimal precision to 1 place (if appropriate)."""
-    if isinstance(value, float):
-        return cast(_T, round(value, 2))
-    return value
 
 
 async def async_setup_entry(
@@ -403,23 +392,19 @@ class RainMachineZone(RainMachineActivitySwitch):
 
         self._attr_extra_state_attributes.update(
             {
-                ATTR_AREA: async_limit_precision(data.get("waterSense").get("area")),
-                ATTR_CURRENT_CYCLE: data.get("cycle"),
-                ATTR_FIELD_CAPACITY: async_limit_precision(
-                    data.get("waterSense").get("fieldCapacity")
-                ),
+                ATTR_AREA: round(data["waterSense"]["area"], 2),
+                ATTR_CURRENT_CYCLE: data["cycle"],
+                ATTR_FIELD_CAPACITY: round(data["waterSense"]["fieldCapacity"], 2),
                 ATTR_ID: data["uid"],
-                ATTR_NO_CYCLES: data.get("noOfCycles"),
-                ATTR_PRECIP_RATE: async_limit_precision(
-                    data.get("waterSense").get("precipitationRate")
-                ),
-                ATTR_RESTRICTIONS: data.get("restriction"),
-                ATTR_SLOPE: SLOPE_TYPE_MAP.get(data.get("slope")),
-                ATTR_SOIL_TYPE: SOIL_TYPE_MAP.get(data.get("soil")),
-                ATTR_SPRINKLER_TYPE: SPRINKLER_TYPE_MAP.get(data.get("group_id")),
+                ATTR_NO_CYCLES: data["noOfCycles"],
+                ATTR_PRECIP_RATE: round(data["waterSense"]["precipitationRate"], 2),
+                ATTR_RESTRICTIONS: data["restriction"],
+                ATTR_SLOPE: SLOPE_TYPE_MAP.get(data["slope"], 99),
+                ATTR_SOIL_TYPE: SOIL_TYPE_MAP.get(data["soil"], 99),
+                ATTR_SPRINKLER_TYPE: SPRINKLER_TYPE_MAP.get(data["group_id"], 99),
                 ATTR_STATUS: RUN_STATUS_MAP[data["state"]],
                 ATTR_SUN_EXPOSURE: SUN_EXPOSURE_MAP.get(data.get("sun")),
-                ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(data.get("type")),
+                ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(data["type"], 99),
             }
         )
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -410,7 +410,9 @@ class RainMachineZone(RainMachineActivitySwitch):
                 ),
                 ATTR_ID: data["uid"],
                 ATTR_NO_CYCLES: data.get("noOfCycles"),
-                ATTR_PRECIP_RATE: data.get("waterSense").get("precipitationRate"),
+                ATTR_PRECIP_RATE: async_limit_precision(
+                    data.get("waterSense").get("precipitationRate")
+                ),
                 ATTR_RESTRICTIONS: data.get("restriction"),
                 ATTR_SLOPE: SLOPE_TYPE_MAP.get(data.get("slope")),
                 ATTR_SOIL_TYPE: SOIL_TYPE_MAP.get(data.get("soil")),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
RainMachine switch attributes that are `floats` are now rounded to two decimals of precision.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per @bdraco's suggestion [here](https://github.com/home-assistant/core/pull/69206#issuecomment-1098399718), there are several overly-precise RainMachine switch attributes; when even the smallest decimal changes, that writes to the state machine. This PR rounds these values to two decimal places and eliminates those extraneous writes.

It also removes some incorrect dict access logic and appropriate assigns unknowns where mappings aren't known.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
