### PR TITLE
Correct time stamp format in Alexa responses

### DIFF
--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -28,7 +28,9 @@ ATTR_REDIRECTION_URL = "redirectionURL"
 
 SYN_RESOLUTION_MATCH = "ER_SUCCESS_MATCH"
 
-DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.0Z"
+# Alexa requires timestamps to be formatted according to ISO 8601, YYYY-MM-DDThh:mm:ssZ
+# https://developer.amazon.com/es-ES/docs/alexa/device-apis/alexa-scenecontroller.html#activate-response-event
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 API_DIRECTIVE = "directive"
 API_ENDPOINT = "endpoint"

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for alexa."""

--- a/tests/components/alexa/test_auth.py
+++ b/tests/components/alexa/test_auth.py
@@ -2,7 +2,7 @@
 from homeassistant.components.alexa.auth import Auth
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 
-from . import TEST_TOKEN_URL
+from .test_common import TEST_TOKEN_URL
 
 
 async def run_auth_get_access_token(

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 
-from . import (
+from .test_common import (
     assert_request_calls_service,
     assert_request_fails,
     get_default_config,

--- a/tests/components/alexa/test_entities.py
+++ b/tests/components/alexa/test_entities.py
@@ -6,7 +6,7 @@ from homeassistant.const import __version__
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 
-from . import get_default_config, get_new_request
+from .test_common import get_default_config, get_new_request
 
 
 async def test_unsupported_domain(hass):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.alexa import messages, smart_home
@@ -30,7 +31,7 @@ from homeassistant.core import Context
 from homeassistant.helpers import entityfilter
 from homeassistant.setup import async_setup_component
 
-from . import (
+from .test_common import (
     MockConfig,
     ReportedProperties,
     assert_power_controller_works,
@@ -172,6 +173,7 @@ def assert_endpoint_capabilities(endpoint, *interfaces):
     return capabilities
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_switch(hass, events):
     """Test switch discovery."""
     device = ("switch.test", "on", {"friendly_name": "Test switch"})
@@ -185,7 +187,7 @@ async def test_switch(hass, events):
     )
 
     await assert_power_controller_works(
-        "switch#test", "switch.turn_on", "switch.turn_off", hass
+        "switch#test", "switch.turn_on", "switch.turn_off", hass, "2022-04-19T07:53:05Z"
     )
 
     properties = await reported_properties(hass, "switch#test")
@@ -209,6 +211,7 @@ async def test_outlet(hass, events):
     )
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_light(hass):
     """Test light discovery."""
     device = ("light.test_1", "on", {"friendly_name": "Test light 1"})
@@ -222,7 +225,7 @@ async def test_light(hass):
     )
 
     await assert_power_controller_works(
-        "light#test_1", "light.turn_on", "light.turn_off", hass
+        "light#test_1", "light.turn_on", "light.turn_off", hass, "2022-04-19T07:53:05Z"
     )
 
 
@@ -302,6 +305,7 @@ async def test_color_light(hass, supported_color_modes):
     # tests
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_script(hass):
     """Test script discovery."""
     device = ("script.test", "off", {"friendly_name": "Test script"})
@@ -318,10 +322,11 @@ async def test_script(hass):
     assert scene_capability["supportsDeactivation"]
 
     await assert_scene_controller_works(
-        "script#test", "script.turn_on", "script.turn_off", hass
+        "script#test", "script.turn_on", "script.turn_off", hass, "2022-04-19T07:53:05Z"
     )
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_input_boolean(hass):
     """Test input boolean discovery."""
     device = ("input_boolean.test", "off", {"friendly_name": "Test input boolean"})
@@ -335,10 +340,15 @@ async def test_input_boolean(hass):
     )
 
     await assert_power_controller_works(
-        "input_boolean#test", "input_boolean.turn_on", "input_boolean.turn_off", hass
+        "input_boolean#test",
+        "input_boolean.turn_on",
+        "input_boolean.turn_off",
+        hass,
+        "2022-04-19T07:53:05Z",
     )
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_scene(hass):
     """Test scene discovery."""
     device = ("scene.test", "off", {"friendly_name": "Test scene"})
@@ -354,9 +364,12 @@ async def test_scene(hass):
     scene_capability = get_capability(capabilities, "Alexa.SceneController")
     assert not scene_capability["supportsDeactivation"]
 
-    await assert_scene_controller_works("scene#test", "scene.turn_on", None, hass)
+    await assert_scene_controller_works(
+        "scene#test", "scene.turn_on", None, hass, "2022-04-19T07:53:05Z"
+    )
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_fan(hass):
     """Test fan discovery."""
     device = ("fan.test_1", "off", {"friendly_name": "Test fan 1"})
@@ -379,7 +392,7 @@ async def test_fan(hass):
     assert "configuration" not in power_capability
 
     await assert_power_controller_works(
-        "fan#test_1", "fan.turn_on", "fan.turn_off", hass
+        "fan#test_1", "fan.turn_on", "fan.turn_off", hass, "2022-04-19T07:53:05Z"
     )
 
     await assert_request_calls_service(
@@ -936,6 +949,7 @@ async def test_lock(hass):
     assert properties["value"] == "UNLOCKED"
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_media_player(hass):
     """Test media player discovery."""
     device = (
@@ -984,7 +998,11 @@ async def test_media_player(hass):
         assert operation in supported_operations
 
     await assert_power_controller_works(
-        "media_player#test", "media_player.turn_on", "media_player.turn_off", hass
+        "media_player#test",
+        "media_player.turn_on",
+        "media_player.turn_off",
+        hass,
+        "2022-04-19T07:53:05Z",
     )
 
     await assert_request_calls_service(
@@ -1532,6 +1550,7 @@ async def test_media_player_seek_error(hass):
         assert msg["payload"]["type"] == "ACTION_NOT_PERMITTED_FOR_CONTENT"
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_alert(hass):
     """Test alert discovery."""
     device = ("alert.test", "off", {"friendly_name": "Test alert"})
@@ -1545,10 +1564,11 @@ async def test_alert(hass):
     )
 
     await assert_power_controller_works(
-        "alert#test", "alert.turn_on", "alert.turn_off", hass
+        "alert#test", "alert.turn_on", "alert.turn_off", hass, "2022-04-19T07:53:05Z"
     )
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_automation(hass):
     """Test automation discovery."""
     device = ("automation.test", "off", {"friendly_name": "Test automation"})
@@ -1562,10 +1582,15 @@ async def test_automation(hass):
     )
 
     await assert_power_controller_works(
-        "automation#test", "automation.turn_on", "automation.turn_off", hass
+        "automation#test",
+        "automation.turn_on",
+        "automation.turn_off",
+        hass,
+        "2022-04-19T07:53:05Z",
     )
 
 
+@freeze_time("2022-04-19 07:53:05")
 async def test_group(hass):
     """Test group discovery."""
     device = ("group.test", "off", {"friendly_name": "Test group"})
@@ -1579,7 +1604,11 @@ async def test_group(hass):
     )
 
     await assert_power_controller_works(
-        "group#test", "homeassistant.turn_on", "homeassistant.turn_off", hass
+        "group#test",
+        "homeassistant.turn_on",
+        "homeassistant.turn_off",
+        hass,
+        "2022-04-19T07:53:05Z",
     )
 
 
@@ -3955,6 +3984,7 @@ async def test_initialize_camera_stream(hass, mock_camera, mock_stream):
     )
 
 
+@freeze_time("2022-04-19 07:53:05")
 @pytest.mark.parametrize(
     "domain",
     ["button", "input_button"],
@@ -3979,7 +4009,11 @@ async def test_button(hass, domain):
     assert scene_capability["supportsDeactivation"] is False
 
     await assert_scene_controller_works(
-        f"{domain}#ring_doorbell", f"{domain}.press", False, hass
+        f"{domain}#ring_doorbell",
+        f"{domain}.press",
+        False,
+        hass,
+        "2022-04-19T07:53:05Z",
     )
 
 

--- a/tests/components/alexa/test_smart_home_http.py
+++ b/tests/components/alexa/test_smart_home_http.py
@@ -6,7 +6,7 @@ from homeassistant.components.alexa import DOMAIN, smart_home_http
 from homeassistant.const import CONTENT_TYPE_JSON
 from homeassistant.setup import async_setup_component
 
-from . import get_new_request
+from .test_common import get_new_request
 
 
 async def do_http_discovery(config, hass, hass_client):

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant import core
 from homeassistant.components.alexa import errors, state_report
 
-from . import TEST_URL, get_default_config
+from .test_common import TEST_URL, get_default_config
 
 
 async def test_report_state(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct time stamp format in Alexa responses

Alexa requires timestamps to be formatted according to ISO 8601, YYYY-MM-DDThh:mm:ssZ, see https://developer.amazon.com/es-ES/docs/alexa/device-apis/alexa-scenecontroller.html#activate-response-event

Before this change we would format timestamps like `2022-04-19T07:53:05.0Z`, they will now be formatted like `2022-04-19T07:53:05Z`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
