### PR TITLE
Mark device actions from hidden or auxiliary entities as secondary

### DIFF
--- a/homeassistant/components/alarm_control_panel/device_action.py
+++ b/homeassistant/components/alarm_control_panel/device_action.py
@@ -5,6 +5,9 @@ from typing import Final
 
 import voluptuous as vol
 
+from homeassistant.components.device_automation import (
+    async_set_entity_device_automation_metadata,
+)
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
@@ -72,9 +75,7 @@ async def async_get_actions(
             CONF_DOMAIN: DOMAIN,
             CONF_ENTITY_ID: entry.entity_id,
         }
-
-        if entry.entity_category or entry.hidden_by:
-            base_action["secondary"] = True
+        async_set_entity_device_automation_metadata(base_action, entry)
 
         # Add actions for each entity that belongs to this integration
         if supported_features & SUPPORT_ALARM_ARM_AWAY:

--- a/homeassistant/components/alarm_control_panel/device_action.py
+++ b/homeassistant/components/alarm_control_panel/device_action.py
@@ -67,11 +67,14 @@ async def async_get_actions(
 
         supported_features = get_supported_features(hass, entry.entity_id)
 
-        base_action = {
+        base_action: dict = {
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
             CONF_ENTITY_ID: entry.entity_id,
         }
+
+        if entry.entity_category or entry.hidden_by:
+            base_action["secondary"] = True
 
         # Add actions for each entity that belongs to this integration
         if supported_features & SUPPORT_ALARM_ARM_AWAY:

--- a/homeassistant/components/alarm_control_panel/device_action.py
+++ b/homeassistant/components/alarm_control_panel/device_action.py
@@ -5,9 +5,6 @@ from typing import Final
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import (
-    async_set_entity_device_automation_metadata,
-)
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
@@ -75,7 +72,6 @@ async def async_get_actions(
             CONF_DOMAIN: DOMAIN,
             CONF_ENTITY_ID: entry.entity_id,
         }
-        async_set_entity_device_automation_metadata(base_action, entry)
 
         # Add actions for each entity that belongs to this integration
         if supported_features & SUPPORT_ALARM_ARM_AWAY:

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -14,7 +14,7 @@ import voluptuous_serialize
 
 from homeassistant.components import websocket_api
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -164,6 +164,16 @@ async def async_get_device_automation_platform(
         ) from err
 
     return platform
+
+
+@callback
+def async_set_entity_device_automation_metadata(
+    automation: dict[str, Any], entry: er.RegistryEntry
+) -> None:
+    """Set device automation metadata based on entity registry entry data."""
+    if "metadata" not in automation:
+        automation["metadata"] = {}
+    automation["metadata"]["secondary"] = bool(entry.entity_category or entry.hidden_by)
 
 
 async def _async_get_device_automations_from_domain(

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -13,7 +13,12 @@ import voluptuous as vol
 import voluptuous_serialize
 
 from homeassistant.components import websocket_api
-from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_validation as cv,
@@ -167,12 +172,20 @@ async def async_get_device_automation_platform(
 
 
 @callback
-def async_set_entity_device_automation_metadata(
-    automation: dict[str, Any], entry: er.RegistryEntry
+def _async_set_entity_device_automation_metadata(
+    hass: HomeAssistant, automation: dict[str, Any]
 ) -> None:
     """Set device automation metadata based on entity registry entry data."""
     if "metadata" not in automation:
         automation["metadata"] = {}
+    if ATTR_ENTITY_ID not in automation or "secondary" in automation["metadata"]:
+        return
+
+    entity_registry = er.async_get(hass)
+    # Guard against the entry being removed before this is called
+    if not (entry := entity_registry.async_get(automation[ATTR_ENTITY_ID])):
+        return
+
     automation["metadata"]["secondary"] = bool(entry.entity_category or entry.hidden_by)
 
 
@@ -252,6 +265,8 @@ async def async_get_device_automations(
                 )
                 continue
             for automation in device_results:
+                if automation_type == DeviceAutomationType.ACTION:
+                    _async_set_entity_device_automation_metadata(hass, automation)
                 combined_results[automation["device_id"]].append(automation)
 
     return combined_results

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1374,7 +1374,7 @@ DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
         **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_DEVICE_ID): string,
         vol.Required(CONF_DOMAIN): str,
-        vol.Remove("secondary"): dict,
+        vol.Remove("metadata"): dict,
     }
 )
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1374,6 +1374,7 @@ DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
         **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_DEVICE_ID): string,
         vol.Required(CONF_DOMAIN): str,
+        vol.Remove("secondary"): dict,
     }
 )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 from collections import OrderedDict
 from collections.abc import Awaitable, Collection
 from contextlib import contextmanager
