### PR TITLE
Avoid calling time.monotonic on coordinator refresh unless we are debugging

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -183,7 +183,8 @@ class DataUpdateCoordinator(Generic[_T]):
         if scheduled and self.hass.is_stopping:
             return
 
-        start = monotonic()
+        if log_timing := self.logger.isEnabledFor(logging.DEBUG):
+            start = monotonic()
         auth_failed = False
 
         try:
@@ -255,12 +256,13 @@ class DataUpdateCoordinator(Generic[_T]):
                 self.logger.info("Fetching %s data recovered", self.name)
 
         finally:
-            self.logger.debug(
-                "Finished fetching %s data in %.3f seconds (success: %s)",
-                self.name,
-                monotonic() - start,
-                self.last_update_success,
-            )
+            if log_timing:
+                self.logger.debug(
+                    "Finished fetching %s data in %.3f seconds (success: %s)",
+                    self.name,
+                    monotonic() - start,
+                    self.last_update_success,
+                )
             if not auth_failed and self._listeners and not self.hass.is_stopping:
                 self._schedule_refresh()
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This code is a hotspot and we call this twice during refresh and throw it away unless we have debug logging turned on

strace showed we had more of these than expected

```
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=427911115}) = 0
epoll_pwait(4, [], 42, 0, NULL, 8)      = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=428905849}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=429671158}) = 0
epoll_pwait(4, [], 42, 0, NULL, 8)      = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=430718548}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=431456878}) = 0
epoll_pwait(4, [], 42, 0, NULL, 8)      = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=432401665}) = 0
getpid()                                = 188
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=433892803}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=434870350}) = 0
epoll_pwait(4, [], 42, 0, NULL, 8)      = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=435936907}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=436671278}) = 0
epoll_pwait(4, [], 42, 0, NULL, 8)      = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=437631117}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=438374551}) = 0
epoll_pwait(4, [], 42, 0, NULL, 8)      = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=439351994}) = 0
getpid()                                = 188
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=440628758}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=441369744}) = 0
clock_gettime64(CLOCK_MONOTONIC, {tv_sec=931589, tv_nsec=441925262}) = 0
```
Note some are from the underlying asyncio libs. We still get a lot after this changed, but we get less now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
