### PR TITLE
Improve typing of deCONZ sensor platform

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -69,6 +69,7 @@ homeassistant.components.deconz.config_flow
 homeassistant.components.deconz.diagnostics
 homeassistant.components.deconz.gateway
 homeassistant.components.deconz.light
+homeassistant.components.deconz.sensor
 homeassistant.components.deconz.services
 homeassistant.components.device_automation.*
 homeassistant.components.device_tracker.*

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -14,7 +14,7 @@ from pydeconz.sensor import (
     LightLevel,
     Power,
     Pressure,
-    SensorBase as PydeconzSensor,
+    SensorResources,
     Switch,
     Temperature,
     Time,
@@ -75,7 +75,7 @@ class DeconzSensorDescriptionMixin:
     """Required values when describing secondary sensor attributes."""
 
     update_key: str
-    value_fn: Callable[[PydeconzSensor], float | int | str | None]
+    value_fn: Callable[[SensorResources], float | int | str | None]
 
 
 @dataclass
@@ -92,13 +92,17 @@ ENTITY_DESCRIPTIONS = {
     AirQuality: [
         DeconzSensorDescription(
             key="air_quality",
-            value_fn=lambda device: device.air_quality,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.air_quality
+            if isinstance(device, AirQuality)
+            else None,
             update_key="airquality",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         DeconzSensorDescription(
             key="air_quality_ppb",
-            value_fn=lambda device: device.air_quality_ppb,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.air_quality_ppb
+            if isinstance(device, AirQuality)
+            else None,
             suffix="PPB",
             update_key="airqualityppb",
             device_class=SensorDeviceClass.AQI,
@@ -109,7 +113,9 @@ ENTITY_DESCRIPTIONS = {
     Consumption: [
         DeconzSensorDescription(
             key="consumption",
-            value_fn=lambda device: device.scaled_consumption,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.scaled_consumption
+            if isinstance(device, Consumption)
+            else None,
             update_key="consumption",
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
@@ -119,7 +125,9 @@ ENTITY_DESCRIPTIONS = {
     Daylight: [
         DeconzSensorDescription(
             key="status",
-            value_fn=lambda device: device.status,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.status
+            if isinstance(device, Daylight)
+            else None,
             update_key="status",
             icon="mdi:white-balance-sunny",
             entity_registry_enabled_default=False,
@@ -128,14 +136,18 @@ ENTITY_DESCRIPTIONS = {
     GenericStatus: [
         DeconzSensorDescription(
             key="status",
-            value_fn=lambda device: device.status,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.status
+            if isinstance(device, GenericStatus)
+            else None,
             update_key="status",
         )
     ],
     Humidity: [
         DeconzSensorDescription(
             key="humidity",
-            value_fn=lambda device: device.scaled_humidity,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.scaled_humidity
+            if isinstance(device, Humidity)
+            else None,
             update_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
@@ -145,7 +157,9 @@ ENTITY_DESCRIPTIONS = {
     LightLevel: [
         DeconzSensorDescription(
             key="light_level",
-            value_fn=lambda device: device.scaled_light_level,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.scaled_light_level
+            if isinstance(device, LightLevel)
+            else None,
             update_key="lightlevel",
             device_class=SensorDeviceClass.ILLUMINANCE,
             native_unit_of_measurement=LIGHT_LUX,
@@ -154,7 +168,7 @@ ENTITY_DESCRIPTIONS = {
     Power: [
         DeconzSensorDescription(
             key="power",
-            value_fn=lambda device: device.power,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.power if isinstance(device, Power) else None,
             update_key="power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
@@ -164,7 +178,9 @@ ENTITY_DESCRIPTIONS = {
     Pressure: [
         DeconzSensorDescription(
             key="pressure",
-            value_fn=lambda device: device.pressure,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.pressure
+            if isinstance(device, Pressure)
+            else None,
             update_key="pressure",
             device_class=SensorDeviceClass.PRESSURE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -174,7 +190,9 @@ ENTITY_DESCRIPTIONS = {
     Temperature: [
         DeconzSensorDescription(
             key="temperature",
-            value_fn=lambda device: device.scaled_temperature,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.scaled_temperature
+            if isinstance(device, Temperature)
+            else None,
             update_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -184,13 +202,16 @@ ENTITY_DESCRIPTIONS = {
     Time: [
         DeconzSensorDescription(
             key="last_set",
-            value_fn=lambda device: device.last_set,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.last_set
+            if isinstance(device, Time)
+            else None,
             update_key="lastset",
             device_class=SensorDeviceClass.TIMESTAMP,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
     ],
 }
+
 
 SENSOR_DESCRIPTIONS = [
     DeconzSensorDescription(
@@ -227,7 +248,7 @@ async def async_setup_entry(
     battery_handler = DeconzBatteryHandler(gateway)
 
     @callback
-    def async_add_sensor(sensors: list[PydeconzSensor] | None = None) -> None:
+    def async_add_sensor(sensors: list[SensorResources] | None = None) -> None:
         """Add sensors from deCONZ.
 
         Create DeconzBattery if sensor has a battery attribute.
@@ -284,12 +305,12 @@ class DeconzSensor(DeconzDevice, SensorEntity):
     """Representation of a deCONZ sensor."""
 
     TYPE = DOMAIN
-    _device: PydeconzSensor
+    _device: SensorResources
     entity_description: DeconzSensorDescription
 
     def __init__(
         self,
-        device: PydeconzSensor,
+        device: SensorResources,
         gateway: DeconzGateway,
         description: DeconzSensorDescription,
     ) -> None:
@@ -381,7 +402,7 @@ class DeconzSensor(DeconzDevice, SensorEntity):
 class DeconzSensorStateTracker:
     """Track sensors without a battery state and signal when battery state exist."""
 
-    def __init__(self, sensor: PydeconzSensor, gateway: DeconzGateway) -> None:
+    def __init__(self, sensor: SensorResources, gateway: DeconzGateway) -> None:
         """Set up tracker."""
         self.sensor = sensor
         self.gateway = gateway
@@ -391,7 +412,6 @@ class DeconzSensorStateTracker:
     def close(self) -> None:
         """Clean up tracker."""
         self.sensor.remove_callback(self.async_update_callback)
-        self.sensor = None
 
     @callback
     def async_update_callback(self) -> None:
@@ -413,7 +433,7 @@ class DeconzBatteryHandler:
         self._trackers: set[DeconzSensorStateTracker] = set()
 
     @callback
-    def create_tracker(self, sensor: PydeconzSensor) -> None:
+    def create_tracker(self, sensor: SensorResources) -> None:
         """Create new tracker for battery state."""
         for tracker in self._trackers:
             if sensor == tracker.sensor:
@@ -421,7 +441,7 @@ class DeconzBatteryHandler:
         self._trackers.add(DeconzSensorStateTracker(sensor, self.gateway))
 
     @callback
-    def remove_tracker(self, sensor: PydeconzSensor) -> None:
+    def remove_tracker(self, sensor: SensorResources) -> None:
         """Remove tracker of battery state."""
         for tracker in self._trackers:
             if sensor == tracker.sensor:

--- a/mypy.ini
+++ b/mypy.ini
@@ -561,6 +561,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.deconz.sensor]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.deconz.services]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -2658,9 +2669,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.number]
-ignore_errors = true
-
-[mypy-homeassistant.components.deconz.sensor]
 ignore_errors = true
 
 [mypy-homeassistant.components.deconz.siren]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -29,7 +29,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.deconz.lock",
     "homeassistant.components.deconz.logbook",
     "homeassistant.components.deconz.number",
-    "homeassistant.components.deconz.sensor",
     "homeassistant.components.deconz.siren",
     "homeassistant.components.deconz.switch",
     "homeassistant.components.denonavr.config_flow",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make value functions work in a strictly typed environment.
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
