### PR TITLE
Implement support for start_up_on_off in ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -291,6 +291,9 @@ class OnOffChannel(ZigbeeChannel):
 
     ON_OFF = 0
     REPORT_CONFIG = ({"attr": "on_off", "config": REPORT_CONFIG_IMMEDIATE},)
+    ZCL_INIT_ATTRS = {
+        "start_up_on_off": True,
+    }
 
     def __init__(
         self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from enum import Enum
 import functools
 
+from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd
 
 from homeassistant.components.select import SelectEntity
@@ -15,12 +16,20 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .core import discovery
-from .core.const import CHANNEL_IAS_WD, DATA_ZHA, SIGNAL_ADD_ENTITIES, Strobe
+from .core.const import (
+    CHANNEL_IAS_WD,
+    CHANNEL_ON_OFF,
+    DATA_ZHA,
+    SIGNAL_ADD_ENTITIES,
+    Strobe,
+)
 from .core.registries import ZHA_ENTITIES
 from .core.typing import ChannelType, ZhaDeviceType
 from .entity import ZhaEntity
 
-MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.SELECT)
+CONFIG_DIAGNOSTIC_MATCH = functools.partial(
+    ZHA_ENTITIES.config_diagnostic_match, Platform.SELECT
+)
 
 
 async def async_setup_entry(
@@ -100,7 +109,7 @@ class ZHANonZCLSelectEntity(ZHAEnumSelectEntity):
         return True
 
 
-@MULTI_MATCH(channel_names=CHANNEL_IAS_WD)
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_IAS_WD)
 class ZHADefaultToneSelectEntity(
     ZHANonZCLSelectEntity, id_suffix=IasWd.Warning.WarningMode.__name__
 ):
@@ -109,7 +118,7 @@ class ZHADefaultToneSelectEntity(
     _enum: Enum = IasWd.Warning.WarningMode
 
 
-@MULTI_MATCH(channel_names=CHANNEL_IAS_WD)
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_IAS_WD)
 class ZHADefaultSirenLevelSelectEntity(
     ZHANonZCLSelectEntity, id_suffix=IasWd.Warning.SirenLevel.__name__
 ):
@@ -118,7 +127,7 @@ class ZHADefaultSirenLevelSelectEntity(
     _enum: Enum = IasWd.Warning.SirenLevel
 
 
-@MULTI_MATCH(channel_names=CHANNEL_IAS_WD)
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_IAS_WD)
 class ZHADefaultStrobeLevelSelectEntity(
     ZHANonZCLSelectEntity, id_suffix=IasWd.StrobeLevel.__name__
 ):
@@ -127,8 +136,72 @@ class ZHADefaultStrobeLevelSelectEntity(
     _enum: Enum = IasWd.StrobeLevel
 
 
-@MULTI_MATCH(channel_names=CHANNEL_IAS_WD)
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_IAS_WD)
 class ZHADefaultStrobeSelectEntity(ZHANonZCLSelectEntity, id_suffix=Strobe.__name__):
     """Representation of a ZHA default siren strobe select entity."""
 
     _enum: Enum = Strobe
