### PR TITLE
Only set attributes based on the configured type for min_max sensors

### DIFF
--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -31,23 +31,10 @@ ATTR_MIN_VALUE = "min_value"
 ATTR_MIN_ENTITY_ID = "min_entity_id"
 ATTR_MAX_VALUE = "max_value"
 ATTR_MAX_ENTITY_ID = "max_entity_id"
-ATTR_COUNT_SENSORS = "count_sensors"
 ATTR_MEAN = "mean"
 ATTR_MEDIAN = "median"
 ATTR_LAST = "last"
 ATTR_LAST_ENTITY_ID = "last_entity_id"
-
-ATTR_TO_PROPERTY = [
-    ATTR_COUNT_SENSORS,
-    ATTR_MAX_VALUE,
-    ATTR_MAX_ENTITY_ID,
-    ATTR_MEAN,
-    ATTR_MEDIAN,
-    ATTR_MIN_VALUE,
-    ATTR_MIN_ENTITY_ID,
-    ATTR_LAST,
-    ATTR_LAST_ENTITY_ID,
-]
 
 ICON = "mdi:calculator"
 
@@ -58,6 +45,7 @@ SENSOR_TYPES = {
     ATTR_MEDIAN: "median",
     ATTR_LAST: "last",
 }
+SENSOR_TYPE_TO_ATTR = {v: k for k, v in SENSOR_TYPES.items()}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -179,7 +167,8 @@ class MinMaxSensor(SensorEntity):
         if name:
             self._name = name
         else:
-            self._name = f"{next(v for k, v in SENSOR_TYPES.items() if self._sensor_type == v)} sensor".capitalize()
+            self._name = f"{sensor_type} sensor".capitalize()
+        self._sensor_attr = SENSOR_TYPE_TO_ATTR[self._sensor_type]
         self._unit_of_measurement = None
         self._unit_of_measurement_mismatch = False
         self.min_value = self.max_value = self.mean = self.last = self.median = None
@@ -213,9 +202,7 @@ class MinMaxSensor(SensorEntity):
         """Return the state of the sensor."""
         if self._unit_of_measurement_mismatch:
             return None
-        return getattr(
-            self, next(k for k, v in SENSOR_TYPES.items() if self._sensor_type == v)
-        )
+        return getattr(self, self._sensor_attr)
 
     @property
     def native_unit_of_measurement(self):
