### PR TITLE
Update aioairzone to v0.4.0

### DIFF
--- a/homeassistant/components/airzone/__init__.py
+++ b/homeassistant/components/airzone/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from aioairzone.common import ConnectionOptions
 from aioairzone.const import (
     AZD_ID,
     AZD_NAME,
@@ -13,7 +12,7 @@ from aioairzone.const import (
     AZD_ZONES,
     DEFAULT_SYSTEM_ID,
 )
-from aioairzone.localapi import AirzoneLocalApi
+from aioairzone.localapi import AirzoneLocalApi, ConnectionOptions
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, Platform

--- a/homeassistant/components/airzone/config_flow.py
+++ b/homeassistant/components/airzone/config_flow.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from aioairzone.common import ConnectionOptions
 from aioairzone.const import DEFAULT_PORT, DEFAULT_SYSTEM_ID
 from aioairzone.exceptions import AirzoneError, InvalidSystem
-from aioairzone.localapi import AirzoneLocalApi
+from aioairzone.localapi import AirzoneLocalApi, ConnectionOptions
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -62,7 +61,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             try:
-                await airzone.validate_airzone()
+                await airzone.validate()
             except InvalidSystem:
                 data_schema = SYSTEM_ID_SCHEMA
                 errors["base"] = "invalid_system_id"

--- a/homeassistant/components/airzone/coordinator.py
+++ b/homeassistant/components/airzone/coordinator.py
@@ -36,7 +36,7 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         async with async_timeout.timeout(AIOAIRZONE_DEVICE_TIMEOUT_SEC):
             try:
-                await self.airzone.update_airzone()
+                await self.airzone.update()
             except AirzoneError as error:
                 raise UpdateFailed(error) from error
             return self.airzone.data()

--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -3,7 +3,7 @@
   "name": "Airzone",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airzone",
-  "requirements": ["aioairzone==0.3.8"],
+  "requirements": ["aioairzone==0.4.0"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioairzone"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.7
 
 # homeassistant.components.airzone
-aioairzone==0.3.8
+aioairzone==0.4.0
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -94,7 +94,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.7
 
 # homeassistant.components.airzone
-aioairzone==0.3.8
+aioairzone==0.4.0
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -121,23 +121,19 @@ async def test_form_duplicated_id(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain=DOMAIN, data=CONFIG)
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
-        return_value=HVAC_MOCK,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
+    )
 
-        assert result["type"] == "abort"
-        assert result["reason"] == "already_configured"
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
 
 
 async def test_connection_error(hass: HomeAssistant):
     """Test connection to host error."""
 
     with patch(
-        "homeassistant.components.airzone.AirzoneLocalApi.validate_airzone",
+        "homeassistant.components.airzone.AirzoneLocalApi.validate",
         side_effect=AirzoneError,
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/airzone/test_coordinator.py
+++ b/tests/components/airzone/test_coordinator.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from aioairzone.exceptions import AirzoneError
+from aioairzone.exceptions import AirzoneError, InvalidMethod, SystemOutOfRange
 
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.components.airzone.coordinator import SCAN_INTERVAL
@@ -24,7 +24,13 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
-    ) as mock_hvac:
+    ) as mock_hvac, patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
+        side_effect=SystemOutOfRange,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
+        side_effect=InvalidMethod,
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         mock_hvac.assert_called_once()

--- a/tests/components/airzone/test_init.py
+++ b/tests/components/airzone/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+from aioairzone.exceptions import InvalidMethod, SystemOutOfRange
+
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -22,6 +24,12 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
+        side_effect=SystemOutOfRange,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
+        side_effect=InvalidMethod,
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -25,6 +25,7 @@ from aioairzone.const import (
     API_UNITS,
     API_ZONE_ID,
 )
+from aioairzone.exceptions import InvalidMethod, SystemOutOfRange
 
 from homeassistant.components.airzone import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT
@@ -171,6 +172,12 @@ async def async_init_integration(
     with patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
+        side_effect=SystemOutOfRange,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
+        side_effect=InvalidMethod,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
Update aioairzone to [v0.4.0](https://github.com/Noltari/aioairzone/compare/0.3.8...0.4.0).

Release notes:
- https://github.com/Noltari/aioairzone/releases/tag/0.4.0

Git Compare: https://github.com/Noltari/aioairzone/compare/0.3.8...0.4.0

## Type of change
- [x] Dependency upgrade https://github.com/Noltari/aioairzone/compare/0.3.8...0.4.0
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
