### PR TITLE
Set source & sound mode at start in media player reproduce state

### DIFF
--- a/homeassistant/components/media_player/reproduce_state.py
+++ b/homeassistant/components/media_player/reproduce_state.py
@@ -83,6 +83,13 @@ async def _async_reproduce_states(
     cur_state = hass.states.get(state.entity_id)
     features = cur_state.attributes[ATTR_SUPPORTED_FEATURES] if cur_state else 0
 
+    # First set source & sound mode to match the saved supported features
+    if (
+        ATTR_INPUT_SOURCE in state.attributes
+        and features & MediaPlayerEntityFeature.SELECT_SOURCE
+    ):
+        await call_service(SERVICE_SELECT_SOURCE, [ATTR_INPUT_SOURCE])
+
     if (
         ATTR_SOUND_MODE in state.attributes
         and features & MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -100,12 +107,6 @@ async def _async_reproduce_states(
         and features & MediaPlayerEntityFeature.VOLUME_MUTE
     ):
         await call_service(SERVICE_VOLUME_MUTE, [ATTR_MEDIA_VOLUME_MUTED])
-
-    if (
-        ATTR_INPUT_SOURCE in state.attributes
-        and features & MediaPlayerEntityFeature.SELECT_SOURCE
-    ):
-        await call_service(SERVICE_SELECT_SOURCE, [ATTR_INPUT_SOURCE])
 
     already_playing = False
 

--- a/homeassistant/components/media_player/reproduce_state.py
+++ b/homeassistant/components/media_player/reproduce_state.py
@@ -84,6 +84,12 @@ async def _async_reproduce_states(
     features = cur_state.attributes[ATTR_SUPPORTED_FEATURES] if cur_state else 0
 
     if (
+        ATTR_SOUND_MODE in state.attributes
+        and features & MediaPlayerEntityFeature.SELECT_SOUND_MODE
+    ):
+        await call_service(SERVICE_SELECT_SOUND_MODE, [ATTR_SOUND_MODE])
+
+    if (
         ATTR_MEDIA_VOLUME_LEVEL in state.attributes
         and features & MediaPlayerEntityFeature.VOLUME_SET
     ):
@@ -100,12 +106,6 @@ async def _async_reproduce_states(
         and features & MediaPlayerEntityFeature.SELECT_SOURCE
     ):
         await call_service(SERVICE_SELECT_SOURCE, [ATTR_INPUT_SOURCE])
-
-    if (
-        ATTR_SOUND_MODE in state.attributes
-        and features & MediaPlayerEntityFeature.SELECT_SOUND_MODE
-    ):
-        await call_service(SERVICE_SELECT_SOUND_MODE, [ATTR_SOUND_MODE])
 
     already_playing = False
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up of https://github.com/home-assistant/core/pull/70055
If device current state does not support of one the scene sound attributes it may fail if the source or sound mode are set last.
For example:
Current sound mode is "external sound output", has no volume set/mute
Captured scene state was "internal speaker" which supports volume set and it exists in the scene.
Setting the volume while current state is "external sound output" may fail because the device current mode does not allow it.
If we first set the sound mode we guarantee that the device state is the same as when the scene was captured.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
