### PR TITLE
Hide credentials from generated titles in generic camera

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -6,6 +6,7 @@ from errno import EHOSTUNREACH, EIO
 from functools import partial
 import io
 import logging
+import re
 from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse, urlunparse
@@ -182,10 +183,14 @@ async def async_test_still(hass, info) -> tuple[dict[str, str], str | None]:
     return {}, f"image/{fmt}"
 
 
+URL_RE = re.compile("//.*:.*@")
+
+
 def slug_url(url) -> str | None:
     """Convert a camera url into a string suitable for a camera name."""
     if not url:
         return None
+    url = URL_RE.sub("//", url)
     url_no_scheme = urlparse(url)._replace(scheme="")
     return slugify(urlunparse(url_no_scheme).strip("/"))
 

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -8,7 +8,6 @@ import io
 import logging
 from types import MappingProxyType
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
 import PIL
 from async_timeout import timeout
@@ -187,10 +186,7 @@ def slug_url(url) -> str | None:
     """Convert a camera url into a string suitable for a camera name."""
     if not url:
         return None
-    # Strip out username/password if present
-    url = str(yarl.URL(url).with_user(None))
-    url_no_scheme = urlparse(url)._replace(scheme="")
-    return slugify(urlunparse(url_no_scheme).strip("/"))
+    return slugify(yarl.URL(url).host)
 
 
 async def async_test_stream(hass, info) -> dict[str, str]:

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -6,7 +6,6 @@ from errno import EHOSTUNREACH, EIO
 from functools import partial
 import io
 import logging
-import re
 from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse, urlunparse
@@ -16,6 +15,7 @@ from async_timeout import timeout
 import av
 from httpx import HTTPStatusError, RequestError, TimeoutException
 import voluptuous as vol
+import yarl
 
 from homeassistant.components.stream.const import SOURCE_TIMEOUT
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
@@ -183,14 +183,12 @@ async def async_test_still(hass, info) -> tuple[dict[str, str], str | None]:
     return {}, f"image/{fmt}"
 
 
-URL_RE = re.compile("//.*:.*@")
-
-
 def slug_url(url) -> str | None:
     """Convert a camera url into a string suitable for a camera name."""
     if not url:
         return None
-    url = URL_RE.sub("//", url)
+    # Strip out username/password if present
+    url = str(yarl.URL(url).with_user(None))
     url_no_scheme = urlparse(url)._replace(scheme="")
     return slugify(urlunparse(url_no_scheme).strip("/"))
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -62,7 +62,7 @@ async def test_form(hass, fakeimg_png, mock_av_open, user_flow):
             TESTDATA,
         )
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "127_0_0_1_testurl_1"
+    assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
         CONF_STREAM_SOURCE: "http://127.0.0.1/testurl/2",
@@ -96,7 +96,7 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
         data,
     )
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "127_0_0_1_testurl_1"
+    assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
@@ -176,7 +176,7 @@ async def test_form_rtsp_mode(hass, fakeimg_png, mock_av_open, user_flow):
         )
     assert "errors" not in result2, f"errors={result2['errors']}"
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "127_0_0_1_testurl_1"
+    assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
@@ -215,7 +215,7 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
     )
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result3["title"] == "127_0_0_1_testurl_2"
+    assert result3["title"] == "127_0_0_1"
     assert result3["options"] == {
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
         CONF_STREAM_SOURCE: "rtsp://user:pass@127.0.0.1/testurl/2",
@@ -233,7 +233,7 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
         "homeassistant.components.generic.camera.GenericCamera.async_camera_image",
         return_value=fakeimgbytes_jpg,
     ):
-        image_obj = await async_get_image(hass, "camera.127_0_0_1_testurl_2")
+        image_obj = await async_get_image(hass, "camera.127_0_0_1")
         assert image_obj.content == fakeimgbytes_jpg
     assert len(mock_setup.mock_calls) == 1
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -202,6 +202,7 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
     )
     data = TESTDATA.copy()
     data.pop(CONF_STILL_IMAGE_URL)
+    data[CONF_STREAM_SOURCE] = "rtsp://user:pass@127.0.0.1/testurl/2"
     with mock_av_open as mock_setup:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -217,7 +218,7 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
     assert result3["title"] == "127_0_0_1_testurl_2"
     assert result3["options"] == {
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
-        CONF_STREAM_SOURCE: "http://127.0.0.1/testurl/2",
+        CONF_STREAM_SOURCE: "rtsp://user:pass@127.0.0.1/testurl/2",
         CONF_USERNAME: "fred_flintstone",
         CONF_PASSWORD: "bambam",
         CONF_LIMIT_REFETCH_TO_URL_CHANGE: False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the generic camera integration is set up via a config flow, a title is automatically generated based on the url.  

Unfortunately the generated string also includes credentials 
e.g. 
`rtsp://username:pass@192.168.0.10/xxx`
creates title
`username_pass_192_168_0_10_xxx`

This PR drops the credentials from the URL before generating the title string.

**Update:**
To deal with [other places there could be sensitive parameters](https://github.com/home-assistant/core/issues/70192#issuecomment-1100960361), the PR now just uses the hostname.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #70192
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
