### PR TITLE
Rework Sonos discovery & availability

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from collections import OrderedDict
 import datetime
-from enum import Enum
 from functools import partial
 import logging
 import socket
@@ -13,7 +12,7 @@ from urllib.parse import urlparse
 from soco import events_asyncio
 import soco.config as soco_config
 from soco.core import SoCo
-from soco.exceptions import NotSupportedException, SoCoException
+from soco.exceptions import SoCoException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -23,7 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOSTS, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval, call_later
 from homeassistant.helpers.typing import ConfigType
 
@@ -74,14 +73,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-class SoCoCreationSource(Enum):
-    """Represent the creation source of a SoCo instance."""
-
-    CONFIGURED = "configured"
-    DISCOVERED = "discovered"
-    REBOOTED = "rebooted"
-
-
 class SonosData:
     """Storage class for platform global data."""
 
@@ -93,7 +84,6 @@ class SonosData:
         self.alarms: dict[str, SonosAlarms] = {}
         self.topology_condition = asyncio.Condition()
         self.hosts_heartbeat = None
-        self.discovery_ignored: set[str] = set()
         self.discovery_known: set[str] = set()
         self.boot_counts: dict[str, int] = {}
         self.mdns_names: dict[str, str] = {}
@@ -165,37 +155,35 @@ class SonosDiscoveryManager:
         self.hass = hass
         self.entry = entry
         self.data = data
-        self.hosts = hosts
+        self.hosts = set(hosts)
         self.discovery_lock = asyncio.Lock()
+        self._known_invisible = set()
+        self._manual_config_required = bool(hosts)
 
     async def async_shutdown(self):
         """Stop all running tasks."""
         await self._async_stop_event_listener()
         self._stop_manual_heartbeat()
 
-    def _create_soco(self, ip_address: str, source: SoCoCreationSource) -> SoCo | None:
-        """Create a soco instance and return if successful."""
-        if ip_address in self.data.discovery_ignored:
-            return None
+    def is_device_invisible(self, ip_address: str) -> bool:
+        """Check if device at provided IP is known to be invisible."""
+        return any(x for x in self._known_invisible if x.ip_address == ip_address)
 
+    def _create_visible_speakers(self, ip_address: str) -> None:
+        """Create all new SonosSpeaker instances with the provided seed IP."""
         try:
             soco = SoCo(ip_address)
-            # Ensure that the player is available and UID is cached
-            uid = soco.uid
-            # Abort early if the device is not visible
-            if not soco.is_visible:
-                return None
-            _ = soco.volume
-            return soco
-        except NotSupportedException as exc:
-            # pylint: disable-next=used-before-assignment
-            _LOGGER.debug("Device %s is not supported, ignoring: %s", uid, exc)
-            self.data.discovery_ignored.add(ip_address)
+            visible_zones = soco.visible_zones
+            self._known_invisible = soco.all_zones - visible_zones
         except (OSError, SoCoException) as ex:
             _LOGGER.warning(
-                "Failed to connect to %s player '%s': %s", source.value, ip_address, ex
+                "Failed to request visible zones from %s: %s", ip_address, ex
             )
-        return None
+            return
+
+        for zone in visible_zones:
+            if zone.uid not in self.data.discovered:
+                self._discovered_player(zone)
 
     async def _async_stop_event_listener(self, event: Event | None = None) -> None:
         for speaker in self.data.discovered.values():
@@ -216,6 +204,8 @@ class SonosDiscoveryManager:
         """Handle a (re)discovered player."""
         try:
             speaker_info = soco.get_speaker_info(True)
+            if soco.uid not in self.data.boot_counts:
+                self.data.boot_counts[soco.uid] = soco.boot_seqnum
             _LOGGER.debug("Adding new speaker: %s", speaker_info)
             speaker = SonosSpeaker(self.hass, soco, speaker_info)
             self.data.discovered[soco.uid] = speaker
