### PR TITLE
Add shorthand notation for boolean conditions

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1010,7 +1010,7 @@ def expand_condition_shorthand(value: Any | None) -> Any:
         except vol.MultipleInvalid:
             pass
 
-        if isinstance(value[CONF_CONDITION], list):
+        if isinstance(value.get(CONF_CONDITION), list):
             try:
                 CONDITION_SHORTHAND_SCHEMA(value)
                 return {

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1005,6 +1005,18 @@ def boolean_condition_shorthand(condition: str) -> Callable[[Any], dict[Hashable
     return validator
 
 
+def ensure_default_condition(value: dict[Hashable, Any]) -> Any:
+    """Assume AND condition if only a list of conditions is given."""
+    if (
+        isinstance(value, dict)
+        and isinstance(value.get(CONF_CONDITION), list)
+        and CONF_CONDITIONS not in value
+    ):
+        value[CONF_CONDITIONS] = value.get(CONF_CONDITION)
+        value[CONF_CONDITION] = "and"
+    return value
+
+
 # Schemas
 PLATFORM_SCHEMA = vol.Schema(
     {
@@ -1315,21 +1327,24 @@ dynamic_template_condition_action = vol.All(
 
 CONDITION_SCHEMA: vol.Schema = vol.Schema(
     vol.Any(
-        key_value_schemas(
-            CONF_CONDITION,
-            {
-                "and": AND_CONDITION_SCHEMA,
-                "device": DEVICE_CONDITION_SCHEMA,
-                "not": NOT_CONDITION_SCHEMA,
-                "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
-                "or": OR_CONDITION_SCHEMA,
-                "state": STATE_CONDITION_SCHEMA,
-                "sun": SUN_CONDITION_SCHEMA,
-                "template": TEMPLATE_CONDITION_SCHEMA,
-                "time": TIME_CONDITION_SCHEMA,
-                "trigger": TRIGGER_CONDITION_SCHEMA,
-                "zone": ZONE_CONDITION_SCHEMA,
-            },
+        vol.All(
+            ensure_default_condition,
+            key_value_schemas(
+                CONF_CONDITION,
+                {
+                    "and": AND_CONDITION_SCHEMA,
+                    "device": DEVICE_CONDITION_SCHEMA,
+                    "not": NOT_CONDITION_SCHEMA,
+                    "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
+                    "or": OR_CONDITION_SCHEMA,
+                    "state": STATE_CONDITION_SCHEMA,
+                    "sun": SUN_CONDITION_SCHEMA,
+                    "template": TEMPLATE_CONDITION_SCHEMA,
+                    "time": TIME_CONDITION_SCHEMA,
+                    "trigger": TRIGGER_CONDITION_SCHEMA,
+                    "zone": ZONE_CONDITION_SCHEMA,
+                },
+            ),
         ),
         dynamic_template_condition_action,
         boolean_condition_shorthand("and"),
@@ -1353,23 +1368,26 @@ dynamic_template_condition_action = vol.All(
 
 
 CONDITION_ACTION_SCHEMA: vol.Schema = vol.Schema(
-    key_value_schemas(
-        CONF_CONDITION,
-        {
-            "and": AND_CONDITION_SCHEMA,
-            "device": DEVICE_CONDITION_SCHEMA,
-            "not": NOT_CONDITION_SCHEMA,
-            "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
-            "or": OR_CONDITION_SCHEMA,
-            "state": STATE_CONDITION_SCHEMA,
-            "sun": SUN_CONDITION_SCHEMA,
-            "template": TEMPLATE_CONDITION_SCHEMA,
-            "time": TIME_CONDITION_SCHEMA,
-            "trigger": TRIGGER_CONDITION_SCHEMA,
-            "zone": ZONE_CONDITION_SCHEMA,
-        },
-        dynamic_template_condition_action,
-        "a valid template",
+    vol.All(
+        ensure_default_condition,
+        key_value_schemas(
+            CONF_CONDITION,
+            {
+                "and": AND_CONDITION_SCHEMA,
+                "device": DEVICE_CONDITION_SCHEMA,
+                "not": NOT_CONDITION_SCHEMA,
+                "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
+                "or": OR_CONDITION_SCHEMA,
+                "state": STATE_CONDITION_SCHEMA,
+                "sun": SUN_CONDITION_SCHEMA,
+                "template": TEMPLATE_CONDITION_SCHEMA,
+                "time": TIME_CONDITION_SCHEMA,
+                "trigger": TRIGGER_CONDITION_SCHEMA,
+                "zone": ZONE_CONDITION_SCHEMA,
+            },
+            dynamic_template_condition_action,
+            "a list of conditions or a valid template",
+        ),
     )
 )
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1236,6 +1236,24 @@ AND_CONDITION_SCHEMA = vol.Schema(
     }
 )
 
+and_condition_shorthand_action = vol.All(
+    vol.Schema(
+        {
+            **CONDITION_BASE_SCHEMA,
+            "and": vol.All(
+                ensure_list,
+                # pylint: disable=unnecessary-lambda
+                [lambda value: CONDITION_SCHEMA(value)],
+            ),
+        }
+    ),
+    lambda config: {
+        CONF_CONDITION: "and",
+        CONF_CONDITIONS: config["and"],
+        **{k: config[k] for k in config.keys() if k not in ["and"]},
+    },
+)
+
 OR_CONDITION_SCHEMA = vol.Schema(
     {
         **CONDITION_BASE_SCHEMA,
@@ -1248,6 +1266,24 @@ OR_CONDITION_SCHEMA = vol.Schema(
     }
 )
 
+or_condition_shorthand_action = vol.All(
+    vol.Schema(
+        {
+            **CONDITION_BASE_SCHEMA,
+            "or": vol.All(
+                ensure_list,
+                # pylint: disable=unnecessary-lambda
+                [lambda value: CONDITION_SCHEMA(value)],
+            ),
+        }
+    ),
+    lambda config: {
+        CONF_CONDITION: "or",
+        CONF_CONDITIONS: config["or"],
+        **{k: config[k] for k in config.keys() if k not in ["or"]},
+    },
+)
+
 NOT_CONDITION_SCHEMA = vol.Schema(
     {
         **CONDITION_BASE_SCHEMA,
@@ -1258,6 +1294,24 @@ NOT_CONDITION_SCHEMA = vol.Schema(
             [lambda value: CONDITION_SCHEMA(value)],
         ),
     }
+)
+
+not_condition_shorthand_action = vol.All(
+    vol.Schema(
+        {
+            **CONDITION_BASE_SCHEMA,
+            "not": vol.All(
+                ensure_list,
+                # pylint: disable=unnecessary-lambda
+                [lambda value: CONDITION_SCHEMA(value)],
+            ),
+        }
+    ),
+    lambda config: {
+        CONF_CONDITION: "not",
+        CONF_CONDITIONS: config["not"],
+        **{k: config[k] for k in config.keys() if k not in ["not"]},
+    },
 )
 
 DEVICE_CONDITION_BASE_SCHEMA = vol.Schema(
@@ -1300,6 +1354,9 @@ CONDITION_SCHEMA: vol.Schema = vol.Schema(
             },
         ),
         dynamic_template_condition_action,
+        and_condition_shorthand_action,
+        or_condition_shorthand_action,
+        not_condition_shorthand_action,
     )
 )
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.components import sun
 import homeassistant.components.automation as automation
@@ -370,6 +371,17 @@ async def test_and_condition_list_shorthand(hass):
 
     hass.states.async_set("sensor.temperature", 100)
     assert test(hass)
+
+
+async def test_malformed_and_condition_list_shorthand(hass):
+    """Test the 'and' condition list shorthand syntax check."""
+    config = {
+        "alias": "Bad shorthand syntax",
+        "condition": ["bad", "syntax"],
+    }
+
+    with pytest.raises(vol.MultipleInvalid):
+        cv.CONDITION_SCHEMA(config)
 
 
 async def test_or_condition(hass):

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -288,6 +288,48 @@ async def test_and_condition_with_template(hass):
     assert test(hass)
 
 
+async def test_and_condition_shorthand(hass):
+    """Test the 'and' condition shorthand."""
+    config = {
+        "alias": "And Condition Shorthand",
+        "and": [
+            {
+                "alias": "Template Condition",
+                "condition": "template",
+                "value_template": '{{ states.sensor.temperature.state == "100" }}',
+            },
+            {
+                "condition": "numeric_state",
+                "entity_id": "sensor.temperature",
+                "below": 110,
+            },
+        ],
+    }
+    config = cv.CONDITION_SCHEMA(config)
+    config = await condition.async_validate_condition_config(hass, config)
+    test = await condition.async_from_config(hass, config)
+
+    assert config["alias"] == "And Condition Shorthand"
+    assert "and" not in config.keys()
+
+    hass.states.async_set("sensor.temperature", 120)
+    assert not test(hass)
+    assert_condition_trace(
+        {
+            "": [{"result": {"result": False}}],
+            "conditions/0": [
+                {"result": {"entities": ["sensor.temperature"], "result": False}}
+            ],
+        }
+    )
+
+    hass.states.async_set("sensor.temperature", 105)
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 100)
+    assert test(hass)
+
+
 async def test_or_condition(hass):
     """Test the 'or' condition."""
     config = {
@@ -460,6 +502,36 @@ async def test_or_condition_with_template(hass):
     config = cv.CONDITION_SCHEMA(config)
     config = await condition.async_validate_condition_config(hass, config)
     test = await condition.async_from_config(hass, config)
+
+    hass.states.async_set("sensor.temperature", 120)
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 105)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature", 100)
+    assert test(hass)
+
+
+async def test_or_condition_shorthand(hass):
+    """Test the 'or' condition shorthand."""
+    config = {
+        "alias": "Or Condition Shorthand",
+        "or": [
+            {'{{ states.sensor.temperature.state == "100" }}'},
+            {
+                "condition": "numeric_state",
+                "entity_id": "sensor.temperature",
+                "below": 110,
+            },
+        ],
+    }
+    config = cv.CONDITION_SCHEMA(config)
+    config = await condition.async_validate_condition_config(hass, config)
+    test = await condition.async_from_config(hass, config)
+
+    assert config["alias"] == "Or Condition Shorthand"
+    assert "or" not in config.keys()
 
     hass.states.async_set("sensor.temperature", 120)
     assert not test(hass)
@@ -656,6 +728,42 @@ async def test_not_condition_with_template(hass):
     config = cv.CONDITION_SCHEMA(config)
     config = await condition.async_validate_condition_config(hass, config)
     test = await condition.async_from_config(hass, config)
+
+    hass.states.async_set("sensor.temperature", 101)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature", 50)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature", 49)
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 100)
+    assert not test(hass)
+
+
+async def test_not_condition_shorthand(hass):
+    """Test the 'or' condition shorthand."""
+    config = {
+        "alias": "Not Condition Shorthand",
+        "not": [
+            {
+                "condition": "template",
+                "value_template": '{{ states.sensor.temperature.state == "100" }}',
+            },
+            {
+                "condition": "numeric_state",
+                "entity_id": "sensor.temperature",
+                "below": 50,
+            },
+        ],
+    }
+    config = cv.CONDITION_SCHEMA(config)
+    config = await condition.async_validate_condition_config(hass, config)
+    test = await condition.async_from_config(hass, config)
+
+    assert config["alias"] == "Not Condition Shorthand"
+    assert "not" not in config.keys()
 
     hass.states.async_set("sensor.temperature", 101)
     assert test(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a shorthand form for `and`, `or` and `not` conditions on the form:

```yaml
or:
  - <condition>
  - and:
    - <condition>
    - <condition>
  - not:
    - <condition>
``` 

Example:
```yaml
automation test:
  - trigger:
     - platform: state
       entity_id: light.bed_light
       to: "on"
    condition:
      - or:
        - condition: state
          entity_id: light.ceiling_lights
          state: "on"
        - condition: state
          entity_id: light.kitchen_lights
          state: "on"
    action:
      - service: light.turn_off
        target:
          entity_id: light.bed_light
```

Edit: The latest commit makes a list of conditions AND by default, such that the conditions in the following snippet behave equally:
```yaml
trigger: []
condition:
  - condition A
  - condition B
action:
  - event: ...
  - condition:
    - condition C
    - condition D
```

`boolean_condition_shorthand` can probably be combined with `ensure_default_condition` for a bit neater code. I'll look at that tomorrow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  home-assistant/home-assistant.io#22408

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
