### PR TITLE
Add unique ID to energy sensors

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -421,12 +421,10 @@ class EnergyCostSensor(SensorEntity):
     def unique_id(self) -> str | None:
         """Return the unique ID of the sensor."""
         entity_registry = er.async_get(self.hass)
-        if (
-            registry_entry := entity_registry.async_get(
-                self._config[self._adapter.entity_energy_key]
-            )
-        ) and registry_entry.unique_id:
-            prefix = registry_entry.unique_id
+        if registry_entry := entity_registry.async_get(
+            self._config[self._adapter.entity_energy_key]
+        ):
+            prefix = registry_entry.id
         else:
             prefix = self._config[self._adapter.entity_energy_key]
 

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.core import (
     split_entity_id,
     valid_entity_id,
 )
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -210,7 +210,7 @@ class EnergyCostSensor(SensorEntity):
     utility.
     """
 
-    _attr_entity_category = EntityCategory.SYSTEM
+    _attr_entity_registry_visible_default = False
     _wrong_state_class_reported = False
     _wrong_unit_reported = False
 
@@ -416,3 +416,18 @@ class EnergyCostSensor(SensorEntity):
     def native_unit_of_measurement(self) -> str | None:
         """Return the units of measurement."""
         return self.hass.config.currency
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID of the sensor."""
+        entity_registry = er.async_get(self.hass)
+        if (
+            registry_entry := entity_registry.async_get(
+                self._config[self._adapter.entity_energy_key]
+            )
+        ) and registry_entry.unique_id:
+            prefix = registry_entry.unique_id
+        else:
+            prefix = self._config[self._adapter.entity_energy_key]
+
+        return f"{prefix}_{self._adapter.source_type}_{self._adapter.entity_id_suffix}"

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -191,8 +191,9 @@ async def test_cost_sensor_price_entity_total_increasing(
     entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(cost_sensor_entity_id)
     assert entry
-    postfix = "cost" if flow_type == "flow_to" else "compensation"
-    assert entry.unique_id == f"{usage_sensor_entity_id}_grid_entity_energy_{postfix}"
+    postfix = "cost" if flow_type == "flow_from" else "compensation"
+    assert entry.unique_id == f"{usage_sensor_entity_id}_grid_{postfix}"
+    assert entry.hidden_by is er.RegistryEntryHider.INTEGRATION
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -399,6 +400,7 @@ async def test_cost_sensor_price_entity_total(
     assert entry
     postfix = "cost" if flow_type == "flow_from" else "compensation"
     assert entry.unique_id == f"{usage_sensor_entity_id}_grid_{postfix}"
+    assert entry.hidden_by is er.RegistryEntryHider.INTEGRATION
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -605,6 +607,7 @@ async def test_cost_sensor_price_entity_total_no_reset(
     assert entry
     postfix = "cost" if flow_type == "flow_from" else "compensation"
     assert entry.unique_id == f"{usage_sensor_entity_id}_grid_{postfix}"
+    assert entry.hidden_by is er.RegistryEntryHider.INTEGRATION
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -1068,3 +1071,4 @@ async def test_inherit_source_unique_id(hass, hass_storage, setup_integration):
     entry = entity_registry.async_get("sensor.gas_consumption_cost")
     assert entry
     assert entry.unique_id == "123456_gas_cost"
+    assert entry.hidden_by is er.RegistryEntryHider.INTEGRATION

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     VOLUME_CUBIC_METERS,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -187,10 +188,11 @@ async def test_cost_sensor_price_entity_total_increasing(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
-    # # Unique ID temp disabled
-    # # entity_registry = er.async_get(hass)
-    # # entry = entity_registry.async_get(cost_sensor_entity_id)
-    # # assert entry.unique_id == "energy_energy_consumption cost"
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(cost_sensor_entity_id)
+    assert entry
+    postfix = "cost" if flow_type == "flow_to" else "compensation"
+    assert entry.unique_id == f"{usage_sensor_entity_id}_grid_entity_energy_{postfix}"
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -392,10 +394,11 @@ async def test_cost_sensor_price_entity_total(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
-    # # Unique ID temp disabled
-    # # entity_registry = er.async_get(hass)
-    # # entry = entity_registry.async_get(cost_sensor_entity_id)
-    # # assert entry.unique_id == "energy_energy_consumption cost"
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(cost_sensor_entity_id)
+    assert entry
+    postfix = "cost" if flow_type == "flow_from" else "compensation"
+    assert entry.unique_id == f"{usage_sensor_entity_id}_grid_{postfix}"
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -597,10 +600,11 @@ async def test_cost_sensor_price_entity_total_no_reset(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
-    # # Unique ID temp disabled
-    # # entity_registry = er.async_get(hass)
-    # # entry = entity_registry.async_get(cost_sensor_entity_id)
-    # # assert entry.unique_id == "energy_energy_consumption cost"
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(cost_sensor_entity_id)
+    assert entry
+    postfix = "cost" if flow_type == "flow_from" else "compensation"
+    assert entry.unique_id == f"{usage_sensor_entity_id}_grid_{postfix}"
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -1018,3 +1022,49 @@ async def test_cost_sensor_state_class_measurement_no_reset(
 
     state = hass.states.get("sensor.energy_consumption_cost")
     assert state.state == STATE_UNKNOWN
+
+
+async def test_inherit_source_unique_id(hass, hass_storage, setup_integration):
+    """Test sensor inherits unique ID from source."""
+    energy_data = data.EnergyManager.default_preferences()
+    energy_data["energy_sources"].append(
+        {
+            "type": "gas",
+            "stat_energy_from": "sensor.gas_consumption",
+            "entity_energy_from": "sensor.gas_consumption",
+            "stat_cost": None,
+            "entity_energy_price": None,
+            "number_energy_price": 0.5,
+        }
+    )
+
+    hass_storage[data.STORAGE_KEY] = {
+        "version": 1,
+        "data": energy_data,
+    }
+
+    now = dt_util.utcnow()
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor", "test", "123456", suggested_object_id="gas_consumption"
+    )
+
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        100,
+        {
+            ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
+        },
+    )
+
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        await setup_integration(hass)
+
+    state = hass.states.get("sensor.gas_consumption_cost")
+    assert state
+    assert state.state == "0.0"
+
+    entry = entity_registry.async_get("sensor.gas_consumption_cost")
+    assert entry
+    assert entry.unique_id == "123456_gas_cost"

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -1048,7 +1048,7 @@ async def test_inherit_source_unique_id(hass, hass_storage, setup_integration):
 
     now = dt_util.utcnow()
     entity_registry = er.async_get(hass)
-    entity_registry.async_get_or_create(
+    source_entry = entity_registry.async_get_or_create(
         "sensor", "test", "123456", suggested_object_id="gas_consumption"
     )
 
@@ -1070,5 +1070,5 @@ async def test_inherit_source_unique_id(hass, hass_storage, setup_integration):
 
     entry = entity_registry.async_get("sensor.gas_consumption_cost")
     assert entry
-    assert entry.unique_id == "123456_gas_cost"
+    assert entry.unique_id == f"{source_entry.id}_gas_cost"
     assert entry.hidden_by is er.RegistryEntryHider.INTEGRATION


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The internal cost and compensation sensor entities, used by the energy dashboard of Home Assistant, are now hidden by default. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Uses the unique ID of the source entity when available.

needs #70370

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/pull/69845
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
