### PR TITLE
Detect duplicate script objects in config validation

### DIFF
--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_REQUIRED,
     CONF_TRACE,
     DOMAIN,
+    LOGGER,
 )
 from .helpers import async_get_blueprints
 
@@ -111,7 +112,8 @@ async def async_validate_config(hass, config):
     for _, p_config in config_per_platform(config, DOMAIN):
         for object_id, cfg in p_config.items():
             if object_id in scripts:
-                raise vol.Invalid(f"Duplicate script detected with name: '{object_id}'")
+                LOGGER.warning("Duplicate script detected with name: '%s'", object_id)
+                continue
             cfg = await _try_async_validate_config_item(hass, object_id, cfg, config)
             if cfg is not None:
                 scripts[object_id] = cfg

--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -110,6 +110,8 @@ async def async_validate_config(hass, config):
     scripts = {}
     for _, p_config in config_per_platform(config, DOMAIN):
         for object_id, cfg in p_config.items():
+            if object_id in scripts:
+                raise vol.Invalid(f"Duplicate script detected with name: '{object_id}'")
             cfg = await _try_async_validate_config_item(hass, object_id, cfg, config)
             if cfg is not None:
                 scripts[object_id] = cfg

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -917,7 +917,7 @@ async def test_setup_with_duplicate_scripts(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test setup with duplicate configs."""
-    assert not await async_setup_component(
+    assert await async_setup_component(
         hass,
         "script",
         {
@@ -934,4 +934,4 @@ async def test_setup_with_duplicate_scripts(
         },
     )
     assert "Duplicate script detected with name: 'duplicate'" in caplog.text
-    assert len(hass.states.async_entity_ids("script")) == 0
+    assert len(hass.states.async_entity_ids("script")) == 1

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -911,3 +911,27 @@ async def test_recursive_script_indirect(hass, script_mode, warning_msg, caplog)
     await asyncio.wait_for(service_called.wait(), 1)
 
     assert warning_msg in caplog.text
+
+
+async def test_setup_with_duplicate_scripts(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test setup with duplicate configs."""
+    assert not await async_setup_component(
+        hass,
+        "script",
+        {
+            "script one": {
+                "duplicate": {
+                    "sequence": [],
+                },
+            },
+            "script two": {
+                "duplicate": {
+                    "sequence": [],
+                },
+            },
+        },
+    )
+    assert "Duplicate script detected with name: 'duplicate'" in caplog.text
+    assert len(hass.states.async_entity_ids("script")) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a valid configuration right now:

```yaml
script one:
  example:
    alias: script 1
    sequence: []

script two:
  example:
    alias: script 2
    sequence: []
```

But you'll end up having just one `example` script ("script 2"). They overwrite each other without warnings or errors.

This makes a small adjustment to the configuration check to detect these cases.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