@@ -1226,72 +1225,17 @@ def async_mock_signal(hass, signal):
     return calls
 
 
-class hashdict(dict):
-    """
-    hashable dict implementation, suitable for use as a key into other dicts.
-
-        >>> h1 = hashdict({"apples": 1, "bananas":2})
-        >>> h2 = hashdict({"bananas": 3, "mangoes": 5})
-        >>> h1+h2
-        hashdict(apples=1, bananas=3, mangoes=5)
-        >>> d1 = {}
-        >>> d1[h1] = "salad"
-        >>> d1[h1]
-        'salad'
-        >>> d1[h2]
-        Traceback (most recent call last):
-        ...
-        KeyError: hashdict(bananas=3, mangoes=5)
-
-    based on answers from
-       http://stackoverflow.com/questions/1151658/python-hashable-dicts
-
-    """
-
-    def __key(self):
-        return tuple(sorted(self.items()))
-
-    def __repr__(self):  # noqa: D105 no docstring
-        return ", ".join(f"{i[0]!s}={i[1]!r}" for i in self.__key())
-
-    def __hash__(self):  # noqa: D105 no docstring
-        return hash(self.__key())
-
-    def __setitem__(self, key, value):  # noqa: D105 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    def __delitem__(self, key):  # noqa: D105 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    def clear(self):  # noqa: D102 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    def pop(self, *args, **kwargs):  # noqa: D102 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    def popitem(self, *args, **kwargs):  # noqa: D102 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    def setdefault(self, *args, **kwargs):  # noqa: D102 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    def update(self, *args, **kwargs):  # noqa: D102 no docstring
-        raise TypeError(f"{self.__class__.__name__} does not support item assignment")
-
-    # update is not ok because it mutates the object
-    # __add__ is ok because it creates a new object
-    # while the new object is under construction, it's ok to mutate it
-    def __add__(self, right):  # noqa: D105 no docstring
-        result = hashdict(self)
-        dict.update(result, right)
-        return result
-
-
 def assert_lists_same(a, b):
-    """Compare two lists, ignoring order."""
-    assert collections.Counter([hashdict(i) for i in a]) == collections.Counter(
-        [hashdict(i) for i in b]
-    )
+    """Compare two lists, ignoring order.
+
+    Check both that all items in a are in b and that all items in b are in a,
+    otherwise assert_lists_same(["1", "1"], ["1", "2"]) could be True.
+    """
+    assert len(a) == len(b)
+    for i in a:
+        assert i in b
+    for i in b:
+        assert i in a
 
 
 def raise_contains_mocks(val):

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -153,7 +153,7 @@ async def test_get_actions_hidden_auxiliary(
     hidden_by,
     entity_category,
 ):
