### PR TITLE
Bump pytomorrowio to 0.3.1

### DIFF
--- a/homeassistant/components/tomorrowio/manifest.json
+++ b/homeassistant/components/tomorrowio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tomorrow.io",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tomorrowio",
-  "requirements": ["pytomorrowio==0.2.1"],
+  "requirements": ["pytomorrowio==0.3.0"],
   "codeowners": ["@raman325"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/tomorrowio/manifest.json
+++ b/homeassistant/components/tomorrowio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tomorrow.io",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tomorrowio",
-  "requirements": ["pytomorrowio==0.3.0"],
+  "requirements": ["pytomorrowio==0.3.1"],
   "codeowners": ["@raman325"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/tomorrowio/manifest.json
+++ b/homeassistant/components/tomorrowio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tomorrow.io",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tomorrowio",
-  "requirements": ["pytomorrowio==0.1.0"],
+  "requirements": ["pytomorrowio==0.2.0"],
   "codeowners": ["@raman325"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/tomorrowio/manifest.json
+++ b/homeassistant/components/tomorrowio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tomorrow.io",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tomorrowio",
-  "requirements": ["pytomorrowio==0.2.0"],
+  "requirements": ["pytomorrowio==0.2.1"],
   "codeowners": ["@raman325"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1955,7 +1955,7 @@ pythonegardia==1.0.40
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.3.0
+pytomorrowio==0.3.1
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1955,7 +1955,7 @@ pythonegardia==1.0.40
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.1.0
+pytomorrowio==0.2.0
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1955,7 +1955,7 @@ pythonegardia==1.0.40
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.2.0
+pytomorrowio==0.2.1
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1955,7 +1955,7 @@ pythonegardia==1.0.40
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.2.1
+pytomorrowio==0.3.0
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1275,7 +1275,7 @@ python_awair==0.2.3
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.2.0
+pytomorrowio==0.2.1
 
 # homeassistant.components.traccar
 pytraccar==0.10.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1275,7 +1275,7 @@ python_awair==0.2.3
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.1.0
+pytomorrowio==0.2.0
 
 # homeassistant.components.traccar
 pytraccar==0.10.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1275,7 +1275,7 @@ python_awair==0.2.3
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.3.0
+pytomorrowio==0.3.1
 
 # homeassistant.components.traccar
 pytraccar==0.10.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1275,7 +1275,7 @@ python_awair==0.2.3
 pytile==2022.02.0
 
 # homeassistant.components.tomorrowio
-pytomorrowio==0.2.1
+pytomorrowio==0.3.0
 
 # homeassistant.components.traccar
 pytraccar==0.10.0


### PR DESCRIPTION
## Proposed change
This release makes the library more robust. Thanks to @lymanepp we also have tests in the lib now to ensure things work as expected.

New features:
- We can now get max API requests from the lib via the API response headers so we don't have to set the max to an arbitrary value
- We can now calculate the number of API requests dynamically which is important because the API has a field limit which means as we add new fields the number of calls will change
- We have some basic handling of per second rate limits
- A single class instance can be used to query weather data for multiple locations. This would allow me to easily handle per second rate limits in the integration by creating a single coordinator for each API key and using that to make all calls.

Changelog:
- https://github.com/raman325/pytomorrowio/releases/tag/v0.2.0
- https://github.com/raman325/pytomorrowio/releases/tag/v0.2.1
- https://github.com/raman325/pytomorrowio/releases/tag/v0.3.0
- https://github.com/raman325/pytomorrowio/releases/tag/v0.3.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
