### PR TITLE
Auto set content type for stream-only in generic camera

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -109,20 +109,6 @@ def build_schema(
     return vol.Schema(spec)
 
 
-def build_schema_content_type(user_input: dict[str, Any] | MappingProxyType[str, Any]):
-    """Create schema for conditional 2nd page specifying stream content_type."""
-    return vol.Schema(
-        {
-            vol.Required(
-                CONF_CONTENT_TYPE,
-                description={
-                    "suggested_value": user_input.get(CONF_CONTENT_TYPE, "image/jpeg")
-                },
-            ): str,
-        }
-    )
-
-
 def get_image_type(image):
     """Get the format of downloaded bytes that could be an image."""
     fmt = None
@@ -283,17 +269,16 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                 if not errors:
                     user_input[CONF_CONTENT_TYPE] = still_format
                     user_input[CONF_LIMIT_REFETCH_TO_URL_CHANGE] = False
-                    if user_input.get(CONF_STILL_IMAGE_URL):
-                        await self.async_set_unique_id(self.flow_id)
-                        return self.async_create_entry(
-                            title=name, data={}, options=user_input
-                        )
-                    # If user didn't specify a still image URL,
-                    # we can't (yet) autodetect it from the stream.
-                    # Show a conditional 2nd page to ask them the content type.
-                    self.cached_user_input = user_input
-                    self.cached_title = name
-                    return await self.async_step_content_type()
+                    if still_url is None:
+                        # If user didn't specify a still image URL,
+                        # The automatically generated still image that stream generates
+                        # is always jpeg
+                        user_input[CONF_CONTENT_TYPE] = "image/jpeg"
+
+                    await self.async_set_unique_id(self.flow_id)
+                    return self.async_create_entry(
+                        title=name, data={}, options=user_input
+                    )
         else:
             user_input = DEFAULT_DATA.copy()
 
@@ -301,22 +286,6 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=build_schema(user_input),
             errors=errors,
-        )
-
-    async def async_step_content_type(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the user's choice for stream content_type."""
-        if user_input is not None:
-            user_input = self.cached_user_input | user_input
-            await self.async_set_unique_id(self.flow_id)
-            return self.async_create_entry(
-                title=self.cached_title, data={}, options=user_input
-            )
-        return self.async_show_form(
-            step_id="content_type",
-            data_schema=build_schema_content_type({}),
-            errors={},
         )
 
     async def async_step_import(self, import_config) -> FlowResult:
@@ -362,6 +331,11 @@ class GenericOptionsFlowHandler(OptionsFlow):
             stream_url = user_input.get(CONF_STREAM_SOURCE)
             if not errors:
                 title = slug_url(still_url) or slug_url(stream_url) or DEFAULT_NAME
+                if still_url is None:
+                    # If user didn't specify a still image URL,
+                    # The automatically generated still image that stream generates
+                    # is always jpeg
+                    still_format = "image/jpeg"
                 data = {
                     CONF_AUTHENTICATION: user_input.get(CONF_AUTHENTICATION),
                     CONF_STREAM_SOURCE: user_input.get(CONF_STREAM_SOURCE),
@@ -376,30 +350,12 @@ class GenericOptionsFlowHandler(OptionsFlow):
                     CONF_FRAMERATE: user_input[CONF_FRAMERATE],
                     CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
                 }
-                if still_url:
-                    return self.async_create_entry(
-                        title=title,
-                        data=data,
-                    )
-                self.cached_title = title
-                self.cached_user_input = data
-                return await self.async_step_content_type()
-
+                return self.async_create_entry(
+                    title=title,
+                    data=data,
+                )
         return self.async_show_form(
             step_id="init",
             data_schema=build_schema(user_input or self.config_entry.options, True),
             errors=errors,
-        )
-
-    async def async_step_content_type(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the user's choice for stream content_type."""
-        if user_input is not None:
-            user_input = self.cached_user_input | user_input
-            return self.async_create_entry(title=self.cached_title, data=user_input)
-        return self.async_show_form(
-            step_id="content_type",
-            data_schema=build_schema_content_type(self.cached_user_input),
-            errors={},
         )

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -203,15 +203,10 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
     data = TESTDATA.copy()
     data.pop(CONF_STILL_IMAGE_URL)
     with mock_av_open as mock_setup:
-        result2 = await hass.config_entries.flow.async_configure(
+        result3 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             data,
         )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
-        {CONF_CONTENT_TYPE: "image/jpeg"},
-    )
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result3["title"] == "127_0_0_1_testurl_2"
@@ -516,20 +511,12 @@ async def test_options_only_stream(hass, fakeimgbytes_png, mock_av_open):
         assert result["step_id"] == "init"
 
         # try updating the config options
-        result2 = await hass.config_entries.options.async_configure(
+        result3 = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input=data,
         )
-        # Should be shown a 2nd form
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result2["step_id"] == "content_type"
-
-        result3 = await hass.config_entries.options.async_configure(
-            result2["flow_id"],
-            user_input={CONF_CONTENT_TYPE: "image/png"},
-        )
         assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result3["data"][CONF_CONTENT_TYPE] == "image/png"
+        assert result3["data"][CONF_CONTENT_TYPE] == "image/jpeg"
 
 
 # These below can be deleted after deprecation period is finished.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
## Context
The generic camera integration has two methods of creating still images:

1. User directly provides a `still_image_url`
2. User provides no `still_image_url` but provides a `stream_url` from which an image is generated.

The config flow added in 2022.4 now automatically works out the `content_type` in the case of 1, but not in the case of 2.

As a result the config flow was updated #69378 to provide an additional page to let users enter the `content_type`.

## The problem
It is not obvious to users what to type in the `content_type` field.

On closer inspection, when a stream is used, the [async_get_image()](https://github.com/home-assistant/core/blob/42c448c422c1e7f129f0a693c1757972cd87abec/homeassistant/components/stream/core.py#L433) function calls [_generate_image()](https://github.com/home-assistant/core/blob/42c448c422c1e7f129f0a693c1757972cd87abec/homeassistant/components/stream/core.py#L407) which uses TurboJPEG to generate a jpeg image from downloaded frames of the stream.

In fact if you set up a stream-only generic camera and specify a content type of "image/abc123" then view the camera's preview, the content type reported in the web browser (e.g. firefox inspect) is "abc123", but the actual file content is jpeg data.

So my interpretation is that:
 - The user supplied `content_type` for a stream is essentially useless
 - The returned content is always jpeg, with the content type set to whatever the user types in the `content_type` box.
 - Browsers are figuring out the real file type and ignoring the reported content type.
 - A more friendly solution for users who are using only streams, would be to silently set the content type to 'image/jpeg', and not ask them for this in the UI.

## This PR 
This PR removes the content_type page and assigns it automatically to image/jpeg if the user has not specified a still image url.

The end behaviour is:

- still and stream specified: content type is detected automatically from the still image
- still only specified: content type is detected automatically from the still image
- stream only specified: content type is set to image/jpeg

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/22360#
- This PR is related to issue: #69128
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
