### PR TITLE
Re-work SimpliSafe authentication to only need username/password

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Iterable
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 from simplipy import API
 from simplipy.device import Device, DeviceTypes
@@ -253,7 +253,7 @@ def _async_get_system_for_service_call(
     for entry_id in base_station_device_entry.config_entries:
         if (simplisafe := hass.data[DOMAIN].get(entry_id)) is None:
             continue
-        return simplisafe.systems[system_id]
+        return cast(SystemType, simplisafe.systems[system_id])
 
     raise ValueError(f"No system for device ID: {device_id}")
 
@@ -281,9 +281,7 @@ def _async_standardize_config_entry(hass: HomeAssistant, entry: ConfigEntry) -> 
             "New SimpliSafe OAuth standard requires re-authentication"
         )
     if CONF_USERNAME not in entry.data:
-        raise ConfigEntryAuthFailed(
-            "Must re-authenticate with SimpliSafe username/email"
-        )
+        raise ConfigEntryAuthFailed("Need to re-auth with username/password")
 
     entry_updates = {}
     if not entry.unique_id:
@@ -602,7 +600,7 @@ class SimpliSafe:
         self.coordinator = DataUpdateCoordinator(
             self._hass,
             LOGGER,
-            name=self.entry.data[CONF_USERNAME],
+            name=self.entry.title,
             update_interval=DEFAULT_SCAN_INTERVAL,
             update_method=self.async_update,
         )

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from .const import DOMAIN, LOGGER
 
 DEFAULT_EMAIL_2FA_SLEEP = 3
-DEFAULT_EMAIL_2FA_TIMEOUT = 30
+DEFAULT_EMAIL_2FA_TIMEOUT = 300
 
 STEP_REAUTH_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/simplisafe/const.py
+++ b/homeassistant/components/simplisafe/const.py
@@ -14,5 +14,3 @@ ATTR_EXIT_DELAY_AWAY = "exit_delay_away"
 ATTR_EXIT_DELAY_HOME = "exit_delay_home"
 ATTR_LIGHT = "light"
 ATTR_VOICE_PROMPT_VOLUME = "voice_prompt_volume"
