### PR TITLE
Update 17track integration to use v1 API

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1064,7 +1064,6 @@ omit =
     homeassistant/components/serial_pm/sensor.py
     homeassistant/components/sesame/lock.py
     homeassistant/components/seven_segments/image_processing.py
-    homeassistant/components/seventeentrack/sensor.py
     homeassistant/components/shiftr/*
     homeassistant/components/shodan/sensor.py
     homeassistant/components/shelly/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -954,6 +954,8 @@ build.json @home-assistant/supervisor
 /tests/components/senz/ @milanmeu
 /homeassistant/components/serial/ @fabaff
 /homeassistant/components/seven_segments/ @fabaff
+/homeassistant/components/seventeentrack/ @McSwindler
+/tests/components/seventeentrack/ @McSwindler
 /homeassistant/components/sharkiq/ @JeffResc @funkybunch @AritroSaha10
 /tests/components/sharkiq/ @JeffResc @funkybunch @AritroSaha10
 /homeassistant/components/shell_command/ @home-assistant/core

--- a/homeassistant/components/seventeentrack/__init__.py
+++ b/homeassistant/components/seventeentrack/__init__.py
@@ -1,1 +1,188 @@
 """The seventeentrack component."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from seventeentrack import Client as SeventeenTrackClient
+from seventeentrack.errors import (
+    InvalidTrackingNumberError,
+    RequestError,
+    SeventeenTrackError,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_DEVICE_ID, CONF_FRIENDLY_NAME, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .config_flow import get_client
+from .const import (
+    CONF_SHOW_ARCHIVED,
+    CONF_TRACKING_NUMBER,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SHOW_ARCHIVED,
+    DOMAIN,
+    PLATFORMS,
+    SERVICE_ADD_PACKAGE,
+)
+from .errors import AuthenticationError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+SERVICE_ADD_PACKAGE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Required(CONF_TRACKING_NUMBER): cv.string,
+        vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    }
+)
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up the SeventeenTrack component."""
+    coordinator = SeventeenTrackDataCoordinator(hass, config_entry)
+
+    await coordinator.async_setup()
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
+
+    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload SeventeenTrack Entry from config_entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, PLATFORMS
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(config_entry.entry_id)
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_ADD_PACKAGE)
+            del hass.data[DOMAIN]
+
+    return unload_ok
+
+
+class SeventeenTrackDataCoordinator(DataUpdateCoordinator):
+    """Get the latest data from SeventeenTrack."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialize the data object."""
+        self.hass = hass
+        self.config_entry: ConfigEntry = config_entry
+        self.client: SeventeenTrackClient = None
+        self.account_id: str = ""
+        super().__init__(
+            self.hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_method=self.async_update,
+            update_interval=timedelta(
+                minutes=self.config_entry.options.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                )
+            ),
+        )
+
+    @property
+    def show_archived(self) -> bool:
+        """Include archived packages when fetching data."""
+        return self.config_entry.options.get(CONF_SHOW_ARCHIVED, DEFAULT_SHOW_ARCHIVED)
+
+    async def async_update(self) -> dict[str, dict]:
+        """Update SeventeenTrack data."""
+        try:
+            packages = await self.client.profile.packages(
+                show_archived=False, tz=str(self.hass.config.time_zone)
+            )
+            summary = await self.client.profile.summary(show_archived=False)
+
+            if self.show_archived:
+                archived_packages = await self.client.profile.packages(
+                    show_archived=True, tz=str(self.hass.config.time_zone)
+                )
+                packages += archived_packages
+
+                archived_summary = await self.client.profile.summary(show_archived=True)
+                for status, qty in archived_summary.items():
+                    summary[status] += qty
+
+        except SeventeenTrackError as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+        _LOGGER.debug("New package data received: %s", packages)
+        _LOGGER.debug("New summary data received: %s", summary)
+
+        return {"packages": packages, "summary": summary}
+
+    async def async_setup(self) -> bool:
+        """Set up SeventeenTrack."""
+        try:
+            self.client = await get_client(self.hass, self.config_entry.data)
+            self.account_id = self.client.profile.account_id
+
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed from err
+        except SeventeenTrackError as err:
+            raise ConfigEntryNotReady(
+                f"There was an error while logging in: {err}"
+            ) from err
+
+        async def async_add_package(service: ServiceCall) -> None:
+            """Add new package."""
+            device_registry: DeviceRegistry = (
+                self.hass.helpers.device_registry.async_get(self.hass)
+            )
+            device = device_registry.async_get(service.data[CONF_DEVICE_ID])
+            if device is None:
+                _LOGGER.error("17Track device not found")
+                return
+            for config_entry_id in device.config_entries:
+                config_entry = self.hass.config_entries.async_get_entry(config_entry_id)
+                if config_entry and config_entry.domain == DOMAIN:
+                    client: SeventeenTrackClient = self.hass.data[DOMAIN][
+                        config_entry_id
+                    ].client
+                    break
+            try:
+                await client.profile.add_package(
+                    service.data[CONF_TRACKING_NUMBER],
+                    service.data.get(CONF_FRIENDLY_NAME),
+                )
+            except RequestError as err:
+                _LOGGER.error("Package exists or could not be added: %s", err)
+                raise SystemError(
+                    "Package already exists or could not be added"
+                ) from err
+            except InvalidTrackingNumberError as err:
+                _LOGGER.error("Could not set friendly_name: %s", err)
+                raise SystemError("Could not set friendly_name") from err
+            await self.async_request_refresh()
+
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_ADD_PACKAGE,
+            async_add_package,
+            schema=SERVICE_ADD_PACKAGE_SCHEMA,
+        )
+        self.config_entry.add_update_listener(self.async_options_updated)
+
+        return True
+
+    @staticmethod
+    async def async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Triggered by config entry options updates."""
+        hass.data[DOMAIN][entry.entry_id].update_interval = timedelta(
+            minutes=entry.options[CONF_SCAN_INTERVAL]
+        )
+        await hass.data[DOMAIN][entry.entry_id].async_request_refresh()

--- a/homeassistant/components/seventeentrack/__init__.py
+++ b/homeassistant/components/seventeentrack/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .config_flow import get_client
 from .const import (
+    CONF_CARRIER_NAME,
     CONF_SHOW_ARCHIVED,
     CONF_TRACKING_NUMBER,
     DEFAULT_SCAN_INTERVAL,
@@ -39,6 +40,7 @@ SERVICE_ADD_PACKAGE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
         vol.Required(CONF_TRACKING_NUMBER): cv.string,
+        vol.Optional(CONF_CARRIER_NAME): cv.string,
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
     }
 )
@@ -155,8 +157,9 @@ class SeventeenTrackDataCoordinator(DataUpdateCoordinator):
                     ].client
                     break
             try:
-                await client.profile.add_package(
+                await client.profile.add_package_with_carrier(
                     service.data[CONF_TRACKING_NUMBER],
+                    service.data.get(CONF_CARRIER_NAME),
                     service.data.get(CONF_FRIENDLY_NAME),
                 )
             except RequestError as err:

--- a/homeassistant/components/seventeentrack/config_flow.py
+++ b/homeassistant/components/seventeentrack/config_flow.py
@@ -1,0 +1,154 @@
+"""Config flow for SeventeenTrack."""
+from __future__ import annotations
+
+from seventeentrack import Client as SeventeenTrackClient
+from seventeentrack.errors import SeventeenTrackError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_TOKEN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import aiohttp_client
+
+from .const import (
+    CONF_SHOW_ARCHIVED,
+    DEFAULT_NAME,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SHOW_ARCHIVED,
+    DOMAIN,
+)
+from .errors import AuthenticationError
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(CONF_TOKEN): str,
+    }
+)
+
+
+async def get_client(hass: HomeAssistant, entry):
+    """Return SeventeenTrack client."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = SeventeenTrackClient(session=session)
+    login_result = await client.profile.login(entry[CONF_TOKEN])
+    if not login_result:
+        raise AuthenticationError
+
+    return client
+
+
+class SeventeenTrackFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle SeventeenTrack config flow."""
+
+    def __init__(self) -> None:
+        """Initialize config flow."""
+        self.entry: config_entries.ConfigEntry | None = None
+        self.account_id: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Get the options flow for this handler."""
+        return SeventeenTrackOptionsFlowHandler(config_entry)
+
+    async def _async_validate_input(self, user_input):
+        """Validate the user input allows us to connect."""
+        errors = {}
+        try:
+            client = await get_client(self.hass, user_input)
+            self.account_id = client.profile.account_id
+
+        except AuthenticationError:
+            errors["base"] = "invalid_auth"
+        except SeventeenTrackError:
+            errors["base"] = "cannot_connect"
+
+        return errors
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+        if user_input is not None:
+
+            errors = await self._async_validate_input(user_input)
+            await self.async_set_unique_id(self.account_id)
+            self._abort_if_unique_id_configured()
+
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=CONFIG_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, user_input=None) -> FlowResult:
+        """Perform reauth upon an API authentication error."""
+        self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
+        """Dialog that informs the user that reauth is required."""
+        errors = {}
+        if self.entry is not None:
+            _token = self.entry.data[CONF_TOKEN]
+        if user_input is not None and self.entry:
+            user_input[CONF_TOKEN] = _token
+            errors = await self._async_validate_input(user_input)
+
+            if not errors:
+                self.hass.config_entries.async_update_entry(
+                    self.entry,
+                    data={
+                        **self.entry.data,
+                        **user_input,
+                    },
+                )
+                await self.hass.config_entries.async_reload(self.entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TOKEN): str,
+                }
+            ),
+            errors=errors,
+        )
+
+
+class SeventeenTrackOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle SeventeenTrack options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        """Manage options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = {
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                ),
+            ): int,
+            vol.Optional(
+                CONF_SHOW_ARCHIVED,
+                default=self.config_entry.options.get(
+                    CONF_SHOW_ARCHIVED, DEFAULT_SHOW_ARCHIVED
+                ),
+            ): bool,
+        }
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/seventeentrack/const.py
+++ b/homeassistant/components/seventeentrack/const.py
@@ -1,0 +1,29 @@
+"""Consts used by SeventeenTrack."""
+from typing import Final
+
+DOMAIN: Final = "seventeentrack"
+
+DEFAULT_NAME: Final = "SeventeenTrack"
+DEFAULT_SCAN_INTERVAL: Final = 10
+DEFAULT_SHOW_ARCHIVED: Final = False
+
+CONF_SHOW_ARCHIVED: Final = "show_archived"
+CONF_TRACKING_NUMBER: Final = "tracking_number"
+
+SERVICE_ADD_PACKAGE: Final = "add_package"
+
+ATTR_DESTINATION_COUNTRY: Final = "destination_country"
+ATTR_INFO_TEXT: Final = "info_text"
+ATTR_TIMESTAMP: Final = "timestamp"
+ATTR_ORIGIN_COUNTRY: Final = "origin_country"
+ATTR_PACKAGES: Final = "packages"
+ATTR_PACKAGE_TYPE: Final = "package_type"
+ATTR_STATUS: Final = "status"
+ATTR_TRACKING_INFO_LANGUAGE: Final = "tracking_info_language"
+
+
+ATTRIBUTION: Final = "Data provided by 17track.net"
+
+ICON: Final = "mdi:package"
+
+PLATFORMS: Final = ["sensor"]

--- a/homeassistant/components/seventeentrack/const.py
+++ b/homeassistant/components/seventeentrack/const.py
@@ -9,6 +9,7 @@ DEFAULT_SHOW_ARCHIVED: Final = False
 
 CONF_SHOW_ARCHIVED: Final = "show_archived"
 CONF_TRACKING_NUMBER: Final = "tracking_number"
+CONF_CARRIER_NAME: Final = "carrier_name"
 
 SERVICE_ADD_PACKAGE: Final = "add_package"
 

--- a/homeassistant/components/seventeentrack/errors.py
+++ b/homeassistant/components/seventeentrack/errors.py
@@ -1,0 +1,6 @@
+"""Errors for the SeventeenTrack component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class AuthenticationError(HomeAssistantError):
+    """Wrong Username or Password."""

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -3,7 +3,7 @@
   "name": "17TRACK",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["seventeentrack==2022.4.5"],
+  "requirements": ["seventeentrack==2022.4.6"],
   "codeowners": ["@McSwindler"],
   "iot_class": "cloud_polling",
   "loggers": ["seventeentrack"]

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "seventeentrack",
   "name": "17TRACK",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["seventeentrack==2022.4.4"],
+  "requirements": ["seventeentrack==2022.4.5"],
   "codeowners": ["@McSwindler"],
   "iot_class": "cloud_polling",
   "loggers": ["seventeentrack"]

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -2,8 +2,8 @@
   "domain": "seventeentrack",
   "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["py17track==2021.12.2"],
-  "codeowners": [],
+  "requirements": ["seventeentrack==2022.4.4"],
+  "codeowners": ["@McSwindler"],
   "iot_class": "cloud_polling",
-  "loggers": ["py17track"]
+  "loggers": ["seventeentrack"]
 }

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from py17track import Client as SeventeenTrackClient
-from py17track.errors import SeventeenTrackError
+from seventeentrack import Client as SeventeenTrackClient
+from seventeentrack import Version as SeventeenTrackVersion
+from seventeentrack.errors import SeventeenTrackError
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification
@@ -14,9 +15,8 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_FRIENDLY_NAME,
     ATTR_LOCATION,
-    CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
+    CONF_TOKEN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
@@ -57,15 +57,14 @@ NOTIFICATION_DELIVERED_ID = "package_delivered_{0}"
 NOTIFICATION_DELIVERED_TITLE = "Package {0} delivered"
 NOTIFICATION_DELIVERED_MESSAGE = (
     "Package Delivered: {0}<br />Visit 17.track for more information: "
-    "https://t.17track.net/track#nums={1}"
+    "https://api.17track.net/en/admin/tracking#nums={1}"
 )
 
 VALUE_DELIVERED = "Delivered"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_TOKEN): cv.string,
         vol.Optional(CONF_SHOW_ARCHIVED, default=False): cv.boolean,
         vol.Optional(CONF_SHOW_DELIVERED, default=False): cv.boolean,
     }
@@ -82,15 +81,15 @@ async def async_setup_platform(
 
     session = aiohttp_client.async_get_clientsession(hass)
 
-    client = SeventeenTrackClient(session=session)
+    client = SeventeenTrackClient(version=SeventeenTrackVersion.V1, session=session)
 
     try:
         login_result = await client.profile.login(
-            config[CONF_USERNAME], config[CONF_PASSWORD]
+            config[CONF_TOKEN]
         )
 
         if not login_result:
-            _LOGGER.error("Invalid username and password provided")
+            _LOGGER.error("Invalid token provided")
             return
     except SeventeenTrackError as err:
         _LOGGER.error("There was an error while logging in: %s", err)

--- a/homeassistant/components/seventeentrack/services.yaml
+++ b/homeassistant/components/seventeentrack/services.yaml
@@ -16,6 +16,13 @@ add_package:
       example: ABC1234
       selector:
         text:
+    carrier_name:
+      name: Carrier Name
+      description: Name of the carrier handling the package.
+      required: false
+      example: Postal Service
+      selector:
+        text:
     friendly_name:
       name: Package friendly name
       description: Set friendly name for the added package.

--- a/homeassistant/components/seventeentrack/services.yaml
+++ b/homeassistant/components/seventeentrack/services.yaml
@@ -1,0 +1,25 @@
+add_package:
+  name: Add Package
+  description: Add a new package to track.
+  fields:
+    device_id:
+      name: 17Track account device
+      description: Select the 17Track account device.
+      required: true
+      selector:
+        device:
+          integration: seventeentrack
+    tracking_number:
+      name: Tracking Number
+      description: Tracking number of the package.
+      required: true
+      example: ABC1234
+      selector:
+        text:
+    friendly_name:
+      name: Package friendly name
+      description: Set friendly name for the added package.
+      required: false
+      example: New Shipment
+      selector:
+        text:

--- a/homeassistant/components/seventeentrack/strings.json
+++ b/homeassistant/components/seventeentrack/strings.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Setup SeventeenTrack",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "api_token": "[%key:common::config_flow::data::api_token%]"
+        }
+      },
+      "reauth_confirm": {
+        "description": "The API token is no longer valid.",
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "data": {
+          "api_token": "[%key:common::config_flow::data::api_token%]"
+        }
+      }
+    },
+    "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    },
+    "error": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Update frequency (minutes)",
+          "show_archived": "Include archived packages"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/seventeentrack/translations/en.json
+++ b/homeassistant/components/seventeentrack/translations/en.json
@@ -1,0 +1,37 @@
+{
+    "config": {
+        "abort": {
+            "reauth_successful": "Re-authentication was successful"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication"
+        },
+        "step": {
+            "reauth_confirm": {
+                "data": {
+                    "api_token": "API Token"
+                },
+                "description": "The API token is no longer valid.",
+                "title": "Reauthenticate Integration"
+            },
+            "user": {
+                "data": {
+                    "name": "Name",
+                    "api_token": "API Token"
+                },
+                "title": "Setup SeventeenTrack"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Update frequency (minutes)",
+                    "show_archived": "Include archived packages"
+                }
+            }
+        }
+    }
+} 

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -321,6 +321,7 @@ FLOWS = {
         "sensorpush",
         "sentry",
         "senz",
+        "seventeentrack",
         "sharkiq",
         "shelly",
         "shopping_list",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2176,7 +2176,7 @@ sensorpush-ble==1.5.1
 sentry-sdk==1.9.3
 
 # homeassistant.components.seventeentrack
-seventeentrack==2022.4.5
+seventeentrack==2022.4.6
 
 # homeassistant.components.sharkiq
 sharkiq==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2176,7 +2176,7 @@ sensorpush-ble==1.5.1
 sentry-sdk==1.9.3
 
 # homeassistant.components.seventeentrack
-seventeentrack==2022.4.4
+seventeentrack==2022.4.5
 
 # homeassistant.components.sharkiq
 sharkiq==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1336,9 +1336,6 @@ py-synologydsm-api==1.0.8
 # homeassistant.components.zabbix
 py-zabbix==1.1.7
 
-# homeassistant.components.seventeentrack
-py17track==2021.12.2
-
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.2
 
@@ -2177,6 +2174,9 @@ sensorpush-ble==1.5.1
 
 # homeassistant.components.sentry
 sentry-sdk==1.9.3
+
+# homeassistant.components.seventeentrack
+seventeentrack==2022.4.4
 
 # homeassistant.components.sharkiq
 sharkiq==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1473,7 +1473,7 @@ sensorpush-ble==1.5.1
 sentry-sdk==1.9.3
 
 # homeassistant.components.seventeentrack
-seventeentrack==2022.4.5
+seventeentrack==2022.4.6
 
 # homeassistant.components.sharkiq
 sharkiq==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1472,6 +1472,9 @@ sensorpush-ble==1.5.1
 # homeassistant.components.sentry
 sentry-sdk==1.9.3
 
+# homeassistant.components.seventeentrack
+seventeentrack==2022.4.5
+
 # homeassistant.components.sharkiq
 sharkiq==0.0.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -933,9 +933,6 @@ py-nightscout==1.2.2
 # homeassistant.components.synology_dsm
 py-synologydsm-api==1.0.8
 
-# homeassistant.components.seventeentrack
-py17track==2021.12.2
-
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.2
 

--- a/tests/components/seventeentrack/conftest.py
+++ b/tests/components/seventeentrack/conftest.py
@@ -1,0 +1,20 @@
+"""Fixtures for Seventeentrack methods."""
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import seventeentrack
+
+
+@pytest.fixture(autouse=True)
+def mock_api():
+    """Mock api."""
+    with patch.object(
+        seventeentrack.client,
+        "Profile",
+        return_value=Mock(account_id="email@email.com"),
+    ) as mock_profile:
+        mock_profile.return_value.login = AsyncMock(return_value=True)
+        mock_profile.return_value.packages = AsyncMock(return_value=[])
+        mock_profile.return_value.summary = AsyncMock(return_value={})
+        mock_profile.return_value.add_package = AsyncMock()
+        yield mock_profile

--- a/tests/components/seventeentrack/conftest.py
+++ b/tests/components/seventeentrack/conftest.py
@@ -16,5 +16,5 @@ def mock_api():
         mock_profile.return_value.login = AsyncMock(return_value=True)
         mock_profile.return_value.packages = AsyncMock(return_value=[])
         mock_profile.return_value.summary = AsyncMock(return_value={})
-        mock_profile.return_value.add_package = AsyncMock()
+        mock_profile.return_value.add_package_with_carrier = AsyncMock()
         yield mock_profile

--- a/tests/components/seventeentrack/test_config_flow.py
+++ b/tests/components/seventeentrack/test_config_flow.py
@@ -1,0 +1,154 @@
+"""Test the Seventeentrack config flow."""
+from unittest.mock import AsyncMock
+
+from seventeentrack.errors import SeventeenTrackError
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.seventeentrack.const import CONF_SHOW_ARCHIVED, DOMAIN
+from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG = {
+    CONF_NAME: "Seventeentrack",
+    CONF_TOKEN: "token",
+}
+MOCK_OPTIONS = {CONF_SCAN_INTERVAL: 10, CONF_SHOW_ARCHIVED: True}
+
+
+async def test_flow_works(hass: HomeAssistant) -> None:
+    """Test user config."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "Seventeentrack"
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_options(hass: HomeAssistant) -> None:
+    """Test updating options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        options=MOCK_OPTIONS,
+        unique_id="email@email.com",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 30, CONF_SHOW_ARCHIVED: True},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {
+        CONF_SCAN_INTERVAL: 30,
+        CONF_SHOW_ARCHIVED: True,
+    }
+
+
+async def test_form_invalid_auth(hass: HomeAssistant, mock_api) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_api.return_value.login = AsyncMock(return_value=False)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_unknwon_error(hass: HomeAssistant, mock_api) -> None:
+    """Test we handle SeventeenTrackError."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_api.side_effect = SeventeenTrackError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_reauth_success(hass: HomeAssistant) -> None:
+    """Test we can reauth."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="email@email.com",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: "test-token",
+        },
+    )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "reauth_successful"
+
+
+async def test_reauth_failed(hass: HomeAssistant, mock_api) -> None:
+    """Test we can reauth."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="email@email.com",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_api.return_value.login = AsyncMock(return_value=False)
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: "test-token",
+        },
+    )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}

--- a/tests/components/seventeentrack/test_init.py
+++ b/tests/components/seventeentrack/test_init.py
@@ -9,6 +9,7 @@ from seventeentrack.errors import (
 )
 
 from homeassistant.components.seventeentrack.const import (
+    CONF_CARRIER_NAME,
     CONF_TRACKING_NUMBER,
     DOMAIN,
     SERVICE_ADD_PACKAGE,
@@ -70,7 +71,7 @@ async def test_add_package(hass: HomeAssistant, mock_api: MagicMock) -> None:
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert mock_api.return_value.add_package.call_count == 0
+    assert mock_api.return_value.add_package_with_carrier.call_count == 0
 
     # test with correct device_id
     await hass.services.async_call(
@@ -79,12 +80,13 @@ async def test_add_package(hass: HomeAssistant, mock_api: MagicMock) -> None:
         {
             CONF_DEVICE_ID: device_id,
             CONF_TRACKING_NUMBER: "AB123",
+            CONF_CARRIER_NAME: "Postal Service",
             CONF_FRIENDLY_NAME: "My package",
         },
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert mock_api.return_value.add_package.call_count == 1
+    assert mock_api.return_value.add_package_with_carrier.call_count == 1
 
 
 async def test_add_package_failures(hass: HomeAssistant, mock_api: MagicMock) -> None:
@@ -107,7 +109,9 @@ async def test_add_package_failures(hass: HomeAssistant, mock_api: MagicMock) ->
     with pytest.raises(
         SystemError, match="Package already exists or could not be added"
     ):
-        mock_api.return_value.add_package = AsyncMock(side_effect=RequestError)
+        mock_api.return_value.add_package_with_carrier = AsyncMock(
+            side_effect=RequestError
+        )
 
         # test package already exists
         await hass.services.async_call(
@@ -124,7 +128,7 @@ async def test_add_package_failures(hass: HomeAssistant, mock_api: MagicMock) ->
         await hass.async_block_till_done()
 
     with pytest.raises(SystemError, match="Could not set friendly_name"):
-        mock_api.return_value.add_package = AsyncMock(
+        mock_api.return_value.add_package_with_carrier = AsyncMock(
             side_effect=InvalidTrackingNumberError
         )
 

--- a/tests/components/seventeentrack/test_init.py
+++ b/tests/components/seventeentrack/test_init.py
@@ -1,0 +1,188 @@
+"""Tests for SpeedTest integration."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from seventeentrack.errors import (
+    InvalidTrackingNumberError,
+    RequestError,
+    SeventeenTrackError,
+)
+
+from homeassistant.components.seventeentrack.const import (
+    CONF_TRACKING_NUMBER,
+    DOMAIN,
+    SERVICE_ADD_PACKAGE,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_DEVICE_ID, CONF_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .test_config_flow import MOCK_CONFIG
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
+    """Test that we do not discover anything or try to set up a controller."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    assert DOMAIN not in hass.data
+
+
+async def test_successful_config_entry(
+    hass: HomeAssistant, mock_api: MagicMock
+) -> None:
+    """Test that Seventeentrack is configured successfully."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state == ConfigEntryState.LOADED
+
+
+async def test_add_package(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test adding new package."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, unique_id="email@email.com"
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # assert mock_api.call_count == 1
+
+    device_registry = hass.helpers.device_registry.async_get(hass)
+    device_id = device_registry.async_get_device(
+        identifiers={(DOMAIN, "email@email.com")}
+    ).id
+
+    # test client api is not called when device_id is wrong
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_PACKAGE,
+        {
+            CONF_DEVICE_ID: "111",
+            CONF_TRACKING_NUMBER: "AB123",
+            CONF_FRIENDLY_NAME: "My package",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_api.return_value.add_package.call_count == 0
+
+    # test with correct device_id
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_PACKAGE,
+        {
+            CONF_DEVICE_ID: device_id,
+            CONF_TRACKING_NUMBER: "AB123",
+            CONF_FRIENDLY_NAME: "My package",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_api.return_value.add_package.call_count == 1
+
+
+async def test_add_package_failures(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test adding new package."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, unique_id="email@email.com"
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # assert mock_api.call_count == 1
+
+    device_registry = hass.helpers.device_registry.async_get(hass)
+    device_id = device_registry.async_get_device(
+        identifiers={(DOMAIN, "email@email.com")}
+    ).id
+
+    with pytest.raises(
+        SystemError, match="Package already exists or could not be added"
+    ):
+        mock_api.return_value.add_package = AsyncMock(side_effect=RequestError)
+
+        # test package already exists
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_PACKAGE,
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_TRACKING_NUMBER: "AB123",
+                CONF_FRIENDLY_NAME: "My package",
+            },
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+
+    with pytest.raises(SystemError, match="Could not set friendly_name"):
+        mock_api.return_value.add_package = AsyncMock(
+            side_effect=InvalidTrackingNumberError
+        )
+
+        # test with correct device_id
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_PACKAGE,
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_TRACKING_NUMBER: "AB123",
+                CONF_FRIENDLY_NAME: "My package",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+
+async def test_setup_failed(hass: HomeAssistant, mock_api) -> None:
+    """Test Seventeentrack failed due to failed authentication."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="email@email.com",
+    )
+    entry.add_to_hass(hass)
+
+    mock_api.return_value.login = AsyncMock(return_value=False)
+    await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state == ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_retry(hass: HomeAssistant, mock_api) -> None:
+    """Test Seventeentrack setup retry due to unknown error."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="email@email.com",
+    )
+    entry.add_to_hass(hass)
+
+    mock_api.side_effect = SeventeenTrackError
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test removing Seventeentrack."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert DOMAIN not in hass.data

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -1,451 +1,113 @@
-"""Tests for the seventeentrack sensor."""
-from __future__ import annotations
+"""Tests for SpeedTest sensors."""
+from unittest.mock import AsyncMock, MagicMock
 
-import datetime
-from unittest.mock import patch
-
+from seventeentrack.errors import SeventeenTrackError
 from seventeentrack.package import Package
-import pytest
 
-from homeassistant.components.seventeentrack.sensor import (
-    CONF_SHOW_ARCHIVED,
-    CONF_SHOW_DELIVERED,
-)
-from homeassistant.const import CONF_TOKEN
-from homeassistant.setup import async_setup_component
-from homeassistant.util import utcnow
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.seventeentrack.const import DOMAIN
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
 
-from tests.common import async_fire_time_changed
+from .test_config_flow import MOCK_CONFIG, MOCK_OPTIONS
 
-VALID_CONFIG_MINIMAL = {
-    "sensor": {
-        "platform": "seventeentrack",
-        CONF_TOKEN: "123abc",
-    }
-}
+from tests.common import MockConfigEntry
 
-INVALID_CONFIG = {"sensor": {"platform": "seventeentrack", "boom": "test"}}
-
-VALID_CONFIG_FULL = {
-    "sensor": {
-        "platform": "seventeentrack",
-        CONF_TOKEN: "123abc",
-        CONF_SHOW_ARCHIVED: True,
-        CONF_SHOW_DELIVERED: True,
-    }
-}
-
-VALID_CONFIG_FULL_NO_DELIVERED = {
-    "sensor": {
-        "platform": "seventeentrack",
-        CONF_TOKEN: "123abc",
-        CONF_SHOW_ARCHIVED: False,
-        CONF_SHOW_DELIVERED: False,
-    }
-}
-
-DEFAULT_SUMMARY = {
+SUMMARY = {
     "Not Found": 0,
-    "In Transit": 0,
+    "In Transit": 1,
     "Expired": 0,
     "Ready to be Picked Up": 0,
-    "Undelivered": 0,
+    "Undelivered": 1,
     "Delivered": 0,
     "Returned": 0,
 }
 
-NEW_SUMMARY_DATA = {
-    "Not Found": 1,
+PACKAGES = [
+    Package(
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        status=10,
+    )
+]
+ARCHIVED_SUMMARY = {
+    "Not Found": 0,
+    "In Transit": 0,
+    "Expired": 1,
+    "Ready to be Picked Up": 0,
+    "Undelivered": 1,
+    "Delivered": 0,
+    "Returned": 0,
+}
+
+ARCHIVED_PACKAGES = [
+    Package(
+        "410",
+        206,
+        "friendly name 2",
+        "info text 2",
+        "location 2",
+        "2020-07-10 10:32",
+        status=20,
+    )
+]
+
+TOTAL_SUMMARY = {
+    "Not Found": 0,
     "In Transit": 1,
     "Expired": 1,
-    "Ready to be Picked Up": 1,
-    "Undelivered": 1,
-    "Delivered": 1,
-    "Returned": 1,
+    "Ready to be Picked Up": 0,
+    "Undelivered": 2,
+    "Delivered": 0,
+    "Returned": 0,
 }
 
 
-class ClientMock:
-    """Mock the seventeentrack client to inject the ProfileMock."""
+async def test_seventeentrack_sensors(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test sensors created for seventeentrack integration."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, options=MOCK_OPTIONS)
+    entry.add_to_hass(hass)
 
-    def __init__(self, session) -> None:
-        """Mock the profile."""
-        self.profile = ProfileMock()
+    mock_api.return_value.packages = AsyncMock(
+        side_effect=[PACKAGES, ARCHIVED_PACKAGES]
+    )
+    mock_api.return_value.summary = AsyncMock(side_effect=[SUMMARY, ARCHIVED_SUMMARY])
 
-
-class ProfileMock:
-    """ProfileMock will mock data coming from 17track."""
-
-    package_list = []
-    login_result = True
-    summary_data = DEFAULT_SUMMARY
-    account_id = "user@email.com"
-
-    @classmethod
-    def reset(cls):
-        """Reset data to defaults."""
-        cls.package_list = []
-        cls.login_result = True
-        cls.summary_data = DEFAULT_SUMMARY
-        cls.account_id = "user@email.com"
-
-    def __init__(self) -> None:
-        """Override Account id."""
-        self.account_id = self.__class__.account_id
-
-    async def login(self, token: str) -> bool:
-        """Login mock."""
-        return self.__class__.login_result
-
-    async def packages(
-        self,
-        package_state: int | str = "",
-        show_archived: bool = False,
-        tz: str = "UTC",
-    ) -> list:
-        """Packages mock."""  # noqa: D401
-        return self.__class__.package_list[:]
-
-    async def summary(self, show_archived: bool = False) -> dict:
-        """Summary mock."""
-        return self.__class__.summary_data
-
-
-@pytest.fixture(autouse=True, name="mock_client")
-def fixture_mock_client():
-    """Mock seventeentrack client."""
-    with patch(
-        "homeassistant.components.seventeentrack.sensor.SeventeenTrackClient",
-        new=ClientMock,
-    ):
-        yield
-    ProfileMock.reset()
-
-
-async def _setup_seventeentrack(hass, config=None, summary_data=None):
-    """Set up component using config."""
-    if not config:
-        config = VALID_CONFIG_MINIMAL
-    if not summary_data:
-        summary_data = {}
-
-    ProfileMock.summary_data = summary_data
-    assert await async_setup_component(hass, "sensor", config)
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == len(SUMMARY) + 1
 
-async def _goto_future(hass, future=None):
-    """Move to future."""
-    if not future:
-        future = utcnow() + datetime.timedelta(minutes=10)
-    with patch("homeassistant.util.utcnow", return_value=future):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-
-async def test_full_valid_config(hass):
-    """Ensure everything starts correctly."""
-    assert await async_setup_component(hass, "sensor", VALID_CONFIG_FULL)
-    await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids()) == len(ProfileMock.summary_data.keys())
-
-
-async def test_valid_config(hass):
-    """Ensure everything starts correctly."""
-    assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
-    await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids()) == len(ProfileMock.summary_data.keys())
-
-
-async def test_invalid_config(hass):
-    """Ensure nothing is created when config is wrong."""
-    assert await async_setup_component(hass, "sensor", INVALID_CONFIG)
-
-    assert not hass.states.async_entity_ids("sensor")
-
-
-async def test_add_package(hass):
-    """Ensure package is added correctly when user add a new package."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-    )
-    ProfileMock.package_list = [package]
-
-    await _setup_seventeentrack(hass)
-    assert hass.states.get("sensor.seventeentrack_package_456") is not None
-    assert len(hass.states.async_entity_ids()) == 1
-
-    package2 = Package(
-        tracking_number="789",
-        destination_country=206,
-        friendly_name="friendly name 2",
-        info_text="info text 2",
-        location="location 2",
-        timestamp="2020-08-10 14:25",
-        origin_country=206,
-        package_type=2,
-    )
-    ProfileMock.package_list = [package, package2]
-
-    await _goto_future(hass)
-
-    assert hass.states.get("sensor.seventeentrack_package_789") is not None
-    assert len(hass.states.async_entity_ids()) == 2
-
-
-async def test_remove_package(hass):
-    """Ensure entity is not there anymore if package is not there."""
-    package1 = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-    )
-    package2 = Package(
-        tracking_number="789",
-        destination_country=206,
-        friendly_name="friendly name 2",
-        info_text="info text 2",
-        location="location 2",
-        timestamp="2020-08-10 14:25",
-        origin_country=206,
-        package_type=2,
-    )
-
-    ProfileMock.package_list = [package1, package2]
-
-    await _setup_seventeentrack(hass)
-
-    assert hass.states.get("sensor.seventeentrack_package_456") is not None
-    assert hass.states.get("sensor.seventeentrack_package_789") is not None
-    assert len(hass.states.async_entity_ids()) == 2
-
-    ProfileMock.package_list = [package2]
-
-    await _goto_future(hass)
-
-    assert hass.states.get("sensor.seventeentrack_package_456") is None
-    assert hass.states.get("sensor.seventeentrack_package_789") is not None
-    assert len(hass.states.async_entity_ids()) == 1
-
-
-async def test_friendly_name_changed(hass):
-    """Test friendly name change."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-    )
-    ProfileMock.package_list = [package]
-
-    await _setup_seventeentrack(hass)
-
-    assert hass.states.get("sensor.seventeentrack_package_456") is not None
-    assert len(hass.states.async_entity_ids()) == 1
-
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 2",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-    )
-    ProfileMock.package_list = [package]
-
-    await _goto_future(hass)
-
-    assert hass.states.get("sensor.seventeentrack_package_456") is not None
-    entity = hass.data["entity_components"]["sensor"].get_entity(
-        "sensor.seventeentrack_package_456"
-    )
-    assert entity.name == "Seventeentrack Package: friendly name 2"
-    assert len(hass.states.async_entity_ids()) == 1
-
-
-async def test_delivered_not_shown(hass):
-    """Ensure delivered packages are not shown."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-        status=40,
-    )
-    ProfileMock.package_list = [package]
-
-    with patch(
-        "homeassistant.components.seventeentrack.sensor.persistent_notification"
-    ) as persistent_notification_mock:
-        await _setup_seventeentrack(hass, VALID_CONFIG_FULL_NO_DELIVERED)
-        await _goto_future(hass)
-
-        assert not hass.states.async_entity_ids()
-        persistent_notification_mock.create.assert_called()
-
-
-async def test_delivered_shown(hass):
-    """Ensure delivered packages are show when user choose to show them."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-        status=40,
-    )
-    ProfileMock.package_list = [package]
-
-    with patch(
-        "homeassistant.components.seventeentrack.sensor.persistent_notification"
-    ) as persistent_notification_mock:
-        await _setup_seventeentrack(hass, VALID_CONFIG_FULL)
-
-        assert hass.states.get("sensor.seventeentrack_package_456") is not None
-        assert len(hass.states.async_entity_ids()) == 1
-        persistent_notification_mock.create.assert_not_called()
-
-
-async def test_becomes_delivered_not_shown_notification(hass):
-    """Ensure notification is triggered when package becomes delivered."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-    )
-    ProfileMock.package_list = [package]
-
-    await _setup_seventeentrack(hass, VALID_CONFIG_FULL_NO_DELIVERED)
-
-    assert hass.states.get("sensor.seventeentrack_package_456") is not None
-    assert len(hass.states.async_entity_ids()) == 1
-
-    package_delivered = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-        status=40,
-    )
-    ProfileMock.package_list = [package_delivered]
-
-    with patch(
-        "homeassistant.components.seventeentrack.sensor.persistent_notification"
-    ) as persistent_notification_mock:
-        await _goto_future(hass)
-
-        persistent_notification_mock.create.assert_called()
-        assert not hass.states.async_entity_ids()
-
-
-async def test_summary_correctly_updated(hass):
-    """Ensure summary entities are not duplicated."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-        status=30,
-    )
-    ProfileMock.package_list = [package]
-
-    await _setup_seventeentrack(hass, summary_data=DEFAULT_SUMMARY)
-
-    assert len(hass.states.async_entity_ids()) == 8
-    for state in hass.states.async_all():
-        if state.entity_id == "sensor.seventeentrack_package_456":
-            break
-        assert state.state == "0"
-
-    assert (
-        len(
-            hass.states.get(
-                "sensor.seventeentrack_packages_ready_to_be_picked_up"
-            ).attributes["packages"]
+    for sensor_type, qty in TOTAL_SUMMARY.items():
+        sensor = hass.states.get(
+            f"sensor.{MOCK_CONFIG[CONF_NAME]}_packages_{slugify(sensor_type)}"
         )
-        == 1
+        if sensor:
+            assert sensor.state == str(qty)
+
+    all_packages_sensor = hass.states.get("sensor.seventeentrack_all_packages")
+    if all_packages_sensor:
+        assert all_packages_sensor.state == "2"
+
+
+async def test_seventeentrack_api_error(
+    hass: HomeAssistant, mock_api: MagicMock
+) -> None:
+    """Test sensors created for seventeentrack integration."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, options=MOCK_OPTIONS)
+    entry.add_to_hass(hass)
+
+    mock_api.return_value.packages = AsyncMock(
+        side_effect=[PACKAGES, ARCHIVED_PACKAGES]
     )
+    mock_api.return_value.summary = AsyncMock(side_effect=SeventeenTrackError)
 
-    ProfileMock.package_list = []
-    ProfileMock.summary_data = NEW_SUMMARY_DATA
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
-    await _goto_future(hass)
-
-    assert len(hass.states.async_entity_ids()) == 7
-    for state in hass.states.async_all():
-        assert state.state == "1"
-
-    assert (
-        hass.states.get(
-            "sensor.seventeentrack_packages_ready_to_be_picked_up"
-        ).attributes["packages"]
-        is None
-    )
-
-
-async def test_utc_timestamp(hass):
-    """Ensure package timestamp is converted correctly from HA-defined time zone to UTC."""
-    package = Package(
-        tracking_number="456",
-        destination_country=206,
-        friendly_name="friendly name 1",
-        info_text="info text 1",
-        location="location 1",
-        timestamp="2020-08-10 10:32",
-        origin_country=206,
-        package_type=2,
-        tz="Asia/Jakarta",
-    )
-    ProfileMock.package_list = [package]
-
-    await _setup_seventeentrack(hass)
-    assert hass.states.get("sensor.seventeentrack_package_456") is not None
-    assert len(hass.states.async_entity_ids()) == 1
-    assert (
-        str(
-            hass.states.get("sensor.seventeentrack_package_456").attributes.get(
-                "timestamp"
-            )
-        )
-        == "2020-08-10 03:32:00+00:00"
-    )
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import datetime
 from unittest.mock import patch
 
-from py17track.package import Package
+from seventeentrack.package import Package
 import pytest
 
 from homeassistant.components.seventeentrack.sensor import (
     CONF_SHOW_ARCHIVED,
     CONF_SHOW_DELIVERED,
 )
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_TOKEN
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
 
@@ -20,8 +20,7 @@ from tests.common import async_fire_time_changed
 VALID_CONFIG_MINIMAL = {
     "sensor": {
         "platform": "seventeentrack",
-        CONF_USERNAME: "test",
-        CONF_PASSWORD: "test",
+        CONF_TOKEN: "123abc",
     }
 }
 
@@ -30,8 +29,7 @@ INVALID_CONFIG = {"sensor": {"platform": "seventeentrack", "boom": "test"}}
 VALID_CONFIG_FULL = {
     "sensor": {
         "platform": "seventeentrack",
-        CONF_USERNAME: "test",
-        CONF_PASSWORD: "test",
+        CONF_TOKEN: "123abc",
         CONF_SHOW_ARCHIVED: True,
         CONF_SHOW_DELIVERED: True,
     }
@@ -40,8 +38,7 @@ VALID_CONFIG_FULL = {
 VALID_CONFIG_FULL_NO_DELIVERED = {
     "sensor": {
         "platform": "seventeentrack",
-        CONF_USERNAME: "test",
-        CONF_PASSWORD: "test",
+        CONF_TOKEN: "123abc",
         CONF_SHOW_ARCHIVED: False,
         CONF_SHOW_DELIVERED: False,
     }
@@ -69,7 +66,7 @@ NEW_SUMMARY_DATA = {
 
 
 class ClientMock:
-    """Mock the py17track client to inject the ProfileMock."""
+    """Mock the seventeentrack client to inject the ProfileMock."""
 
     def __init__(self, session) -> None:
         """Mock the profile."""
@@ -82,7 +79,7 @@ class ProfileMock:
     package_list = []
     login_result = True
     summary_data = DEFAULT_SUMMARY
-    account_id = "123"
+    account_id = "user@email.com"
 
     @classmethod
     def reset(cls):
@@ -90,13 +87,13 @@ class ProfileMock:
         cls.package_list = []
         cls.login_result = True
         cls.summary_data = DEFAULT_SUMMARY
-        cls.account_id = "123"
+        cls.account_id = "user@email.com"
 
     def __init__(self) -> None:
         """Override Account id."""
         self.account_id = self.__class__.account_id
 
-    async def login(self, email: str, password: str) -> bool:
+    async def login(self, token: str) -> bool:
         """Login mock."""
         return self.__class__.login_result
 
@@ -116,7 +113,7 @@ class ProfileMock:
 
 @pytest.fixture(autouse=True, name="mock_client")
 def fixture_mock_client():
-    """Mock py17track client."""
+    """Mock seventeentrack client."""
     with patch(
         "homeassistant.components.seventeentrack.sensor.SeventeenTrackClient",
         new=ClientMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The old user authentication method is no longer supported. You will need to get an API token from your account settings on [17track.net](https://api.17track.net/en)

Upon receiving the token, setup the integration through the UI. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updating the 17Track component to use the official V1 API instead of the no-longer supported unofficial API

New library was created, based on the old one (py17track): https://github.com/McSwindler/seventeentrack

New library matches previous spec for the most part to maintain an easy migration. Creating the client now requires a version variable, and the login method now uses token instead of username and password.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65399
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22428

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
