### PR TITLE
Fix Plugwise to not use invalid discovery data

### DIFF
--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -92,8 +92,26 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         _properties = discovery_info.properties
 
         unique_id = discovery_info.hostname.split(".")[0]
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured({CONF_HOST: discovery_info.host})
+        if config_entry := await self.async_set_unique_id(unique_id):
+            try:
+                await validate_gw_input(
+                    self.hass,
+                    {
+                        CONF_HOST: discovery_info.host,
+                        CONF_PORT: discovery_info.port,
+                        CONF_USERNAME: config_entry.data[CONF_USERNAME],
+                        CONF_PASSWORD: config_entry.data[CONF_PASSWORD],
+                    },
+                )
+            except Exception:  # pylint: disable=broad-except
+                self._abort_if_unique_id_configured()
+            else:
+                self._abort_if_unique_id_configured(
+                    {
+                        CONF_HOST: discovery_info.host,
+                        CONF_PORT: discovery_info.port,
+                    }
+                )
 
         if DEFAULT_USERNAME not in unique_id:
             self._username = STRETCH_USERNAME

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -197,18 +197,38 @@ async def test_zeroconf_flow_stretch(
     assert len(mock_smile_config_flow.connect.mock_calls) == 1
 
 
-async def test_zercoconf_discovery_update_configuration(hass: HomeAssistant) -> None:
+async def test_zercoconf_discovery_update_configuration(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_smile_config_flow: MagicMock,
+) -> None:
     """Test if a discovered device is configured and updated with new host."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title=CONF_NAME,
-        data={CONF_HOST: "0.0.0.0", CONF_PASSWORD: TEST_PASSWORD},
+        data={
+            CONF_HOST: "0.0.0.0",
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+        },
         unique_id=TEST_HOSTNAME,
     )
     entry.add_to_hass(hass)
 
     assert entry.data[CONF_HOST] == "0.0.0.0"
 
+    # Test that an invalid discovery doesn't update the entry
+    mock_smile_config_flow.connect.side_effect = ConnectionFailedError
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_ZEROCONF},
+        data=TEST_DISCOVERY,
+    )
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "already_configured"
+    assert entry.data[CONF_HOST] == "0.0.0.0"
+
+    mock_smile_config_flow.connect.side_effect = None
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When discovery data comes in, currently the Plugwise integration will just update the configuration entry based on the unique ID. However, it doesn't test if this information
is actually valid/usable.

This PR adjusts that behavior to ensure the data found actually works.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69896
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
