### PR TITLE
Add Insteon USB discovery

### DIFF
--- a/homeassistant/components/insteon/config_flow.py
+++ b/homeassistant/components/insteon/config_flow.py
@@ -1,19 +1,24 @@
 """Test config flow for Insteon."""
+from __future__ import annotations
+
 import logging
 
 from pyinsteon import async_connect
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import usb
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_DEVICE,
     CONF_HOST,
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
 )
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
@@ -107,6 +112,9 @@ def _remove_x10(device, options):
 class InsteonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Insteon config flow handler."""
 
+    _device_path: str | None = None
+    _device_name: str | None = None
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
@@ -176,6 +184,38 @@ class InsteonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not await _async_connect(**import_info):
             return self.async_abort(reason="cannot_connect")
         return self.async_create_entry(title="", data=import_info)
+
+    async def async_step_usb(self, discovery_info: usb.UsbServiceInfo) -> FlowResult:
+        """Handle USB discovery."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        dev_path = await self.hass.async_add_executor_job(
+            usb.get_serial_by_id, discovery_info.device
+        )
+        self._device_path = dev_path
+        self._device_name = usb.human_readable_device_name(
+            dev_path,
+            discovery_info.serial_number,
+            discovery_info.manufacturer,
+            discovery_info.description,
+            discovery_info.vid,
+            discovery_info.pid,
+        )
+        self._set_confirm_only()
+        self.context["title_placeholders"] = {CONF_NAME: self._device_name}
+        await self.async_set_unique_id(config_entries.DEFAULT_DISCOVERY_UNIQUE_ID)
+        return await self.async_step_confirm_usb()
+
+    async def async_step_confirm_usb(self, user_input=None):
+        """Confirm a discovery."""
+        if user_input is not None:
+            return await self.async_step_plm({CONF_DEVICE: self._device_path})
+
+        return self.async_show_form(
+            step_id="confirm_usb",
+            description_placeholders={CONF_NAME: self._device_name},
+        )
 
 
 class InsteonOptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -6,5 +6,11 @@
   "codeowners": ["@teharris1"],
   "config_flow": true,
   "iot_class": "local_push",
-  "loggers": ["pyinsteon", "pypubsub"]
+  "loggers": ["pyinsteon", "pypubsub"],
+  "after_dependencies": ["usb"],
+  "usb": [
+    {
+      "vid": "10BF"
+    }
+  ]
 }

--- a/homeassistant/components/insteon/strings.json
+++ b/homeassistant/components/insteon/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name}",
     "step": {
       "user": {
         "description": "Select the Insteon modem type.",
@@ -31,6 +32,9 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "confirm_usb": {
+        "description": "Do you want to setup {name}?"
       }
     },
     "error": {

--- a/homeassistant/components/insteon/translations/en.json
+++ b/homeassistant/components/insteon/translations/en.json
@@ -8,7 +8,11 @@
             "cannot_connect": "Failed to connect",
             "select_single": "Select one option."
         },
+        "flow_title": "{name}",
         "step": {
+            "confirm_usb": {
+                "description": "Do you want to setup {name}?"
+            },
             "hubv1": {
                 "data": {
                     "host": "IP Address",

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -7,6 +7,10 @@ To update, run python3 -m script.hassfest
 
 USB = [
     {
+        "domain": "insteon",
+        "vid": "10BF"
+    },
+    {
         "domain": "modem_callerid",
         "vid": "0572",
         "pid": "1340"

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -615,7 +615,7 @@ async def test_discovery_via_usb(hass):
     assert result["step_id"] == "confirm_usb"
 
     with patch(
-        "homeassistant.components.insteon.config_flow._async_connect", return_value=True
+        "homeassistant.components.insteon.config_flow.async_connect"
     ), patch("homeassistant.components.insteon.async_setup_entry", return_value=True):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import usb
 from homeassistant.components.insteon.config_flow import (
     HUB1,
     HUB2,
@@ -594,3 +595,56 @@ async def test_options_override_bad_data(hass: HomeAssistant):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "input_error"}
+
+
+async def test_discovery_via_usb(hass):
+    """Test usb flow."""
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyINSTEON",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="insteon radio",
+        manufacturer="test",
+    )
+    result = await hass.config_entries.flow.async_init(
+        "insteon", context={"source": config_entries.SOURCE_USB}, data=discovery_info
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "confirm_usb"
+
+    with patch(
+        "homeassistant.components.insteon.config_flow._async_connect", return_value=True
+    ), patch("homeassistant.components.insteon.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["data"] == {"device": "/dev/ttyINSTEON"}
+
+
+async def test_discovery_via_usb_already_setup(hass):
+    """Test usb flow -- already setup."""
+
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE: "/dev/ttyUSB1"}}
+    ).add_to_hass(hass)
+
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyINSTEON",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="insteon radio",
+        manufacturer="test",
+    )
+    result = await hass.config_entries.flow.async_init(
+        "insteon", context={"source": config_entries.SOURCE_USB}, data=discovery_info
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -614,9 +614,9 @@ async def test_discovery_via_usb(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "confirm_usb"
 
-    with patch(
-        "homeassistant.components.insteon.config_flow.async_connect"
-    ), patch("homeassistant.components.insteon.async_setup_entry", return_value=True):
+    with patch("homeassistant.components.insteon.config_flow.async_connect"), patch(
+        "homeassistant.components.insteon.async_setup_entry", return_value=True
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds USB discovery for the Insteon PLM USB Modem.

Based on vendor ID found at https://devicehunt.com/view/type/usb/vendor/10BF

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
