### PR TITLE
Add calendar event end trigger

### DIFF
--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -79,10 +79,9 @@ class CalendarEventListener:
             self._unsub_refresh()
         self._unsub_refresh = None
 
-    async def _fetch_events(self, now: datetime.datetime) -> None:
+    async def _fetch_events(self, last_endtime: datetime.datetime) -> None:
         """Update the set of eligible events."""
-        last_endtime = now
-        end_time = now + UPDATE_INTERVAL
+        end_time = last_endtime + UPDATE_INTERVAL
         _LOGGER.debug("Fetching events between %s, %s", last_endtime, end_time)
         events = await self._entity.async_get_events(self._hass, last_endtime, end_time)
 

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -81,10 +81,10 @@ class CalendarEventListener:
 
     async def _fetch_events(self, now: datetime.datetime) -> None:
         """Update the set of eligible events."""
-        start_date = now
-        end_date = now + UPDATE_INTERVAL
-        _LOGGER.debug("Fetching events between %s, %s", start_date, end_date)
-        events = await self._entity.async_get_events(self._hass, start_date, end_date)
+        last_endtime = now
+        end_time = now + UPDATE_INTERVAL
+        _LOGGER.debug("Fetching events between %s, %s", last_endtime, end_time)
+        events = await self._entity.async_get_events(self._hass, last_endtime, end_time)
 
         # Build list of events and the appropriate time to trigger an alarm. The
         # returned events may have already started but matched the start/end time
@@ -97,7 +97,7 @@ class CalendarEventListener:
                 if self._event_type == EVENT_START
                 else event.end_datetime_local
             )
-            if event_time > now:
+            if event_time > last_endtime:
                 event_list.append((event_time, event))
         event_list.sort(key=lambda x: x[0])
         self._events = event_list

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -19,7 +19,7 @@ import pytest
 
 from homeassistant.components import calendar
 import homeassistant.components.automation as automation
-from homeassistant.components.calendar.trigger import EVENT_START
+from homeassistant.components.calendar.trigger import EVENT_END, EVENT_START
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -189,10 +189,38 @@ async def test_event_start_trigger(hass, calls, fake_schedule):
     ]
 
 
+async def test_event_end_trigger(hass, calls, fake_schedule):
+    """Test the a calendar trigger based on end time."""
+    event_data = fake_schedule.create_event(
+        start=datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
+        end=datetime.datetime.fromisoformat("2022-04-19 12:00:00+00:00"),
+    )
+    await create_automation(hass, EVENT_END)
+
+    # Event started, nothing should fire yet
+    await fake_schedule.fire_until(
+        datetime.datetime.fromisoformat("2022-04-19 11:10:00+00:00")
+    )
+    assert len(calls()) == 0
+
+    # Event ends
+    await fake_schedule.fire_until(
+        datetime.datetime.fromisoformat("2022-04-19 12:10:00+00:00")
+    )
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_END,
+            "calendar_event": event_data,
+        }
+    ]
+
+
 async def test_calendar_trigger_with_no_events(hass, calls, fake_schedule):
     """Test a calendar trigger setup  with no events."""
 
     await create_automation(hass, EVENT_START)
+    await create_automation(hass, EVENT_END)
 
     # No calls, at arbitrary times
     await fake_schedule.fire_until(
@@ -201,7 +229,7 @@ async def test_calendar_trigger_with_no_events(hass, calls, fake_schedule):
     assert len(calls()) == 0
 
 
-async def test_multiple_events(hass, calls, fake_schedule):
+async def test_multiple_start_events(hass, calls, fake_schedule):
     """Test that a trigger fires for multiple events."""
 
     event_data1 = fake_schedule.create_event(
@@ -226,6 +254,36 @@ async def test_multiple_events(hass, calls, fake_schedule):
         {
             "platform": "calendar",
             "event": EVENT_START,
+            "calendar_event": event_data2,
+        },
+    ]
+
+
+async def test_multiple_end_events(hass, calls, fake_schedule):
+    """Test that a trigger fires for multiple events."""
+
+    event_data1 = fake_schedule.create_event(
+        start=datetime.datetime.fromisoformat("2022-04-19 10:45:00+00:00"),
+        end=datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
+    )
+    event_data2 = fake_schedule.create_event(
+        start=datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
+        end=datetime.datetime.fromisoformat("2022-04-19 11:15:00+00:00"),
+    )
+    await create_automation(hass, EVENT_END)
+
+    await fake_schedule.fire_until(
+        datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00")
+    )
+    assert calls() == [
+        {
+            "platform": "calendar",
+            "event": EVENT_END,
+            "calendar_event": event_data1,
+        },
+        {
+            "platform": "calendar",
+            "event": EVENT_END,
             "calendar_event": event_data2,
         },
     ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to trigger an automation from the end of an event.

Overall set of PRs for triggers:
- [X] Typing cleanup (https://github.com/home-assistant/core/pull/68660)
- [X] Add initial trigger for start events (getting scaffolding all setup) ([this PR](https://github.com/home-assistant/core/pull/68674))
- [X] Frontend (https://github.com/home-assistant/frontend/pull/12343)
- [X] Add trigger for end events (this pr)
- [ ] Add offset support

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/22328
- Related arch discussion: https://github.com/home-assistant/architecture/discussions/700


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
