### PR TITLE
Reduce state updates for OctoPrint

### DIFF
--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -188,7 +188,7 @@ class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
         read_time = self.coordinator.data["last_read_time"]
 
         return (read_time + timedelta(seconds=job.progress.print_time_left)).replace(
-            second=0, microsecond=0
+            second=0
         )
 
 
@@ -218,7 +218,7 @@ class OctoPrintStartTimeSensor(OctoPrintSensorBase):
         read_time = self.coordinator.data["last_read_time"]
 
         return (read_time - timedelta(seconds=job.progress.print_time)).replace(
-            second=0, microsecond=0
+            second=0
         )
 
 

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -187,7 +187,9 @@ class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
 
         read_time = self.coordinator.data["last_read_time"]
 
-        return read_time + timedelta(seconds=job.progress.print_time_left)
+        return (read_time + timedelta(seconds=job.progress.print_time_left)).replace(
+            second=0, microsecond=0
+        )
 
 
 class OctoPrintStartTimeSensor(OctoPrintSensorBase):
@@ -215,7 +217,9 @@ class OctoPrintStartTimeSensor(OctoPrintSensorBase):
 
         read_time = self.coordinator.data["last_read_time"]
 
-        return read_time - timedelta(seconds=job.progress.print_time)
+        return (read_time - timedelta(seconds=job.progress.print_time)).replace(
+            second=0, microsecond=0
+        )
 
 
 class OctoPrintTemperatureSensor(OctoPrintSensorBase):

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -23,7 +23,7 @@ async def test_sensors(hass):
     }
     with patch(
         "homeassistant.util.dt.utcnow",
-        return_value=datetime(2020, 2, 20, 9, 10, 0, tzinfo=timezone.utc),
+        return_value=datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=timezone.utc),
     ):
         await init_integration(hass, "sensor", printer=printer, job=job)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The OctoPrint REST API only exposes the number of seconds since a print
was started and as the estimate for when a print is finished. These
values are subtracted and added to the current time to get a timestamp
for start and estimated finish respectively. There are, however, no
guarantees that the OctoPrint and HA clock is in sync, and even if they
were, the network latency means that the calculation is inherently
unstable, and may flap from one second to another over and over while a
print is ongoing.

To improve this, the start and estimated finish times are truncated to
the closest minute. This does not fix the problem to 100%, but it
reduces the likelihood for it happening significantly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
