### PR TITLE
Defer profiler imports until needed to reduce memory pressure

### DIFF
--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -96,6 +96,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return f"Failed to serialize {type(obj)}"
 
     def _dump_log_objects(call: ServiceCall) -> None:
+        # Imports deferred to avoid loading modules
+        # in memory since usually only one part of this
+        # integration is used at a time
         import objgraph  # pylint: disable=import-outside-toplevel
 
         obj_type = call.data[CONF_TYPE]
@@ -218,6 +221,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
+    # Imports deferred to avoid loading modules
+    # in memory since usually only one part of this
+    # integration is used at a time
     import cProfile  # pylint: disable=import-outside-toplevel
 
     start_time = int(time.time() * 1000000)
@@ -246,6 +252,9 @@ async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
 
 
 async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall):
+    # Imports deferred to avoid loading modules
+    # in memory since usually only one part of this
+    # integration is used at a time
     from guppy import hpy  # pylint: disable=import-outside-toplevel
 
     start_time = int(time.time() * 1000000)
@@ -271,6 +280,9 @@ async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall)
 
 
 def _write_profile(profiler, cprofile_path, callgrind_path):
+    # Imports deferred to avoid loading modules
+    # in memory since usually only one part of this
+    # integration is used at a time
     from pyprof2calltree import convert  # pylint: disable=import-outside-toplevel
 
     profiler.create_stats()
@@ -283,6 +295,9 @@ def _write_memory_profile(heap, heap_path):
 
 
 def _log_objects(*_):
+    # Imports deferred to avoid loading modules
+    # in memory since usually only one part of this
+    # integration is used at a time
     import objgraph  # pylint: disable=import-outside-toplevel
 
     _LOGGER.critical("Memory Growth: %s", objgraph.growth(limit=100))

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -96,7 +96,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return f"Failed to serialize {type(obj)}"
 
     def _dump_log_objects(call: ServiceCall) -> None:
-        import objgraph
+        import objgraph  # pylint: disable=import-outside-toplevel
+
         obj_type = call.data[CONF_TYPE]
 
         _LOGGER.critical(
@@ -217,7 +218,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
-    import cProfile # pylint: disable=import-outside-toplevel
+    import cProfile  # pylint: disable=import-outside-toplevel
+
     start_time = int(time.time() * 1000000)
     persistent_notification.async_create(
         hass,
@@ -244,7 +246,8 @@ async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
 
 
 async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall):
-    from guppy import hpy # pylint: disable=import-outside-toplevel
+    from guppy import hpy  # pylint: disable=import-outside-toplevel
+
     start_time = int(time.time() * 1000000)
     persistent_notification.async_create(
         hass,
@@ -268,7 +271,8 @@ async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall)
 
 
 def _write_profile(profiler, cprofile_path, callgrind_path):
-    from pyprof2calltree import convert # pylint: disable=import-outside-toplevel
+    from pyprof2calltree import convert  # pylint: disable=import-outside-toplevel
+
     profiler.create_stats()
     profiler.dump_stats(cprofile_path)
     convert(profiler.getstats(), callgrind_path)
@@ -279,5 +283,6 @@ def _write_memory_profile(heap, heap_path):
 
 
 def _log_objects(*_):
-    import objgraph # pylint: disable=import-outside-toplevel
+    import objgraph  # pylint: disable=import-outside-toplevel
+
     _LOGGER.critical("Memory Growth: %s", objgraph.growth(limit=100))

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -1,6 +1,5 @@
 """The profiler integration."""
 import asyncio
-import cProfile
 from datetime import timedelta
 import logging
 import reprlib
@@ -10,9 +9,6 @@ import time
 import traceback
 from typing import Any
 
-from guppy import hpy
-import objgraph
-from pyprof2calltree import convert
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification
@@ -100,6 +96,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return f"Failed to serialize {type(obj)}"
 
     def _dump_log_objects(call: ServiceCall) -> None:
+        import objgraph
         obj_type = call.data[CONF_TYPE]
 
         _LOGGER.critical(
@@ -220,6 +217,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
+    import cProfile # pylint: disable=import-outside-toplevel
     start_time = int(time.time() * 1000000)
     persistent_notification.async_create(
         hass,
@@ -246,6 +244,7 @@ async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
 
 
 async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall):
+    from guppy import hpy # pylint: disable=import-outside-toplevel
     start_time = int(time.time() * 1000000)
     persistent_notification.async_create(
         hass,
@@ -269,6 +268,7 @@ async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall)
 
 
 def _write_profile(profiler, cprofile_path, callgrind_path):
+    from pyprof2calltree import convert # pylint: disable=import-outside-toplevel
     profiler.create_stats()
     profiler.dump_stats(cprofile_path)
     convert(profiler.getstats(), callgrind_path)
@@ -279,4 +279,5 @@ def _write_memory_profile(heap, heap_path):
 
 
 def _log_objects(*_):
+    import objgraph # pylint: disable=import-outside-toplevel
     _LOGGER.critical("Memory Growth: %s", objgraph.growth(limit=100))

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -39,9 +39,7 @@ async def test_basic_usage(hass, tmpdir):
         last_filename = f"{test_dir}/{filename}"
         return last_filename
 
-    with patch("homeassistant.components.profiler.cProfile.Profile"), patch.object(
-        hass.config, "path", _mock_path
-    ):
+    with patch("cProfile.Profile"), patch.object(hass.config, "path", _mock_path):
         await hass.services.async_call(DOMAIN, SERVICE_START, {CONF_SECONDS: 0.000001})
         await hass.async_block_till_done()
 
@@ -70,9 +68,7 @@ async def test_memory_usage(hass, tmpdir):
         last_filename = f"{test_dir}/{filename}"
         return last_filename
 
-    with patch("homeassistant.components.profiler.hpy") as mock_hpy, patch.object(
-        hass.config, "path", _mock_path
-    ):
+    with patch("guppy.hpy") as mock_hpy, patch.object(hass.config, "path", _mock_path):
         await hass.services.async_call(DOMAIN, SERVICE_MEMORY, {CONF_SECONDS: 0.000001})
         await hass.async_block_till_done()
 
@@ -94,7 +90,7 @@ async def test_object_growth_logging(hass, caplog):
     assert hass.services.has_service(DOMAIN, SERVICE_START_LOG_OBJECTS)
     assert hass.services.has_service(DOMAIN, SERVICE_STOP_LOG_OBJECTS)
 
-    with patch("homeassistant.components.profiler.objgraph.growth"):
+    with patch("objgraph.growth"):
         await hass.services.async_call(
             DOMAIN, SERVICE_START_LOG_OBJECTS, {CONF_SCAN_INTERVAL: 10}
         )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


I'm working through reducing the memory needed so my RPi3b test target doesn't run out of memory anymore by looking at what is imported after bootstrapping integrations:
```diff
diff --git a/homeassistant/bootstrap.py b/homeassistant/bootstrap.py
index 986171cbee..e2c24f4d2e 100644
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -249,6 +249,12 @@ async def async_from_config_dict(
         return None
 
     await _async_set_up_integrations(hass, config)
+    import json
+    from homeassistant.helpers.json import ExtendedJSONEncoder
+
+    _LOGGER.error(
+        "Sys modules: %s", json.dumps(sys.modules, cls=ExtendedJSONEncoder, indent=4)
+    )
 
     stop = monotonic()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
``` 

Defer profiler imports until needed to reduce memory pressure


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
