### PR TITLE
Merge stop & error script actions

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1545,16 +1545,9 @@ _SCRIPT_STOP_SCHEMA = vol.Schema(
     {
         **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_STOP): vol.Any(None, string),
+        vol.Optional(CONF_ERROR, default=False): boolean,
     }
 )
-
-_SCRIPT_ERROR_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Optional(CONF_ERROR): vol.Any(None, string),
-    }
-)
-
 
 _SCRIPT_PARALLEL_SEQUENCE = vol.Schema(
     {
@@ -1593,7 +1586,6 @@ SCRIPT_ACTION_CHOOSE = "choose"
 SCRIPT_ACTION_WAIT_FOR_TRIGGER = "wait_for_trigger"
 SCRIPT_ACTION_VARIABLES = "variables"
 SCRIPT_ACTION_STOP = "stop"
-SCRIPT_ACTION_ERROR = "error"
 SCRIPT_ACTION_IF = "if"
 SCRIPT_ACTION_PARALLEL = "parallel"
 
@@ -1639,9 +1631,6 @@ def determine_script_action(action: dict[str, Any]) -> str:
     if CONF_STOP in action:
         return SCRIPT_ACTION_STOP
 
-    if CONF_ERROR in action:
-        return SCRIPT_ACTION_ERROR
-
     if CONF_PARALLEL in action:
         return SCRIPT_ACTION_PARALLEL
 
@@ -1661,7 +1650,6 @@ ACTION_TYPE_SCHEMAS: dict[str, Callable[[Any], dict]] = {
     SCRIPT_ACTION_WAIT_FOR_TRIGGER: _SCRIPT_WAIT_FOR_TRIGGER_SCHEMA,
     SCRIPT_ACTION_VARIABLES: _SCRIPT_SET_SCHEMA,
     SCRIPT_ACTION_STOP: _SCRIPT_STOP_SCHEMA,
-    SCRIPT_ACTION_ERROR: _SCRIPT_ERROR_SCHEMA,
     SCRIPT_ACTION_IF: _SCRIPT_IF_SCHEMA,
     SCRIPT_ACTION_PARALLEL: _SCRIPT_PARALLEL_SCHEMA,
 }

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -240,7 +240,6 @@ STATIC_VALIDATION_ACTION_TYPES = (
     cv.SCRIPT_ACTION_FIRE_EVENT,
     cv.SCRIPT_ACTION_ACTIVATE_SCENE,
     cv.SCRIPT_ACTION_VARIABLES,
-    cv.SCRIPT_ACTION_ERROR,
     cv.SCRIPT_ACTION_STOP,
 )
 
@@ -972,16 +971,13 @@ class _ScriptRun:
     async def _async_stop_step(self):
         """Stop script execution."""
         stop = self._action[CONF_STOP]
-        self._log("Stop script sequence: %s", stop)
-        trace_set_result(stop=stop)
-        raise _StopScript(stop)
-
-    async def _async_error_step(self):
-        """Abort and error script execution."""
         error = self._action[CONF_ERROR]
-        self._log("Error script sequence: %s", error)
-        trace_set_result(error=error)
-        raise _AbortScript(error)
+        trace_set_result(stop=stop, error=error)
+        if error:
+            self._log("Error script sequence: %s", stop)
+            raise _AbortScript(stop)
+        self._log("Stop script sequence: %s", stop)
+        raise _StopScript(stop)
 
     @async_trace_path("parallel")
     async def _async_parallel_step(self) -> None:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -4164,7 +4164,6 @@ async def test_validate_action_config(hass):
         },
         cv.SCRIPT_ACTION_VARIABLES: {"variables": {"hello": "world"}},
         cv.SCRIPT_ACTION_STOP: {"stop": "Stop it right there buddy..."},
-        cv.SCRIPT_ACTION_ERROR: {"error": "Stand up, and try again!"},
         cv.SCRIPT_ACTION_IF: {
             "if": [
                 {
@@ -4481,12 +4480,12 @@ async def test_stop_action(hass, caplog):
     assert_action_trace(
         {
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
-            "1": [{"result": {"stop": "In the name of love"}}],
+            "1": [{"result": {"stop": "In the name of love", "error": False}}],
         }
     )
 
 
-async def test_error_action(hass, caplog):
+async def test_stop_action_with_error(hass, caplog):
     """Test if automation fails on calling the error action."""
     event = "test_event"
     events = async_capture_events(hass, event)
@@ -4497,7 +4496,8 @@ async def test_error_action(hass, caplog):
             {"event": event},
             {
                 "alias": alias,
-                "error": "Epic one...",
+                "stop": "Epic one...",
+                "error": True,
             },
             {"event": event},
         ]
@@ -4515,7 +4515,10 @@ async def test_error_action(hass, caplog):
         {
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [
-                {"error_type": script._AbortScript, "result": {"error": "Epic one..."}}
+                {
+                    "error_type": script._AbortScript,
+                    "result": {"stop": "Epic one...", "error": True},
+                }
             ],
         },
         expected_script_execution="aborted",
@@ -4609,7 +4612,7 @@ async def test_continue_on_error_with_stop(hass: HomeAssistant) -> None:
 
     assert_action_trace(
         {
-            "0": [{"result": {"stop": "Stop it!"}}],
+            "0": [{"result": {"stop": "Stop it!", "error": False}}],
         },
         expected_script_execution="finished",
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR merges the `stop` and `error` script action into a single `stop` action.

Reasoning see: <https://github.com/home-assistant/frontend/pull/12299#discussion_r851361751>

Technically this is a breaking change, but this is not yet on stable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22402
- Link to frontend Pull Request: <https://github.com/home-assistant/frontend/pull/12299>

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
