### PR TITLE
Bump pyevilgenius to 2.0.0

### DIFF
--- a/homeassistant/components/evil_genius_labs/__init__.py
+++ b/homeassistant/components/evil_genius_labs/__init__.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import logging
 from typing import cast
 
+from aiohttp import ContentTypeError
 from async_timeout import timeout
 import pyevilgenius
 
@@ -54,6 +55,8 @@ class EvilGeniusUpdateCoordinator(DataUpdateCoordinator[dict]):
 
     info: dict
 
+    product: dict | None
+
     def __init__(
         self, hass: HomeAssistant, name: str, client: pyevilgenius.EvilGeniusDevice
     ) -> None:
@@ -71,14 +74,30 @@ class EvilGeniusUpdateCoordinator(DataUpdateCoordinator[dict]):
         """Return the device name."""
         return cast(str, self.data["name"]["value"])
 
+    @property
+    def product_name(self) -> str | None:
+        """Return the product name."""
+        if self.product is None:
+            return None
+
+        return cast(str, self.product["productName"])
+
     async def _async_update_data(self) -> dict:
         """Update Evil Genius data."""
         if not hasattr(self, "info"):
             async with timeout(5):
                 self.info = await self.client.get_info()
 
+        if not hasattr(self, "product"):
+            async with timeout(5):
+                try:
+                    self.product = await self.client.get_product()
+                except ContentTypeError:
+                    # Older versions of the API don't support this
+                    self.product = None
+
         async with timeout(5):
-            return cast(dict, await self.client.get_data())
+            return cast(dict, await self.client.get_all())
 
 
 class EvilGeniusEntity(CoordinatorEntity[EvilGeniusUpdateCoordinator]):
@@ -92,6 +111,7 @@ class EvilGeniusEntity(CoordinatorEntity[EvilGeniusUpdateCoordinator]):
             identifiers={(DOMAIN, info["wiFiChipId"])},
             connections={(dr.CONNECTION_NETWORK_MAC, info["macAddress"])},
             name=self.coordinator.device_name,
+            model=self.coordinator.product_name,
             manufacturer="Evil Genius Labs",
             sw_version=info["coreVersion"].replace("_", "."),
             configuration_url=self.coordinator.client.url,

--- a/homeassistant/components/evil_genius_labs/config_flow.py
+++ b/homeassistant/components/evil_genius_labs/config_flow.py
@@ -32,7 +32,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     try:
         async with async_timeout.timeout(10):
-            data = await hub.get_data()
+            data = await hub.get_all()
             info = await hub.get_info()
     except aiohttp.ClientError as err:
         _LOGGER.debug("Unable to connect: %s", err)

--- a/homeassistant/components/evil_genius_labs/diagnostics.py
+++ b/homeassistant/components/evil_genius_labs/diagnostics.py
@@ -19,5 +19,5 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "info": async_redact_data(coordinator.info, TO_REDACT),
-        "data": coordinator.data,
+        "all": coordinator.data,
     }

--- a/homeassistant/components/evil_genius_labs/manifest.json
+++ b/homeassistant/components/evil_genius_labs/manifest.json
@@ -3,7 +3,7 @@
   "name": "Evil Genius Labs",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/evil_genius_labs",
-  "requirements": ["pyevilgenius==1.0.0"],
+  "requirements": ["pyevilgenius==2.0.0"],
   "codeowners": ["@balloob"],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1468,7 +1468,7 @@ pyephember==0.3.1
 pyeverlights==0.1.0
 
 # homeassistant.components.evil_genius_labs
-pyevilgenius==1.0.0
+pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
 pyezviz==0.2.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -962,7 +962,7 @@ pyefergy==22.1.1
 pyeverlights==0.1.0
 
 # homeassistant.components.evil_genius_labs
-pyevilgenius==1.0.0
+pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
 pyezviz==0.2.0.6

--- a/tests/components/evil_genius_labs/conftest.py
+++ b/tests/components/evil_genius_labs/conftest.py
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(scope="session")
-def data_fixture():
+def all_fixture():
     """Fixture data."""
     data = json.loads(load_fixture("data.json", "evil_genius_labs"))
     return {item["name"]: item for item in data}
