### PR TITLE
Mark device triggers from hidden or auxiliary entities as secondary

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -265,11 +265,7 @@ async def async_get_device_automations(
                 )
                 continue
             for automation in device_results:
-                if automation_type in (
-                    DeviceAutomationType.ACTION,
-                    DeviceAutomationType.CONDITION,
-                ):
-                    _async_set_entity_device_automation_metadata(hass, automation)
+                _async_set_entity_device_automation_metadata(hass, automation)
                 combined_results[automation["device_id"]].append(automation)
 
     return combined_results

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -123,8 +125,57 @@ async def test_get_triggers(
             "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
         for trigger in expected_trigger_types
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["triggered", "disarmed", "arming"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/arcam_fmj/test_device_trigger.py
+++ b/tests/components/arcam_fmj/test_device_trigger.py
@@ -52,6 +52,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
             "type": "turn_on",
             "device_id": device_entry.id,
             "entity_id": "media_player.arcam_fmj_5678",
+            "metadata": {"secondary": False},
         },
     ]
     triggers = await async_get_device_automations(

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -9,11 +9,14 @@ from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGER
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
@@ -71,6 +74,7 @@ async def test_get_triggers(hass, device_reg, entity_reg, enable_custom_integrat
             "type": trigger["type"],
             "device_id": device_entry.id,
             "entity_id": platform.ENTITIES[device_class].entity_id,
+            "metadata": {"secondary": False},
         }
         for device_class in BinarySensorDeviceClass
         for trigger in ENTITY_TRIGGERS[device_class]
@@ -78,7 +82,55 @@ async def test_get_triggers(hass, device_reg, entity_reg, enable_custom_integrat
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["turned_on", "turned_off"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
 
 
 async def test_get_triggers_no_state(hass, device_reg, entity_reg):
@@ -111,6 +163,7 @@ async def test_get_triggers_no_state(hass, device_reg, entity_reg):
             "type": trigger["type"],
             "device_id": device_entry.id,
             "entity_id": entity_ids[device_class],
+            "metadata": {"secondary": False},
         }
         for device_class in BinarySensorDeviceClass
         for trigger in ENTITY_TRIGGERS[device_class]
@@ -118,7 +171,7 @@ async def test_get_triggers_no_state(hass, device_reg, entity_reg):
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
 
 
 async def test_get_trigger_capabilities(hass, device_reg, entity_reg):

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -8,7 +8,8 @@ from homeassistant.components.button import DOMAIN
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -59,7 +60,56 @@ async def test_get_triggers(
             "type": "pressed",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["pressed"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -7,6 +7,8 @@ from homeassistant.components.climate import DOMAIN, const, device_trigger
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers import config_validation as cv, device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -61,24 +63,78 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "hvac_mode_changed",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": entity_id,
+            "metadata": {"secondary": False},
+        }
+        for trigger in [
+            "hvac_mode_changed",
+            "current_temperature_changed",
+            "current_humidity_changed",
+        ]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    entity_id = f"{DOMAIN}.test_5678"
+    hass.states.async_set(
+        entity_id,
+        const.HVAC_MODE_COOL,
+        {
+            const.ATTR_HVAC_ACTION: const.CURRENT_HVAC_IDLE,
+            const.ATTR_CURRENT_HUMIDITY: 23,
+            const.ATTR_CURRENT_TEMPERATURE: 18,
         },
+    )
+    expected_triggers = [
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "current_temperature_changed",
+            "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": entity_id,
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "current_humidity_changed",
-            "device_id": device_entry.id,
-            "entity_id": entity_id,
-        },
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in [
+            "hvac_mode_changed",
+            "current_temperature_changed",
+            "current_humidity_changed",
+        ]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -89,6 +89,7 @@ async def test_get_triggers(hass, aioclient_mock):
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -96,6 +97,7 @@ async def test_get_triggers(hass, aioclient_mock):
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -103,6 +105,7 @@ async def test_get_triggers(hass, aioclient_mock):
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_RELEASE,
             CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -110,6 +113,7 @@ async def test_get_triggers(hass, aioclient_mock):
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_OFF,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -117,6 +121,7 @@ async def test_get_triggers(hass, aioclient_mock):
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_OFF,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -124,6 +129,7 @@ async def test_get_triggers(hass, aioclient_mock):
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_RELEASE,
             CONF_SUBTYPE: device_trigger.CONF_TURN_OFF,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -131,6 +137,7 @@ async def test_get_triggers(hass, aioclient_mock):
             ATTR_ENTITY_ID: "sensor.tradfri_on_off_switch_battery",
             CONF_PLATFORM: "device",
             CONF_TYPE: ATTR_BATTERY_LEVEL,
+            "metadata": {"secondary": True},
         },
     ]
 
@@ -188,6 +195,7 @@ async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
             ATTR_ENTITY_ID: "binary_sensor.keypad_low_battery",
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_BAT_LOW,
+            "metadata": {"secondary": True},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -195,6 +203,7 @@ async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
             ATTR_ENTITY_ID: "binary_sensor.keypad_low_battery",
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_NOT_BAT_LOW,
+            "metadata": {"secondary": True},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -202,6 +211,7 @@ async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
             ATTR_ENTITY_ID: "binary_sensor.keypad_tampered",
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_TAMPERED,
+            "metadata": {"secondary": True},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -209,6 +219,7 @@ async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
             ATTR_ENTITY_ID: "binary_sensor.keypad_tampered",
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_NOT_TAMPERED,
+            "metadata": {"secondary": True},
         },
         {
             CONF_DEVICE_ID: device.id,
@@ -216,6 +227,7 @@ async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
             ATTR_ENTITY_ID: "sensor.keypad_battery",
             CONF_PLATFORM: "device",
             CONF_TYPE: ATTR_BATTERY_LEVEL,
+            "metadata": {"secondary": True},
         },
     ]
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -151,6 +151,7 @@ async def test_websocket_get_triggers(hass, hass_ws_client, device_reg, entity_r
             "type": "changed_states",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
+            "metadata": {"secondary": False},
         },
         {
             "platform": "device",
@@ -158,6 +159,7 @@ async def test_websocket_get_triggers(hass, hass_ws_client, device_reg, entity_r
             "type": "turned_off",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
+            "metadata": {"secondary": False},
         },
         {
             "platform": "device",
@@ -165,6 +167,7 @@ async def test_websocket_get_triggers(hass, hass_ws_client, device_reg, entity_r
             "type": "turned_on",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
+            "metadata": {"secondary": False},
         },
     ]
 

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -97,6 +97,7 @@ async def test_enumerate_remote(hass, utcnow):
             "entity_id": "sensor.testdevice_battery",
             "platform": "device",
             "type": "battery_level",
+            "metadata": {"secondary": False},
         },
         {
             "device_id": device.id,
@@ -104,6 +105,7 @@ async def test_enumerate_remote(hass, utcnow):
             "entity_id": "button.testdevice_identify",
             "platform": "device",
             "type": "pressed",
+            "metadata": {"secondary": True},
         },
     ]
 