@@ -232,11 +219,13 @@ class MinMaxSensor(SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        return {
-            attr: getattr(self, attr)
-            for attr in ATTR_TO_PROPERTY
-            if getattr(self, attr) is not None
-        }
+        if self._sensor_type == "min":
+            return {ATTR_MIN_ENTITY_ID: self.min_entity_id}
+        if self._sensor_type == "max":
+            return {ATTR_MAX_ENTITY_ID: self.max_entity_id}
+        if self._sensor_type == "last":
+            return {ATTR_LAST_ENTITY_ID: self.last_entity_id}
+        return None
 
     @property
     def icon(self):

--- a/tests/components/min_max/test_config_flow.py
+++ b/tests/components/min_max/test_config_flow.py
@@ -132,4 +132,3 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     # Check the state of the entity has changed as expected
     state = hass.states.get(f"{platform}.my_min_max")
     assert state.state == "21.1"
-    assert state.attributes["count_sensors"] == 3

--- a/tests/components/min_max/test_init.py
+++ b/tests/components/min_max/test_init.py
@@ -44,7 +44,6 @@ async def test_setup_and_remove_config_entry(
     # Check the platform is setup correctly
     state = hass.states.get(min_max_entity_id)
     assert state.state == "20.0"
-    assert state.attributes["count_sensors"] == 2
 
     # Remove the config entry
     assert await hass.config_entries.async_remove(config_entry.entry_id)

--- a/tests/components/min_max/test_sensor.py
+++ b/tests/components/min_max/test_sensor.py
@@ -51,10 +51,6 @@ async def test_min_sensor(hass):
 
     assert str(float(MIN_VALUE)) == state.state
     assert entity_ids[2] == state.attributes.get("min_entity_id")
-    assert state.attributes.get("max_value") == MAX_VALUE
-    assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert state.attributes.get("mean") == MEAN
-    assert state.attributes.get("median") == MEDIAN
 
 
 async def test_max_sensor(hass):
@@ -80,11 +76,7 @@ async def test_max_sensor(hass):
     state = hass.states.get("sensor.test_max")
 
     assert str(float(MAX_VALUE)) == state.state
-    assert entity_ids[2] == state.attributes.get("min_entity_id")
-    assert state.attributes.get("min_value") == MIN_VALUE
     assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert state.attributes.get("mean") == MEAN
-    assert state.attributes.get("median") == MEDIAN
 
 
 async def test_mean_sensor(hass):
@@ -110,11 +102,6 @@ async def test_mean_sensor(hass):
     state = hass.states.get("sensor.test_mean")
 
     assert str(float(MEAN)) == state.state
-    assert state.attributes.get("min_value") == MIN_VALUE
-    assert entity_ids[2] == state.attributes.get("min_entity_id")
-    assert state.attributes.get("max_value") == MAX_VALUE
-    assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert state.attributes.get("median") == MEDIAN
 
 
 async def test_mean_1_digit_sensor(hass):
@@ -141,11 +128,6 @@ async def test_mean_1_digit_sensor(hass):
     state = hass.states.get("sensor.test_mean")
 
     assert str(float(MEAN_1_DIGIT)) == state.state
-    assert state.attributes.get("min_value") == MIN_VALUE
-    assert entity_ids[2] == state.attributes.get("min_entity_id")
-    assert state.attributes.get("max_value") == MAX_VALUE
-    assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert state.attributes.get("median") == MEDIAN
 
 
 async def test_mean_4_digit_sensor(hass):
@@ -172,11 +154,6 @@ async def test_mean_4_digit_sensor(hass):
     state = hass.states.get("sensor.test_mean")
 
     assert str(float(MEAN_4_DIGITS)) == state.state
-    assert state.attributes.get("min_value") == MIN_VALUE
-    assert entity_ids[2] == state.attributes.get("min_entity_id")
-    assert state.attributes.get("max_value") == MAX_VALUE
-    assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert state.attributes.get("median") == MEDIAN
 
 
 async def test_median_sensor(hass):
@@ -202,11 +179,6 @@ async def test_median_sensor(hass):
     state = hass.states.get("sensor.test_median")
 
     assert str(float(MEDIAN)) == state.state
-    assert state.attributes.get("min_value") == MIN_VALUE
-    assert entity_ids[2] == state.attributes.get("min_entity_id")
-    assert state.attributes.get("max_value") == MAX_VALUE
-    assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert state.attributes.get("mean") == MEAN
 
 
 async def test_not_enough_sensor_value(hass):
@@ -241,20 +213,14 @@ async def test_not_enough_sensor_value(hass):
 
     state = hass.states.get("sensor.test_max")
     assert STATE_UNKNOWN != state.state
-    assert entity_ids[1] == state.attributes.get("min_entity_id")
-    assert VALUES[1] == state.attributes.get("min_value")
     assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert VALUES[1] == state.attributes.get("max_value")
 
     hass.states.async_set(entity_ids[2], STATE_UNKNOWN)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_max")
     assert STATE_UNKNOWN != state.state
-    assert entity_ids[1] == state.attributes.get("min_entity_id")
-    assert VALUES[1] == state.attributes.get("min_value")
     assert entity_ids[1] == state.attributes.get("max_entity_id")
-    assert VALUES[1] == state.attributes.get("max_value")
 
     hass.states.async_set(entity_ids[1], STATE_UNAVAILABLE)
     await hass.async_block_till_done()
@@ -336,11 +302,6 @@ async def test_last_sensor(hass):
         state = hass.states.get("sensor.test_last")
         assert str(float(value)) == state.state
         assert entity_id == state.attributes.get("last_entity_id")
-
-    assert state.attributes.get("min_value") == MIN_VALUE
-    assert state.attributes.get("max_value") == MAX_VALUE
-    assert state.attributes.get("mean") == MEAN
-    assert state.attributes.get("median") == MEDIAN
 
 
 async def test_reload(hass):

--- a/tests/components/min_max/test_sensor.py
+++ b/tests/components/min_max/test_sensor.py
@@ -27,6 +27,31 @@ MEAN_4_DIGITS = round(sum(VALUES) / COUNT, 4)
 MEDIAN = round(statistics.median(VALUES), 2)
 
 
+async def test_default_name_sensor(hass):
+    """Test the min sensor with a default name."""
+    config = {
+        "sensor": {
+            "platform": "min_max",
+            "type": "min",
+            "entity_ids": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    entity_ids = config["sensor"]["entity_ids"]
+
+    for entity_id, value in dict(zip(entity_ids, VALUES)).items():
+        hass.states.async_set(entity_id, value)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.min_sensor")
+
+    assert str(float(MIN_VALUE)) == state.state
+    assert entity_ids[2] == state.attributes.get("min_entity_id")
+
+
 async def test_min_sensor(hass):
     """Test the min sensor."""
     config = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

`min_max` sensors generated a significant amount of
database rows because they included all attributes
regardless of the configured type. For active sensors
these attributes added up to multiple megabytes per day for each
sensor (https://github.com/home-assistant/core/issues/56987#issuecomment-1100575672).

`min_max` sensors now only set attributes based on the
configured type of sensor as below:

- `min`: `min_entity_id`
- `max`: `max_entity_id`
- `last`: `last_entity_id`

The following attributes are no longer present:
`min`, `max`, `mean`, `median`, `last`, `count_sensors`

If access to the data previously provided by the attributes is needed, create a separate `min_max` sensor for that required type instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56987
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
