### PR TITLE
Add verisure lock method attribute

### DIFF
--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -98,7 +98,6 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     def changed_by(self) -> str | None:
         """Last change triggered by."""
         return self.coordinator.data["locks"][self.serial_number].get("userString")
-    
     @property
     def changed_method(self) -> str:
         """Last change method."""
@@ -116,7 +115,6 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
             self.coordinator.data["locks"][self.serial_number]["lockedState"]
             == "LOCKED"
         )
-    
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -99,7 +99,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
         """Last change triggered by."""
         return self.coordinator.data["locks"][self.serial_number].get("userString")
 
-        @property
+    @property
     def changed_method(self) -> str:
         """Last change method."""
         return self.coordinator.data["locks"][self.serial_number]["method"]
@@ -117,7 +117,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
             == "LOCKED"
         )
 
-        @property
+    @property
     def extra_state_attributes(self):
         """Return the state attributes."""
         return {"method": self.changed_method}

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -98,7 +98,8 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     def changed_by(self) -> str | None:
         """Last change triggered by."""
         return self.coordinator.data["locks"][self.serial_number].get("userString")
-    @property
+
+        @property
     def changed_method(self) -> str:
         """Last change method."""
         return self.coordinator.data["locks"][self.serial_number]["method"]
@@ -115,7 +116,8 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
             self.coordinator.data["locks"][self.serial_number]["lockedState"]
             == "LOCKED"
         )
-    @property
+
+        @property
     def extra_state_attributes(self):
         """Return the state attributes."""
         return {"method": self.changed_method}

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -102,7 +102,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     @property
     def changed_method(self) -> str | None:
         """Last change method."""
-        return self.coordinator.data["locks"][self.serial_number].get("method")
+        return self.coordinator.data["locks"][self.serial_number]["method"]
 
     @property
     def code_format(self) -> str:

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -100,7 +100,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
         return self.coordinator.data["locks"][self.serial_number].get("userString")
     
     @property
-    def changed_method(self) -> str | None:
+    def changed_method(self) -> str:
         """Last change method."""
         return self.coordinator.data["locks"][self.serial_number]["method"]
 

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -98,6 +98,11 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     def changed_by(self) -> str | None:
         """Last change triggered by."""
         return self.coordinator.data["locks"][self.serial_number].get("userString")
+    
+    @property
+    def changed_method(self) -> str | None:
+        """Last change method."""
+        return self.coordinator.data["locks"][self.serial_number].get("method")
 
     @property
     def code_format(self) -> str:

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -116,6 +116,11 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
             self.coordinator.data["locks"][self.serial_number]["lockedState"]
             == "LOCKED"
         )
+    
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {"method": self.changed_method}
 
     async def async_unlock(self, **kwargs) -> None:
         """Send unlock command."""


### PR DESCRIPTION
Get method of change. Use to see if door was locked/unlocked from inside our outside. Usable to arm/disarm alarms, turn on/off lights, heating and so on.

From Raw debug file ("Download Diagnostics" In the "Device Info" panel of the lock Device):

Locked from inside:
 "method": "THUMB",
  "lockedState": "LOCKED",

Unlocked from inside:
"method": "THUMB",
"lockedState": "UNLOCKED",

Locked from outside:
"method": "STAR",
"lockedState": "LOCKED",

Unlocked from outside:
"method": "CODE",
"lockedState": "UNLOCKED",

Locked from Verisure App:
"method": "REMOTE",
"lockedState": "LOCKED",

Unlocked from Verisure App:
"method": "REMOTE",
"lockedState": "UNLOCKED",

Automatically locked:
 "method": "AUTO",
 "lockedState": "LOCKED",

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22612

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