@@ -20,6 +20,12 @@ def data_fixture():
 def info_fixture():
     """Fixture info."""
     return json.loads(load_fixture("info.json", "evil_genius_labs"))
+
+
+@pytest.fixture(scope="session")
+def product_fixture():
+    """Fixture info."""
+    return {"productName": "Fibonacci256"}
 
 
 @pytest.fixture
@@ -32,15 +38,18 @@ def config_entry(hass):
 
 @pytest.fixture
 async def setup_evil_genius_labs(
-    hass, config_entry, data_fixture, info_fixture, platforms
+    hass, config_entry, all_fixture, info_fixture, product_fixture, platforms
 ):
     """Test up Evil Genius Labs instance."""
     with patch(
-        "pyevilgenius.EvilGeniusDevice.get_data",
-        return_value=data_fixture,
+        "pyevilgenius.EvilGeniusDevice.get_all",
+        return_value=all_fixture,
     ), patch(
         "pyevilgenius.EvilGeniusDevice.get_info",
         return_value=info_fixture,
+    ), patch(
+        "pyevilgenius.EvilGeniusDevice.get_product",
+        return_value=product_fixture,
     ), patch(
         "homeassistant.components.evil_genius_labs.PLATFORMS", platforms
     ):

--- a/tests/components/evil_genius_labs/test_config_flow.py
+++ b/tests/components/evil_genius_labs/test_config_flow.py
@@ -10,7 +10,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
 
 
-async def test_form(hass: HomeAssistant, data_fixture, info_fixture) -> None:
+async def test_form(
+    hass: HomeAssistant, all_fixture, info_fixture, product_fixture
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -19,11 +21,14 @@ async def test_form(hass: HomeAssistant, data_fixture, info_fixture) -> None:
     assert result["errors"] is None
 
     with patch(
-        "pyevilgenius.EvilGeniusDevice.get_data",
-        return_value=data_fixture,
+        "pyevilgenius.EvilGeniusDevice.get_all",
+        return_value=all_fixture,
     ), patch(
         "pyevilgenius.EvilGeniusDevice.get_info",
         return_value=info_fixture,
+    ), patch(
+        "pyevilgenius.EvilGeniusDevice.get_product",
+        return_value=product_fixture,
     ), patch(
         "homeassistant.components.evil_genius_labs.async_setup_entry",
         return_value=True,
@@ -51,7 +56,7 @@ async def test_form_cannot_connect(hass: HomeAssistant, caplog) -> None:
     )
 
     with patch(
-        "pyevilgenius.EvilGeniusDevice.get_data",
+        "pyevilgenius.EvilGeniusDevice.get_all",
         side_effect=aiohttp.ClientError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -73,7 +78,7 @@ async def test_form_timeout(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "pyevilgenius.EvilGeniusDevice.get_data",
+        "pyevilgenius.EvilGeniusDevice.get_all",
         side_effect=asyncio.TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -94,7 +99,7 @@ async def test_form_unknown(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "pyevilgenius.EvilGeniusDevice.get_data",
+        "pyevilgenius.EvilGeniusDevice.get_all",
         side_effect=ValueError("BOOM"),
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/evil_genius_labs/test_diagnostics.py
+++ b/tests/components/evil_genius_labs/test_diagnostics.py
@@ -8,7 +8,7 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 @pytest.mark.parametrize("platforms", [[]])
 async def test_entry_diagnostics(
-    hass, hass_client, setup_evil_genius_labs, config_entry, data_fixture, info_fixture
+    hass, hass_client, setup_evil_genius_labs, config_entry, all_fixture, info_fixture
 ):
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
@@ -17,5 +17,5 @@ async def test_entry_diagnostics(
             "wiFiSsidDefault": REDACTED,
             "wiFiSSID": REDACTED,
         },
-        "data": data_fixture,
+        "all": all_fixture,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pyevilgenius to 2.0.0

https://github.com/home-assistant-libs/pyevilgenius/releases/tag/2.0.0
https://github.com/home-assistant-libs/pyevilgenius/compare/1.0.0...2.0.0

Now able to set the product name in the device registry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