+
+
+class ZCLEnumSelectEntity(ZhaEntity, SelectEntity):
+    """Representation of a ZHA ZCL enum select entity."""
+
+    _select_attr: str
+    _attr_entity_category = EntityCategory.CONFIG
+    _enum: Enum
+
+    @classmethod
+    def create_entity(
+        cls,
+        unique_id: str,
+        zha_device: ZhaDeviceType,
+        channels: list[ChannelType],
+        **kwargs,
+    ) -> ZhaEntity | None:
+        """Entity Factory.
+
+        Return entity if it is a supported configuration, otherwise return None
+        """
+        channel = channels[0]
+        if cls._select_attr in channel.cluster.unsupported_attributes:
+            return None
+
+        return cls(unique_id, zha_device, channels, **kwargs)
+
+    def __init__(
+        self,
+        unique_id: str,
+        zha_device: ZhaDeviceType,
+        channels: list[ChannelType],
+        **kwargs,
+    ) -> None:
+        """Init this select entity."""
+        self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
+        self._channel: ChannelType = channels[0]
+        super().__init__(unique_id, zha_device, channels, **kwargs)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        option = self._channel.cluster.get(self._select_attr)
+        if option is None:
+            return None
+        option = self._enum(option)
+        return option.name.replace("_", " ")
+
+    async def async_select_option(self, option: str | int) -> None:
+        """Change the selected option."""
+        await self._channel.cluster.write_attributes(
+            {self._select_attr: self._enum[option.replace(" ", "_")]}
+        )
+        self.async_write_ha_state()
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_ON_OFF)
+class ZHAStartupOnOffSelectEntity(
+    ZCLEnumSelectEntity, id_suffix=OnOff.StartUpOnOff.__name__
+):
+    """Representation of a ZHA startup onoff select entity."""
+
+    _select_attr = "start_up_on_off"
+    _enum: Enum = OnOff.StartUpOnOff

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -44,6 +44,16 @@ from .zha_devices_list import (
 NO_TAIL_ID = re.compile("_\\d$")
 UNIQUE_ID_HD = re.compile(r"^(([\da-fA-F]{2}:){7}[\da-fA-F]{2}-\d{1,3})", re.X)
 
+IGNORE_SUFFIXES = [zigpy.zcl.clusters.general.OnOff.StartUpOnOff.__name__]
+
+
+def contains_ignored_suffix(unique_id: str) -> bool:
+    """Return true if the unique_id ends with an ignored suffix."""
+    for suffix in IGNORE_SUFFIXES:
+        if suffix.lower() in unique_id.lower():
+            return True
+    return False
+
 
 @pytest.fixture
 def channels_mock(zha_device_mock):
@@ -142,7 +152,7 @@ async def test_devices(
         _, component, entity_cls, unique_id, channels = call[0]
         # the factory can return None. We filter these out to get an accurate created entity count
         response = entity_cls.create_entity(unique_id, zha_dev, channels)
-        if response:
+        if response and not contains_ignored_suffix(response.name):
             created_entity_count += 1
             unique_id_head = UNIQUE_ID_HD.match(unique_id).group(
                 0
@@ -178,7 +188,9 @@ async def test_devices(
     await hass_disable_services.async_block_till_done()
 
     zha_entity_ids = {
-        ent for ent in entity_ids if ent.split(".")[0] in zha_const.PLATFORMS
+        ent
+        for ent in entity_ids
+        if not contains_ignored_suffix(ent) and ent.split(".")[0] in zha_const.PLATFORMS
     }
     assert zha_entity_ids == {
         e[DEV_SIG_ENT_MAP_ID] for e in device[DEV_SIG_ENT_MAP].values()
@@ -319,12 +331,15 @@ async def test_discover_endpoint(device_info, channels_mock, hass):
     ha_ent_info = {}
     for call in new_ent.call_args_list:
         component, entity_cls, unique_id, channels = call[0]
-        unique_id_head = UNIQUE_ID_HD.match(unique_id).group(0)  # ieee + endpoint_id
-        ha_ent_info[(unique_id_head, entity_cls.__name__)] = (
-            component,
-            unique_id,
-            channels,
-        )
+        if not contains_ignored_suffix(unique_id):
+            unique_id_head = UNIQUE_ID_HD.match(unique_id).group(
+                0
+            )  # ieee + endpoint_id
+            ha_ent_info[(unique_id_head, entity_cls.__name__)] = (
+                component,
+                unique_id,
+                channels,
+            )
 
     for comp_id, ent_info in device_info[DEV_SIG_ENT_MAP].items():
         component, unique_id = comp_id

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -34,6 +34,28 @@ async def siren(hass, zigpy_device_mock, zha_device_joined_restored):
 
 
 @pytest.fixture
+async def light(hass, zigpy_device_mock):
+    """Siren fixture."""
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    general.Identify.cluster_id,
+                    general.OnOff.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [general.Ota.cluster_id],
+            }
+        },
+    )
+
+    return zigpy_device
+
+
+@pytest.fixture
 def core_rs(hass_storage):
     """Core.restore_state fixture."""
 
@@ -149,3 +171,67 @@ async def test_select_restore_state(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == security.IasWd.Warning.WarningMode.Burglar.name
+
+
+async def test_on_off_select(hass, light, zha_device_joined_restored):
+    """Test zha on off select."""
+
+    entity_registry = er.async_get(hass)
+    on_off_cluster = light.endpoints[1].on_off
+    on_off_cluster.PLUGGED_ATTR_READS = {
+        "start_up_on_off": general.OnOff.StartUpOnOff.On
+    }
+    zha_device = await zha_device_joined_restored(light)
+    select_name = general.OnOff.StartUpOnOff.__name__
+    entity_id = await find_entity_id(
+        Platform.SELECT,
+        zha_device,
+        hass,
+        qualifier=select_name.lower(),
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes["options"] == ["Off", "On", "Toggle", "PreviousValue"]
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category == ENTITY_CATEGORY_CONFIG
+
+    # Test select option with string value
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {
+            "entity_id": entity_id,
+            "option": general.OnOff.StartUpOnOff.Off.name,
+        },
+        blocking=True,
+    )
+
+    assert on_off_cluster.write_attributes.call_count == 1
+    assert on_off_cluster.write_attributes.call_args[0][0] == {
+        "start_up_on_off": general.OnOff.StartUpOnOff.Off
+    }
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == general.OnOff.StartUpOnOff.Off.name
+
+
+async def test_on_off_select_unsupported(hass, light, zha_device_joined_restored):
+    """Test zha on off select unsupported."""
+
+    on_off_cluster = light.endpoints[1].on_off
+    on_off_cluster.add_unsupported_attribute("start_up_on_off")
+    zha_device = await zha_device_joined_restored(light)
+    select_name = general.OnOff.StartUpOnOff.__name__
+    entity_id = await find_entity_id(
+        Platform.SELECT,
+        zha_device,
+        hass,
+        qualifier=select_name.lower(),
+    )
+    assert entity_id is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces support for configuring the state of devices after power loss to ZHA. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
