### PR TITLE
Revert "Add target_temp_step to generic_thermostat (#58691)"

### DIFF
--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -75,7 +75,6 @@ CONF_HOT_TOLERANCE = "hot_tolerance"
 CONF_KEEP_ALIVE = "keep_alive"
 CONF_INITIAL_HVAC_MODE = "initial_hvac_mode"
 CONF_PRECISION = "precision"
-CONF_TEMP_STEP = "target_temp_step"
 
 CONF_PRESETS = {
     p: f"{p}_temp"
@@ -105,9 +104,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             [HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF]
         ),
         vol.Optional(CONF_PRECISION): vol.In(
-            [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
-        ),
-        vol.Optional(CONF_TEMP_STEP): vol.In(
             [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
         ),
         vol.Optional(CONF_UNIQUE_ID): cv.string,
@@ -141,7 +137,6 @@ async def async_setup_platform(
         key: config[value] for key, value in CONF_PRESETS.items() if value in config
     }
     precision = config.get(CONF_PRECISION)
-    target_temperature_step = config.get(CONF_TEMP_STEP)
     unit = hass.config.units.temperature_unit
     unique_id = config.get(CONF_UNIQUE_ID)
 
@@ -162,7 +157,6 @@ async def async_setup_platform(
                 initial_hvac_mode,
                 presets,
                 precision,
-                target_temperature_step,
                 unit,
                 unique_id,
             )
@@ -189,7 +183,6 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         initial_hvac_mode,
         presets,
         precision,
-        target_temperature_step,
         unit,
         unique_id,
     ):
@@ -205,7 +198,6 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self._hvac_mode = initial_hvac_mode
         self._saved_target_temp = target_temp or next(iter(presets.values()), None)
         self._temp_precision = precision
-        self._temp_target_temperature_step = target_temperature_step
         if self.ac_mode:
             self._hvac_list = [HVAC_MODE_COOL, HVAC_MODE_OFF]
         else:
@@ -333,9 +325,8 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
-        if self._temp_target_temperature_step is not None:
-            return self._temp_target_temperature_step
-        # if a target_temperature_step is not defined, fallback to equal the precision
+        # Since this integration does not yet have a step size parameter
+        # we have to re-use the precision as the step size for now.
         return self.precision
 
     @property

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -62,7 +62,6 @@ MAX_TEMP = 65.0
 TARGET_TEMP = 42.0
 COLD_TOLERANCE = 0.5
 HOT_TOLERANCE = 0.5
-TARGET_TEMP_STEP = 0.5
 
 
 async def test_setup_missing_conf(hass):
@@ -277,7 +276,6 @@ async def test_default_setup_params(hass, setup_comp_2):
     assert state.attributes.get("min_temp") == 7
     assert state.attributes.get("max_temp") == 35
     assert state.attributes.get("temperature") == 7
-    assert state.attributes.get("target_temp_step") == 0.1
 
 
 async def test_get_hvac_modes(hass, setup_comp_2):
@@ -1181,7 +1179,7 @@ async def test_temp_change_heater_trigger_off_long_enough_2(hass, setup_comp_8):
 @pytest.fixture
 async def setup_comp_9(hass):
     """Initialize components."""
-    hass.config.units.temperature_unit = TEMP_FAHRENHEIT
+    hass.config.temperature_unit = TEMP_FAHRENHEIT
     assert await async_setup_component(
         hass,
         DOMAIN,
@@ -1208,8 +1206,6 @@ async def test_precision(hass, setup_comp_9):
     await common.async_set_temperature(hass, 23.27)
     state = hass.states.get(ENTITY)
     assert state.attributes.get("temperature") == 23.3
-    # check that target_temp_step defaults to precision
-    assert state.attributes.get("target_temp_step") == 0.1
 
 
 async def test_custom_setup_params(hass):
@@ -1226,7 +1222,6 @@ async def test_custom_setup_params(hass):
                 "min_temp": MIN_TEMP,
                 "max_temp": MAX_TEMP,
                 "target_temp": TARGET_TEMP,
-                "target_temp_step": 0.5,
             }
         },
     )
@@ -1236,7 +1231,6 @@ async def test_custom_setup_params(hass):
     assert state.attributes.get("min_temp") == MIN_TEMP
     assert state.attributes.get("max_temp") == MAX_TEMP
     assert state.attributes.get("temperature") == TARGET_TEMP
-    assert state.attributes.get("target_temp_step") == TARGET_TEMP_STEP
 
 
 @pytest.mark.parametrize("hvac_mode", [HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL])


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts commit ba4ca3e38e87fe40d673328993358ad6a519c3c6.

This PR caused any test that ran after it to break because it switched the units to F and did not restore them back to C which other tests rely on

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