@@ -232,44 +222,86 @@ class SonosDiscoveryManager:
             _LOGGER.warning("Failed to add SonosSpeaker using %s", soco, exc_info=True)
 
     def _manual_hosts(self, now: datetime.datetime | None = None) -> None:
-        """Players from network configuration."""
+        """Add and maintain Sonos devices from a manual configuration."""
         for host in self.hosts:
             ip_addr = socket.gethostbyname(host)
-            known_uid = next(
+            soco = SoCo(ip_addr)
+            try:
+                visible_zones = soco.visible_zones
+            except OSError:
+                _LOGGER.warning("Could not get visible Sonos devices from %s", ip_addr)
+            else:
+                if new_hosts := {
+                    x.ip_address
+                    for x in visible_zones
+                    if x.ip_address not in self.hosts
+                }:
+                    _LOGGER.debug("Adding to manual hosts: %s", new_hosts)
+                    self.hosts.update(new_hosts)
+                dispatcher_send(
+                    self.hass,
+                    f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
+                    "manual zone scan",
+                )
+                break
+
+        for host in self.hosts.copy():
+            ip_addr = socket.gethostbyname(host)
+            if self.is_device_invisible(ip_addr):
+                _LOGGER.debug("Discarding %s from manual hosts", ip_addr)
+                self.hosts.discard(ip_addr)
+                continue
+
+            known_speaker = next(
                 (
-                    uid
-                    for uid, speaker in self.data.discovered.items()
+                    speaker
+                    for speaker in self.data.discovered.values()
                     if speaker.soco.ip_address == ip_addr
                 ),
                 None,
             )
-            if not known_uid:
-                if soco := self._create_soco(ip_addr, SoCoCreationSource.CONFIGURED):
-                    self._discovered_player(soco)
+            if not known_speaker:
+                self._create_visible_speakers(ip_addr)
+            elif not known_speaker.available:
+                try:
+                    known_speaker.soco.renderingControl.GetVolume(
+                        [("InstanceID", 0), ("Channel", "Master")], timeout=1
+                    )
+                except OSError:
+                    _LOGGER.debug(
+                        "Manual poll to %s failed, keeping unavailable", ip_addr
+                    )
+                else:
+                    dispatcher_send(
+                        self.hass,
+                        f"{SONOS_SPEAKER_ACTIVITY}-{known_speaker.uid}",
+                        "manual rediscovery",
+                    )
 
         self.data.hosts_heartbeat = call_later(
             self.hass, DISCOVERY_INTERVAL.total_seconds(), self._manual_hosts
         )
 
-    def _discovered_ip(self, ip_address):
-        if soco := self._create_soco(ip_address, SoCoCreationSource.DISCOVERED):
-            self._discovered_player(soco)
-
-    async def _async_create_discovered_player(self, uid, discovered_ip, boot_seqnum):
-        """Only create one player at a time."""
+    async def _async_create_discovered_player(
+        self, uid, discovered_ip, boot_seqnum
+    ) -> None:
+        """Handle discovered player creation and activity."""
         async with self.discovery_lock:
-            if uid not in self.data.discovered:
+            if not self.data.discovered:
+                # Initial discovery, attempt to add all visible zones
                 await self.hass.async_add_executor_job(
-                    self._discovered_ip, discovered_ip
+                    self._create_visible_speakers,
+                    discovered_ip,
                 )
-                return
-
-            if boot_seqnum and boot_seqnum > self.data.boot_counts[uid]:
+            elif uid not in self.data.discovered:
+                if self.is_device_invisible(discovered_ip):
+                    return
+                await self.hass.async_add_executor_job(
+                    self._discovered_player, SoCo(discovered_ip)
+                )
+            elif boot_seqnum and boot_seqnum > self.data.boot_counts[uid]:
                 self.data.boot_counts[uid] = boot_seqnum
-                if soco := await self.hass.async_add_executor_job(
-                    self._create_soco, discovered_ip, SoCoCreationSource.REBOOTED
-                ):
-                    async_dispatcher_send(self.hass, f"{SONOS_REBOOTED}-{uid}", soco)
+                async_dispatcher_send(self.hass, f"{SONOS_REBOOTED}-{uid}")
             else:
                 async_dispatcher_send(
                     self.hass, f"{SONOS_SPEAKER_ACTIVITY}-{uid}", "discovery"
@@ -308,9 +340,17 @@ class SonosDiscoveryManager:
         self, source, info, discovered_ip, uid, boot_seqnum, model, mdns_name
     ):
         """Handle discovery via ssdp or zeroconf."""
+        if self._manual_config_required:
+            _LOGGER.warning(
+                "Automatic discovery is working, Sonos hosts in configuration.yaml are not needed"
+            )
+            self._manual_config_required = False
         if model in DISCOVERY_IGNORED_MODELS:
             _LOGGER.debug("Ignoring device: %s", info)
             return
+        if self.is_device_invisible(discovered_ip):
+            return
+
         if boot_seqnum:
             boot_seqnum = int(boot_seqnum)
             self.data.boot_counts.setdefault(uid, boot_seqnum)

--- a/homeassistant/components/sonos/diagnostics.py
+++ b/homeassistant/components/sonos/diagnostics.py
@@ -49,7 +49,7 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     payload = {"current_timestamp": time.monotonic()}
 
-    for section in ("discovered", "discovery_known", "discovery_ignored"):
+    for section in ("discovered", "discovery_known"):
         payload[section] = {}
         data = getattr(hass.data[DATA_SONOS], section)
         if isinstance(data, set):

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -582,15 +582,10 @@ class SonosSpeaker:
         )
         await self.async_offline()
 
