### PR TITLE
Add load_media_failed callback to cast MediaStatusListener

### DIFF
--- a/homeassistant/components/cast/helpers.py
+++ b/homeassistant/components/cast/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Optional
 
 import attr
+import pychromecast
 from pychromecast import dial
 from pychromecast.const import CAST_TYPE_GROUP
 from pychromecast.models import CastInfo
@@ -86,7 +87,12 @@ class ChromeCastZeroconf:
         return cls.__zconf
 
 
-class CastStatusListener:
+class CastStatusListener(
+    pychromecast.controllers.media.MediaStatusListener,
+    pychromecast.controllers.multizone.MultiZoneManagerListener,
+    pychromecast.controllers.receiver.CastStatusListener,
+    pychromecast.socket_client.ConnectionStatusListener,
+):
     """Helper class to handle pychromecast status callbacks.
 
     Necessary because a CastDevice entity or dynamic group can create a new
@@ -112,23 +118,27 @@ class CastStatusListener:
         if not cast_device._cast_info.is_audio_group:
             self._mz_mgr.register_listener(chromecast.uuid, self)
 
-    def new_cast_status(self, cast_status):
+    def new_cast_status(self, status):
         """Handle reception of a new CastStatus."""
         if self._valid:
-            self._cast_device.new_cast_status(cast_status)
+            self._cast_device.new_cast_status(status)
 
-    def new_media_status(self, media_status):
+    def new_media_status(self, status):
         """Handle reception of a new MediaStatus."""
         if self._valid:
-            self._cast_device.new_media_status(media_status)
+            self._cast_device.new_media_status(status)
 
-    def new_connection_status(self, connection_status):
+    def load_media_failed(self, item, error_code):
+        """Handle reception of a new MediaStatus."""
+        if self._valid:
+            self._cast_device.load_media_failed(item, error_code)
+
+    def new_connection_status(self, status):
         """Handle reception of a new ConnectionStatus."""
         if self._valid:
-            self._cast_device.new_connection_status(connection_status)
+            self._cast_device.new_connection_status(status)
 
-    @staticmethod
-    def added_to_multizone(group_uuid):
+    def added_to_multizone(self, group_uuid):
         """Handle the cast added to a group."""
 
     def removed_from_multizone(self, group_uuid):

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==11.0.0"],
+  "requirements": ["pychromecast==12.0.0"],
   "after_dependencies": [
     "cloud",
     "http",

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -10,6 +10,7 @@ import logging
 
 import pychromecast
 from pychromecast.controllers.homeassistant import HomeAssistantController
+from pychromecast.controllers.media import MEDIA_PLAYER_ERROR_CODES
 from pychromecast.controllers.multizone import MultizoneManager
 from pychromecast.controllers.receiver import VOLUME_CONTROL_TYPE_FIXED
 from pychromecast.quick_play import quick_play
@@ -382,6 +383,17 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
         self.media_status = media_status
         self.media_status_received = dt_util.utcnow()
         self.schedule_update_ha_state()
+
+    def load_media_failed(self, item, error_code):
+        """Handle load media failed."""
+        _LOGGER.debug(
+            "[%s %s] Load media failed with code %s(%s) for item %s",
+            self.entity_id,
+            self._cast_info.friendly_name,
+            error_code,
+            MEDIA_PLAYER_ERROR_CODES.get(error_code, "unknown code"),
+            item,
+        )
 
     def new_connection_status(self, connection_status):
         """Handle updates of connection status."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ pycfdns==1.2.2
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==11.0.0
+pychromecast==12.0.0
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -929,7 +929,7 @@ pybotvac==0.0.23
 pycfdns==1.2.2
 
 # homeassistant.components.cast
-pychromecast==11.0.0
+pychromecast==12.0.0
 
 # homeassistant.components.climacell
 pyclimacell==0.18.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `load_media_failed` callback to cast `MediaStatusListener`

Bump pychromecast from 11.0.0. to 11.2.0

Changes:
- 12.0.0 (https://github.com/home-assistant-libs/pychromecast/releases/tag/12.0.0)
  - https://github.com/home-assistant-libs/pychromecast/pull/615
  - https://github.com/home-assistant-libs/pychromecast/pull/614

**Full Changelog**: https://github.com/home-assistant-libs/pychromecast/compare/11.0.0...12.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