@@ -116,6 +118,7 @@ async def test_enumerate_remote(hass, utcnow):
                     "platform": "device",
                     "type": button,
                     "subtype": subtype,
+                    "metadata": {},
                 }
             )
 
@@ -142,6 +145,7 @@ async def test_enumerate_button(hass, utcnow):
             "entity_id": "sensor.testdevice_battery",
             "platform": "device",
             "type": "battery_level",
+            "metadata": {"secondary": False},
         },
         {
             "device_id": device.id,
@@ -149,6 +153,7 @@ async def test_enumerate_button(hass, utcnow):
             "entity_id": "button.testdevice_identify",
             "platform": "device",
             "type": "pressed",
+            "metadata": {"secondary": True},
         },
     ]
 
@@ -160,6 +165,7 @@ async def test_enumerate_button(hass, utcnow):
                 "platform": "device",
                 "type": "button1",
                 "subtype": subtype,
+                "metadata": {},
             }
         )
 
@@ -186,6 +192,7 @@ async def test_enumerate_doorbell(hass, utcnow):
             "entity_id": "sensor.testdevice_battery",
             "platform": "device",
             "type": "battery_level",
+            "metadata": {"secondary": False},
         },
         {
             "device_id": device.id,
@@ -193,6 +200,7 @@ async def test_enumerate_doorbell(hass, utcnow):
             "entity_id": "button.testdevice_identify",
             "platform": "device",
             "type": "pressed",
+            "metadata": {"secondary": True},
         },
     ]
 
