### PR TITLE
Add available tones property to siren entity description

### DIFF
--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -159,7 +159,7 @@ class SirenEntity(ToggleEntity):
     """Representation of a siren device."""
 
     entity_description: SirenEntityDescription
-    _attr_available_tones: list[int | str] | dict[int, str] | None = None
+    _attr_available_tones: list[int | str] | dict[int, str] | None
 
     @final
     @property

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -152,6 +152,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SirenEntityDescription(ToggleEntityDescription):
     """A class that describes siren entities."""
 
+    available_tones: list[int | str] | dict[int, str] | None = None
+
 
 class SirenEntity(ToggleEntity):
     """Representation of a siren device."""
@@ -180,4 +182,8 @@ class SirenEntity(ToggleEntity):
 
         Requires SirenEntityFeature.TONES.
         """
-        return self._attr_available_tones
+        if hasattr(self, "_attr_available_tones"):
+            return self._attr_available_tones
+        if hasattr(self, "entity_description"):
+            return self.entity_description.available_tones
+        return None

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -24,9 +24,9 @@ class MockSirenEntity(SirenEntity):
     ):
         """Initialize mock siren entity."""
         self._attr_supported_features = supported_features
-        if available_tones_as_attr:
+        if available_tones_as_attr is not None:
             self._attr_available_tones = available_tones_as_attr
-        else:
+        elif available_tones_in_desc is not None:
             self.entity_description = SirenEntityDescription(
                 "mock", available_tones=available_tones_in_desc
             )
@@ -64,18 +64,21 @@ async def test_no_available_tones(hass):
 
 async def test_available_tones_list(hass):
     """Test that valid tones from tone list will get passed in."""
-    siren = MockSirenEntity(SirenEntityFeature.TONES, ["a", "b"])
-    siren.hass = hass
-    assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": "a"}
-
-
-async def test_available_tones_in_description(hass):
-    """Test that valid tones from tone list get passed in from entity description."""
     siren = MockSirenEntity(
-        SirenEntityFeature.TONES, available_tones_in_desc=["a", "b"]
+        SirenEntityFeature.TONES, available_tones_as_attr=["a", "b"]
     )
     siren.hass = hass
     assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": "a"}
+
+
+async def test_available_tones(hass):
+    """Test different available tones scenarios."""
+    siren = MockSirenEntity(
+        SirenEntityFeature.TONES, available_tones_in_desc=["a", "b"]
+    )
+    assert siren.available_tones == ["a", "b"]
+    siren = MockSirenEntity(SirenEntityFeature.TONES)
+    assert siren.available_tones is None
 
 
 async def test_available_tones_dict(hass):


### PR DESCRIPTION
## Proposed change
Siren entity description should have `available_tones` property and the logic for the entity class's `available_tones` property should be updated to handle that


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