-    """Test we get the expected actions from a hidden or secondary alarm_control_panel."""
+    """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_reg.async_get_or_create(

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -127,6 +127,7 @@ async def test_get_actions(
             "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
         for action in expected_action_types
     ]
@@ -175,7 +176,7 @@ async def test_get_actions_hidden_auxiliary(
             "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-            "secondary": True,
+            "metadata": {"secondary": True},
         }
         for action in ["disarm", "arm_away"]
     ]
@@ -203,12 +204,14 @@ async def test_get_actions_arm_night_only(hass, device_reg, entity_reg):
             "type": "arm_night",
             "device_id": device_entry.id,
             "entity_id": "alarm_control_panel.test_5678",
+            "metadata": {"secondary": False},
         },
         {
             "domain": DOMAIN,
             "type": "disarm",
             "device_id": device_entry.id,
             "entity_id": "alarm_control_panel.test_5678",
+            "metadata": {"secondary": False},
         },
     ]
     actions = await async_get_device_automations(

--- a/tests/components/button/test_device_action.py
+++ b/tests/components/button/test_device_action.py
@@ -6,6 +6,7 @@ from homeassistant.components.button import DOMAIN
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -49,7 +50,56 @@ async def test_get_actions(
             "type": "press",
             "device_id": device_entry.id,
             "entity_id": "button.test_5678",
+            "metadata": {"secondary": False},
         }
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (entity_registry.RegistryEntryHider.INTEGRATION, None),
+        (entity_registry.RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["press"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -6,6 +6,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.climate import DOMAIN, const, device_action
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.helpers import config_validation as cv, device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -86,10 +88,60 @@ async def test_get_actions(
             "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
         for action in expected_action_types
     ]
 
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+        supported_features=0,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["set_hvac_mode"]
+    ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -57,18 +57,21 @@ async def test_websocket_get_actions(hass, hass_ws_client, device_reg, entity_re
             "type": "turn_off",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
+            "metadata": {"secondary": False},
         },
         {
             "domain": "light",
             "type": "turn_on",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
+            "metadata": {"secondary": False},
         },
         {
             "domain": "light",
             "type": "toggle",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
+            "metadata": {"secondary": False},
         },
     ]
 

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -5,6 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.fan import DOMAIN
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -39,19 +41,64 @@ async def test_get_actions(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_actions = [
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "turn_on",
+            "type": action,
             "device_id": device_entry.id,
-            "entity_id": "fan.test_5678",
-        },
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
+        }
+        for action in ["turn_on", "turn_off"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "turn_off",
+            "type": action,
             "device_id": device_entry.id,
-            "entity_id": "fan.test_5678",
-        },
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["turn_on", "turn_off"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -13,10 +13,13 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_get_device_automation_capabilities,
     async_get_device_automations,
     async_mock_service,
@@ -60,48 +63,78 @@ async def test_get_actions(hass, device_reg, entity_reg):
         supported_features=LightEntityFeature.FLASH,
         capabilities={"supported_color_modes": ["brightness"]},
     )
-    expected_actions = [
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "turn_off",
+            "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "turn_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "toggle",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "brightness_increase",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "brightness_decrease",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "flash",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for action in [
+            "turn_off",
+            "turn_on",
+            "toggle",
+            "brightness_decrease",
+            "brightness_increase",
+            "flash",
+        ]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )
-    assert actions == expected_actions
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+        supported_features=0,
+        capabilities={"supported_color_modes": ["onoff"]},
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["turn_on", "turn_off", "toggle"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
 
 
 async def test_get_action_capabilities(hass, device_reg, entity_reg):

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -5,6 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.lock import DOMAIN, LockEntityFeature
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -74,6 +76,7 @@ async def test_get_actions(
             "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
         for action in basic_action_types
     ]
@@ -83,8 +86,58 @@ async def test_get_actions(
             "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
         for action in expected_action_types
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+        supported_features=0,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["lock", "unlock"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/mobile_app/test_device_action.py
+++ b/tests/components/mobile_app/test_device_action.py
@@ -13,7 +13,7 @@ async def test_get_actions(hass, push_registration):
 
     assert await async_get_device_automations(
         hass, device_automation.DeviceAutomationType.ACTION, device_id
-    ) == [{"domain": DOMAIN, "device_id": device_id, "type": "notify"}]
+    ) == [{"domain": DOMAIN, "device_id": device_id, "metadata": {}, "type": "notify"}]
 
     capabilitites = await device_automation._async_get_device_automation_capabilities(
         hass,

--- a/tests/components/number/test_device_action.py
+++ b/tests/components/number/test_device_action.py
@@ -6,6 +6,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.number import DOMAIN, device_action
 from homeassistant.helpers import config_validation as cv, device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -47,7 +49,56 @@ async def test_get_actions(hass, device_reg, entity_reg):
             "type": "set_value",
             "device_id": device_entry.id,
             "entity_id": "number.test_5678",
+            "metadata": {"secondary": False},
         },
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["set_value"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -70,6 +121,7 @@ async def test_get_action_no_state(hass, device_reg, entity_reg):
             "type": "set_value",
             "device_id": device_entry.id,
             "entity_id": "number.test_5678",
+            "metadata": {"secondary": False},
         },
     ]
     actions = await async_get_device_automations(

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -6,10 +6,13 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_get_device_automations,
     async_mock_service,
     mock_device_registry,
@@ -48,27 +51,65 @@ async def test_get_actions(hass, device_reg, entity_reg):
     expected_actions = [
         {
             "domain": DOMAIN,
-            "type": "turn_off",
+            "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "turn_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "toggle",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for action in ["turn_off", "turn_on", "toggle"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )
-    assert actions == expected_actions
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["turn_off", "turn_on", "toggle"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
 
 
 async def test_action(hass, calls, enable_custom_integrations):

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -105,7 +105,7 @@ async def test_get_actions(hass, device_reg: DeviceRegistry, device, expected):
     actions = [action for action in actions if action["domain"] == DOMAIN]
 
     expected_actions = [
-        {"domain": DOMAIN, "device_id": device_entry.id, **action_type}
+        {"domain": DOMAIN, "device_id": device_entry.id, "metadata": {}, **action_type}
         for action_type in expected
     ]
 

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -6,10 +6,13 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_get_device_automations,
     async_mock_service,
     mock_device_registry,
@@ -45,30 +48,69 @@ async def test_get_actions(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_actions = [
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "turn_off",
+            "type": action,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "turn_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "domain": DOMAIN,
-            "type": "toggle",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for action in ["turn_off", "turn_on", "toggle"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )
-    assert actions == expected_actions
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["turn_off", "turn_on", "toggle"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
 
 
 async def test_action(hass, calls, enable_custom_integrations):

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -5,6 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -39,19 +41,64 @@ async def test_get_actions(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_actions = [
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "clean",
+            "type": action,
             "device_id": device_entry.id,
             "entity_id": "vacuum.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for action in ["clean", "dock"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "dock",
+            "type": action,
             "device_id": device_entry.id,
-            "entity_id": "vacuum.test_5678",
-        },
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["clean", "dock"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -5,6 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.water_heater import DOMAIN
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -39,19 +41,64 @@ async def test_get_actions(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_actions = [
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "turn_on",
+            "type": action,
             "device_id": device_entry.id,
-            "entity_id": "water_heater.test_5678",
-        },
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
+        }
+        for action in ["turn_on", "turn_off"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
         {
             "domain": DOMAIN,
-            "type": "turn_off",
+            "type": action,
             "device_id": device_entry.id,
-            "entity_id": "water_heater.test_5678",
-        },
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["turn_on", "turn_off"]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -58,31 +58,40 @@ async def test_get_actions(hass, device_ias):
     )
 
     expected_actions = [
-        {"domain": DOMAIN, "type": "squawk", "device_id": reg_device.id},
-        {"domain": DOMAIN, "type": "warn", "device_id": reg_device.id},
+        {
+            "domain": DOMAIN,
+            "type": "squawk",
+            "device_id": reg_device.id,
+            "metadata": {},
+        },
+        {"domain": DOMAIN, "type": "warn", "device_id": reg_device.id, "metadata": {}},
         {
             "domain": Platform.SELECT,
             "type": "select_option",
             "device_id": reg_device.id,
             "entity_id": "select.fakemanufacturer_fakemodel_e769900a_ias_wd_warningmode",
+            "metadata": {"secondary": True},
         },
         {
             "domain": Platform.SELECT,
             "type": "select_option",
             "device_id": reg_device.id,
             "entity_id": "select.fakemanufacturer_fakemodel_e769900a_ias_wd_sirenlevel",
+            "metadata": {"secondary": True},
         },
         {
             "domain": Platform.SELECT,
             "type": "select_option",
             "device_id": reg_device.id,
             "entity_id": "select.fakemanufacturer_fakemodel_e769900a_ias_wd_strobelevel",
+            "metadata": {"secondary": True},
         },
         {
             "domain": Platform.SELECT,
             "type": "select_option",
             "device_id": reg_device.id,
             "entity_id": "select.fakemanufacturer_fakemodel_e769900a_ias_wd_strobe",
+            "metadata": {"secondary": True},
         },
     ]
 

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -38,28 +38,40 @@ async def test_get_actions(
             "type": "clear_lock_usercode",
             "device_id": device.id,
             "entity_id": "lock.touchscreen_deadbolt",
+            "metadata": {"secondary": False},
         },
         {
             "domain": DOMAIN,
             "type": "set_lock_usercode",
             "device_id": device.id,
             "entity_id": "lock.touchscreen_deadbolt",
+            "metadata": {"secondary": False},
+        },
+        {
+            "domain": DOMAIN,
+            "type": "refresh_value",
+            "device_id": device.id,
+            "entity_id": "binary_sensor.touchscreen_deadbolt_low_battery_level",
+            "metadata": {"secondary": True},
         },
         {
             "domain": DOMAIN,
             "type": "refresh_value",
             "device_id": device.id,
             "entity_id": "lock.touchscreen_deadbolt",
+            "metadata": {"secondary": False},
         },
         {
             "domain": DOMAIN,
             "type": "set_value",
             "device_id": device.id,
+            "metadata": {},
         },
         {
             "domain": DOMAIN,
             "type": "ping",
             "device_id": device.id,
+            "metadata": {},
         },
         {
             "domain": DOMAIN,
@@ -68,6 +80,7 @@ async def test_get_actions(
             "parameter": 3,
             "bitmask": None,
             "subtype": "3 (Beeper)",
+            "metadata": {},
         },
     ]
     actions = await async_get_device_automations(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mark device actions from hidden or auxiliary entities as secondary.

A `secondary` flag is set in a `metadata` dict which is added to the device action definitions:
`"metadata" : {"secondary": True}`

This can be used by the frontend to not overwhelm the user with a long list of device automations

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
