### PR TITLE
Move google calendar api logic to new python library

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -8,6 +8,8 @@ import logging
 from typing import Any
 
 import aiohttp
+from gcal_sync.api import GoogleCalendarService
+from gcal_sync.model import DateOrDatetime, Event
 from httplib2.error import ServerNotFoundError
 from oauth2client.file import Storage
 import voluptuous as vol
@@ -37,7 +39,7 @@ from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.typing import ConfigType
 
 from . import config_flow
-from .api import DeviceAuth, GoogleCalendarService
+from .api import ApiAuthImpl, DeviceAuth
 from .const import (
     CONF_CALENDAR_ACCESS,
     DATA_CONFIG,
@@ -212,7 +214,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryAuthFailed(
             "Required scopes are not available, reauth required"
         )
-    calendar_service = GoogleCalendarService(hass, session)
+    calendar_service = GoogleCalendarService(hass.loop, ApiAuthImpl(hass, session))
     hass.data[DOMAIN][DATA_SERVICE] = calendar_service
 
     await async_setup_services(hass, hass.data[DOMAIN][DATA_CONFIG], calendar_service)
@@ -263,11 +265,12 @@ async def async_setup_services(
     async def _scan_for_calendars(call: ServiceCall) -> None:
         """Scan for new calendars."""
         try:
-            calendars = await calendar_service.async_list_calendars()
+            result = await calendar_service.async_list_calendars()
         except ServerNotFoundError as err:
             raise HomeAssistantError(str(err)) from err
         tasks = []
-        for calendar in calendars:
+        for calendar_item in result.items:
+            calendar = calendar_item.dict(exclude_unset=True)
             calendar[CONF_TRACK] = config[CONF_TRACK_NEW]
             tasks.append(
                 hass.services.async_call(DOMAIN, SERVICE_FOUND_CALENDARS, calendar)
@@ -278,8 +281,8 @@ async def async_setup_services(
 
     async def _add_event(call: ServiceCall) -> None:
         """Add a new event to calendar."""
-        start = {}
-        end = {}
+        start: DateOrDatetime | None = None
+        end: DateOrDatetime | None = None
 
         if EVENT_IN in call.data:
             if EVENT_IN_DAYS in call.data[EVENT_IN]:
@@ -288,8 +291,8 @@ async def async_setup_services(
                 start_in = now + timedelta(days=call.data[EVENT_IN][EVENT_IN_DAYS])
                 end_in = start_in + timedelta(days=1)
 
-                start = {"date": start_in.strftime("%Y-%m-%d")}
-                end = {"date": end_in.strftime("%Y-%m-%d")}
+                start = DateOrDatetime(date=start_in)
+                end = DateOrDatetime(date=end_in)
 
             elif EVENT_IN_WEEKS in call.data[EVENT_IN]:
                 now = datetime.now()
@@ -297,29 +300,34 @@ async def async_setup_services(
                 start_in = now + timedelta(weeks=call.data[EVENT_IN][EVENT_IN_WEEKS])
                 end_in = start_in + timedelta(days=1)
 
-                start = {"date": start_in.strftime("%Y-%m-%d")}
-                end = {"date": end_in.strftime("%Y-%m-%d")}
+                start = DateOrDatetime(date=start_in)
+                end = DateOrDatetime(date=end_in)
 
         elif EVENT_START_DATE in call.data:
-            start = {"date": str(call.data[EVENT_START_DATE])}
-            end = {"date": str(call.data[EVENT_END_DATE])}
+            start = DateOrDatetime(date=call.data[EVENT_START_DATE])
+            end = DateOrDatetime(date=call.data[EVENT_END_DATE])
 
         elif EVENT_START_DATETIME in call.data:
-            start_dt = str(
-                call.data[EVENT_START_DATETIME].strftime("%Y-%m-%dT%H:%M:%S")
+            start_dt = call.data[EVENT_START_DATETIME]
+            end_dt = call.data[EVENT_END_DATETIME]
+            start = DateOrDatetime(
+                date_time=start_dt, timezone=str(hass.config.time_zone)
             )
-            end_dt = str(call.data[EVENT_END_DATETIME].strftime("%Y-%m-%dT%H:%M:%S"))
-            start = {"dateTime": start_dt, "timeZone": str(hass.config.time_zone)}
-            end = {"dateTime": end_dt, "timeZone": str(hass.config.time_zone)}
+            end = DateOrDatetime(date_time=end_dt, timezone=str(hass.config.time_zone))
+
+        if start is None or end is None:
+            raise ValueError(
+                "Missing required fields to set start or end date/datetime"
+            )
 
         await calendar_service.async_create_event(
             call.data[EVENT_CALENDAR_ID],
-            {
-                "summary": call.data[EVENT_SUMMARY],
-                "description": call.data[EVENT_DESCRIPTION],
-                "start": start,
-                "end": end,
-            },
+            Event(
+                summary=call.data[EVENT_SUMMARY],
+                description=call.data[EVENT_DESCRIPTION],
+                start=start,
+                end=end,
+            ),
         )
 
     # Only expose the add event service if we have the correct permissions

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -156,7 +156,7 @@ class ApiAuthImpl(AbstractAuth):
     def __init__(
         self, hass: HomeAssistant, session: config_entry_oauth2_flow.OAuth2Session
     ) -> None:
-        """Init the Google Calendar service."""
+        """Init the Google Calendar client library auth implementation."""
         self._hass = hass
         self._session = session
 

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -8,7 +8,7 @@ import logging
 import time
 from typing import Any
 
-from googleapiclient import discovery as google_discovery
+from gcal_sync.auth import AbstractAuth
 import oauth2client
 from oauth2client.client import (
     Credentials,
@@ -150,28 +150,8 @@ async def async_create_device_flow(hass: HomeAssistant) -> DeviceFlow:
     return DeviceFlow(hass, oauth_flow, device_flow_info)
 
 
-def _async_google_creds(hass: HomeAssistant, token: dict[str, Any]) -> Credentials:
-    """Convert a Home Assistant token to a Google API Credentials object."""
-    conf = hass.data[DOMAIN][DATA_CONFIG]
-    return OAuth2Credentials(
-        access_token=token["access_token"],
-        client_id=conf[CONF_CLIENT_ID],
-        client_secret=conf[CONF_CLIENT_SECRET],
-        refresh_token=token["refresh_token"],
-        token_expiry=datetime.datetime.fromtimestamp(token["expires_at"]),
-        token_uri=oauth2client.GOOGLE_TOKEN_URI,
-        scopes=[conf[CONF_CALENDAR_ACCESS].scope],
-        user_agent=None,
-    )
-
-
-def _api_time_format(date_time: datetime.datetime | None) -> str | None:
-    """Convert a datetime to the api string format."""
-    return date_time.isoformat("T") if date_time else None
-
-
-class GoogleCalendarService:
-    """Calendar service interface to Google."""
+class ApiAuthImpl(AbstractAuth):
+    """Authentication implementation for google calendar api library."""
 
     def __init__(
         self, hass: HomeAssistant, session: config_entry_oauth2_flow.OAuth2Session
@@ -180,65 +160,18 @@ class GoogleCalendarService:
         self._hass = hass
         self._session = session
 
-    async def _async_get_service(self) -> google_discovery.Resource:
-        """Get the calendar service with valid credetnails."""
+    async def async_get_creds(self) -> OAuth2Credentials:
+        """Convert a Home Assistant token to a Google API Credentials object."""
         await self._session.async_ensure_token_valid()
-        creds = _async_google_creds(self._hass, self._session.token)
-
-        def _build() -> google_discovery.Resource:
-            return google_discovery.build(
-                "calendar", "v3", credentials=creds, cache_discovery=False
-            )
-
-        return await self._hass.async_add_executor_job(_build)
-
-    async def async_list_calendars(
-        self,
-    ) -> list[dict[str, Any]]:
-        """Return the list of calendars the user has added to their list."""
-        service = await self._async_get_service()
-
-        def _list_calendars() -> list[dict[str, Any]]:
-            cal_list = service.calendarList()
-            return cal_list.list().execute()["items"]
-
-        return await self._hass.async_add_executor_job(_list_calendars)
-
-    async def async_create_event(
-        self, calendar_id: str, event: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Return the list of calendars the user has added to their list."""
-        service = await self._async_get_service()
-
-        def _create_event() -> dict[str, Any]:
-            events = service.events()
-            return events.insert(calendarId=calendar_id, body=event).execute()
-
-        return await self._hass.async_add_executor_job(_create_event)
-
-    async def async_list_events(
-        self,
-        calendar_id: str,
-        start_time: datetime.datetime | None = None,
-        end_time: datetime.datetime | None = None,
-        search: str | None = None,
-        page_token: str | None = None,
-    ) -> tuple[list[dict[str, Any]], str | None]:
-        """Return the list of events."""
-        service = await self._async_get_service()
-
-        def _list_events() -> tuple[list[dict[str, Any]], str | None]:
-            events = service.events()
-            result = events.list(
-                calendarId=calendar_id,
-                timeMin=_api_time_format(start_time if start_time else dt.now()),
-                timeMax=_api_time_format(end_time),
-                q=search,
-                maxResults=EVENT_PAGE_SIZE,
-                pageToken=page_token,
-                singleEvents=True,  # Flattens recurring events
-                orderBy="startTime",
-            ).execute()
-            return (result["items"], result.get("nextPageToken"))
-
-        return await self._hass.async_add_executor_job(_list_events)
+        conf = self._hass.data[DOMAIN][DATA_CONFIG]
+        token = self._session.token
+        return OAuth2Credentials(
+            access_token=token["access_token"],
+            client_id=conf[CONF_CLIENT_ID],
+            client_secret=conf[CONF_CLIENT_SECRET],
+            refresh_token=token["refresh_token"],
+            token_expiry=datetime.datetime.fromtimestamp(token["expires_at"]),
+            token_uri=oauth2client.GOOGLE_TOKEN_URI,
+            scopes=[conf[CONF_CALENDAR_ACCESS].scope],
+            user_agent=None,
+        )

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -6,6 +6,8 @@ from datetime import date, datetime, timedelta
 import logging
 from typing import Any
 
+from gcal_sync.api import GoogleCalendarService, ListEventsRequest
+from gcal_sync.model import Event
 from httplib2 import ServerNotFoundError
 
 from homeassistant.components.calendar import (
@@ -34,7 +36,6 @@ from . import (
     DOMAIN,
     SERVICE_SCAN_CALENDARS,
 )
-from .api import GoogleCalendarService
 from .const import DISCOVER_CALENDAR
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,54 +148,55 @@ class GoogleCalendarEntity(CalendarEntity):
         """Return the name of the entity."""
         return self._name
 
-    def _event_filter(self, event: dict[str, Any]) -> bool:
+    def _event_filter(self, event: Event) -> bool:
         """Return True if the event is visible."""
         if self._ignore_availability:
             return True
-        return event.get(TRANSPARENCY, OPAQUE) == OPAQUE
+        return event.transparency == OPAQUE
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
         event_list: list[dict[str, Any]] = []
-        page_token: str | None = None
+
+        request = ListEventsRequest(
+            calendar_id=self._calendar_id,
+            start_time=start_date,
+            end_time=end_date,
+            search=self._search,
+        )
         while True:
             try:
-                items, page_token = await self._calendar_service.async_list_events(
-                    self._calendar_id,
-                    start_time=start_date,
-                    end_time=end_date,
-                    search=self._search,
-                    page_token=page_token,
-                )
+                result = await self._calendar_service.async_list_events(request)
             except ServerNotFoundError as err:
                 _LOGGER.error("Unable to connect to Google: %s", err)
                 return []
 
-            event_list.extend(filter(self._event_filter, items))
-            if not page_token:
+            event_list.extend(filter(self._event_filter, result.items))
+            if not result.page_token:
                 break
+
+            request.page_token = result.page_token
 
         return [_get_calendar_event(event) for event in event_list]
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:
         """Get the latest data."""
+        request = ListEventsRequest(calendar_id=self._calendar_id, search=self._search)
         try:
-            items, _ = await self._calendar_service.async_list_events(
-                self._calendar_id, search=self._search
-            )
+            result = await self._calendar_service.async_list_events(request)
         except ServerNotFoundError as err:
             _LOGGER.error("Unable to connect to Google: %s", err)
             return
 
+        items = result.items
         # Pick the first visible event and apply offset calculations.
         valid_items = filter(self._event_filter, items)
         event = copy.deepcopy(next(valid_items, None))
         if event:
-            (summary, offset) = extract_offset(event.get("summary", ""), self._offset)
-            event["summary"] = summary
+            (event.summary, offset) = extract_offset(event.summary, self._offset)
             self._event = _get_calendar_event(event)
             self._offset_value = offset
         else:
@@ -212,12 +214,12 @@ def _get_date_or_datetime(date_dict: dict[str, str]) -> datetime | date:
     return parsed_datetime
 
 
-def _get_calendar_event(event: dict[str, Any]) -> CalendarEvent:
+def _get_calendar_event(event: Event) -> CalendarEvent:
     """Return a CalendarEvent from an API event."""
     return CalendarEvent(
-        summary=event["summary"],
-        start=_get_date_or_datetime(event["start"]),
-        end=_get_date_or_datetime(event["end"]),
-        description=event.get("description"),
-        location=event.get("location"),
+        summary=event.summary,
+        start=event.start.value,
+        end=event.end.value,
+        description=event.description,
+        location=event.location,
     )

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -5,6 +5,7 @@
   "dependencies": ["auth"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
   "requirements": [
+    "gcal-sync==0.3.1",
     "google-api-python-client==2.38.0",
     "httplib2==0.20.4",
     "oauth2client==4.1.3"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -675,6 +675,9 @@ gTTS==2.2.4
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==3.0.0
 
+# homeassistant.components.google
+gcal-sync==0.3.1
+
 # homeassistant.components.geniushub
 geniushub-client==0.6.30
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -472,6 +472,9 @@ gTTS==2.2.4
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==3.0.0
 
+# homeassistant.components.google
+gcal-sync==0.3.1
+
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.6
 

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -201,7 +201,7 @@ def mock_token_read(
 @pytest.fixture(autouse=True)
 def calendar_resource() -> YieldFixture[google_discovery.Resource]:
     """Fixture to mock out the Google discovery API."""
-    with patch("homeassistant.components.google.api.google_discovery.build") as mock:
+    with patch("gcal_sync.api.google_discovery.build") as mock:
         yield mock
 
 

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -307,7 +307,7 @@ async def test_update_error(
     """Test that the calendar update handles a server error."""
 
     now = dt_util.now()
-    with patch("homeassistant.components.google.api.google_discovery.build") as mock:
+    with patch("gcal_sync.api.google_discovery.build") as mock:
         mock.return_value.calendarList.return_value.list.return_value.execute.return_value = {
             "items": [test_api_calendar]
         }
@@ -333,7 +333,7 @@ async def test_update_error(
     # Advance time to avoid throttling
     now += datetime.timedelta(minutes=30)
     with patch(
-        "homeassistant.components.google.api.google_discovery.build",
+        "gcal_sync.api.google_discovery.build",
         side_effect=httplib2.ServerNotFoundError("unit test"),
     ), patch("homeassistant.util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
@@ -346,9 +346,9 @@ async def test_update_error(
 
     # Advance time beyond update/throttle point
     now += datetime.timedelta(minutes=30)
-    with patch(
-        "homeassistant.components.google.api.google_discovery.build"
-    ) as mock, patch("homeassistant.util.utcnow", return_value=now):
+    with patch("gcal_sync.api.google_discovery.build") as mock, patch(
+        "homeassistant.util.utcnow", return_value=now
+    ):
         mock.return_value.events.return_value.list.return_value.execute.return_value = {
             "items": [
                 {
@@ -499,7 +499,7 @@ async def test_scan_calendar_error(
 ):
     """Test that the calendar update handles a server error."""
     with patch(
-        "homeassistant.components.google.api.google_discovery.build",
+        "gcal_sync.api.google_discovery.build",
         side_effect=httplib2.ServerNotFoundError("unit test"),
     ):
         assert await component_setup()

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -254,7 +254,7 @@ async def test_calendar_config_track_new(
     assert_state(state, expected_state)
 
 
-async def test_add_event(
+async def test_add_event_missing_required_fields(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
@@ -262,30 +262,21 @@ async def test_add_event(
     mock_insert_event: Mock,
     setup_config_entry: MockConfigEntry,
 ) -> None:
-    """Test service call that adds an event."""
+    """Test service call that adds an event missing required fields."""
 
     assert await component_setup()
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_ADD_EVENT,
-        {
-            "calendar_id": CALENDAR_ID,
-            "summary": "Summary",
-            "description": "Description",
-        },
-        blocking=True,
-    )
-    mock_insert_event.assert_called()
-    assert mock_insert_event.mock_calls[0] == call(
-        calendarId=CALENDAR_ID,
-        body={
-            "summary": "Summary",
-            "description": "Description",
-            "start": {},
-            "end": {},
-        },
-    )
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_EVENT,
+            {
+                "calendar_id": CALENDAR_ID,
+                "summary": "Summary",
+                "description": "Description",
+            },
+            blocking=True,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move google calendar api logic to new python library called `gsync_api`.

The long term motivation is to provide a more efficient and more reliable integration by synchronizing data from cloud down to device, rather than polling calendar state repeatedly. In particular, with the move to calendar triggers this may involve multiple independent fetches of events during a date range.  See [DESIGN](https://github.com/allenporter/gcal_sync/blob/main/DESIGN.md) for more details on long term plan.

As a first step, this PR moves the home assistant google calendar `api.py` wrapper into a new library. Short term improvements include higher test coverage, conforming to more typical API patterns, and better enforcement of API semantics using pydantic. This may introduce errors when initially rolled out, but will be better in the long term for understanding API expectations.  Note that existing tests are left with minimal modifications to show compatibility.

Commit history: https://github.com/allenporter/gcal_sync/compare/0.1.0...0.3.1 - Not sure how to show commits from zero
https://github.com/allenporter/gcal_sync/commits/main

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
