### PR TITLE
Add recorder platform to input_select

### DIFF
--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -20,6 +20,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.integration_platform import (
+    async_process_integration_platform_for_component,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.helpers.service
 from homeassistant.helpers.storage import Store
@@ -138,6 +141,11 @@ class InputSelectStore(Store):
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up an input select."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    # Process integration platforms right away since
+    # we will create entities before firing EVENT_COMPONENT_LOADED
+    await async_process_integration_platform_for_component(hass, DOMAIN)
+
     id_manager = collection.IDManager()
 
     yaml_collection = collection.YamlCollection(

--- a/homeassistant/components/input_select/recorder.py
+++ b/homeassistant/components/input_select/recorder.py
@@ -1,0 +1,11 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.const import ATTR_EDITABLE
+from homeassistant.core import HomeAssistant, callback
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude editable hint from being recorded in the database."""
+    return {ATTR_EDITABLE}

--- a/homeassistant/components/input_select/recorder.py
+++ b/homeassistant/components/input_select/recorder.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant, callback
 
+from . import ATTR_OPTIONS
+
 
 @callback
 def exclude_attributes(hass: HomeAssistant) -> set[str]:
-    """Exclude editable hint from being recorded in the database."""
-    return {ATTR_EDITABLE}
+    """Exclude editable hint and options from being recorded in the database."""
+    return {ATTR_EDITABLE, ATTR_OPTIONS}

--- a/homeassistant/components/input_select/recorder.py
+++ b/homeassistant/components/input_select/recorder.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant, callback
 
-from . import ATTR_OPTIONS
-
 
 @callback
 def exclude_attributes(hass: HomeAssistant) -> set[str]:
-    """Exclude editable hint and options from being recorded in the database."""
-    return {ATTR_EDITABLE, ATTR_OPTIONS}
+    """Exclude editable hint from being recorded in the database."""
+    return {ATTR_EDITABLE}

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.input_select import DOMAIN
+from homeassistant.components.input_select import ATTR_OPTIONS, DOMAIN
 from homeassistant.components.recorder.models import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -54,3 +54,4 @@ async def test_exclude_attributes(
     states: list[State] = await hass.async_add_executor_job(_fetch_states)
     assert len(states) == 1
     assert ATTR_EDITABLE not in states[0].attributes
+    assert ATTR_OPTIONS not in states[0].attributes

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -54,4 +54,4 @@ async def test_exclude_attributes(
     states: list[State] = await hass.async_add_executor_job(_fetch_states)
     assert len(states) == 1
     assert ATTR_EDITABLE not in states[0].attributes
-    assert ATTR_OPTIONS not in states[0].attributes
+    assert ATTR_OPTIONS in states[0].attributes

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -1,0 +1,56 @@
+"""The tests for recorder platform."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.input_select import DOMAIN
+from homeassistant.components.recorder.models import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.const import ATTR_EDITABLE
+from homeassistant.core import HomeAssistant, State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed, async_init_recorder_component
+from tests.components.recorder.common import async_wait_recording_done_without_instance
+
+
+async def test_exclude_attributes(
+    hass: HomeAssistant, enable_custom_integrations: None
+):
+    """Test attributes to be excluded."""
+    await async_init_recorder_component(hass)
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test": {
+                    "options": ["first option", "middle option", "last option"],
+                    "initial": "middle option",
+                }
+            }
+        },
+    )
+
+    state = hass.states.get("input_select.test")
+    assert state
+    assert state.attributes[ATTR_EDITABLE] is False
+
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    await async_wait_recording_done_without_instance(hass)
+
+    def _fetch_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(States, StateAttributes):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    assert len(states) == 1
+    assert ATTR_EDITABLE not in states[0].attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The `editable` attribute from `input_select` entities is no longer recorded.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the recorder platform to the `input_select` integration to exclude the `editable` attribute from being recorded.

The `editable` attribute is a hint used by the frontend to know if this entry can be edited or not (depending on if the helper was added via YAML or via the UI).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