@@ -204,6 +212,7 @@ async def test_enumerate_doorbell(hass, utcnow):
                 "platform": "device",
                 "type": "doorbell",
                 "subtype": subtype,
+                "metadata": {},
             }
         )
 

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -37,6 +37,7 @@ async def test_get_triggers(hass, mock_bridge_v1, device_reg):
             "device_id": hue_tap_device.id,
             "type": t_type,
             "subtype": t_subtype,
+            "metadata": {},
         }
         for t_type, t_subtype in device_trigger.HUE_TAP_REMOTE
     ]
@@ -56,6 +57,7 @@ async def test_get_triggers(hass, mock_bridge_v1, device_reg):
         "device_id": hue_dimmer_device.id,
         "type": "battery_level",
         "entity_id": "sensor.hue_dimmer_switch_1_battery_level",
+        "metadata": {"secondary": True},
     }
     expected_triggers = [
         trigger_batt,
@@ -66,6 +68,7 @@ async def test_get_triggers(hass, mock_bridge_v1, device_reg):
                 "device_id": hue_dimmer_device.id,
                 "type": t_type,
                 "subtype": t_subtype,
+                "metadata": {},
             }
             for t_type, t_subtype in device_trigger.HUE_DIMMER_REMOTE
         ),

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -62,6 +62,7 @@ async def test_get_triggers(hass, mock_bridge_v2, v2_resources_test_data, device
         "device_id": hue_wall_switch_device.id,
         "type": "battery_level",
         "entity_id": "sensor.wall_switch_with_2_controls_battery",
+        "metadata": {"secondary": True},
     }
 
     expected_triggers = [
@@ -74,6 +75,7 @@ async def test_get_triggers(hass, mock_bridge_v2, v2_resources_test_data, device
                 "unique_id": resource_id,
                 "type": event_type.value,
                 "subtype": control_id,
+                "metadata": {},
             }
             for event_type in (
                 ButtonEvent.INITIAL_PRESS,

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -9,6 +9,8 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.humidifier import DOMAIN, const, device_trigger
 from homeassistant.const import ATTR_MODE, ATTR_SUPPORTED_FEATURES, STATE_OFF, STATE_ON
 from homeassistant.helpers import config_validation as cv, device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -66,31 +68,70 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "target_humidity_changed",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": entity_id,
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in [
+            "target_humidity_changed",
+            "turned_off",
+            "turned_on",
+            "changed_states",
+        ]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "turned_off",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "changed_states",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": True},
+        }
+        for trigger in [
+            "target_humidity_changed",
+            "turned_off",
+            "turned_on",
+            "changed_states",
+        ]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/kodi/test_device_trigger.py
+++ b/tests/components/kodi/test_device_trigger.py
@@ -57,17 +57,12 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "turn_off",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{MP_DOMAIN}.kodi_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turn_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{MP_DOMAIN}.kodi_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["turn_off", "turn_on"]
     ]
 
     # Test triggers are either kodi specific triggers or media_player entity triggers

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -25,27 +25,11 @@ async def test_get_triggers_module_device(hass, entry, lcn_connection):
         {
             CONF_PLATFORM: "device",
             CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "transmitter",
+            CONF_TYPE: trigger,
             CONF_DEVICE_ID: device.id,
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "transponder",
-            CONF_DEVICE_ID: device.id,
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "fingerprint",
-            CONF_DEVICE_ID: device.id,
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "send_keys",
-            CONF_DEVICE_ID: device.id,
-        },
+            "metadata": {},
+        }
+        for trigger in ["transmitter", "transponder", "fingerprint", "send_keys"]
     ]
 
     triggers = await async_get_device_automations(

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -8,11 +8,14 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
@@ -54,29 +57,65 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "changed_states",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_off",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
 
 
 async def test_get_trigger_capabilities(hass, device_reg, entity_reg):

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -14,6 +14,8 @@ from homeassistant.const import (
     STATE_UNLOCKING,
 )
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -61,38 +63,60 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "locked",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["locked", "unlocked", "unlocking", "locking", "jammed"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "unlocked",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "unlocking",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "locking",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "jammed",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["locked", "unlocked", "unlocking", "locking", "jammed"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -99,72 +99,22 @@ async def test_get_triggers(hass, device_reg):
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
             CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "on",
+            CONF_SUBTYPE: subtype,
             CONF_TYPE: "press",
-        },
+            "metadata": {},
+        }
+        for subtype in ["on", "stop", "off", "raise", "lower"]
+    ]
+    expected_triggers += [
         {
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
             CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "stop",
-            CONF_TYPE: "press",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "off",
-            CONF_TYPE: "press",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "raise",
-            CONF_TYPE: "press",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "lower",
-            CONF_TYPE: "press",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "on",
+            CONF_SUBTYPE: subtype,
             CONF_TYPE: "release",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "stop",
-            CONF_TYPE: "release",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "off",
-            CONF_TYPE: "release",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "raise",
-            CONF_TYPE: "release",
-        },
-        {
-            CONF_DEVICE_ID: device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_PLATFORM: "device",
-            CONF_SUBTYPE: "lower",
-            CONF_TYPE: "release",
-        },
+            "metadata": {},
+        }
+        for subtype in ["on", "stop", "off", "raise", "lower"]
     ]
 
     triggers = await async_get_device_automations(

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -14,6 +14,8 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -73,8 +75,64 @@ async def test_get_triggers(hass, device_reg, entity_reg):
             "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
         for trigger in trigger_types
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in [
+            "turned_on",
+            "turned_off",
+            "idle",
+            "paused",
+            "playing",
+            "changed_states",
+        ]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -61,6 +61,7 @@ async def test_get_triggers(hass, device_reg, entity_reg, mqtt_mock):
             "discovery_id": "bla",
             "type": "button_short_press",
             "subtype": "button_1",
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(
@@ -166,6 +167,7 @@ async def test_discover_bad_triggers(hass, device_reg, entity_reg, mqtt_mock):
             "discovery_id": "bla",
             "type": "button_short_press",
             "subtype": "button_1",
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(
@@ -210,6 +212,7 @@ async def test_update_remove_triggers(hass, device_reg, entity_reg, mqtt_mock):
             "discovery_id": "bla",
             "type": "button_short_press",
             "subtype": "button_1",
+            "metadata": {},
         },
     ]
     expected_triggers2 = [dict(expected_triggers1[0])]

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -112,12 +112,14 @@ async def test_get_triggers(hass):
             "domain": DOMAIN,
             "type": "camera_motion",
             "device_id": device_entry.id,
+            "metadata": {},
         },
         {
             "platform": "device",
             "domain": DOMAIN,
             "type": "camera_person",
             "device_id": device_entry.id,
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(
@@ -159,6 +161,7 @@ async def test_multiple_devices(hass):
         "domain": DOMAIN,
         "type": "camera_sound",
         "device_id": entry1.device_id,
+        "metadata": {},
     }
 
     triggers = await async_get_device_automations(
@@ -170,6 +173,7 @@ async def test_multiple_devices(hass):
         "domain": DOMAIN,
         "type": "doorbell_chime",
         "device_id": entry2.device_id,
+        "metadata": {},
     }
 
 

--- a/tests/components/netatmo/test_device_trigger.py
+++ b/tests/components/netatmo/test_device_trigger.py
@@ -84,6 +84,7 @@ async def test_get_triggers(
                         "subtype": subtype,
                         "device_id": device_entry.id,
                         "entity_id": f"{platform}.{NETATMO_DOMAIN}_5678",
+                        "metadata": {"secondary": False},
                     }
                 )
         else:
