### PR TITLE
Fix handling unassigned areas in lutron_caseta

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -12,7 +12,7 @@ from pylutron_caseta.smartbridge import Smartbridge
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, Platform
+from homeassistant.const import ATTR_SUGGESTED_AREA, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -41,6 +41,7 @@ from .const import (
     DOMAIN,
     LUTRON_CASETA_BUTTON_EVENT,
     MANUFACTURER,
+    UNASSIGNED_AREA,
 )
 from .device_trigger import (
     DEVICE_TYPE_SUBTYPE_MAP_TO_LIP,
@@ -195,20 +196,28 @@ def _async_register_button_devices(
         if "serial" not in device or device["serial"] in seen:
             continue
         seen.add(device["serial"])
+        device_args = {
+            "name": device["name"],
+            "manufacturer": MANUFACTURER,
+            "config_entry_id": config_entry_id,
+            "identifiers": {(DOMAIN, device["serial"])},
+            "model": f"{device['model']} ({device['type']})",
+            "via_device": (DOMAIN, bridge_device["serial"]),
+        }
+        if "_" in device["name"]:
+            device_args["suggested_area"] = _area_and_name_from_name(device["name"])[0]
 
-        dr_device = device_registry.async_get_or_create(
-            name=device["name"],
-            suggested_area=device["name"].split("_")[0],
-            manufacturer=MANUFACTURER,
-            config_entry_id=config_entry_id,
-            identifiers={(DOMAIN, device["serial"])},
-            model=f"{device['model']} ({device['type']})",
-            via_device=(DOMAIN, bridge_device["serial"]),
-        )
-
+        dr_device = device_registry.async_get_or_create(**device_args)
         button_devices_by_dr_id[dr_device.id] = device
 
     return button_devices_by_dr_id
+
+
+def _area_and_name_from_name(device_name: str) -> tuple[str, str]:
+    """Return the area and name from the devices internal name."""
+    if "_" in device_name:
+        return device_name.split("_", 1)
+    return UNASSIGNED_AREA, device_name
 
 
 @callback
@@ -230,7 +239,7 @@ def _async_subscribe_pico_remote_events(
             action = ACTION_RELEASE
 
         type_ = device["type"]
-        area, name = device["name"].split("_", 1)
+        area, name = _area_and_name_from_name(device["name"])
         button_number = device["button_number"]
         # The original implementation used LIP instead of LEAP
         # so we need to convert the button number to maintain compat
@@ -322,15 +331,17 @@ class LutronCasetaDevice(Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
-        return DeviceInfo(
+        device = self._device
+        info = DeviceInfo(
             identifiers={(DOMAIN, self.serial)},
             manufacturer=MANUFACTURER,
-            model=f"{self._device['model']} ({self._device['type']})",
+            model=f"{device['model']} ({device['type']})",
             name=self.name,
-            suggested_area=self._device["name"].split("_")[0],
             via_device=(DOMAIN, self._bridge_device["serial"]),
             configuration_url="https://device-login.lutron.com",
         )
+        if "_" in device["name"]:
+            info[ATTR_SUGGESTED_AREA] = _area_and_name_from_name(device["name"])[0]
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -204,8 +204,9 @@ def _async_register_button_devices(
             "model": f"{device['model']} ({device['type']})",
             "via_device": (DOMAIN, bridge_device["serial"]),
         }
-        if "_" in device["name"]:
-            device_args["suggested_area"] = _area_and_name_from_name(device["name"])[0]
+        area, _ = _area_and_name_from_name(device["name"])
+        if area != UNASSIGNED_AREA:
+            device_args["suggested_area"] = area
 
         dr_device = device_registry.async_get_or_create(**device_args)
         button_devices_by_dr_id[dr_device.id] = device
@@ -340,8 +341,9 @@ class LutronCasetaDevice(Entity):
             via_device=(DOMAIN, self._bridge_device["serial"]),
             configuration_url="https://device-login.lutron.com",
         )
-        if "_" in device["name"]:
-            info[ATTR_SUGGESTED_AREA] = _area_and_name_from_name(device["name"])[0]
+        area, _ = _area_and_name_from_name(device["name"])
+        if area != UNASSIGNED_AREA:
+            info[ATTR_SUGGESTED_AREA] = area
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/const.py
+++ b/homeassistant/components/lutron_caseta/const.py
@@ -33,3 +33,5 @@ ACTION_RELEASE = "release"
 CONF_SUBTYPE = "subtype"
 
 BRIDGE_TIMEOUT = 35
+
+UNASSIGNED_AREA = "Unassigned"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix handling unassigned areas in lutron_caseta
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #70248
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
