### PR TITLE
Eliminate duplicated run state logic in RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -1,6 +1,8 @@
 """Define constants for the SimpliSafe component."""
 import logging
 
+from homeassistant.backports.enum import StrEnum
+
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "rainmachine"
@@ -17,3 +19,18 @@ DATA_ZONES = "zones"
 
 DEFAULT_PORT = 8080
 DEFAULT_ZONE_RUN = 60 * 10
+
+
+class RunStates(StrEnum):
+    """Define an enum for program/zone run states."""
+
+    NOT_RUNNING = "Not Running"
+    QUEUED = "Queued"
+    RUNNING = "Running"
+
+
+RUN_STATE_MAP = {
+    0: RunStates.NOT_RUNNING,
+    1: RunStates.RUNNING,
+    2: RunStates.QUEUED,
+}

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -26,6 +26,8 @@ from .const import (
     DATA_RESTRICTIONS_UNIVERSAL,
     DATA_ZONES,
     DOMAIN,
+    RUN_STATE_MAP,
+    RunStates,
 )
 from .model import (
     RainMachineDescriptionMixinApiCategory,
@@ -40,15 +42,6 @@ TYPE_FLOW_SENSOR_START_INDEX = "flow_sensor_start_index"
 TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
 TYPE_FREEZE_TEMP = "freeze_protect_temp"
 TYPE_ZONE_RUN_COMPLETION_TIME = "zone_run_completion_time"
-
-ZONE_STATE_NOT_RUNNING = "not_running"
-ZONE_STATE_PENDING = "pending"
-ZONE_STATE_RUNNING = "running"
-ZONE_STATE_MAP = {
-    0: ZONE_STATE_NOT_RUNNING,
-    1: ZONE_STATE_RUNNING,
-    2: ZONE_STATE_PENDING,
-}
 
 
 @dataclass
@@ -219,7 +212,7 @@ class ZoneTimeRemainingSensor(RainMachineEntity, SensorEntity):
         data = self.coordinator.data[self.entity_description.uid]
         now = utcnow()
 
-        if ZONE_STATE_MAP.get(data["state"]) != ZONE_STATE_RUNNING:
+        if RUN_STATE_MAP.get(data["state"]) != RunStates.RUNNING:
             # If the zone isn't actively running, return immediately:
             return
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -30,6 +30,7 @@ from .const import (
     DATA_ZONES,
     DEFAULT_ZONE_RUN,
     DOMAIN,
+    RUN_STATE_MAP,
 )
 from .model import RainMachineDescriptionMixinUid
 
@@ -54,8 +55,6 @@ ATTR_VEGETATION_TYPE = "vegetation_type"
 ATTR_ZONES = "zones"
 
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-
-RUN_STATUS_MAP = {0: "Not Running", 1: "Running", 2: "Queued"}
 
 SOIL_TYPE_MAP = {
     0: "Not Set",
@@ -328,7 +327,7 @@ class RainMachineProgram(RainMachineActivitySwitch):
                 ATTR_ID: self.entity_description.uid,
                 ATTR_NEXT_RUN: next_run,
                 ATTR_SOAK: data.get("soak"),
-                ATTR_STATUS: RUN_STATUS_MAP[data["status"]],
+                ATTR_STATUS: RUN_STATE_MAP[data["status"]],
                 ATTR_ZONES: [z for z in data["wateringTimes"] if z["active"]],
             }
         )
@@ -402,7 +401,7 @@ class RainMachineZone(RainMachineActivitySwitch):
                 ATTR_SLOPE: SLOPE_TYPE_MAP.get(data["slope"], 99),
                 ATTR_SOIL_TYPE: SOIL_TYPE_MAP.get(data["soil"], 99),
                 ATTR_SPRINKLER_TYPE: SPRINKLER_TYPE_MAP.get(data["group_id"], 99),
-                ATTR_STATUS: RUN_STATUS_MAP[data["state"]],
+                ATTR_STATUS: RUN_STATE_MAP[data["state"]],
                 ATTR_SUN_EXPOSURE: SUN_EXPOSURE_MAP.get(data.get("sun")),
                 ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(data["type"], 99),
             }

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from regenmaschine.controller import Controller
 from regenmaschine.errors import RequestError
@@ -114,6 +114,17 @@ class RainMachineSwitchDescription(
     SwitchEntityDescription, RainMachineDescriptionMixinUid
 ):
     """Describe a RainMachine switch."""
+
+
+_T = TypeVar("_T")
+
+
+@callback
+def async_limit_precision(value: _T) -> _T:
+    """Reduce a value's decimal precision to 1 place (if appropriate)."""
+    if isinstance(value, float):
+        return cast(_T, round(value, 2))
+    return value
 
 
 async def async_setup_entry(

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, TypeVar, cast
+from typing import Any
 
 from regenmaschine.controller import Controller
 from regenmaschine.errors import RequestError
@@ -114,17 +114,6 @@ class RainMachineSwitchDescription(
     SwitchEntityDescription, RainMachineDescriptionMixinUid
 ):
     """Describe a RainMachine switch."""
-
-
-_T = TypeVar("_T")
-
-
-@callback
-def async_limit_precision(value: _T) -> _T:
-    """Reduce a value's decimal precision to 1 place (if appropriate)."""
-    if isinstance(value, float):
-        return cast(_T, round(value, 2))
-    return value
 
 
 async def async_setup_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/core/pull/69206, I accidentally replicated zone run state (running, queued, not running) logic that already existed in a form. This PR removes the deduplication and adjusts the implementation to work for all cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/69206
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
