### PR TITLE
Update Rainforest Eagle to use eagle100 instead of uEagle

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -821,8 +821,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/radiotherm/ @vinnyfuria
 /homeassistant/components/rainbird/ @konikvranik
 /homeassistant/components/raincloud/ @vanstinator
-/homeassistant/components/rainforest_eagle/ @gtdiehl @jcalbert
-/tests/components/rainforest_eagle/ @gtdiehl @jcalbert
+/homeassistant/components/rainforest_eagle/ @gtdiehl @jcalbert @hastarin
+/tests/components/rainforest_eagle/ @gtdiehl @jcalbert @hastarin
 /homeassistant/components/rainmachine/ @bachya
 /tests/components/rainmachine/ @bachya
 /homeassistant/components/random/ @fabaff

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -8,7 +8,7 @@ import aioeagle
 import aiohttp
 import async_timeout
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
-from uEagle import Eagle as Eagle100Reader
+from eagle100 import Eagle as Eagle100Reader
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TYPE

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -7,8 +7,8 @@ import logging
 import aioeagle
 import aiohttp
 import async_timeout
-from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 from eagle100 import Eagle as Eagle100Reader
+from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TYPE

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rainforest Eagle",
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
   "requirements": ["aioeagle==1.1.0", "eagle100==0.1.0"],
-  "codeowners": ["@gtdiehl", "@jcalbert"],
+  "codeowners": ["@gtdiehl", "@jcalbert", "@hastarin"],
   "iot_class": "local_polling",
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rainforest_eagle",
   "name": "Rainforest Eagle",
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
-  "requirements": ["aioeagle==1.1.0", "eagle100==0.1.0"],
+  "requirements": ["aioeagle==1.1.0", "eagle100==0.1.1"],
   "codeowners": ["@gtdiehl", "@jcalbert", "@hastarin"],
   "iot_class": "local_polling",
   "config_flow": true,

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rainforest_eagle",
   "name": "Rainforest Eagle",
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
-  "requirements": ["aioeagle==1.1.0", "uEagle==0.0.2"],
+  "requirements": ["aioeagle==1.1.0", "eagle100==0.1.0"],
   "codeowners": ["@gtdiehl", "@jcalbert"],
   "iot_class": "local_polling",
   "config_flow": true,
@@ -11,5 +11,5 @@
       "macaddress": "D8D5B9*"
     }
   ],
-  "loggers": ["aioeagle", "uEagle"]
+  "loggers": ["aioeagle", "eagle100"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -571,6 +571,9 @@ dweepy==0.3.0
 # homeassistant.components.dynalite
 dynalite_devices==0.1.46
 
+# homeassistant.components.rainforest_eagle
+eagle100==0.1.0
+
 # homeassistant.components.ebusd
 ebusdpy==0.0.17
 
@@ -2347,9 +2350,6 @@ twilio==6.32.0
 
 # homeassistant.components.twitch
 twitchAPI==2.5.2
-
-# homeassistant.components.rainforest_eagle
-eagle100==0.1.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -572,7 +572,7 @@ dweepy==0.3.0
 dynalite_devices==0.1.46
 
 # homeassistant.components.rainforest_eagle
-eagle100==0.1.0
+eagle100==0.1.1
 
 # homeassistant.components.ebusd
 ebusdpy==0.0.17

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2349,7 +2349,7 @@ twilio==6.32.0
 twitchAPI==2.5.2
 
 # homeassistant.components.rainforest_eagle
-uEagle==0.0.2
+eagle100==0.1.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1537,7 +1537,7 @@ twilio==6.32.0
 twitchAPI==2.5.2
 
 # homeassistant.components.rainforest_eagle
-uEagle==0.0.2
+eagle100==0.1.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -421,7 +421,7 @@ dsmr_parser==0.33
 dynalite_devices==0.1.46
 
 # homeassistant.components.rainforest_eagle
-eagle100==0.1.0
+eagle100==0.1.1
 
 # homeassistant.components.elgato
 elgato==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -420,6 +420,9 @@ dsmr_parser==0.33
 # homeassistant.components.dynalite
 dynalite_devices==0.1.46
 
+# homeassistant.components.rainforest_eagle
+eagle100==0.1.0
+
 # homeassistant.components.elgato
 elgato==3.0.0
 
@@ -1535,9 +1538,6 @@ twilio==6.32.0
 
 # homeassistant.components.twitch
 twitchAPI==2.5.2
-
-# homeassistant.components.rainforest_eagle
-eagle100==0.1.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
In the Rainforest Eagle integration, replace [uEagle](https://pypi.org/project/uEagle/) with [eagle100](https://pypi.org/project/eagle100/).

The Rainforest Eagle integration uses a package called [uEagle](https://github.com/jcalbert/uEagle) for communicating with the older Eagle 100 devices. There is a known issue with this package that means the device stops responding entirely. There has been a [pull request](https://github.com/jcalbert/uEagle/pull/8) pending on that repository for almost a year.

I've created a new package with the pull request merged in and published it as eagle100. The proposed changes simply use the new package instead.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
