### PR TITLE
Add clear_skipped service to update entity

### DIFF
--- a/homeassistant/components/update/services.yaml
+++ b/homeassistant/components/update/services.yaml
@@ -25,3 +25,10 @@ skip:
   target:
     entity:
       domain: update
+
+clear_skipped:
+  name: Clear skipped update
+  description: Removes the skipped version marker from an update.
+  target:
+    entity:
+      domain: update

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -202,6 +202,21 @@ async def test_entity_with_no_install(
     assert state.attributes[ATTR_LATEST_VERSION] == "1.0.1"
     assert state.attributes[ATTR_SKIPPED_VERSION] == "1.0.1"
 
+    # We can clear the skipped marker again
+    await hass.services.async_call(
+        DOMAIN,
+        "clear_skipped",
+        {ATTR_ENTITY_ID: "update.update_no_install"},
+        blocking=True,
+    )
+
+    state = hass.states.get("update.update_no_install")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_INSTALLED_VERSION] == "1.0.0"
+    assert state.attributes[ATTR_LATEST_VERSION] == "1.0.1"
+    assert state.attributes[ATTR_SKIPPED_VERSION] is None
+
 
 async def test_entity_with_no_updates(
     hass: HomeAssistant,
@@ -279,7 +294,7 @@ async def test_entity_with_auto_update(
         blocking=True,
     )
 
-    # Should not be to skip the update
+    # Should not be able to skip the update
     with pytest.raises(
         HomeAssistantError,
         match="Skipping update is not supported for Update with auto update",
@@ -287,6 +302,18 @@ async def test_entity_with_auto_update(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SKIP,
+            {ATTR_ENTITY_ID: "update.update_with_auto_update"},
+            blocking=True,
+        )
+
+    # Should not be able to clear a skipped the update
+    with pytest.raises(
+        HomeAssistantError,
+        match="Clearing skipped update is not supported for Update with auto update",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "clear_skipped",
             {ATTR_ENTITY_ID: "update.update_with_auto_update"},
             blocking=True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a new service to the `update` entity, that can clear a previously marked version as skipped.

This allows for automations that e.g., once a week remove the markers and thus re-trigger the update notifications.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22403

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
