### PR TITLE
Use StrEnum [fritzbox_callmonitor]

### DIFF
--- a/homeassistant/components/fritzbox_callmonitor/const.py
+++ b/homeassistant/components/fritzbox_callmonitor/const.py
@@ -1,11 +1,6 @@
 """Constants for the AVM Fritz!Box call monitor integration."""
 from homeassistant.const import Platform
 
-STATE_RINGING = "ringing"
-STATE_DIALING = "dialing"
-STATE_TALKING = "talking"
-STATE_IDLE = "idle"
-
 FRITZ_STATE_RING = "RING"
 FRITZ_STATE_CALL = "CALL"
 FRITZ_STATE_CONNECT = "CONNECT"

--- a/tests/components/fritzbox_callmonitor/test_config_flow.py
+++ b/tests/components/fritzbox_callmonitor/test_config_flow.py
@@ -4,12 +4,7 @@ from unittest.mock import PropertyMock
 from fritzconnection.core.exceptions import FritzConnectionException, FritzSecurityError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
-from homeassistant.components.fritzbox_callmonitor.config_flow import (
-    RESULT_INSUFFICIENT_PERMISSIONS,
-    RESULT_INVALID_AUTH,
-    RESULT_MALFORMED_PREFIXES,
-    RESULT_NO_DEVIES_FOUND,
-)
+from homeassistant.components.fritzbox_callmonitor.config_flow import ConnectResult
 from homeassistant.components.fritzbox_callmonitor.const import (
     CONF_PHONEBOOK,
     CONF_PREFIXES,
@@ -230,7 +225,7 @@ async def test_setup_cannot_connect(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == RESULT_NO_DEVIES_FOUND
+    assert result["reason"] == ConnectResult.NO_DEVIES_FOUND
 
 
 async def test_setup_insufficient_permissions(hass: HomeAssistant) -> None:
@@ -249,7 +244,7 @@ async def test_setup_insufficient_permissions(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == RESULT_INSUFFICIENT_PERMISSIONS
+    assert result["reason"] == ConnectResult.INSUFFICIENT_PERMISSIONS
 
 
 async def test_setup_invalid_auth(hass: HomeAssistant) -> None:
@@ -268,7 +263,7 @@ async def test_setup_invalid_auth(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] == {"base": RESULT_INVALID_AUTH}
+    assert result["errors"] == {"base": ConnectResult.INVALID_AUTH}
 
 
 async def test_options_flow_correct_prefixes(hass: HomeAssistant) -> None:
@@ -326,7 +321,7 @@ async def test_options_flow_incorrect_prefixes(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] == RESULT_TYPE_FORM
-        assert result["errors"] == {"base": RESULT_MALFORMED_PREFIXES}
+        assert result["errors"] == {"base": ConnectResult.MALFORMED_PREFIXES}
 
 
 async def test_options_flow_no_prefixes(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
Replace string constants with `StrEnum` to enable better typing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
