### PR TITLE
Propagate destination of watched folder moves

### DIFF
--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -63,19 +63,30 @@ def create_event_handler(patterns, hass):
             super().__init__(patterns)
             self.hass = hass
 
-        def process(self, event):
+        def process(self, event, moved=False):
             """On Watcher event, fire HA event."""
             _LOGGER.debug("process(%s)", event)
             if not event.is_directory:
                 folder, file_name = os.path.split(event.src_path)
+                fireable = {
+                    "event_type": event.event_type,
+                    "path": event.src_path,
+                    "file": file_name,
+                    "folder": folder,
+                }
+
+                if moved:
+                    dest_folder, dest_file_name = os.path.split(event.dest_path)
+                    fireable.update(
+                        {
+                            "dest_path": event.dest_path,
+                            "dest_file": dest_file_name,
+                            "dest_folder": dest_folder,
+                        }
+                    )
                 self.hass.bus.fire(
                     DOMAIN,
-                    {
-                        "event_type": event.event_type,
-                        "path": event.src_path,
-                        "file": file_name,
-                        "folder": folder,
-                    },
+                    fireable,
                 )
 
         def on_modified(self, event):
@@ -84,7 +95,7 @@ def create_event_handler(patterns, hass):
 
         def on_moved(self, event):
             """File moved."""
-            self.process(event)
+            self.process(event, moved=True)
 
         def on_created(self, event):
             """File created."""

--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the folder_watcher component."""
 import os
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from homeassistant.components import folder_watcher
@@ -43,7 +44,9 @@ def test_event():
         hass = Mock()
         handler = folder_watcher.create_event_handler(["*"], hass)
         handler.on_created(
-            Mock(is_directory=False, src_path="/hello/world.txt", event_type="created")
+            SimpleNamespace(
+                is_directory=False, src_path="/hello/world.txt", event_type="created"
+            )
         )
         assert hass.bus.fire.called
         assert hass.bus.fire.mock_calls[0][1][0] == folder_watcher.DOMAIN
@@ -52,4 +55,40 @@ def test_event():
             "path": "/hello/world.txt",
             "file": "world.txt",
             "folder": "/hello",
+        }
+
+
+def test_move_event():
+    """Check that Home Assistant events are fired correctly on watchdog event."""
+
+    class MockPatternMatchingEventHandler:
+        """Mock base class for the pattern matcher event handler."""
+
+        def __init__(self, patterns):
+            pass
+
+    with patch(
+        "homeassistant.components.folder_watcher.PatternMatchingEventHandler",
+        MockPatternMatchingEventHandler,
+    ):
+        hass = Mock()
+        handler = folder_watcher.create_event_handler(["*"], hass)
+        handler.on_moved(
+            SimpleNamespace(
+                is_directory=False,
+                src_path="/hello/world.txt",
+                dest_path="/hello/earth.txt",
+                event_type="moved",
+            )
+        )
+        assert hass.bus.fire.called
+        assert hass.bus.fire.mock_calls[0][1][0] == folder_watcher.DOMAIN
+        assert hass.bus.fire.mock_calls[0][1][1] == {
+            "event_type": "moved",
+            "path": "/hello/world.txt",
+            "dest_path": "/hello/earth.txt",
+            "file": "world.txt",
+            "dest_file": "earth.txt",
+            "folder": "/hello",
+            "dest_folder": "/hello",
         }


### PR DESCRIPTION
The `Mock` to `SimpleNamespace` change is to prevent the `Mock` from
generating a new `Mock` when accessing non-existent attributes.

This is pulling the information from the events in the [watchdog `on_deleted`](https://python-watchdog.readthedocs.io/en/stable/api.html#watchdog.events.FileSystemEventHandler.on_deleted) handler including the `dest_path`

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The details are already available in the Watchdog event, this change
propagates that information all the way to be usable in automations.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22427

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
