### PR TITLE
Address late review of deconz climate

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -62,7 +62,6 @@ FAN_MODE_TO_DECONZ = {
     FAN_ON: THERMOSTAT_FAN_MODE_ON,
     FAN_OFF: THERMOSTAT_FAN_MODE_OFF,
 }
-
 DECONZ_TO_FAN_MODE = {value: key for key, value in FAN_MODE_TO_DECONZ.items()}
 
 HVAC_MODE_TO_DECONZ: dict[str, str] = {
@@ -71,6 +70,7 @@ HVAC_MODE_TO_DECONZ: dict[str, str] = {
     HVAC_MODE_HEAT: THERMOSTAT_MODE_HEAT,
     HVAC_MODE_OFF: THERMOSTAT_MODE_OFF,
 }
+DECONZ_TO_HVAC_MODE = {value: key for key, value in HVAC_MODE_TO_DECONZ.items()}
 
 DECONZ_PRESET_AUTO = "auto"
 DECONZ_PRESET_COMPLEX = "complex"
@@ -86,7 +86,6 @@ PRESET_MODE_TO_DECONZ = {
     DECONZ_PRESET_HOLIDAY: THERMOSTAT_PRESET_HOLIDAY,
     DECONZ_PRESET_MANUAL: THERMOSTAT_PRESET_MANUAL,
 }
-
 DECONZ_TO_PRESET_MODE = {value: key for key, value in PRESET_MODE_TO_DECONZ.items()}
 
 
@@ -195,7 +194,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         Need to be one of HVAC_MODE_*.
         """
         if self._device.mode in self.supported_hvac_modes:
-            return HVAC_MODE_TO_DECONZ[self._device.mode]
+            return DECONZ_TO_HVAC_MODE[self._device.mode]
         return HVAC_MODE_HEAT if self._device.state_on else HVAC_MODE_OFF
 
     @property

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -70,7 +70,6 @@ HVAC_MODE_TO_DECONZ: dict[str, str] = {
     HVAC_MODE_HEAT: THERMOSTAT_MODE_HEAT,
     HVAC_MODE_OFF: THERMOSTAT_MODE_OFF,
 }
-DECONZ_TO_HVAC_MODE = {value: key for key, value in HVAC_MODE_TO_DECONZ.items()}
 
 DECONZ_PRESET_AUTO = "auto"
 DECONZ_PRESET_COMPLEX = "complex"
@@ -156,6 +155,10 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
             if "coolsetpoint" in device.raw["config"]:
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)
 
+        self._deconz_to_hvac_mode = {
+            HVAC_MODE_TO_DECONZ[item]: item for item in self._attr_hvac_modes
+        }
+
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 
         if device.fan_mode:
@@ -190,8 +193,8 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
 
         Need to be one of HVAC_MODE_*.
         """
-        if self._device.mode in self._attr_hvac_modes:
-            return DECONZ_TO_HVAC_MODE[self._device.mode]
+        if self._device.mode in self._deconz_to_hvac_mode:
+            return self._deconz_to_hvac_mode[self._device.mode]
         return HVAC_MODE_HEAT if self._device.state_on else HVAC_MODE_OFF
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -788,3 +788,25 @@ async def test_add_new_climate_device(hass, aioclient_mock, mock_deconz_websocke
     assert len(hass.states.async_all()) == 2
     assert hass.states.get("climate.thermostat").state == HVAC_MODE_AUTO
     assert hass.states.get("sensor.thermostat_battery").state == "100"
+
+
+async def test_not_allow_clip_thermostat(hass, aioclient_mock):
+    """Test that CLIP thermostats are not allowed."""
+    data = {
+        "sensors": {
+            "1": {
+                "name": "CLIP thermostat sensor",
+                "type": "CLIPThermostat",
+                "state": {},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+        }
+    }
+
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(
+            hass, aioclient_mock, options={CONF_ALLOW_CLIP_SENSOR: False}
+        )
+
+    assert len(hass.states.async_all()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Late comment from #69882

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #69882
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
