### PR TITLE
Add binary sensors to generic camera

### DIFF
--- a/homeassistant/components/generic/__init__.py
+++ b/homeassistant/components/generic/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 DOMAIN = "generic"
-PLATFORMS = [Platform.CAMERA]
+PLATFORMS = [Platform.CAMERA, Platform.BINARY_SENSOR]
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/homeassistant/components/generic/binary_sensor.py
+++ b/homeassistant/components/generic/binary_sensor.py
@@ -1,0 +1,81 @@
+"""Support for attaching stand-alone motion sensors to generic cameras."""
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_OCCUPANCY,
+)
+from homeassistant.components.group.binary_sensor import BinarySensorGroup
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN
+from .const import CONF_DOORBELL_SENSOR, CONF_MOTION_SENSOR
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Add Motion and Doorbell sensors related to the camera."""
+
+    to_add = []
+
+    if entry.options.get(CONF_MOTION_SENSOR) not in (None, ""):
+        to_add.append(
+            BinarySensorMirror(
+                hass,
+                entry.unique_id,
+                True,
+                entry.title,
+                entry.options.get(CONF_MOTION_SENSOR),
+            )
+        )
+
+    if entry.options.get(CONF_DOORBELL_SENSOR) not in (None, ""):
+        to_add.append(
+            BinarySensorMirror(
+                hass,
+                entry.unique_id,
+                False,
+                entry.title,
+                entry.options.get(CONF_DOORBELL_SENSOR),
+            )
+        )
+
+    async_add_entities(to_add)
+
+
+class BinarySensorMirror(BinarySensorGroup):
+    """A binary sensor mirrored from another binary sensor, but linked to the generic camera device."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        identifier,
+        is_motion: bool,
+        title,
+        entity_id,
+    ):
+        """Initialize a generic camera's linked sensor. We simply use a Group of one to duplicate the sensor."""
+        super().__init__(
+            identifier + ("_motion" if is_motion else "_doorbell"),
+            title + (" Motion" if is_motion else " Doorbell"),
+            DEVICE_CLASS_MOTION if is_motion else DEVICE_CLASS_OCCUPANCY,
+            [entity_id],
+            None,
+        )
+        self.hass = hass
+
+        self._dev_id = identifier
+        self._title = title
+
+    @property
+    def device_info(self):
+        """Return Device description based on camera name."""
+        return {
+            "identifiers": {(DOMAIN, self._dev_id)},
+            "name": self._title,
+            "manufacturer": "Home Assistant",
+            "model": "Generic Camera",
+        }

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -215,3 +215,13 @@ class GenericCamera(Camera):
         except TemplateError as err:
             _LOGGER.error("Error parsing template %s: %s", self._stream_source, err)
             return None
