### PR TITLE
Support variables on any action/condition/trigger

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1063,6 +1063,7 @@ SCRIPT_ACTION_BASE_SCHEMA = {
     vol.Optional(CONF_ALIAS): string,
     vol.Optional(CONF_CONTINUE_ON_ERROR): boolean,
     vol.Optional(CONF_ENABLED): boolean,
+    vol.Optional(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
 }
 
 EVENT_SCHEMA = vol.Schema(
@@ -1104,6 +1105,7 @@ NUMERIC_STATE_THRESHOLD_SCHEMA = vol.Any(
 CONDITION_BASE_SCHEMA = {
     vol.Optional(CONF_ALIAS): string,
     vol.Optional(CONF_ENABLED): boolean,
+    vol.Optional(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
 }
 
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
@@ -1542,9 +1544,6 @@ def determine_script_action(action: dict[str, Any]) -> str:
     if CONF_WAIT_FOR_TRIGGER in action:
         return SCRIPT_ACTION_WAIT_FOR_TRIGGER
 
-    if CONF_VARIABLES in action:
-        return SCRIPT_ACTION_VARIABLES
-
     if CONF_IF in action:
         return SCRIPT_ACTION_IF
 
@@ -1559,6 +1558,11 @@ def determine_script_action(action: dict[str, Any]) -> str:
 
     if CONF_PARALLEL in action:
         return SCRIPT_ACTION_PARALLEL
+
+    # All actions support variables, so if no other action matches,
+    # but it has a variable section: it's a variable action.
+    if CONF_VARIABLES in action:
+        return SCRIPT_ACTION_VARIABLES
 
     raise ValueError("Unable to determine action")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

⚠️ This is a work in progress

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We started adding `variables` to more places over the recent months/year. Most notably would be the last release 2022.4 added support for setting variables on any trigger.

This PR is for adding consistency, streamlining the use of variables in automations and scripts, by supporting it on any action, condition, or trigger.

This allows for things like:

```yaml
action:
  ...
  - choose:
      variables:
        ...
```

```yaml
action:
  ...
  - repeat:
      variables:
        ...
      ...
```

And even nested in things like and/or/not conditions:

```
- condition: or
  variables:
    ...
  conditions:
    - multiple template conditions
```

---

I'm exploring how to achieve this. One way is to pass around an additional variables dictionary down the script execution tree.

The other one is replacing the current `_variables` instance in scripts with a context var, allowing to quickly make a shallow/cheap context copy before every step to handle scoping (which would only be needed if actual variables are provided in the such a step).

The interesting one would be the `variables` action, as that one is not scoped (well its scope toward the whole script). Thus that one needs to be able to break out of the scope (and affect all other current running scopes).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
