### PR TITLE
Allow passing extra play_media data to tts.say

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_EXTRA,
     DOMAIN as DOMAIN_MP,
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
@@ -124,6 +125,7 @@ SCHEMA_SERVICE_SAY = vol.Schema(
         vol.Optional(ATTR_CACHE): cv.boolean,
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
         vol.Optional(ATTR_LANGUAGE): cv.string,
+        vol.Optional(ATTR_MEDIA_EXTRA): dict,
         vol.Optional(ATTR_OPTIONS): dict,
     }
 )
@@ -214,6 +216,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
                 ATTR_ENTITY_ID: entity_ids,
             }
+            if extra := service.data.get(ATTR_MEDIA_EXTRA):
+                data[ATTR_MEDIA_EXTRA] = extra
 
             await hass.services.async_call(
                 DOMAIN_MP,

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -125,7 +125,7 @@ SCHEMA_SERVICE_SAY = vol.Schema(
         vol.Optional(ATTR_CACHE): cv.boolean,
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
         vol.Optional(ATTR_LANGUAGE): cv.string,
-        vol.Optional(ATTR_MEDIA_EXTRA): dict,
+        vol.Optional(ATTR_MEDIA_EXTRA): MEDIA_PLAYER_PLAY_MEDIA_SCHEMA[ATTR_MEDIA_EXTRA],
         vol.Optional(ATTR_OPTIONS): dict,
     }
 )

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -20,6 +20,7 @@ import voluptuous as vol
 import yarl
 
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.media_player import MEDIA_PLAYER_PLAY_MEDIA_SCHEMA
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
@@ -125,7 +126,9 @@ SCHEMA_SERVICE_SAY = vol.Schema(
         vol.Optional(ATTR_CACHE): cv.boolean,
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
         vol.Optional(ATTR_LANGUAGE): cv.string,
-        vol.Optional(ATTR_MEDIA_EXTRA): MEDIA_PLAYER_PLAY_MEDIA_SCHEMA[ATTR_MEDIA_EXTRA],
+        vol.Optional(ATTR_MEDIA_EXTRA): MEDIA_PLAYER_PLAY_MEDIA_SCHEMA[
+            ATTR_MEDIA_EXTRA
+        ],
         vol.Optional(ATTR_OPTIONS): dict,
     }
 )

--- a/homeassistant/components/tts/services.yaml
+++ b/homeassistant/components/tts/services.yaml
@@ -24,6 +24,15 @@ say:
       default: false
       selector:
         boolean:
+    extra:
+      name: Extra play_media` data
+      description:
+        A dictionary containing platform-specific extra data passed to
+        `media_player.play_media`, e.g., enqueue, title, thumbnail.
+      advanced: true
+      example: platform specific
+      selector:
+        object:
     language:
       name: Language
       description: Language to use for speech generation.

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.components.demo.tts import DemoProvider
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_EXTRA,
     DOMAIN as DOMAIN_MP,
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
@@ -87,11 +88,11 @@ async def test_setup_component_and_test_service(hass, empty_cache_dir):
     )
 
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-    assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
-    )
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_CONTENT_ID: "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
     await hass.async_block_till_done()
     assert (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
@@ -119,11 +120,11 @@ async def test_setup_component_and_test_service_with_config_language(
         blocking=True,
     )
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-    assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
-    )
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_CONTENT_ID: "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
     await hass.async_block_till_done()
     assert (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
@@ -154,11 +155,11 @@ async def test_setup_component_and_test_service_with_config_language_special(
         blocking=True,
     )
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-    assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_demo.mp3"
-    )
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_CONTENT_ID: "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
     await hass.async_block_till_done()
     assert (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_demo.mp3"
@@ -195,11 +196,11 @@ async def test_setup_component_and_test_service_with_service_language(
         blocking=True,
     )
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-    assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
-    )
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_CONTENT_ID: "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
     await hass.async_block_till_done()
     assert (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
@@ -259,11 +260,11 @@ async def test_setup_component_and_test_service_with_service_options(
     opt_hash = tts._hash_options({"voice": "alex", "age": 5})
 
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-    assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == f"http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3"
-    )
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_CONTENT_ID: f"http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
     await hass.async_block_till_done()
     assert (
         empty_cache_dir
@@ -296,11 +297,11 @@ async def test_setup_component_and_test_with_service_options_def(hass, empty_cac
         opt_hash = tts._hash_options({"voice": "alex"})
 
         assert len(calls) == 1
-        assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-        assert (
-            calls[0].data[ATTR_MEDIA_CONTENT_ID]
-            == f"http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3"
-        )
+        assert calls[0].data == {
+            tts.ATTR_ENTITY_ID: ["media_player.something"],
+            ATTR_MEDIA_CONTENT_ID: f"http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3",
+            ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+        }
         await hass.async_block_till_done()
         assert (
             empty_cache_dir
@@ -359,12 +360,11 @@ async def test_setup_component_and_test_service_with_base_url_set(hass):
         blocking=True,
     )
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-    assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID] == "http://fnord"
-        "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-        "_en_-_demo.mp3"
-    )
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_CONTENT_ID: "http://fnord/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
 
 
 async def test_setup_component_and_test_service_clear_cache(hass, empty_cache_dir):
@@ -729,3 +729,39 @@ def test_invalid_base_url(value):
     """Test we catch bad base urls."""
     with pytest.raises(vol.Invalid):
         tts.valid_base_url(value)
+
+
+async def test_setup_component_and_test_service_with_extra_play_media(
+    hass, empty_cache_dir
+):
+    """Set up the demo platform and call service with extra play_media data."""
+    calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+    config = {tts.DOMAIN: {"platform": "demo"}}
+
+    with assert_setup_component(1, tts.DOMAIN):
+        assert await async_setup_component(hass, tts.DOMAIN, config)
+
+    await hass.services.async_call(
+        tts.DOMAIN,
+        "demo_say",
+        {
+            "entity_id": "media_player.something",
+            tts.ATTR_MESSAGE: "There is someone at the door.",
+            tts.ATTR_LANGUAGE: "de",
+            ATTR_MEDIA_EXTRA: {"enqueue": True},
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {
+        tts.ATTR_ENTITY_ID: ["media_player.something"],
+        ATTR_MEDIA_EXTRA: {"enqueue": True},
+        ATTR_MEDIA_CONTENT_ID: "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3",
+        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+    }
+    await hass.async_block_till_done()
+    assert (
+        empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
+    ).is_file()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow passing extra `play_media` data to `tts.say`

This makes it simple to enqueue tts messages for media player platforms which support enqueuing (for example Google Cast) if the media player is already playing a tts message:

```yaml
service: tts.google_say
data:
  entity_id: media_player.lab
  message: >-
    This is a test. It's a very very good test. I'll soon tell you which test it
    is if you want to know. Are you ready? It's test number 1!
  extra:
    enqueue: true
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
