### PR TITLE
Move google calendar integration to aiohttp

### DIFF
--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -8,13 +8,13 @@ import logging
 import time
 from typing import Any
 
-from googleapiclient import discovery as google_discovery
+import aiohttp
+from gcal_sync.auth import AbstractAuth
 import oauth2client
 from oauth2client.client import (
     Credentials,
     DeviceFlowInfo,
     FlowExchangeError,
-    OAuth2Credentials,
     OAuth2DeviceCodeError,
     OAuth2WebServerFlow,
 )
@@ -150,95 +150,19 @@ async def async_create_device_flow(hass: HomeAssistant) -> DeviceFlow:
     return DeviceFlow(hass, oauth_flow, device_flow_info)
 
 
-def _async_google_creds(hass: HomeAssistant, token: dict[str, Any]) -> Credentials:
-    """Convert a Home Assistant token to a Google API Credentials object."""
-    conf = hass.data[DOMAIN][DATA_CONFIG]
-    return OAuth2Credentials(
-        access_token=token["access_token"],
-        client_id=conf[CONF_CLIENT_ID],
-        client_secret=conf[CONF_CLIENT_SECRET],
-        refresh_token=token["refresh_token"],
-        token_expiry=datetime.datetime.fromtimestamp(token["expires_at"]),
-        token_uri=oauth2client.GOOGLE_TOKEN_URI,
-        scopes=[conf[CONF_CALENDAR_ACCESS].scope],
-        user_agent=None,
-    )
-
-
-def _api_time_format(date_time: datetime.datetime | None) -> str | None:
-    """Convert a datetime to the api string format."""
-    return date_time.isoformat("T") if date_time else None
-
-
-class GoogleCalendarService:
-    """Calendar service interface to Google."""
+class ApiAuthImpl(AbstractAuth):
+    """Authentication implementation for google calendar api library."""
 
     def __init__(
-        self, hass: HomeAssistant, session: config_entry_oauth2_flow.OAuth2Session
+        self,
+        websession: aiohttp.ClientSession,
+        session: config_entry_oauth2_flow.OAuth2Session,
     ) -> None:
-        """Init the Google Calendar service."""
-        self._hass = hass
+        """Init the Google Calendar client library auth implementation."""
+        super().__init__(websession)
         self._session = session
 
-    async def _async_get_service(self) -> google_discovery.Resource:
-        """Get the calendar service with valid credetnails."""
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token."""
         await self._session.async_ensure_token_valid()
-        creds = _async_google_creds(self._hass, self._session.token)
-
-        def _build() -> google_discovery.Resource:
-            return google_discovery.build(
-                "calendar", "v3", credentials=creds, cache_discovery=False
-            )
-
-        return await self._hass.async_add_executor_job(_build)
-
-    async def async_list_calendars(
-        self,
-    ) -> list[dict[str, Any]]:
-        """Return the list of calendars the user has added to their list."""
-        service = await self._async_get_service()
-
-        def _list_calendars() -> list[dict[str, Any]]:
-            cal_list = service.calendarList()
-            return cal_list.list().execute()["items"]
-
-        return await self._hass.async_add_executor_job(_list_calendars)
-
-    async def async_create_event(
-        self, calendar_id: str, event: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Return the list of calendars the user has added to their list."""
-        service = await self._async_get_service()
-
-        def _create_event() -> dict[str, Any]:
-            events = service.events()
-            return events.insert(calendarId=calendar_id, body=event).execute()
-
-        return await self._hass.async_add_executor_job(_create_event)
-
-    async def async_list_events(
-        self,
-        calendar_id: str,
-        start_time: datetime.datetime | None = None,
-        end_time: datetime.datetime | None = None,
-        search: str | None = None,
-        page_token: str | None = None,
-    ) -> tuple[list[dict[str, Any]], str | None]:
-        """Return the list of events."""
-        service = await self._async_get_service()
-
-        def _list_events() -> tuple[list[dict[str, Any]], str | None]:
-            events = service.events()
-            result = events.list(
-                calendarId=calendar_id,
-                timeMin=_api_time_format(start_time if start_time else dt.now()),
-                timeMax=_api_time_format(end_time),
-                q=search,
-                maxResults=EVENT_PAGE_SIZE,
-                pageToken=page_token,
-                singleEvents=True,  # Flattens recurring events
-                orderBy="startTime",
-            ).execute()
-            return (result["items"], result.get("nextPageToken"))
-
-        return await self._hass.async_add_executor_job(_list_events)
+        return self._session.token["access_token"]

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -191,9 +191,8 @@ class GoogleCalendarEntity(CalendarEntity):
             _LOGGER.error("Unable to connect to Google: %s", err)
             return
 
