### PR TITLE
Fix bug in google calendar offset calculation (#70024)

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -120,13 +120,20 @@ class GoogleCalendarEventDevice(CalendarEventDevice):
         self._event: dict[str, Any] | None = None
         self._name: str = data[CONF_NAME]
         self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
-        self._offset_reached = False
+        self._offset_value: timedelta | None = None
         self.entity_id = entity_id
 
     @property
     def extra_state_attributes(self) -> dict[str, bool]:
         """Return the device state attributes."""
-        return {"offset_reached": self._offset_reached}
+        return {"offset_reached": self.offset_reached}
+
+    @property
+    def offset_reached(self) -> bool:
+        """Return whether or not the event offset was reached."""
+        if self._event and self._offset_value:
+            return is_offset_reached(get_date(self._event["start"]), self._offset_value)
+        return False
 
     @property
     def event(self) -> dict[str, Any] | None:
@@ -187,6 +194,4 @@ class GoogleCalendarEventDevice(CalendarEventDevice):
                 self._event.get("summary", ""), self._offset
             )
             self._event["summary"] = summary
-            self._offset_reached = is_offset_reached(
-                get_date(self._event["start"]), offset
-            )
+            self._offset_value = offset

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -505,3 +505,77 @@ async def test_scan_calendar_error(
         assert await component_setup()
 
     assert not hass.states.get(TEST_ENTITY)
+
+
+async def test_future_event_update_behavior(
+    hass, mock_events_list_items, component_setup
+):
+    """Test an future event that becomes active."""
+    now = dt_util.now()
+    now_utc = dt_util.utcnow()
+    one_hour_from_now = now + datetime.timedelta(minutes=60)
+    end_event = one_hour_from_now + datetime.timedelta(minutes=90)
+    event = {
+        **TEST_EVENT,
+        "start": {"dateTime": one_hour_from_now.isoformat()},
+        "end": {"dateTime": end_event.isoformat()},
+    }
+    mock_events_list_items([event])
+    assert await component_setup()
+
+    # Event has not started yet
+    state = hass.states.get(TEST_ENTITY)
+    assert state.name == TEST_ENTITY_NAME
+    assert state.state == STATE_OFF
+
+    # Advance time until event has started
+    now += datetime.timedelta(minutes=60)
+    now_utc += datetime.timedelta(minutes=30)
+    with patch("homeassistant.util.dt.utcnow", return_value=now_utc), patch(
+        "homeassistant.util.dt.now", return_value=now
+    ):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+    # Event has started
+    state = hass.states.get(TEST_ENTITY)
+    assert state.state == STATE_ON
+
+
+async def test_future_event_offset_update_behavior(
+    hass, mock_events_list_items, component_setup
+):
+    """Test an future event that becomes active."""
+    now = dt_util.now()
+    now_utc = dt_util.utcnow()
+    one_hour_from_now = now + datetime.timedelta(minutes=60)
+    end_event = one_hour_from_now + datetime.timedelta(minutes=90)
+    event_summary = "Test Event in Progress"
+    event = {
+        **TEST_EVENT,
+        "start": {"dateTime": one_hour_from_now.isoformat()},
+        "end": {"dateTime": end_event.isoformat()},
+        "summary": f"{event_summary} !!-15",
+    }
+    mock_events_list_items([event])
+    assert await component_setup()
+
+    # Event has not started yet
+    state = hass.states.get(TEST_ENTITY)
+    assert state.name == TEST_ENTITY_NAME
+    assert state.state == STATE_OFF
+    assert not state.attributes["offset_reached"]
+
+    # Advance time until event has started
+    now += datetime.timedelta(minutes=45)
+    now_utc += datetime.timedelta(minutes=45)
+    with patch("homeassistant.util.dt.utcnow", return_value=now_utc), patch(
+        "homeassistant.util.dt.now", return_value=now
+    ):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+    # Event has not started, but the offset was reached
+    state = hass.states.get(TEST_ENTITY)
+    assert state.state == STATE_OFF
+    assert state.attributes["offset_reached"]


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cherry pick of https://github.com/home-assistant/core/pull/70024 against RC since the original PR depends on a larger data model change.

Move the offset reached computation outside of the update method so that it is
computed when state updates occur rather than when data refreshes happen (which
are throttled and happen at most every 15 minutes).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Issue #69892
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
