### PR TITLE
Fix #69952: Daikin AC Temperature jumps after being set

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -117,6 +117,11 @@ async def async_setup_entry(
     async_add_entities([DaikinClimate(daikin_api)], update_before_add=True)
 
 
+def format_target_temperature(target_temperature):
+    """Format target temperature to be sent to the Daikin unit, taking care of keeping at most 1 decimal digit."""
+    return str(round(float(target_temperature), 1)).rstrip("0").rstrip(".")
+
+
 class DaikinClimate(ClimateEntity):
     """Representation of a Daikin HVAC."""
 
@@ -163,9 +168,9 @@ class DaikinClimate(ClimateEntity):
             # temperature
             elif attr == ATTR_TEMPERATURE:
                 try:
-                    values[HA_ATTR_TO_DAIKIN[ATTR_TARGET_TEMPERATURE]] = str(
-                        round(float(value), 1)
-                    )
+                    values[
+                        HA_ATTR_TO_DAIKIN[ATTR_TARGET_TEMPERATURE]
+                    ] = format_target_temperature(value)
                 except ValueError:
                     _LOGGER.error("Invalid temperature %s", value)
 

--- a/tests/components/daikin/test_temperature_format.py
+++ b/tests/components/daikin/test_temperature_format.py
@@ -1,0 +1,20 @@
+"""The tests for the Daikin target temperature conversion."""
+from homeassistant.components.daikin.climate import format_target_temperature
+
+
+def test_int_conversion():
+    """Check no decimal are kept when target temp is an integer."""
+    formatted = format_target_temperature("16")
+    assert formatted == "16"
+
+
+def test_decimal_conversion():
+    """Check 1 decimal is kept when target temp is a decimal."""
+    formatted = format_target_temperature("16.1")
+    assert formatted == "16.1"
+
+
+def test_decimal_conversion_more_digits():
+    """Check at most 1 decimal is kept when target temp is a decimal with more than 1 decimal."""
+    formatted = format_target_temperature("16.09")
+    assert formatted == "16.1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
In a previous merge request, I introduced support for decimal temperature values. Works fine for some units.
But it seems that some units don't like the extra decimal and reject the commands when they are formatted with a decimal.
This PR supports both : 
- Any integer temperature is formatted without decimal digits : "16.0" => "16" sent to the unit
- Any decimal temperature is formatted with 1 decimal digit : "16.1", "16.09" => "16.1" sent to the unit


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue: fixes #69952

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