-
-CONF_USER_ID = "user_id"

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==2022.03.3"],
+  "requirements": ["simplisafe-python==2022.04.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "dhcp": [

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==2022.04.0"],
+  "requirements": ["simplisafe-python==2022.04.1"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "dhcp": [

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -1,23 +1,35 @@
 {
   "config": {
     "step": {
-      "user": {
-        "description": "SimpliSafe authenticates with Home Assistant via the SimpliSafe web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation]({docs_url}) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below.",
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Please re-enter the password for {username}.",
         "data": {
-          "auth_code": "Authorization Code"
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "sms_2fa": {
+        "description": "Input the two-factor authentication code sent to you via SMS.",
+        "data": {
+          "code": "Code"
+        }
+      },
+      "user": {
+        "description": "Input your username and password.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
     "error": {
-      "identifier_exists": "Account already registered",
+      "2fa_timed_out": "Timed out while waiting for two-factor authentication",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "still_awaiting_mfa": "Still awaiting MFA email click",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "This SimpliSafe account is already in use.",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "wrong_account": "The user credentials provided do not match this SimpliSafe account."
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -2,43 +2,33 @@
     "config": {
         "abort": {
             "already_configured": "This SimpliSafe account is already in use.",
-            "reauth_successful": "Re-authentication was successful",
-            "wrong_account": "The user credentials provided do not match this SimpliSafe account."
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
-            "identifier_exists": "Account already registered",
+            "2fa_timed_out": "Timed out while waiting for two-factor authentication",
             "invalid_auth": "Invalid authentication",
-            "still_awaiting_mfa": "Still awaiting MFA email click",
             "unknown": "Unexpected error"
         },
         "step": {
-            "input_auth_code": {
-                "data": {
-                    "auth_code": "Authorization Code"
-                },
-                "description": "Input the authorization code from the SimpliSafe web app URL:",
-                "title": "Finish Authorization"
-            },
-            "mfa": {
-                "description": "Check your email for a link from SimpliSafe. After verifying the link, return here to complete the installation of the integration.",
-                "title": "SimpliSafe Multi-Factor Authentication"
-            },
             "reauth_confirm": {
                 "data": {
                     "password": "Password"
                 },
-                "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
+                "description": "Please re-enter the password for {username}.",
                 "title": "Reauthenticate Integration"
+            },
+            "sms_2fa": {
+                "data": {
+                    "code": "Code"
+                },
+                "description": "Input the two-factor authentication code sent to you via SMS."
             },
             "user": {
                 "data": {
-                    "auth_code": "Authorization Code",
-                    "code": "Code (used in Home Assistant UI)",
                     "password": "Password",
-                    "username": "Email"
+                    "username": "Username"
                 },
-                "description": "SimpliSafe authenticates with Home Assistant via the SimpliSafe web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation]({docs_url}) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below.",
-                "title": "Fill in your information."
+                "description": "Input your username and password."
             }
         }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2143,7 +2143,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==2022.03.3
+simplisafe-python==2022.04.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2143,7 +2143,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==2022.04.0
+simplisafe-python==2022.04.1
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1388,7 +1388,7 @@ sharkiq==0.0.1
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==2022.04.0
+simplisafe-python==2022.04.1
 
 # homeassistant.components.slack
 slackclient==2.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1388,7 +1388,7 @@ sharkiq==0.0.1
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==2022.03.3
+simplisafe-python==2022.04.0
 
 # homeassistant.components.slack
 slackclient==2.5.0

--- a/tests/components/simplisafe/common.py
+++ b/tests/components/simplisafe/common.py
@@ -1,0 +1,4 @@
+"""Define common SimpliSafe test constants/etc."""
+REFRESH_TOKEN = "token123"
+USERNAME = "user@email.com"
+USER_ID = "12345"

--- a/tests/components/simplisafe/conftest.py
+++ b/tests/components/simplisafe/conftest.py
@@ -3,25 +3,36 @@ import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from simplipy.api import AuthStates
 from simplipy.system.v3 import SystemV3
 
-from homeassistant.components.simplisafe.config_flow import CONF_AUTH_CODE
-from homeassistant.components.simplisafe.const import CONF_USER_ID, DOMAIN
-from homeassistant.const import CONF_TOKEN
+from homeassistant.components.simplisafe.const import DOMAIN
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.setup import async_setup_component
+
+from .common import REFRESH_TOKEN, USER_ID, USERNAME
 
 from tests.common import MockConfigEntry, load_fixture
 
-REFRESH_TOKEN = "token123"
+CODE = "12345"
+PASSWORD = "password"
 SYSTEM_ID = "system_123"
-USER_ID = "12345"
+
+
+@pytest.fixture(name="api_auth_state")
+def api_auth_state_fixture():
+    """Define a SimpliSafe API auth state."""
+    return AuthStates.PENDING_2FA_SMS
 
 
 @pytest.fixture(name="api")
-def api_fixture(data_subscription, system_v3, websocket):
-    """Define a fixture for a simplisafe-python API object."""
+def api_fixture(api_auth_state, data_subscription, system_v3, websocket):
+    """Define a simplisafe-python API object."""
     return Mock(
         async_get_systems=AsyncMock(return_value={SYSTEM_ID: system_v3}),
+        async_verify_2fa_email=AsyncMock(),
+        async_verify_2fa_sms=AsyncMock(),
+        auth_state=api_auth_state,
         refresh_token=REFRESH_TOKEN,
         subscription_data=data_subscription,
         user_id=USER_ID,
@@ -30,27 +41,28 @@ def api_fixture(data_subscription, system_v3, websocket):
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config):
-    """Define a config entry fixture."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=USER_ID, data=config)
+def config_entry_fixture(hass, config, unique_id):
+    """Define a config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=unique_id, data=config)
     entry.add_to_hass(hass)
     return entry
 
 
 @pytest.fixture(name="config")
-def config_fixture(hass):
-    """Define a config entry data fixture."""
+def config_fixture():
+    """Define config entry data config."""
     return {
-        CONF_USER_ID: USER_ID,
         CONF_TOKEN: REFRESH_TOKEN,
+        CONF_USERNAME: USERNAME,
     }
 
 
-@pytest.fixture(name="config_code")
-def config_code_fixture(hass):
-    """Define a authorization code."""
+@pytest.fixture(name="credentials_config")
+def credentials_config_fixture():
+    """Define a username/password config."""
     return {
-        CONF_AUTH_CODE: "code123",
+        CONF_USERNAME: USERNAME,
+        CONF_PASSWORD: PASSWORD,
     }
 
 
@@ -78,14 +90,23 @@ def data_subscription_fixture():
     return json.loads(load_fixture("subscription_data.json", "simplisafe"))
 
 
+@pytest.fixture(name="reauth_config")
+def reauth_config_fixture():
+    """Define a reauth config."""
+    return {
+        CONF_PASSWORD: PASSWORD,
+    }
+
+
 @pytest.fixture(name="setup_simplisafe")
 async def setup_simplisafe_fixture(hass, api, config):
     """Define a fixture to set up SimpliSafe."""
     with patch(
-        "homeassistant.components.simplisafe.config_flow.API.async_from_auth",
+        "homeassistant.components.simplisafe.config_flow.API.async_from_credentials",
         return_value=api,
     ), patch(
-        "homeassistant.components.simplisafe.API.async_from_auth", return_value=api
+        "homeassistant.components.simplisafe.API.async_from_credentials",
+        return_value=api,
     ), patch(
         "homeassistant.components.simplisafe.API.async_from_refresh_token",
         return_value=api,
@@ -99,9 +120,17 @@ async def setup_simplisafe_fixture(hass, api, config):
         yield
 
 
+@pytest.fixture(name="sms_config")
+def sms_config_fixture():
+    """Define a SMS-based two-factor authentication config."""
+    return {
+        CONF_CODE: CODE,
+    }
+
+
 @pytest.fixture(name="system_v3")
 def system_v3_fixture(data_latest_event, data_sensor, data_settings, data_subscription):
-    """Define a fixture for a simplisafe-python V3 System object."""
+    """Define a simplisafe-python V3 System object."""
     system = SystemV3(Mock(subscription_data=data_subscription), SYSTEM_ID)
     system.async_get_latest_event = AsyncMock(return_value=data_latest_event)
     system.sensor_data = data_sensor
@@ -110,9 +139,15 @@ def system_v3_fixture(data_latest_event, data_sensor, data_settings, data_subscr
     return system
 
 
+@pytest.fixture(name="unique_id")
+def unique_id_fixture():
+    """Define a unique ID."""
+    return USER_ID
+
+
 @pytest.fixture(name="websocket")
 def websocket_fixture():
-    """Define a fixture for a simplisafe-python websocket object."""
+    """Define a simplisafe-python websocket object."""
     return Mock(
         async_connect=AsyncMock(),
         async_disconnect=AsyncMock(),

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -2,15 +2,22 @@
 from unittest.mock import patch
 
 import pytest
-from simplipy.errors import InvalidCredentialsError, SimplipyError
+from simplipy.api import AuthStates
+from simplipy.errors import InvalidCredentialsError, SimplipyError, Verify2FAPending
 
 from homeassistant import data_entry_flow
 from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_CODE
+from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+
+from .common import REFRESH_TOKEN, USER_ID, USERNAME
+
+CONF_USER_ID = "user_id"
 
 
-async def test_duplicate_error(hass, config_entry, config_code, setup_simplisafe):
+async def test_duplicate_error(
+    hass, config_entry, credentials_config, setup_simplisafe, sms_config
+):
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -19,33 +26,16 @@ async def test_duplicate_error(hass, config_entry, config_code, setup_simplisafe
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_code
+        result["flow_id"], user_input=credentials_config
+    )
+    assert result["step_id"] == "sms_2fa"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=sms_config
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
-
-
-@pytest.mark.parametrize(
-    "exc,error_string",
-    [(InvalidCredentialsError, "invalid_auth"), (SimplipyError, "unknown")],
-)
-async def test_errors(hass, config_code, exc, error_string):
-    """Test that exceptions show the appropriate error."""
-    with patch(
-        "homeassistant.components.simplisafe.API.async_from_auth",
-        side_effect=exc,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}
-        )
-        assert result["step_id"] == "user"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=config_code
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": error_string}
 
 
 async def test_options_flow(hass, config_entry):
@@ -65,82 +55,246 @@ async def test_options_flow(hass, config_entry):
         assert config_entry.options == {CONF_CODE: "4321"}
 
 
-async def test_step_reauth_old_format(
-    hass, config, config_code, config_entry, setup_simplisafe
+@pytest.mark.parametrize("unique_id", [USERNAME, USER_ID])
+async def test_step_reauth(
+    hass, config, config_entry, reauth_config, setup_simplisafe, sms_config
 ):
-    """Test the re-auth step with "old" config entries (those with user IDs)."""
+    """Test the re-auth step (testing both username and user ID as unique ID)."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config
     )
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reauth_confirm"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_code
+        result["flow_id"], user_input=reauth_config
+    )
+    assert result["step_id"] == "sms_2fa"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=sms_config
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "reauth_successful"
 
     assert len(hass.config_entries.async_entries()) == 1
     [config_entry] = hass.config_entries.async_entries(DOMAIN)
+    assert config_entry.unique_id == USER_ID
     assert config_entry.data == config
 
 
-async def test_step_reauth_new_format(
-    hass, config, config_code, config_entry, setup_simplisafe
+@pytest.mark.parametrize(
+    "exc,error_string",
+    [(InvalidCredentialsError, "invalid_auth"), (SimplipyError, "unknown")],
+)
+async def test_step_reauth_errors(hass, config, error_string, exc, reauth_config):
+    """Test that errors during the reauth step are handled."""
+    with patch(
+        "homeassistant.components.simplisafe.API.async_from_credentials",
+        side_effect=exc,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_REAUTH}, data=config
+        )
+        assert result["step_id"] == "reauth_confirm"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=reauth_config
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": error_string}
+
+
+@pytest.mark.parametrize(
+    "config,unique_id",
+    [
+        (
+            {
+                CONF_TOKEN: REFRESH_TOKEN,
+                CONF_USER_ID: USER_ID,
+            },
+            USERNAME,
+        ),
+        (
+            {
+                CONF_TOKEN: REFRESH_TOKEN,
+                CONF_USER_ID: USER_ID,
+            },
+            USER_ID,
+        ),
+    ],
+)
+async def test_step_reauth_from_scratch(
+    hass, config, config_entry, credentials_config, setup_simplisafe, sms_config
 ):
-    """Test the re-auth step with "new" config entries (those with user IDs)."""
+    """Test the re-auth step when a complete redo is needed."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config
     )
     assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_code
+        result["flow_id"], user_input=credentials_config
+    )
+    assert result["step_id"] == "sms_2fa"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=sms_config
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "reauth_successful"
 
     assert len(hass.config_entries.async_entries()) == 1
     [config_entry] = hass.config_entries.async_entries(DOMAIN)
-    assert config_entry.data == config
+    assert config_entry.unique_id == USER_ID
+    assert config_entry.data == {
+        CONF_TOKEN: REFRESH_TOKEN,
+        CONF_USERNAME: USERNAME,
+    }
 
 
-async def test_step_reauth_wrong_account(
-    hass, api, config, config_code, config_entry, setup_simplisafe
+@pytest.mark.parametrize(
+    "exc,error_string",
+    [(InvalidCredentialsError, "invalid_auth"), (SimplipyError, "unknown")],
+)
+async def test_step_user_errors(hass, credentials_config, error_string, exc):
+    """Test that errors during the user step are handled."""
+    with patch(
+        "homeassistant.components.simplisafe.API.async_from_credentials",
+        side_effect=exc,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        assert result["step_id"] == "user"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=credentials_config
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": error_string}
+
+
+@pytest.mark.parametrize("api_auth_state", [AuthStates.PENDING_2FA_EMAIL])
+async def test_step_user_email_2fa(
+    api, hass, config, credentials_config, setup_simplisafe
 ):
-    """Test the re-auth step returning a different account from this one."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_REAUTH}, data=config
-    )
-    assert result["step_id"] == "user"
-
-    # Simulate the next auth call returning a different user ID than the one we've
-    # identified as this entry's unique ID:
-    api.user_id = "67890"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_code
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "wrong_account"
-
-    assert len(hass.config_entries.async_entries()) == 1
-    [config_entry] = hass.config_entries.async_entries(DOMAIN)
-    assert config_entry.unique_id == "12345"
-
-
-async def test_step_user(hass, config, config_code, setup_simplisafe):
-    """Test the user step."""
+    """Test the user step with email-based 2FA."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    # Patch API.async_verify_2fa_email to first return pending, then return all done:
+    api.async_verify_2fa_email.side_effect = [Verify2FAPending, None]
+
+    # Patch the amount of time slept between calls so to not slow down this test:
+    with patch(
+        "homeassistant.components.simplisafe.config_flow.DEFAULT_EMAIL_2FA_SLEEP", 0
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=credentials_config
+        )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    assert len(hass.config_entries.async_entries()) == 1
+    [config_entry] = hass.config_entries.async_entries(DOMAIN)
+    assert config_entry.unique_id == USER_ID
+    assert config_entry.data == config
+
+
+@pytest.mark.parametrize("api_auth_state", [AuthStates.PENDING_2FA_EMAIL])
+async def test_step_user_email_2fa_timeout(
+    api, hass, config, credentials_config, setup_simplisafe
+):
+    """Test a timeout during the user step with email-based 2FA."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    # Patch API.async_verify_2fa_email to return pending:
+    api.async_verify_2fa_email.side_effect = Verify2FAPending
+
+    # Patch the amount of time slept between calls and the timeout duration so to not
+    # slow down this test:
+    with patch(
+        "homeassistant.components.simplisafe.config_flow.DEFAULT_EMAIL_2FA_SLEEP", 0
+    ), patch(
+        "homeassistant.components.simplisafe.config_flow.DEFAULT_EMAIL_2FA_TIMEOUT", 0
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=credentials_config
+        )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "2fa_timed_out"}
+
+
+async def test_step_user_sms_2fa(
+    hass, config, credentials_config, setup_simplisafe, sms_config
+):
+    """Test the user step with SMS-based 2FA."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_code
+        result["flow_id"], user_input=credentials_config
+    )
+    assert result["step_id"] == "sms_2fa"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=sms_config
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     assert len(hass.config_entries.async_entries()) == 1
     [config_entry] = hass.config_entries.async_entries(DOMAIN)
+    assert config_entry.unique_id == USER_ID
     assert config_entry.data == config
+
+
+@pytest.mark.parametrize(
+    "exc,error_string", [(InvalidCredentialsError, "invalid_auth")]
+)
+async def test_step_user_sms_2fa_errors(
+    api,
+    hass,
+    config,
+    credentials_config,
+    error_string,
+    exc,
+    setup_simplisafe,
+    sms_config,
+):
+    """Test that errors during the SMS-based 2FA step are handled."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=credentials_config
+    )
+    assert result["step_id"] == "sms_2fa"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    # Simulate entering the incorrect SMS code:
+    api.async_verify_2fa_sms.side_effect = InvalidCredentialsError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=sms_config
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"code": error_string}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`simplisafe-python` was recently updated to allow for a simpler SimpliSafe authentication flow: instead of the current, very challenging setup that requires the manual collection of an OAuth authorization code from a browser console, the library can now simply use the account username/password.

Changelog: https://github.com/bachya/simplisafe-python/releases/tag/2022.04.1
Diff: https://github.com/bachya/simplisafe-python/compare/2022.03.3...2022.04.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/70817
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22423

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
