### PR TITLE
Avoid importing distutils in plex

### DIFF
--- a/homeassistant/components/plex/models.py
+++ b/homeassistant/components/plex/models.py
@@ -1,5 +1,4 @@
 """Models to represent various Plex objects used in the integration."""
-from distutils.util import strtobool
 import logging
 
 from homeassistant.components.media_player.const import (
@@ -8,6 +7,7 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_TVSHOW,
     MEDIA_TYPE_VIDEO,
 )
+from homeassistant.helpers.template import result_as_boolean
 from homeassistant.util import dt as dt_util
 
 LIVE_TV_SECTION = "Live TV"
@@ -162,7 +162,7 @@ class PlexMediaSearchResult:
             return offset * 1000
         resume = self._params.get("resume", False)
         if isinstance(resume, str):
-            resume = bool(strtobool(resume))
+            resume = result_as_boolean(resume)
         if resume:
             return self.media.viewOffset
         return 0
@@ -172,5 +172,5 @@ class PlexMediaSearchResult:
         """Return value of shuffle parameter."""
         shuffle = self._params.get("shuffle", False)
         if isinstance(shuffle, str):
-            shuffle = bool(strtobool(shuffle))
+            shuffle = result_as_boolean(shuffle)
         return shuffle


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I'm working through reducing the memory needed so my RPi3b test target doesn't run out of memory anymore by looking at what is imported after bootstrapping integrations:
```diff
diff --git a/homeassistant/bootstrap.py b/homeassistant/bootstrap.py
index 986171cbee..e2c24f4d2e 100644
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -249,6 +249,12 @@ async def async_from_config_dict(
         return None
 
     await _async_set_up_integrations(hass, config)
+    import json
+    from homeassistant.helpers.json import ExtendedJSONEncoder
+
+    _LOGGER.error(
+        "Sys modules: %s", json.dumps(sys.modules, cls=ExtendedJSONEncoder, indent=4)
+    )
 
     stop = monotonic()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
```

Avoid importing distutils in plex since we already have a helper for this