@@ -94,6 +95,7 @@ async def test_get_triggers(
                     "type": event_type,
                     "device_id": device_entry.id,
                     "entity_id": f"{platform}.{NETATMO_DOMAIN}_5678",
+                    "metadata": {"secondary": False},
                 }
             )
     triggers = [

--- a/tests/components/philips_js/test_device_trigger.py
+++ b/tests/components/philips_js/test_device_trigger.py
@@ -28,6 +28,7 @@ async def test_get_triggers(hass, mock_device):
             "domain": DOMAIN,
             "type": "turn_on",
             "device_id": mock_device.id,
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -8,11 +8,14 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
@@ -54,29 +57,65 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "changed_states",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_off",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
 
 
 async def test_get_trigger_capabilities(hass, device_reg, entity_reg):

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -90,7 +90,13 @@ async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
     device_entry = device_reg.async_get_device(event.device_identifiers, set())
 
     expected_triggers = [
-        {"domain": DOMAIN, "device_id": device_entry.id, "platform": "device", **expect}
+        {
+            "domain": DOMAIN,
+            "device_id": device_entry.id,
+            "platform": "device",
+            "metadata": {},
+            **expect,
+        }
         for expect in expected
     ]
 

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -12,7 +12,8 @@ from homeassistant.components.select.device_trigger import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv, device_registry
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -63,7 +64,56 @@ async def test_get_triggers(
             "type": "current_option_changed",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
         }
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["current_option_changed"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -9,11 +9,14 @@ from homeassistant.components.sensor import DOMAIN, SensorDeviceClass
 from homeassistant.components.sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.const import CONF_PLATFORM, PERCENTAGE, STATE_UNKNOWN
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
@@ -72,6 +75,7 @@ async def test_get_triggers(hass, device_reg, entity_reg, enable_custom_integrat
             "type": trigger["type"],
             "device_id": device_entry.id,
             "entity_id": platform.ENTITIES[device_class].entity_id,
+            "metadata": {"secondary": False},
         }
         for device_class in SensorDeviceClass
         if device_class in UNITS_OF_MEASUREMENT
@@ -82,7 +86,56 @@ async def test_get_triggers(hass, device_reg, entity_reg, enable_custom_integrat
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
     assert len(triggers) == 26
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+        unit_of_measurement="dogs",
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["value"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -60,16 +60,11 @@ async def test_get_triggers_block_device(
                 CONF_PLATFORM: "device",
                 CONF_DEVICE_ID: coap_wrapper.device_id,
                 CONF_DOMAIN: DOMAIN,
-                CONF_TYPE: "single",
+                CONF_TYPE: type,
                 CONF_SUBTYPE: "button1",
-            },
-            {
-                CONF_PLATFORM: "device",
-                CONF_DEVICE_ID: coap_wrapper.device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_TYPE: "long",
-                CONF_SUBTYPE: "button1",
-            },
+                "metadata": {},
+            }
+            for type in ["single", "long"]
         ]
 
     triggers = await async_get_device_automations(
@@ -87,37 +82,11 @@ async def test_get_triggers_rpc_device(hass, rpc_wrapper):
             CONF_PLATFORM: "device",
             CONF_DEVICE_ID: rpc_wrapper.device_id,
             CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "btn_down",
+            CONF_TYPE: type,
             CONF_SUBTYPE: "button1",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: rpc_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "btn_up",
-            CONF_SUBTYPE: "button1",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: rpc_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "single_push",
-            CONF_SUBTYPE: "button1",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: rpc_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "double_push",
-            CONF_SUBTYPE: "button1",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: rpc_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "long_push",
-            CONF_SUBTYPE: "button1",
-        },
+            "metadata": {},
+        }
+        for type in ["btn_down", "btn_up", "single_push", "double_push", "long_push"]
     ]
 
     triggers = await async_get_device_automations(
@@ -159,30 +128,11 @@ async def test_get_triggers_button(hass):
             CONF_PLATFORM: "device",
             CONF_DEVICE_ID: coap_wrapper.device_id,
             CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "single",
+            CONF_TYPE: type,
             CONF_SUBTYPE: "button",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: coap_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "double",
-            CONF_SUBTYPE: "button",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: coap_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "triple",
-            CONF_SUBTYPE: "button",
-        },
-        {
-            CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: coap_wrapper.device_id,
-            CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "long",
-            CONF_SUBTYPE: "button",
-        },
+            "metadata": {},
+        }
+        for type in ["single", "double", "triple", "long"]
     ]
 
     triggers = await async_get_device_automations(

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -8,11 +8,14 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
@@ -54,29 +57,65 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "changed_states",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_off",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
 
 
 async def test_get_trigger_capabilities(hass, device_reg, entity_reg):

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -47,6 +47,7 @@ async def test_get_triggers_btn(hass, device_reg, entity_reg, mqtt_mock, setup_t
             "discovery_id": "00000049A3BC_button_1_SINGLE",
             "type": "button_short_press",
             "subtype": "button_1",
+            "metadata": {},
         },
         {
             "platform": "device",
@@ -55,6 +56,7 @@ async def test_get_triggers_btn(hass, device_reg, entity_reg, mqtt_mock, setup_t
             "discovery_id": "00000049A3BC_button_2_SINGLE",
             "type": "button_short_press",
             "subtype": "button_2",
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(
@@ -83,6 +85,7 @@ async def test_get_triggers_swc(hass, device_reg, entity_reg, mqtt_mock, setup_t
             "discovery_id": "00000049A3BC_switch_1_TOGGLE",
             "type": "button_short_press",
             "subtype": "switch_1",
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(
@@ -232,6 +235,7 @@ async def test_discover_bad_triggers(
             "discovery_id": "00000049A3BC_switch_1_TOGGLE",
             "type": "button_short_press",
             "subtype": "switch_1",
+            "metadata": {},
         },
     ]
     triggers = await async_get_device_automations(
@@ -272,6 +276,7 @@ async def test_update_remove_triggers(
             "discovery_id": "00000049A3BC_switch_1_TOGGLE",
             "type": "button_short_press",
             "subtype": "switch_1",
+            "metadata": {},
         },
         {
             "platform": "device",
@@ -280,6 +285,7 @@ async def test_update_remove_triggers(
             "discovery_id": "00000049A3BC_switch_1_HOLD",
             "type": "button_long_press",
             "subtype": "switch_1",
+            "metadata": {},
         },
     ]
     expected_triggers2 = copy.deepcopy(expected_triggers1)

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -10,12 +10,14 @@ from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.device_registry import DeviceRegistry
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    assert_lists_same,
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
@@ -59,29 +61,65 @@ async def test_get_triggers(
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "changed_states",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_off",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": "turned_on",
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert triggers == expected_triggers
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["changed_states", "turned_off", "turned_on"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
 
 
 async def test_get_trigger_capabilities(

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -7,6 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN, STATE_CLEANING, STATE_DOCKED
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -54,17 +56,60 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "cleaning",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["cleaning", "docked"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "docked",
+            "type": trigger,
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
-        },
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["cleaning", "docked"]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -30,6 +30,7 @@ async def test_get_triggers(hass, client):
         "domain": DOMAIN,
         "type": "webostv.turn_on",
         "device_id": device.id,
+        "metadata": {},
     }
 
     triggers = await async_get_device_automations(

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -65,6 +65,7 @@ async def test_get_triggers(hass, wemo_entity):
             CONF_DOMAIN: DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: EVENT_TYPE_LONG_PRESS,
+            "metadata": {},
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
@@ -72,6 +73,7 @@ async def test_get_triggers(hass, wemo_entity):
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "changed_states",
+            "metadata": {"secondary": False},
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
@@ -79,6 +81,7 @@ async def test_get_triggers(hass, wemo_entity):
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_off",
+            "metadata": {"secondary": False},
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
@@ -86,6 +89,7 @@ async def test_get_triggers(hass, wemo_entity):
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_on",
+            "metadata": {"secondary": False},
         },
     ]
     triggers = await async_get_device_automations(

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -102,6 +102,7 @@ async def test_triggers(hass, mock_devices):
             "platform": "device",
             "type": "device_offline",
             "subtype": "device_offline",
+            "metadata": {},
         },
         {
             "device_id": reg_device.id,
@@ -109,6 +110,7 @@ async def test_triggers(hass, mock_devices):
             "platform": "device",
             "type": SHAKEN,
             "subtype": SHAKEN,
+            "metadata": {},
         },
         {
             "device_id": reg_device.id,
@@ -116,6 +118,7 @@ async def test_triggers(hass, mock_devices):
             "platform": "device",
             "type": DOUBLE_PRESS,
             "subtype": DOUBLE_PRESS,
+            "metadata": {},
         },
         {
             "device_id": reg_device.id,
@@ -123,6 +126,7 @@ async def test_triggers(hass, mock_devices):
             "platform": "device",
             "type": SHORT_PRESS,
             "subtype": SHORT_PRESS,
+            "metadata": {},
         },
         {
             "device_id": reg_device.id,
@@ -130,6 +134,7 @@ async def test_triggers(hass, mock_devices):
             "platform": "device",
             "type": LONG_PRESS,
             "subtype": LONG_PRESS,
+            "metadata": {},
         },
         {
             "device_id": reg_device.id,
@@ -137,6 +142,7 @@ async def test_triggers(hass, mock_devices):
             "platform": "device",
             "type": LONG_RELEASE,
             "subtype": LONG_RELEASE,
+            "metadata": {},
         },
     ]
     assert _same_lists(triggers, expected_triggers)
@@ -161,6 +167,7 @@ async def test_no_triggers(hass, mock_devices):
             "platform": "device",
             "type": "device_offline",
             "subtype": "device_offline",
+            "metadata": {},
         }
     ]
 

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -50,6 +50,7 @@ async def test_get_notification_notification_triggers(
         "type": "event.notification.notification",
         "device_id": device.id,
         "command_class": CommandClass.NOTIFICATION,
+        "metadata": {},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -316,6 +317,7 @@ async def test_get_node_status_triggers(hass, client, lock_schlage_be469, integr
         "type": "state.node_status",
         "device_id": device.id,
         "entity_id": entity_id,
+        "metadata": {"secondary": True},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -470,6 +472,7 @@ async def test_get_basic_value_notification_triggers(
         "property_key": None,
         "endpoint": 0,
         "subtype": "Endpoint 0",
+        "metadata": {},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -637,6 +640,7 @@ async def test_get_central_scene_value_notification_triggers(
         "property_key": "001",
         "endpoint": 0,
         "subtype": "Endpoint 0 Scene 001",
+        "metadata": {},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -810,6 +814,7 @@ async def test_get_scene_activation_value_notification_triggers(
         "property_key": None,
         "endpoint": 0,
         "subtype": "Endpoint 0",
+        "metadata": {},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -972,6 +977,7 @@ async def test_get_value_updated_value_triggers(
         "domain": DOMAIN,
         "type": "zwave_js.value_updated.value",
         "device_id": device.id,
+        "metadata": {},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -1132,6 +1138,7 @@ async def test_get_value_updated_config_parameter_triggers(
         "endpoint": 0,
         "command_class": CommandClass.CONFIGURATION.value,
         "subtype": "3 (Beeper)",
+        "metadata": {},
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mark device triggers from hidden or auxiliary entities as secondary.
This is a follow-up to https://github.com/home-assistant/core/pull/70278

A `secondary` flag is set in a `metadata` dict which is added to the device trigger definitions:
`"metadata" : {"secondary": True}`

This can be used by the frontend to not overwhelm the user with a long list of device automations

Set as draft as this PR depends on #70333

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
