### PR TITLE
Replace Climate CURRENT_HVAC_* constants with HVACAction enum

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -75,6 +75,7 @@ from .const import (  # noqa: F401
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 
@@ -188,7 +189,7 @@ class ClimateEntity(Entity):
     _attr_current_temperature: float | None = None
     _attr_fan_mode: str | None
     _attr_fan_modes: list[str] | None
-    _attr_hvac_action: str | None = None
+    _attr_hvac_action: HVACAction | str | None = None
     _attr_hvac_mode: HVACMode | str | None
     _attr_hvac_modes: list[HVACMode | str]
     _attr_is_aux_heat: bool | None
@@ -345,11 +346,8 @@ class ClimateEntity(Entity):
         return self._attr_hvac_modes
 
     @property
-    def hvac_action(self) -> str | None:
-        """Return the current running hvac operation if supported.
-
-        Need to be one of CURRENT_HVAC_*.
-        """
+    def hvac_action(self) -> HVACAction | str | None:
+        """Return the current running hvac operation if supported."""
         return self._attr_hvac_action
 
     @property

--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -87,24 +87,26 @@ SWING_VERTICAL = "vertical"
 SWING_HORIZONTAL = "horizontal"
 
 
-# This are support current states of HVAC
+class HVACAction(StrEnum):
+    """HVAC action for climate devices."""
+
+    COOLING = "cooling"
+    DRYING = "drying"
+    FAN = "fan"
+    HEATING = "heating"
+    IDLE = "idle"
+    OFF = "off"
+
+
+# These CURRENT_HVAC_* constants are deprecated as of Home Assistant 2022.5.
+# Please use the HVACAction enum instead.
 CURRENT_HVAC_OFF = "off"
 CURRENT_HVAC_HEAT = "heating"
 CURRENT_HVAC_COOL = "cooling"
 CURRENT_HVAC_DRY = "drying"
 CURRENT_HVAC_IDLE = "idle"
 CURRENT_HVAC_FAN = "fan"
-
-
-# A list of possible HVAC actions.
-CURRENT_HVAC_ACTIONS = [
-    CURRENT_HVAC_OFF,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_COOL,
-    CURRENT_HVAC_DRY,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_FAN,
-]
+CURRENT_HVAC_ACTIONS = [cls.value for cls in HVACAction]
 
 
 ATTR_AUX_HEAT = "aux_heat"

--- a/homeassistant/components/demo/climate.py
+++ b/homeassistant/components/demo/climate.py
@@ -5,9 +5,8 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    CURRENT_HVAC_COOL,
-    CURRENT_HVAC_HEAT,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -43,7 +42,7 @@ async def async_setup_platform(
                 current_humidity=None,
                 swing_mode=None,
                 hvac_mode=HVACMode.HEAT,
-                hvac_action=CURRENT_HVAC_HEAT,
+                hvac_action=HVACAction.HEATING,
                 aux=None,
                 target_temp_high=None,
                 target_temp_low=None,
@@ -61,7 +60,7 @@ async def async_setup_platform(
                 current_humidity=54,
                 swing_mode="Off",
                 hvac_mode=HVACMode.COOL,
-                hvac_action=CURRENT_HVAC_COOL,
+                hvac_action=HVACAction.COOLING,
                 aux=False,
                 target_temp_high=None,
                 target_temp_low=None,

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -52,7 +52,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         entity_id,
         const.HVAC_MODE_COOL,
         {
-            const.ATTR_HVAC_ACTION: const.CURRENT_HVAC_IDLE,
+            const.ATTR_HVAC_ACTION: const.HVACAction.IDLE,
             const.ATTR_CURRENT_HUMIDITY: 23,
             const.ATTR_CURRENT_TEMPERATURE: 18,
         },
@@ -92,7 +92,7 @@ async def test_if_fires_on_state_change(hass, calls):
         "climate.entity",
         const.HVAC_MODE_COOL,
         {
-            const.ATTR_HVAC_ACTION: const.CURRENT_HVAC_IDLE,
+            const.ATTR_HVAC_ACTION: const.HVACAction.IDLE,
             const.ATTR_CURRENT_HUMIDITY: 23,
             const.ATTR_CURRENT_TEMPERATURE: 18,
         },
@@ -154,7 +154,7 @@ async def test_if_fires_on_state_change(hass, calls):
         "climate.entity",
         const.HVAC_MODE_AUTO,
         {
-            const.ATTR_HVAC_ACTION: const.CURRENT_HVAC_COOL,
+            const.ATTR_HVAC_ACTION: const.HVACAction.COOLING,
             const.ATTR_CURRENT_HUMIDITY: 23,
             const.ATTR_CURRENT_TEMPERATURE: 18,
         },
@@ -168,7 +168,7 @@ async def test_if_fires_on_state_change(hass, calls):
         "climate.entity",
         const.HVAC_MODE_AUTO,
         {
-            const.ATTR_HVAC_ACTION: const.CURRENT_HVAC_COOL,
+            const.ATTR_HVAC_ACTION: const.HVACAction.COOLING,
             const.ATTR_CURRENT_HUMIDITY: 23,
             const.ATTR_CURRENT_TEMPERATURE: 23,
         },
@@ -182,7 +182,7 @@ async def test_if_fires_on_state_change(hass, calls):
         "climate.entity",
         const.HVAC_MODE_AUTO,
         {
-            const.ATTR_HVAC_ACTION: const.CURRENT_HVAC_COOL,
+            const.ATTR_HVAC_ACTION: const.HVACAction.COOLING,
             const.ATTR_CURRENT_HUMIDITY: 7,
             const.ATTR_CURRENT_TEMPERATURE: 23,
         },

--- a/tests/components/demo/test_climate.py
+++ b/tests/components/demo/test_climate.py
@@ -20,7 +20,6 @@ from homeassistant.components.climate.const import (
     ATTR_SWING_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    CURRENT_HVAC_COOL,
     DOMAIN,
     PRESET_AWAY,
     PRESET_ECO,
@@ -31,6 +30,7 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_SWING_MODE,
     SERVICE_SET_TEMPERATURE,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.const import (
@@ -290,7 +290,7 @@ async def test_set_hvac_bad_attr_and_state(hass):
     Also check the state.
     """
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get(ATTR_HVAC_ACTION) == CURRENT_HVAC_COOL
+    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.COOLING
     assert state.state == HVACMode.COOL
 
     with pytest.raises(vol.Invalid):
@@ -302,7 +302,7 @@ async def test_set_hvac_bad_attr_and_state(hass):
         )
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get(ATTR_HVAC_ACTION) == CURRENT_HVAC_COOL
+    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.COOLING
     assert state.state == HVACMode.COOL
 
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -1161,7 +1161,7 @@ async def test_get_with_templates(hass, mqtt_mock, caplog):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("hvac_action") == "cooling"
     assert (
-        "Invalid ['off', 'heating', 'cooling', 'drying', 'idle', 'fan'] action: None, ignoring"
+        "Invalid ['cooling', 'drying', 'fan', 'heating', 'idle', 'off'] action: None, ignoring"
         in caplog.text
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Developers only: All `CURRENT_HVAC_*` constants from the Climate platform, have been deprecated. Use the new `HVACAction` enum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1297/files

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