+
+    @property
+    def device_info(self):
+        """Return Device description based on camera name."""
+        return {
+            "identifiers": {(DOMAIN, self._attr_unique_id)},
+            "name": self.name,
+            "manufacturer": "Home Assistant",
+            "model": "Generic Camera",
+        }

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -36,8 +36,10 @@ from homeassistant.util import slugify
 from .camera import generate_auth
 from .const import (
     CONF_CONTENT_TYPE,
+    CONF_DOORBELL_SENSOR,
     CONF_FRAMERATE,
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
+    CONF_MOTION_SENSOR,
     CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
@@ -56,6 +58,8 @@ DEFAULT_DATA = {
     CONF_LIMIT_REFETCH_TO_URL_CHANGE: False,
     CONF_FRAMERATE: 2,
     CONF_VERIFY_SSL: True,
+    CONF_MOTION_SENSOR: "",
+    CONF_DOORBELL_SENSOR: "",
 }
 
 SUPPORTED_IMAGE_TYPES = {"png", "jpeg", "gif", "svg+xml", "webp"}
@@ -98,6 +102,14 @@ def build_schema(
         vol.Required(
             CONF_VERIFY_SSL, default=user_input.get(CONF_VERIFY_SSL, True)
         ): bool,
+        vol.Optional(
+            CONF_MOTION_SENSOR,
+            description={"suggested_value": user_input.get(CONF_MOTION_SENSOR, "")},
+        ): str,
+        vol.Optional(
+            CONF_DOORBELL_SENSOR,
+            description={"suggested_value": user_input.get(CONF_DOORBELL_SENSOR, "")},
+        ): str,
     }
     if is_options_flow:
         spec[
@@ -328,6 +340,7 @@ class GenericOptionsFlowHandler(OptionsFlow):
             errors = errors | await async_test_stream(self.hass, user_input)
             still_url = user_input.get(CONF_STILL_IMAGE_URL)
             stream_url = user_input.get(CONF_STREAM_SOURCE)
+
             if not errors:
                 title = slug_url(still_url) or slug_url(stream_url) or DEFAULT_NAME
                 if still_url is None:
@@ -348,6 +361,8 @@ class GenericOptionsFlowHandler(OptionsFlow):
                     ],
                     CONF_FRAMERATE: user_input[CONF_FRAMERATE],
                     CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+                    CONF_MOTION_SENSOR: user_input.get(CONF_MOTION_SENSOR),
+                    CONF_DOORBELL_SENSOR: user_input.get(CONF_DOORBELL_SENSOR),
                 }
                 return self.async_create_entry(
                     title=title,

--- a/homeassistant/components/generic/const.py
+++ b/homeassistant/components/generic/const.py
@@ -8,6 +8,8 @@ CONF_STILL_IMAGE_URL = "still_image_url"
 CONF_STREAM_SOURCE = "stream_source"
 CONF_FRAMERATE = "framerate"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
+CONF_MOTION_SENSOR = "motion_sensor_id"
+CONF_DOORBELL_SENSOR = "doorbell_sensor_id"
 FFMPEG_OPTION_MAP = {CONF_RTSP_TRANSPORT: "rtsp_transport"}
 RTSP_TRANSPORTS = {
     "tcp": "TCP",

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -31,7 +31,9 @@
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "Frame Rate (Hz)",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "motion_sensor_id": "[%key:component::generic::config::step::user::data::motion_sensor_id%]",
+          "doorbell_sensor_id": "[%key:component::generic::config::step::user::data::doorbell_sensor_id%]"
         }
       },
       "content_type": {
@@ -57,7 +59,9 @@
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "[%key:component::generic::config::step::user::data::framerate%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "motion_sensor_id": "[%key:component::generic::config::step::user::data::motion_sensor_id%]",
+          "doorbell_sensor_id": "[%key:component::generic::config::step::user::data::doorbell_sensor_id%]"
         }
       },
       "content_type": {

--- a/homeassistant/components/generic/translations/en.json
+++ b/homeassistant/components/generic/translations/en.json
@@ -39,7 +39,9 @@
                     "still_image_url": "Still Image URL (e.g. http://...)",
                     "stream_source": "Stream Source URL (e.g. rtsp://...)",
                     "username": "Username",
-                    "verify_ssl": "Verify SSL certificate"
+                    "verify_ssl": "Verify SSL certificate",
+                    "motion_sensor_id": "Entity ID of camera's motion sensor",
+                    "doorbell_sensor_id": "Entity ID of camera's doorbell sensor"
                 },
                 "description": "Enter the settings to connect to the camera."
             }
@@ -78,7 +80,9 @@
                     "still_image_url": "Still Image URL (e.g. http://...)",
                     "stream_source": "Stream Source URL (e.g. rtsp://...)",
                     "username": "Username",
-                    "verify_ssl": "Verify SSL certificate"
+                    "verify_ssl": "Verify SSL certificate",
+                    "motion_sensor_id": "Entity ID of camera's motion sensor",
+                    "doorbell_sensor_id": "Entity ID of camera's doorbell sensor"
                 }
             }
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Not sure if this is the kind of thing HA wants to have, but I'm offering it anyway.

This change adds optional motion and doorbell sensors (binary_sensor) to the Generic Camera integration. So you can combine a stand-alone motion sensor or doorbell button with a basic camera. The camera and sensors are combined together into a Device named after the camera entity, so that other integrations can use the device and associated sensors as if they are one. The binary sensors are duplicated into the device, using a group entity to copy the state of the source sensor. Therefore, the sensors you use remain as a stand alone sensor as well.

This is specifically intended to work with the Homekit integration. When the camera is set up as an accessory, the HomeKit integration can automatically find the sensors linked to the camera without having to make the user do all of the homekit config in yaml. This means Homekit can give me "Doorbell" and motion notifications, even though I only have a basic camera and separate zigbee PIR sensor and doorbell button. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-- I haven't done this yet. I want to confirm that the changes have a chance of getting integrated first...
Also, there are some untranslated words for the default naming of the sensors. Not sure if that is OK.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

No changes to these.
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
