### PR TITLE
Update pylint to 2.13.7

### DIFF
--- a/homeassistant/components/xiaomi_miio/diagnostics.py
+++ b/homeassistant/components/xiaomi_miio/diagnostics.py
@@ -1,6 +1,8 @@
 """Diagnostics support for Xiaomi Miio."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC, CONF_TOKEN, CONF_UNIQUE_ID
@@ -19,9 +21,9 @@ TO_REDACT = {
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
-) -> dict:
+) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    diagnostics_data = {
+    diagnostics_data: dict[str, Any] = {
         "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT)
     }
 
@@ -30,6 +32,6 @@ async def async_get_config_entry_diagnostics(
         if isinstance(coordinator.data, dict):
             diagnostics_data["coordinator_data"] = coordinator.data
         else:
-            diagnostics_data["coordinator_data"] = coordinator.data.__repr__()
+            diagnostics_data["coordinator_data"] = repr(coordinator.data)
 
     return diagnostics_data

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -70,7 +70,7 @@ async def async_process_integration_platform_for_component(
     are created.
     """
     if DATA_INTEGRATION_PLATFORMS not in hass.data:
-        # There are no integraton platforms loaded yet
+        # There are no integration platforms loaded yet
         return
     integration_platforms: list[IntegrationPlatform] = hass.data[
         DATA_INTEGRATION_PLATFORMS

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -828,7 +828,6 @@ class TemplateState(TemplateStateBase):
     __slots__ = ("_state",)
 
     # Inheritance is done so functions that check against State keep working
-    # pylint: disable=super-init-not-called
     def __init__(self, hass: HomeAssistant, state: State, collect: bool = True) -> None:
         """Initialize template state."""
         super().__init__(hass, collect, state.entity_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ good-names = [
 # consider-using-assignment-expr (Pylint CodeStyle extension)
 disable = [
     "format",
-    "abstract-class-little-used",
     "abstract-method",
     "cyclic-import",
     "duplicate-code",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.2.1
 mock-open==1.4.0
 mypy==0.942
 pre-commit==2.17.0
-pylint==2.13.5
+pylint==2.13.7
 pipdeptree==2.2.1
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Proposed change
Update pylint from `2.13.5` to `2.13.7`. Mainly bug fixes.
Changelog 2.13.7: https://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-13-7
Changelog 2.13.6: https://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-13-6
Compare view: https://github.com/PyCQA/pylint/compare/v2.13.5...v2.13.7

Include some minor code changes
* Change `__repr__` usage to `repr(...)`
* Removed unused disable comment
* Remove `abstract-class-little-used` from disabled checker list. The check doesn't exist anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