-    async def async_rebooted(self, soco: SoCo) -> None:
+    async def async_rebooted(self) -> None:
         """Handle a detected speaker reboot."""
-        _LOGGER.debug(
-            "%s rebooted, reconnecting with %s",
-            self.zone_name,
-            soco,
-        )
+        _LOGGER.debug("%s rebooted, reconnecting", self.zone_name)
         await self.async_offline()
-        self.soco = soco
         self.speaker_activity("reboot")
 
     #

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -118,7 +118,8 @@ def soco_fixture(
         mock_soco.surround_enabled = True
         mock_soco.soundbar_audio_input_format = "Dolby 5.1"
         mock_soco.get_battery_info.return_value = battery_info
-        mock_soco.all_zones = [mock_soco]
+        mock_soco.all_zones = {mock_soco}
+        mock_soco.visible_zones = {mock_soco}
         yield mock_soco
 
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,27 +1,11 @@
 """Tests for the Sonos Media Player platform."""
-from unittest.mock import PropertyMock
-
 import pytest
-from soco.exceptions import NotSupportedException
 
-from homeassistant.components.sonos import DATA_SONOS, DOMAIN, media_player
+from homeassistant.components.sonos import DOMAIN, media_player
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import device_registry as dr
-
-
-async def test_discovery_ignore_unsupported_device(
-    hass, async_setup_sonos, soco, caplog
-):
-    """Test discovery setup."""
-    message = f"GetVolume not supported on {soco.ip_address}"
-    type(soco).volume = PropertyMock(side_effect=NotSupportedException(message))
-
-    await async_setup_sonos()
-
-    assert message in caplog.text
-    assert not hass.data[DATA_SONOS].discovered
 
 
 async def test_services(hass, async_autosetup_sonos, hass_read_only_user):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reworks the Sonos speaker discovery logic for both multicast discovery & hardcoded hostnames:
* Uses 'visible_zones' to find all devices immediately on startup instead of waiting for each speaker to announce itself
* Automatically finds all devices when using a manual config with an incomplete list of hosts
* Avoids making repetitive network calls when invisible zones exist (e.g., satellites or stereo pairs)
* Warns (once) on startup if hardcoded hosts are unnecessary (i.e. multicast discovery is working fine)
* Fix: Re-discovers unavailable hosts when they reappear when in manual mode
* Renames methods & docstrings to better describe intents.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68912
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