`distutils` also imports `setuputils` as part of its dep chain
```
    "setuptools._distutils": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils' (/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/__init__.py)>"
    },
    "distutils.debug": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.debug' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/debug.py'>"
    },
    "distutils.errors": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.errors' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/errors.py'>"
    },
    "getopt": {
        "__type": "<class 'module'>",
        "repr": "<module 'getopt' from '/opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/getopt.py'>"
    },
    "distutils.fancy_getopt": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.fancy_getopt' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/fancy_getopt.py'>"
    },
    "distutils.dep_util": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.dep_util' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/dep_util.py'>"
    },
    "distutils.log": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.log' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/log.py'>"
    },
    "distutils.spawn": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.spawn' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/spawn.py'>"
    },
    "distutils.py35compat": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.py35compat' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/py35compat.py'>"
    },
    "distutils.util": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.util' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/util.py'>"
    },
    "distutils.dist": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.dist' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/dist.py'>"
    },
    "distutils.dir_util": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.dir_util' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/dir_util.py'>"
    },
    "distutils.file_util": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.file_util' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/file_util.py'>"
    },
    "distutils.archive_util": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.archive_util' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/archive_util.py'>"
    },
    "distutils.cmd": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.cmd' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/cmd.py'>"
    },
    "distutils.config": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.config' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/config.py'>"
    },
    "distutils.extension": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.extension' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/extension.py'>"
    },
    "distutils.core": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.core' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/core.py'>"
    },
    "_distutils_hack.override": {
        "__type": "<class 'module'>",
        "repr": "<module '_distutils_hack.override' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/_distutils_hack/override.py'>"
    },
    "setuptools._deprecation_warning": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._deprecation_warning' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_deprecation_warning.py'>"
    },
    "setuptools.version": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.version' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/version.py'>"
    },
    "distutils.filelist": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.filelist' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/filelist.py'>"
    },
    "setuptools.monkey": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.monkey' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/monkey.py'>"
    },
    "setuptools.extension": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extension' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/extension.py'>"
    },
    "distutils.command": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.command' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/command/__init__.py'>"
    },
    "setuptools.extern": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/extern/__init__.py'>"
    },
    "setuptools._vendor": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/__init__.py'>"
    },
    "setuptools._vendor.packaging.__about__": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.packaging.__about__' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/__about__.py'>"
    },
    "setuptools._vendor.packaging": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.packaging": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools._vendor.ordered_set": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.ordered_set' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.ordered_set": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.ordered_set' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools._vendor.more_itertools.recipes": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.more_itertools.recipes' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/more_itertools/recipes.py'>"
    },
    "setuptools._vendor.more_itertools.more": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.more_itertools.more' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/more_itertools/more.py'>"
    },
    "setuptools._vendor.more_itertools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.more_itertools' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.more_itertools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.more_itertools' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools._vendor.pyparsing": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.pyparsing' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.pyparsing": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.pyparsing' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools._vendor.packaging._manylinux": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.packaging._manylinux' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/_manylinux.py'>"
    },
    "setuptools._vendor.packaging._musllinux": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.packaging._musllinux' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/_musllinux.py'>"
    },
    "setuptools.extern.packaging.tags": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging.tags' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/tags.py'>"
    },
    "setuptools.extern.packaging._structures": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging._structures' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/_structures.py'>"
    },
    "setuptools.extern.packaging.version": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging.version' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/version.py'>"
    },
    "setuptools.extern.packaging.utils": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging.utils' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/utils.py'>"
    },
    "setuptools.extern.packaging.specifiers": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging.specifiers' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/specifiers.py'>"
    },
    "setuptools.extern.packaging.markers": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging.markers' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/markers.py'>"
    },
    "setuptools.extern.packaging.requirements": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.packaging.requirements' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/packaging/requirements.py'>"
    },
    "setuptools._vendor.jaraco": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.jaraco' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.jaraco": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.jaraco' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.jaraco.context": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.jaraco.context' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/jaraco/context.py'>"
    },
    "setuptools.extern.jaraco.functools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.jaraco.functools' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/jaraco/functools.py'>"
    },
    "setuptools._vendor.zipp": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.zipp' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/zipp.py'>"
    },
    "setuptools._vendor.importlib_metadata._functools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._functools' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_functools.py'>"
    },
    "setuptools._vendor.importlib_metadata._text": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._text' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_text.py'>"
    },
    "setuptools._vendor.importlib_metadata._adapters": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._adapters' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_adapters.py'>"
    },
    "setuptools._vendor.importlib_metadata._compat": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._compat' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_compat.py'>"
    },
    "setuptools._vendor.importlib_metadata._meta": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._meta' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_meta.py'>"
    },
    "setuptools._vendor.importlib_metadata._collections": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._collections' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_collections.py'>"
    },
    "setuptools._vendor.importlib_metadata._itertools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.importlib_metadata._itertools' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_itertools.py'>"
    },
    "setuptools._vendor.importlib_metadata": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.importlib_metadata' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.importlib_metadata": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.importlib_metadata' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools._vendor.nspektr._compat": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._vendor.nspektr._compat' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/nspektr/_compat.py'>"
    },
    "setuptools._vendor.nspektr": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.nspektr' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools.extern.nspektr": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.nspektr' (<setuptools.extern.VendorImporter object at 0x11f915340>)>"
    },
    "setuptools._importlib": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._importlib' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_importlib.py'>"
    },
    "distutils.command.bdist": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.command.bdist' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/command/bdist.py'>"
    },
    "setuptools.command": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.command' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/command/__init__.py'>"
    },
    "setuptools.windows_support": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.windows_support' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/windows_support.py'>"
    },
    "setuptools.config": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.config' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/config.py'>"
    },
    "setuptools.extern.jaraco.text": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.extern.jaraco.text' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_vendor/jaraco/text/__init__.py'>"
    },
    "setuptools._reqs": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._reqs' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_reqs.py'>"
    },
    "setuptools._itertools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._itertools' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_itertools.py'>"
    },
    "setuptools._entry_points": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._entry_points' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_entry_points.py'>"
    },
    "setuptools.dist": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.dist' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/dist.py'>"
    },
    "setuptools.py34compat": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.py34compat' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/py34compat.py'>"
    },
    "setuptools._imp": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools._imp' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_imp.py'>"
    },
    "setuptools.depends": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.depends' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/depends.py'>"
    },
    "setuptools.logging": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.logging' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/logging.py'>"
    },
    "distutils.ccompiler": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils.ccompiler' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/ccompiler.py'>"
    },
    "setuptools.msvc": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools.msvc' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/msvc.py'>"
    },
    "setuptools": {
        "__type": "<class 'module'>",
        "repr": "<module 'setuptools' from '/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/__init__.py'>"
    },
    "distutils": {
        "__type": "<class 'module'>",
        "repr": "<module 'distutils' (/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/setuptools/_distutils/__init__.py)>"
    },
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
