### PR TITLE
Add the ability to process integration platforms on demand

### DIFF
--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -22,7 +22,7 @@ class IntegrationPlatform:
 
     platform_name: str
     process_platform: Callable[[HomeAssistant, str, Any], Awaitable[None]]
-    processed_platforms: set[str]
+    seen_components: set[str]
 
 
 async def async_process_integration_platform(
@@ -39,9 +39,9 @@ async def async_process_integration_platform(
     ]
     for integration_platform in integration_platforms:
         platform_name = integration_platform.platform_name
-        if component_name in integration_platform.processed_platforms:
+        if component_name in integration_platform.seen_components:
             continue
-        integration_platform.processed_platforms.add(component_name)
+        integration_platform.seen_components.add(component_name)
 
         try:
             platform = integration.get_platform(platform_name)

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -25,41 +25,51 @@ class IntegrationPlatform:
     seen_components: set[str]
 
 
+async def _async_process_single_integration_platform(
+    hass: HomeAssistant, component_name: str, integration_platform: IntegrationPlatform
+) -> None:
+    """Process a single integration platform."""
+    platform_name = integration_platform.platform_name
+    if component_name in integration_platform.seen_components:
+        return
+    integration_platform.seen_components.add(component_name)
+
+    integration = await async_get_integration(hass, component_name)
+
+    try:
+        platform = integration.get_platform(platform_name)
+    except ImportError as err:
+        if f"{component_name}.{platform_name}" not in str(err):
+            _LOGGER.exception(
+                "Unexpected error importing %s/%s.py",
+                component_name,
+                platform_name,
+            )
+        return
+
+    try:
+        await integration_platform.process_platform(hass, component_name, platform)  # type: ignore[misc,operator] # https://github.com/python/mypy/issues/5485
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception(
+            "Error processing platform %s.%s", component_name, platform_name
+        )
+
+
 async def async_process_integration_platform(
     hass: HomeAssistant, component_name: str
 ) -> None:
     """Process component being loaded or on demand."""
-    if "." in component_name:
-        return
-
-    integration = await async_get_integration(hass, component_name)
-
     integration_platforms: list[IntegrationPlatform] = hass.data[
         DATA_INTEGRATION_PLATFORMS
     ]
-    for integration_platform in integration_platforms:
-        platform_name = integration_platform.platform_name
-        if component_name in integration_platform.seen_components:
-            continue
-        integration_platform.seen_components.add(component_name)
-
-        try:
-            platform = integration.get_platform(platform_name)
-        except ImportError as err:
-            if f"{component_name}.{platform_name}" not in str(err):
-                _LOGGER.exception(
-                    "Unexpected error importing %s/%s.py",
-                    component_name,
-                    platform_name,
-                )
-            continue
-
-        try:
-            await integration_platform.process_platform(hass, component_name, platform)  # type: ignore[misc,operator] # https://github.com/python/mypy/issues/5485
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception(
-                "Error processing platform %s.%s", component_name, platform_name
+    await asyncio.gather(
+        *[
+            _async_process_single_integration_platform(
+                hass, component_name, integration_platform
             )
+            for integration_platform in integration_platforms
+        ]
+    )
 
 
 @bind_hass
@@ -75,21 +85,25 @@ async def async_process_integration_platforms(
 
         async def _async_component_loaded(event: Event) -> None:
             """Handle a new component loaded."""
-            await async_process_integration_platform(hass, event.data[ATTR_COMPONENT])
+            comp = event.data[ATTR_COMPONENT]
+            if "." not in comp:
+                await async_process_integration_platform(hass, comp)
 
         hass.bus.async_listen(EVENT_COMPONENT_LOADED, _async_component_loaded)
 
     integration_platforms: list[IntegrationPlatform] = hass.data[
         DATA_INTEGRATION_PLATFORMS
     ]
-    integration_platforms.append(
-        IntegrationPlatform(platform_name, process_platform, set())
-    )
-
-    if hass.config.components:
+    integration_platform = IntegrationPlatform(platform_name, process_platform, set())
+    integration_platforms.append(integration_platform)
+    if top_level_components := (
+        comp for comp in hass.config.components if "." not in comp
+    ):
         await asyncio.gather(
             *[
-                async_process_integration_platform(hass, comp)
-                for comp in hass.config.components
+                _async_process_single_integration_platform(
+                    hass, comp, integration_platform
+                )
+                for comp in top_level_components
             ]
         )

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -58,7 +58,17 @@ async def _async_process_single_integration_platform(
 async def async_process_integration_platform(
     hass: HomeAssistant, component_name: str
 ) -> None:
-    """Process component being loaded or on demand."""
+    """Process integration platforms on demand.
+
+    This function will load the integration platforms
+    for an integration instead of waiting for the EVENT_COMPONENT_LOADED
+    event to be fired for the integration.
+
+    When the integration will create entities before
+    it has finished setting up; call this function to ensure
+    that the integration platforms are loaded before the entities
+    are created.
+    """
     integration_platforms: list[IntegrationPlatform] = hass.data[
         DATA_INTEGRATION_PLATFORMS
     ]

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -29,12 +29,12 @@ async def _async_process_single_integration_platform(
     hass: HomeAssistant, component_name: str, integration_platform: IntegrationPlatform
 ) -> None:
     """Process a single integration platform."""
-    platform_name = integration_platform.platform_name
     if component_name in integration_platform.seen_components:
         return
     integration_platform.seen_components.add(component_name)
 
     integration = await async_get_integration(hass, component_name)
+    platform_name = integration_platform.platform_name
 
     try:
         platform = integration.get_platform(platform_name)

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -60,6 +60,7 @@ async def test_cover_intents_loading(hass):
         )
 
     assert await async_setup_component(hass, "cover", {})
+    await hass.async_block_till_done()
 
     hass.states.async_set("cover.garage_door", "closed")
     calls = async_mock_service(hass, "cover", SERVICE_OPEN_COVER)
@@ -81,6 +82,7 @@ async def test_turn_on_intent(hass):
     """Test HassTurnOn intent."""
     result = await async_setup_component(hass, "homeassistant", {})
     result = await async_setup_component(hass, "intent", {})
+    await hass.async_block_till_done()
     assert result
 
     hass.states.async_set("light.test_light", "off")

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -24,6 +24,7 @@ async def test_system_health_info_storage(hass, hass_storage):
         "data": {"config": {"resources": [], "views": []}},
     }
     assert await async_setup_component(hass, "lovelace", {})
+    await hass.async_block_till_done()
     info = await get_system_health_info(hass, "lovelace")
     assert info == {"dashboards": 1, "mode": "storage", "resources": 0, "views": 0}
 
@@ -32,6 +33,7 @@ async def test_system_health_info_yaml(hass):
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    await hass.async_block_till_done()
     with patch(
         "homeassistant.components.lovelace.dashboard.load_yaml",
         return_value={"views": [{"cards": []}]},
@@ -44,6 +46,7 @@ async def test_system_health_info_yaml_not_found(hass):
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    await hass.async_block_till_done()
     info = await get_system_health_info(hass, "lovelace")
     assert info == {
         "dashboards": 1,

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -35,3 +35,9 @@ async def test_process_integration_platforms(hass):
     assert len(processed) == 2
     assert processed[1][0] == "event"
     assert processed[1][1] == event_platform
+
+    # Verify we only process the platform once if we call it manually
+    await hass.helpers.integration_platform.async_process_integration_platform(
+        hass, "event"
+    )
+    assert len(processed) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the ability to process integration platforms on demand

Supports https://github.com/home-assistant/core/pull/70154 and https://github.com/home-assistant/core/pull/70168

Reduces the number of `component_loaded` listeners by 5 on `default_config`

In a future PR we can use this helper to simplify the `sun` integration as well which will reduce it by 1 more.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io