-        items = result.items
         # Pick the first visible event and apply offset calculations.
-        valid_items = filter(self._event_filter, items)
+        valid_items = filter(self._event_filter, result.items)
         event = copy.deepcopy(next(valid_items, None))
         if event:
             (event.summary, offset) = extract_offset(event.summary, self._offset)

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import copy
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
-from httplib2 import ServerNotFoundError
+from gcal_sync.api import GoogleCalendarService, ListEventsRequest
+from gcal_sync.exceptions import ApiException
+from gcal_sync.model import Event
 
 from homeassistant.components.calendar import (
     ENTITY_ID_FORMAT,
@@ -22,7 +24,7 @@ from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import Throttle, dt
+from homeassistant.util import Throttle
 
 from . import (
     CONF_CAL_ID,
@@ -34,7 +36,6 @@ from . import (
     DOMAIN,
     SERVICE_SCAN_CALENDARS,
 )
-from .api import GoogleCalendarService
 from .const import DISCOVER_CALENDAR
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,77 +148,67 @@ class GoogleCalendarEntity(CalendarEntity):
         """Return the name of the entity."""
         return self._name
 
-    def _event_filter(self, event: dict[str, Any]) -> bool:
+    def _event_filter(self, event: Event) -> bool:
         """Return True if the event is visible."""
         if self._ignore_availability:
             return True
-        return event.get(TRANSPARENCY, OPAQUE) == OPAQUE
+        return event.transparency == OPAQUE
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
         event_list: list[dict[str, Any]] = []
-        page_token: str | None = None
+
+        request = ListEventsRequest(
+            calendar_id=self._calendar_id,
+            start_time=start_date,
+            end_time=end_date,
+            search=self._search,
+        )
         while True:
             try:
-                items, page_token = await self._calendar_service.async_list_events(
-                    self._calendar_id,
-                    start_time=start_date,
-                    end_time=end_date,
-                    search=self._search,
-                    page_token=page_token,
-                )
-            except ServerNotFoundError as err:
+                result = await self._calendar_service.async_list_events(request)
+            except ApiException as err:
                 _LOGGER.error("Unable to connect to Google: %s", err)
                 return []
 
-            event_list.extend(filter(self._event_filter, items))
-            if not page_token:
+            event_list.extend(filter(self._event_filter, result.items))
+            if not result.page_token:
                 break
+
+            request.page_token = result.page_token
 
         return [_get_calendar_event(event) for event in event_list]
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:
         """Get the latest data."""
+        request = ListEventsRequest(calendar_id=self._calendar_id, search=self._search)
         try:
-            items, _ = await self._calendar_service.async_list_events(
-                self._calendar_id, search=self._search
-            )
-        except ServerNotFoundError as err:
+            result = await self._calendar_service.async_list_events(request)
+        except ApiException as err:
             _LOGGER.error("Unable to connect to Google: %s", err)
             return
 
+        items = result.items
         # Pick the first visible event and apply offset calculations.
         valid_items = filter(self._event_filter, items)
         event = copy.deepcopy(next(valid_items, None))
         if event:
-            (summary, offset) = extract_offset(event.get("summary", ""), self._offset)
-            event["summary"] = summary
+            (event.summary, offset) = extract_offset(event.summary, self._offset)
             self._event = _get_calendar_event(event)
             self._offset_value = offset
         else:
             self._event = None
 
 
-def _get_date_or_datetime(date_dict: dict[str, str]) -> datetime | date:
-    """Convert a google calendar API response to a datetime or date object."""
-    if "date" in date_dict:
-        parsed_date = dt.parse_date(date_dict["date"])
-        assert parsed_date
-        return parsed_date
-    parsed_datetime = dt.parse_datetime(date_dict["dateTime"])
-    assert parsed_datetime
-    return parsed_datetime
-
-
-def _get_calendar_event(event: dict[str, Any]) -> CalendarEvent:
+def _get_calendar_event(event: Event) -> CalendarEvent:
     """Return a CalendarEvent from an API event."""
     return CalendarEvent(
-        summary=event["summary"],
-        start=_get_date_or_datetime(event["start"]),
-        end=_get_date_or_datetime(event["end"]),
-        description=event.get("description"),
-        location=event.get("location"),
+        summary=event.summary,
+        start=event.start.value,
+        end=event.end.value,
+        description=event.description,
+        location=event.location,
     )

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["auth"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
-  "requirements": ["gcal-sync==0.4.1", "oauth2client==4.1.3"],
+  "requirements": ["gcal-sync==0.5.0", "oauth2client==4.1.3"],
   "codeowners": ["@allenporter"],
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"]

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -4,11 +4,7 @@
   "config_flow": true,
   "dependencies": ["auth"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
-  "requirements": [
-    "google-api-python-client==2.38.0",
-    "httplib2==0.20.4",
-    "oauth2client==4.1.3"
-  ],
+  "requirements": ["gcal-sync==0.4.0", "oauth2client==4.1.3"],
   "codeowners": ["@allenporter"],
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"]

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["auth"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
-  "requirements": ["gcal-sync==0.4.0", "oauth2client==4.1.3"],
+  "requirements": ["gcal-sync==0.4.1", "oauth2client==4.1.3"],
   "codeowners": ["@allenporter"],
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -679,7 +679,7 @@ gTTS==2.2.4
 garages-amsterdam==3.0.0
 
 # homeassistant.components.google
-gcal-sync==0.4.0
+gcal-sync==0.4.1
 
 # homeassistant.components.geniushub
 geniushub-client==0.6.30

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -678,6 +678,9 @@ gTTS==2.2.4
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==3.0.0
 
+# homeassistant.components.google
+gcal-sync==0.4.0
+
 # homeassistant.components.geniushub
 geniushub-client==0.6.30
 
@@ -716,9 +719,6 @@ goalzero==0.2.1
 
 # homeassistant.components.goodwe
 goodwe==0.2.15
-
-# homeassistant.components.google
-google-api-python-client==2.38.0
 
 # homeassistant.components.google_pubsub
 google-cloud-pubsub==2.11.0
@@ -826,7 +826,6 @@ homepluscontrol==0.0.5
 # homeassistant.components.horizon
 horimote==0.4.1
 
-# homeassistant.components.google
 # homeassistant.components.remember_the_milk
 httplib2==0.20.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -679,7 +679,7 @@ gTTS==2.2.4
 garages-amsterdam==3.0.0
 
 # homeassistant.components.google
-gcal-sync==0.4.1
+gcal-sync==0.5.0
 
 # homeassistant.components.geniushub
 geniushub-client==0.6.30

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -476,7 +476,7 @@ gTTS==2.2.4
 garages-amsterdam==3.0.0
 
 # homeassistant.components.google
-gcal-sync==0.4.1
+gcal-sync==0.5.0
 
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -476,7 +476,7 @@ gTTS==2.2.4
 garages-amsterdam==3.0.0
 
 # homeassistant.components.google
-gcal-sync==0.4.0
+gcal-sync==0.4.1
 
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -475,6 +475,9 @@ gTTS==2.2.4
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==3.0.0
 
+# homeassistant.components.google
+gcal-sync==0.4.0
+
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.6
 
@@ -507,9 +510,6 @@ goalzero==0.2.1
 
 # homeassistant.components.goodwe
 goodwe==0.2.15
-
-# homeassistant.components.google
-google-api-python-client==2.38.0
 
 # homeassistant.components.google_pubsub
 google-cloud-pubsub==2.11.0
@@ -584,7 +584,6 @@ homematicip==1.0.2
 # homeassistant.components.home_plus_control
 homepluscontrol==0.0.5
 
-# homeassistant.components.google
 # homeassistant.components.remember_the_milk
 httplib2==0.20.4
 

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 import datetime
 from typing import Any, Generator, TypeVar
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import mock_open, patch
 
-from googleapiclient import discovery as google_discovery
 from oauth2client.client import Credentials, OAuth2Credentials
 import pytest
 import yaml
@@ -18,6 +17,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 ApiResult = Callable[[dict[str, Any]], None]
 ComponentSetup = Callable[[], Awaitable[bool]]
@@ -198,22 +198,21 @@ def mock_token_read(
     storage.put(creds)
 
 
-@pytest.fixture(autouse=True)
-def calendar_resource() -> YieldFixture[google_discovery.Resource]:
-    """Fixture to mock out the Google discovery API."""
-    with patch("homeassistant.components.google.api.google_discovery.build") as mock:
-        yield mock
-
-
 @pytest.fixture
 def mock_events_list(
-    calendar_resource: google_discovery.Resource,
-) -> Callable[[dict[str, Any]], None]:
+    aioclient_mock: AiohttpClientMocker,
+) -> ApiResult:
     """Fixture to construct a fake event list API response."""
 
-    def _put_result(response: dict[str, Any]) -> None:
-        calendar_resource.return_value.events.return_value.list.return_value.execute.return_value = (
-            response
+    def _put_result(
+        response: dict[str, Any], calendar_id: str = None, exc: Exception = None
+    ) -> None:
+        if calendar_id is None:
+            calendar_id = CALENDAR_ID
+        aioclient_mock.get(
+            f"https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events",
+            json=response,
+            exc=exc,
         )
         return
 
@@ -235,13 +234,15 @@ def mock_events_list_items(
 
 @pytest.fixture
 def mock_calendars_list(
-    calendar_resource: google_discovery.Resource,
+    aioclient_mock: AiohttpClientMocker,
 ) -> ApiResult:
     """Fixture to construct a fake calendar list API response."""
 
-    def _put_result(response: dict[str, Any]) -> None:
-        calendar_resource.return_value.calendarList.return_value.list.return_value.execute.return_value = (
-            response
+    def _put_result(response: dict[str, Any], exc=None) -> None:
+        aioclient_mock.get(
+            "https://www.googleapis.com/calendar/v3/users/me/calendarList",
+            json=response,
+            exc=exc,
         )
         return
 
@@ -250,12 +251,19 @@ def mock_calendars_list(
 
 @pytest.fixture
 def mock_insert_event(
-    calendar_resource: google_discovery.Resource,
-) -> Mock:
-    """Fixture to create a mock to capture new events added to the API."""
-    insert_mock = Mock()
-    calendar_resource.return_value.events.return_value.insert = insert_mock
-    return insert_mock
+    aioclient_mock: AiohttpClientMocker,
+) -> Callable[[..., dict[str, Any]], None]:
+    """Fixture for capturing event creation."""
+
+    def _expect_result(calendar_id: str | None = None) -> None:
+        if calendar_id is None:
+            calendar_id = CALENDAR_ID
+        aioclient_mock.post(
+            f"https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events",
+        )
+        return
+
+    return _expect_result
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -256,9 +256,7 @@ def mock_insert_event(
 ) -> Callable[[..., dict[str, Any]], None]:
     """Fixture for capturing event creation."""
 
-    def _expect_result(calendar_id: str | None = None) -> None:
-        if calendar_id is None:
-            calendar_id = CALENDAR_ID
+    def _expect_result(calendar_id: str = CALENDAR_ID) -> None:
         aioclient_mock.post(
             f"{API_BASE_URL}/calendars/{calendar_id}/events",
         )

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -6,6 +6,7 @@ import datetime
 from typing import Any, Generator, TypeVar
 from unittest.mock import mock_open, patch
 
+from gcal_sync.auth import API_BASE_URL
 from oauth2client.client import Credentials, OAuth2Credentials
 import pytest
 import yaml
@@ -210,7 +211,7 @@ def mock_events_list(
         if calendar_id is None:
             calendar_id = CALENDAR_ID
         aioclient_mock.get(
-            f"https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events",
+            f"{API_BASE_URL}/calendars/{calendar_id}/events",
             json=response,
             exc=exc,
         )
@@ -240,7 +241,7 @@ def mock_calendars_list(
 
     def _put_result(response: dict[str, Any], exc=None) -> None:
         aioclient_mock.get(
-            "https://www.googleapis.com/calendar/v3/users/me/calendarList",
+            f"{API_BASE_URL}/users/me/calendarList",
             json=response,
             exc=exc,
         )
@@ -259,7 +260,7 @@ def mock_insert_event(
         if calendar_id is None:
             calendar_id = CALENDAR_ID
         aioclient_mock.post(
-            f"https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events",
+            f"{API_BASE_URL}/calendars/{calendar_id}/events",
         )
         return
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -6,7 +6,7 @@ import datetime
 import http
 import time
 from typing import Any
-from unittest.mock import Mock, call, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -134,10 +134,12 @@ async def test_calendar_yaml_error(
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
     test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
 ) -> None:
     """Test setup with yaml file not found."""
     mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
 
     with patch("homeassistant.components.google.open", side_effect=FileNotFoundError()):
         assert await component_setup()
@@ -182,6 +184,7 @@ async def test_track_new(
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
     test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
     mock_calendars_yaml: None,
     expected_state: State,
     setup_config_entry: MockConfigEntry,
@@ -189,6 +192,7 @@ async def test_track_new(
     """Test behavior of configuration.yaml settings for tracking new calendars not in the config."""
 
     mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     state = hass.states.get(TEST_API_ENTITY)
@@ -202,11 +206,13 @@ async def test_found_calendar_from_api(
     mock_calendars_yaml: None,
     mock_calendars_list: ApiResult,
     test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
 ) -> None:
     """Test finding a calendar from the API."""
 
     mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     state = hass.states.get(TEST_API_ENTITY)
@@ -240,6 +246,7 @@ async def test_calendar_config_track_new(
     component_setup: ComponentSetup,
     mock_calendars_yaml: None,
     mock_calendars_list: ApiResult,
+    mock_events_list: ApiResult,
     test_api_calendar: dict[str, Any],
     calendars_config_track: bool,
     expected_state: State,
@@ -248,44 +255,35 @@ async def test_calendar_config_track_new(
     """Test calendar config that overrides whether or not a calendar is tracked."""
 
     mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     state = hass.states.get(TEST_YAML_ENTITY)
     assert_state(state, expected_state)
 
 
-async def test_add_event(
+async def test_add_event_missing_required_fields(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
     test_api_calendar: dict[str, Any],
-    mock_insert_event: Mock,
     setup_config_entry: MockConfigEntry,
 ) -> None:
-    """Test service call that adds an event."""
+    """Test service call that adds an event missing required fields."""
 
     assert await component_setup()
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_ADD_EVENT,
-        {
-            "calendar_id": CALENDAR_ID,
-            "summary": "Summary",
-            "description": "Description",
-        },
-        blocking=True,
-    )
-    mock_insert_event.assert_called()
-    assert mock_insert_event.mock_calls[0] == call(
-        calendarId=CALENDAR_ID,
-        body={
-            "summary": "Summary",
-            "description": "Description",
-            "start": {},
-            "end": {},
-        },
-    )
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_EVENT,
+            {
+                "calendar_id": CALENDAR_ID,
+                "summary": "Summary",
+                "description": "Description",
+            },
+            blocking=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -308,16 +306,26 @@ async def test_add_event_date_in_x(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
+    mock_insert_event: Callable[[..., dict[str, Any]], None],
     test_api_calendar: dict[str, Any],
-    mock_insert_event: Mock,
     date_fields: dict[str, Any],
     start_timedelta: datetime.timedelta,
     end_timedelta: datetime.timedelta,
     setup_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test service call that adds an event with various time ranges."""
 
+    mock_calendars_list({})
     assert await component_setup()
+
+    now = datetime.datetime.now()
+    start_date = now + start_timedelta
+    end_date = now + end_timedelta
+
+    mock_insert_event(
+        calendar_id=CALENDAR_ID,
+    )
 
     await hass.services.async_call(
         DOMAIN,
@@ -330,37 +338,35 @@ async def test_add_event_date_in_x(
         },
         blocking=True,
     )
-    mock_insert_event.assert_called()
-
-    now = datetime.datetime.now()
-    start_date = now + start_timedelta
-    end_date = now + end_timedelta
-
-    assert mock_insert_event.mock_calls[0] == call(
-        calendarId=CALENDAR_ID,
-        body={
-            "summary": "Summary",
-            "description": "Description",
-            "start": {"date": start_date.date().isoformat()},
-            "end": {"date": end_date.date().isoformat()},
-        },
-    )
+    assert len(aioclient_mock.mock_calls) == 2
+    assert aioclient_mock.mock_calls[1][2] == {
+        "summary": "Summary",
+        "description": "Description",
+        "start": {"date": start_date.date().isoformat()},
+        "end": {"date": end_date.date().isoformat()},
+    }
 
 
 async def test_add_event_date(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
-    mock_insert_event: Mock,
+    mock_insert_event: Callable[[str, dict[str, Any]], None],
     setup_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test service call that sets a date range."""
 
+    mock_calendars_list({})
     assert await component_setup()
 
     now = utcnow()
     today = now.date()
     end_date = today + datetime.timedelta(days=2)
+
+    mock_insert_event(
+        calendar_id=CALENDAR_ID,
+    )
 
     await hass.services.async_call(
         DOMAIN,
@@ -374,34 +380,36 @@ async def test_add_event_date(
         },
         blocking=True,
     )
-    mock_insert_event.assert_called()
-
-    assert mock_insert_event.mock_calls[0] == call(
-        calendarId=CALENDAR_ID,
-        body={
-            "summary": "Summary",
-            "description": "Description",
-            "start": {"date": today.isoformat()},
-            "end": {"date": end_date.isoformat()},
-        },
-    )
+    assert len(aioclient_mock.mock_calls) == 2
+    assert aioclient_mock.mock_calls[1][2] == {
+        "summary": "Summary",
+        "description": "Description",
+        "start": {"date": today.isoformat()},
+        "end": {"date": end_date.isoformat()},
+    }
 
 
 async def test_add_event_date_time(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
+    mock_insert_event: Callable[[str, dict[str, Any]], None],
     test_api_calendar: dict[str, Any],
-    mock_insert_event: Mock,
     setup_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test service call that adds an event with a date time range."""
 
+    mock_calendars_list({})
     assert await component_setup()
 
     start_datetime = datetime.datetime.now()
     delta = datetime.timedelta(days=3, hours=3)
     end_datetime = start_datetime + delta
+
+    mock_insert_event(
+        calendar_id=CALENDAR_ID,
+    )
 
     await hass.services.async_call(
         DOMAIN,
@@ -415,34 +423,32 @@ async def test_add_event_date_time(
         },
         blocking=True,
     )
-    mock_insert_event.assert_called()
-
-    assert mock_insert_event.mock_calls[0] == call(
-        calendarId=CALENDAR_ID,
-        body={
-            "summary": "Summary",
-            "description": "Description",
-            "start": {
-                "dateTime": start_datetime.isoformat(timespec="seconds"),
-                "timeZone": "America/Regina",
-            },
-            "end": {
-                "dateTime": end_datetime.isoformat(timespec="seconds"),
-                "timeZone": "America/Regina",
-            },
+    assert len(aioclient_mock.mock_calls) == 2
+    assert aioclient_mock.mock_calls[1][2] == {
+        "summary": "Summary",
+        "description": "Description",
+        "start": {
+            "dateTime": start_datetime.isoformat(timespec="seconds"),
+            "timeZone": "America/Regina",
         },
-    )
+        "end": {
+            "dateTime": end_datetime.isoformat(timespec="seconds"),
+            "timeZone": "America/Regina",
+        },
+    }
 
 
 async def test_scan_calendars(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
-    test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test finding a calendar from the API."""
 
+    mock_calendars_list({"items": []})
     assert await component_setup()
 
     calendar_1 = {
@@ -454,7 +460,9 @@ async def test_scan_calendars(
         "summary": "Calendar 2",
     }
 
+    aioclient_mock.clear_requests()
     mock_calendars_list({"items": [calendar_1]})
+    mock_events_list({}, calendar_id="calendar-id-1")
     await hass.services.async_call(DOMAIN, SERVICE_SCAN_CALENDARS, {}, blocking=True)
     await hass.async_block_till_done()
 
@@ -464,7 +472,10 @@ async def test_scan_calendars(
     assert state.state == STATE_OFF
     assert not hass.states.get("calendar.calendar_2")
 
+    aioclient_mock.clear_requests()
     mock_calendars_list({"items": [calendar_1, calendar_2]})
+    mock_events_list({}, calendar_id="calendar-id-1")
+    mock_events_list({}, calendar_id="calendar-id-2")
     await hass.services.async_call(DOMAIN, SERVICE_SCAN_CALENDARS, {}, blocking=True)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move google calendar api logic to new python library called `gcal_sync` which is a streamlined aiohttp based client library with a google calendar pydantic data model. This removed dependencies on the older httplib2 and google python client library APIs.

This is an updated version of https://github.com/home-assistant/core/pull/70140 which is double the PR lines changed delta to also include the aiohttp migration as the same time as the data model changes.

Commit history: https://github.com/allenporter/gcal_sync/compare/0.1.0...0.4.1 (earliest commit i can link)
https://github.com/allenporter/gcal_sync/commits/main


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
