### PR TITLE
tts.say to use media source URLs

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
 )
+from homeassistant.components.media_source import generate_media_source_id
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DESCRIPTION,
@@ -104,17 +105,20 @@ def valid_base_url(value: str) -> str:
     return normalize_url(value)
 
 
-PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_PLATFORM): vol.All(cv.string, _deprecated_platform),
-        vol.Optional(CONF_CACHE, default=DEFAULT_CACHE): cv.boolean,
-        vol.Optional(CONF_CACHE_DIR, default=DEFAULT_CACHE_DIR): cv.string,
-        vol.Optional(CONF_TIME_MEMORY, default=DEFAULT_TIME_MEMORY): vol.All(
-            vol.Coerce(int), vol.Range(min=60, max=57600)
-        ),
-        vol.Optional(CONF_BASE_URL): valid_base_url,
-        vol.Optional(CONF_SERVICE_NAME): cv.string,
-    }
+PLATFORM_SCHEMA = vol.All(
+    cv.PLATFORM_SCHEMA.extend(
+        {
+            vol.Required(CONF_PLATFORM): vol.All(cv.string, _deprecated_platform),
+            vol.Optional(CONF_CACHE, default=DEFAULT_CACHE): cv.boolean,
+            vol.Optional(CONF_CACHE_DIR, default=DEFAULT_CACHE_DIR): cv.string,
+            vol.Optional(CONF_TIME_MEMORY, default=DEFAULT_TIME_MEMORY): vol.All(
+                vol.Coerce(int), vol.Range(min=60, max=57600)
+            ),
+            vol.Optional(CONF_BASE_URL): valid_base_url,
+            vol.Optional(CONF_SERVICE_NAME): cv.string,
+        }
+    ),
+    cv.deprecated(CONF_BASE_URL),
 )
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE.extend(PLATFORM_SCHEMA.schema)
 
@@ -197,6 +201,34 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             cache = service.data.get(ATTR_CACHE)
             language = service.data.get(ATTR_LANGUAGE)
             options = service.data.get(ATTR_OPTIONS)
+
+            if tts.base_url is None or tts.base_url == get_url(hass):
+                tts.process_options(p_type, language, options)
+                params = {
+                    "message": message,
+                }
+                if cache is not None:
+                    params["cache"] = "true" if cache else "false"
+                if language is not None:
+                    params["language"] = language
+                if options is not None:
+                    params.update(options)
+
+                await hass.services.async_call(
+                    DOMAIN_MP,
+                    SERVICE_PLAY_MEDIA,
+                    {
+                        ATTR_ENTITY_ID: entity_ids,
+                        ATTR_MEDIA_CONTENT_ID: generate_media_source_id(
+                            DOMAIN,
+                            str(yarl.URL.build(path=p_type, query=params)),
+                        ),
+                        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+                    },
+                    blocking=True,
+                    context=service.context,
+                )
+                return
 
             try:
                 url = await tts.async_get_url_path(
@@ -344,23 +376,16 @@ class SpeechManager:
             PLATFORM_FORMAT.format(domain=engine, platform=DOMAIN)
         )
 
-    async def async_get_url_path(
+    @callback
+    def process_options(
         self,
         engine: str,
-        message: str,
-        cache: bool | None = None,
         language: str | None = None,
         options: dict | None = None,
-    ) -> str:
-        """Get URL for play message.
-
-        This method is a coroutine.
-        """
+    ) -> tuple[str, dict | None]:
+        """Validate and process options."""
         if (provider := self.providers.get(engine)) is None:
             raise HomeAssistantError(f"Provider {engine} not found")
-
-        msg_hash = hashlib.sha1(bytes(message, "utf-8")).hexdigest()
-        use_cache = cache if cache is not None else self.use_cache
 
         # Languages
         language = language or provider.default_language
@@ -382,9 +407,25 @@ class SpeechManager:
             ]
             if invalid_opts:
                 raise HomeAssistantError(f"Invalid options found: {invalid_opts}")
-            options_key = _hash_options(options)
-        else:
-            options_key = "-"
+
+        return language, options
+
+    async def async_get_url_path(
+        self,
+        engine: str,
+        message: str,
+        cache: bool | None = None,
+        language: str | None = None,
+        options: dict | None = None,
+    ) -> str:
+        """Get URL for play message.
+
+        This method is a coroutine.
+        """
+        language, options = self.process_options(engine, language, options)
+        options_key = _hash_options(options) if options else "-"
+        msg_hash = hashlib.sha1(bytes(message, "utf-8")).hexdigest()
+        use_cache = cache if cache is not None else self.use_cache
 
         key = KEY_PATTERN.format(
             msg_hash, language.replace("_", "-"), options_key, engine

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -105,20 +105,17 @@ def valid_base_url(value: str) -> str:
     return normalize_url(value)
 
 
-PLATFORM_SCHEMA = vol.All(
-    cv.PLATFORM_SCHEMA.extend(
-        {
-            vol.Required(CONF_PLATFORM): vol.All(cv.string, _deprecated_platform),
-            vol.Optional(CONF_CACHE, default=DEFAULT_CACHE): cv.boolean,
-            vol.Optional(CONF_CACHE_DIR, default=DEFAULT_CACHE_DIR): cv.string,
-            vol.Optional(CONF_TIME_MEMORY, default=DEFAULT_TIME_MEMORY): vol.All(
-                vol.Coerce(int), vol.Range(min=60, max=57600)
-            ),
-            vol.Optional(CONF_BASE_URL): valid_base_url,
-            vol.Optional(CONF_SERVICE_NAME): cv.string,
-        }
-    ),
-    cv.deprecated(CONF_BASE_URL),
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_PLATFORM): vol.All(cv.string, _deprecated_platform),
+        vol.Optional(CONF_CACHE, default=DEFAULT_CACHE): cv.boolean,
+        vol.Optional(CONF_CACHE_DIR, default=DEFAULT_CACHE_DIR): cv.string,
+        vol.Optional(CONF_TIME_MEMORY, default=DEFAULT_TIME_MEMORY): vol.All(
+            vol.Coerce(int), vol.Range(min=60, max=57600)
+        ),
+        vol.Optional(CONF_BASE_URL): valid_base_url,
+        vol.Optional(CONF_SERVICE_NAME): cv.string,
+    }
 )
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE.extend(PLATFORM_SCHEMA.schema)
 
@@ -145,6 +142,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         cache_dir = conf.get(CONF_CACHE_DIR, DEFAULT_CACHE_DIR)
         time_memory = conf.get(CONF_TIME_MEMORY, DEFAULT_TIME_MEMORY)
         base_url = conf.get(CONF_BASE_URL)
+        if base_url is not None:
+            _LOGGER.warning(
+                "TTS base_url option is deprecated. Configure internal/external URL instead"
+            )
         hass.data[BASE_URL_KEY] = base_url
 
         await tts.async_init_cache(use_cache, cache_dir, time_memory, base_url)

--- a/homeassistant/components/tts/media_source.py
+++ b/homeassistant/components/tts/media_source.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import mimetypes
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from yarl import URL
 
@@ -46,17 +46,19 @@ class TTSMediaSource(MediaSource):
             raise Unresolvable("No message specified.")
 
         options = dict(parsed.query)
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "engine": parsed.name,
             "message": options.pop("message"),
             "language": options.pop("language", None),
             "options": options,
         }
+        if "cache" in options:
+            kwargs["cache"] = options.pop("cache") == "true"
 
         manager: SpeechManager = self.hass.data[DOMAIN]
 
         try:
-            url = await manager.async_get_url_path(**kwargs)  # type: ignore[arg-type]
+            url = await manager.async_get_url_path(**kwargs)
         except HomeAssistantError as err:
             raise Unresolvable(str(err)) from err
 

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -6,17 +6,27 @@ from unittest.mock import patch
 from gtts import gTTSError
 import pytest
 
+from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
-import homeassistant.components.tts as tts
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
 from tests.components.tts.conftest import mutagen_mock  # noqa: F401
+
+
+async def get_media_source_url(hass, media_content_id):
+    """Get the media source url."""
+    if media_source.DOMAIN not in hass.config.components:
+        assert await async_setup_component(hass, media_source.DOMAIN, {})
+
+    resolved = await media_source.async_resolve_media(hass, media_content_id)
+    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -67,8 +77,9 @@ async def test_service_say(hass, mock_gtts, calls):
     )
 
     assert len(calls) == 1
+    url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2
-    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
+    assert url.endswith(".mp3")
 
     assert mock_gtts.mock_calls[0][2] == {
         "text": "There is a person at the front door.",
@@ -96,6 +107,7 @@ async def test_service_say_german_config(hass, mock_gtts, calls):
     )
 
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
         "text": "There is a person at the front door.",
@@ -124,6 +136,7 @@ async def test_service_say_german_service(hass, mock_gtts, calls):
     )
 
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
         "text": "There is a person at the front door.",
@@ -148,5 +161,7 @@ async def test_service_say_error(hass, mock_gtts, calls):
         blocking=True,
     )
 
-    assert len(calls) == 0
+    assert len(calls) == 1
+    with pytest.raises(HomeAssistantError):
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -5,15 +5,24 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
-import homeassistant.components.tts as tts
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
+
+
+async def get_media_source_url(hass, media_content_id):
+    """Get the media source url."""
+    if media_source.DOMAIN not in hass.config.components:
+        assert await async_setup_component(hass, media_source.DOMAIN, {})
+
+    resolved = await media_source.async_resolve_media(hass, media_content_id)
+    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -58,11 +67,13 @@ async def test_service_say(hass):
             blocking=True,
         )
 
+        url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+
     mock_speak.assert_called_once()
     mock_speak.assert_called_with("HomeAssistant", {})
 
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".wav") != -1
+    assert url.endswith(".wav")
 
 
 async def test_service_say_with_effect(hass):
@@ -89,11 +100,13 @@ async def test_service_say_with_effect(hass):
             blocking=True,
         )
 
+        url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+
     mock_speak.assert_called_once()
     mock_speak.assert_called_with("HomeAssistant", {"Volume": "amount:2.0;"})
 
     assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".wav") != -1
+    assert url.endswith(".wav")
 
 
 async def test_service_say_http_error(hass):
@@ -120,5 +133,7 @@ async def test_service_say_http_error(hass):
         )
         await hass.async_block_till_done()
 
+        with pytest.raises(Exception):
+            await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+
     mock_speak.assert_called_once()
-    assert len(calls) == 0

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -4,9 +4,8 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 import voluptuous as vol
-import yarl
 
-from homeassistant.components import tts
+from homeassistant.components import media_source, tts
 from homeassistant.components.demo.tts import DemoProvider
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
@@ -16,6 +15,7 @@ from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
 )
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.util.network import normalize_url
 
@@ -24,9 +24,13 @@ from tests.common import assert_setup_component, async_mock_service
 ORIG_WRITE_TAGS = tts.SpeechManager.write_tags
 
 
-def relative_url(url):
-    """Convert an absolute url to a relative one."""
-    return str(yarl.URL(url).relative())
+async def get_media_source_url(hass, media_content_id):
+    """Get the media source url."""
+    if media_source.DOMAIN not in hass.config.components:
+        assert await async_setup_component(hass, media_source.DOMAIN, {})
+
+    resolved = await media_source.async_resolve_media(hass, media_content_id)
+    return resolved.url
 
 
 @pytest.fixture
@@ -89,8 +93,8 @@ async def test_setup_component_and_test_service(hass, empty_cache_dir):
     assert len(calls) == 1
     assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
     assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
     )
     await hass.async_block_till_done()
     assert (
@@ -121,8 +125,8 @@ async def test_setup_component_and_test_service_with_config_language(
     assert len(calls) == 1
     assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
     assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
     )
     await hass.async_block_till_done()
     assert (
@@ -156,8 +160,8 @@ async def test_setup_component_and_test_service_with_config_language_special(
     assert len(calls) == 1
     assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
     assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_demo.mp3"
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_demo.mp3"
     )
     await hass.async_block_till_done()
     assert (
@@ -197,8 +201,8 @@ async def test_setup_component_and_test_service_with_service_language(
     assert len(calls) == 1
     assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
     assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3"
     )
     await hass.async_block_till_done()
     assert (
@@ -217,18 +221,18 @@ async def test_setup_component_test_service_with_wrong_service_language(
     with assert_setup_component(1, tts.DOMAIN):
         assert await async_setup_component(hass, tts.DOMAIN, config)
 
-    await hass.services.async_call(
-        tts.DOMAIN,
-        "demo_say",
-        {
-            "entity_id": "media_player.something",
-            tts.ATTR_MESSAGE: "There is someone at the door.",
-            tts.ATTR_LANGUAGE: "lang",
-        },
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            tts.DOMAIN,
+            "demo_say",
+            {
+                "entity_id": "media_player.something",
+                tts.ATTR_MESSAGE: "There is someone at the door.",
+                tts.ATTR_LANGUAGE: "lang",
+            },
+            blocking=True,
+        )
     assert len(calls) == 0
-    await hass.async_block_till_done()
     assert not (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_lang_-_demo.mp3"
     ).is_file()
@@ -261,8 +265,8 @@ async def test_setup_component_and_test_service_with_service_options(
     assert len(calls) == 1
     assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
     assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == f"http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3"
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == f"/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3"
     )
     await hass.async_block_till_done()
     assert (
@@ -298,8 +302,8 @@ async def test_setup_component_and_test_with_service_options_def(hass, empty_cac
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert (
-            calls[0].data[ATTR_MEDIA_CONTENT_ID]
-            == f"http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3"
+            await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+            == f"/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_de_{opt_hash}_demo.mp3"
         )
         await hass.async_block_till_done()
         assert (
@@ -319,17 +323,18 @@ async def test_setup_component_and_test_service_with_service_options_wrong(
     with assert_setup_component(1, tts.DOMAIN):
         assert await async_setup_component(hass, tts.DOMAIN, config)
 
-    await hass.services.async_call(
-        tts.DOMAIN,
-        "demo_say",
-        {
-            "entity_id": "media_player.something",
-            tts.ATTR_MESSAGE: "There is someone at the door.",
-            tts.ATTR_LANGUAGE: "de",
-            tts.ATTR_OPTIONS: {"speed": 1},
-        },
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            tts.DOMAIN,
+            "demo_say",
+            {
+                "entity_id": "media_player.something",
+                tts.ATTR_MESSAGE: "There is someone at the door.",
+                tts.ATTR_LANGUAGE: "de",
+                tts.ATTR_OPTIONS: {"speed": 1},
+            },
+            blocking=True,
+        )
     opt_hash = tts._hash_options({"speed": 1})
 
     assert len(calls) == 0
@@ -386,8 +391,8 @@ async def test_setup_component_and_test_service_clear_cache(hass, empty_cache_di
         blocking=True,
     )
     # To make sure the file is persisted
-    await hass.async_block_till_done()
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     await hass.async_block_till_done()
     assert (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
@@ -397,7 +402,6 @@ async def test_setup_component_and_test_service_clear_cache(hass, empty_cache_di
         tts.DOMAIN, tts.SERVICE_CLEAR_CACHE, {}, blocking=True
     )
 
-    await hass.async_block_till_done()
     assert not (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
     ).is_file()
@@ -414,8 +418,6 @@ async def test_setup_component_and_test_service_with_receive_voice(
     with assert_setup_component(1, tts.DOMAIN):
         assert await async_setup_component(hass, tts.DOMAIN, config)
 
-    client = await hass_client()
-
     await hass.services.async_call(
         tts.DOMAIN,
         "demo_say",
@@ -427,7 +429,9 @@ async def test_setup_component_and_test_service_with_receive_voice(
     )
     assert len(calls) == 1
 
-    req = await client.get(relative_url(calls[0].data[ATTR_MEDIA_CONTENT_ID]))
+    url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    client = await hass_client()
+    req = await client.get(url)
     _, demo_data = demo_provider.get_tts_audio("bla", "en")
     demo_data = tts.SpeechManager.write_tags(
         "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3",
@@ -452,8 +456,6 @@ async def test_setup_component_and_test_service_with_receive_voice_german(
     with assert_setup_component(1, tts.DOMAIN):
         assert await async_setup_component(hass, tts.DOMAIN, config)
 
-    client = await hass_client()
-
     await hass.services.async_call(
         tts.DOMAIN,
         "demo_say",
@@ -464,7 +466,9 @@ async def test_setup_component_and_test_service_with_receive_voice_german(
         blocking=True,
     )
     assert len(calls) == 1
-    req = await client.get(relative_url(calls[0].data[ATTR_MEDIA_CONTENT_ID]))
+    url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    client = await hass_client()
+    req = await client.get(url)
     _, demo_data = demo_provider.get_tts_audio("bla", "de")
     demo_data = tts.SpeechManager.write_tags(
         "42f18378fd4393d18c8dd11d03fa9563c1e54491_de_-_demo.mp3",
@@ -595,8 +599,8 @@ async def test_setup_component_test_with_cache_dir(
         )
     assert len(calls) == 1
     assert (
-        calls[0].data[ATTR_MEDIA_CONTENT_ID]
-        == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
     )
 
 

--- a/tests/components/voicerss/test_tts.py
+++ b/tests/components/voicerss/test_tts.py
@@ -6,12 +6,13 @@ import shutil
 
 import pytest
 
+from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
-import homeassistant.components.tts as tts
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
@@ -25,6 +26,15 @@ FORM_DATA = {
     "f": "8khz_8bit_mono",
     "src": "I person is on front of your door.",
 }
+
+
+async def get_media_source_url(hass, media_content_id):
+    """Get the media source url."""
+    if media_source.DOMAIN not in hass.config.components:
+        assert await async_setup_component(hass, media_source.DOMAIN, {})
+
+    resolved = await media_source.async_resolve_media(hass, media_content_id)
+    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -77,9 +87,10 @@ async def test_service_say(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
+    url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert url.endswith(".mp3")
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
-    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
 
 
 async def test_service_say_german_config(hass, aioclient_mock):
@@ -112,6 +123,7 @@ async def test_service_say_german_config(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == form_data
 
@@ -141,6 +153,7 @@ async def test_service_say_german_service(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == form_data
 
@@ -167,7 +180,8 @@ async def test_service_say_error(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    with pytest.raises(HomeAssistantError):
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
 
@@ -194,7 +208,8 @@ async def test_service_say_timeout(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    with pytest.raises(HomeAssistantError):
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
 
@@ -226,6 +241,7 @@ async def test_service_say_error_msg(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    with pytest.raises(media_source.Unresolvable):
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -6,11 +6,12 @@ import shutil
 
 import pytest
 
+from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
-import homeassistant.components.tts as tts
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
@@ -19,6 +20,15 @@ from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unuse
 )
 
 URL = "https://tts.voicetech.yandex.net/generate?"
+
+
+async def get_media_source_url(hass, media_content_id):
+    """Get the media source url."""
+    if media_source.DOMAIN not in hass.config.components:
+        assert await async_setup_component(hass, media_source.DOMAIN, {})
+
+    resolved = await media_source.async_resolve_media(hass, media_content_id)
+    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -73,11 +83,11 @@ async def test_service_say(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
-
-    assert len(aioclient_mock.mock_calls) == 1
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(aioclient_mock.mock_calls) == 1
 
 
 async def test_service_say_russian_config(hass, aioclient_mock):
@@ -111,11 +121,12 @@ async def test_service_say_russian_config(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
-    assert len(aioclient_mock.mock_calls) == 1
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(aioclient_mock.mock_calls) == 1
 
 
 async def test_service_say_russian_service(hass, aioclient_mock):
@@ -147,11 +158,11 @@ async def test_service_say_russian_service(hass, aioclient_mock):
             tts.ATTR_MESSAGE: "HomeAssistant",
             tts.ATTR_LANGUAGE: "ru-RU",
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
-
-    assert len(aioclient_mock.mock_calls) == 1
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(aioclient_mock.mock_calls) == 1
 
 
 async def test_service_say_timeout(hass, aioclient_mock):
@@ -184,10 +195,13 @@ async def test_service_say_timeout(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    assert len(calls) == 1
+    with pytest.raises(media_source.Unresolvable):
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
 
 
@@ -221,10 +235,12 @@ async def test_service_say_http_error(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    assert len(calls) == 1
+    with pytest.raises(media_source.Unresolvable):
+        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
 
 
 async def test_service_say_specified_speaker(hass, aioclient_mock):
@@ -258,11 +274,11 @@ async def test_service_say_specified_speaker(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
-
-    assert len(aioclient_mock.mock_calls) == 1
     assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(aioclient_mock.mock_calls) == 1
 
 
 async def test_service_say_specified_emotion(hass, aioclient_mock):
@@ -296,11 +312,12 @@ async def test_service_say_specified_emotion(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
 
     assert len(aioclient_mock.mock_calls) == 1
-    assert len(calls) == 1
 
 
 async def test_service_say_specified_low_speed(hass, aioclient_mock):
@@ -330,11 +347,12 @@ async def test_service_say_specified_low_speed(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
 
     assert len(aioclient_mock.mock_calls) == 1
-    assert len(calls) == 1
 
 
 async def test_service_say_specified_speed(hass, aioclient_mock):
@@ -362,11 +380,12 @@ async def test_service_say_specified_speed(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
 
     assert len(aioclient_mock.mock_calls) == 1
-    assert len(calls) == 1
 
 
 async def test_service_say_specified_options(hass, aioclient_mock):
@@ -397,8 +416,9 @@ async def test_service_say_specified_options(hass, aioclient_mock):
             tts.ATTR_MESSAGE: "HomeAssistant",
             "options": {"emotion": "evil", "speed": 2},
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
 
     assert len(aioclient_mock.mock_calls) == 1
-    assert len(calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The TTS `base_url` option is deprecated. Configure internal/external URL instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate the TTS `base_url` option. It was introduced in the past before we had internal/external URL. Correctly configuring internal/external URL is now preferred as it solves other cases too. 

**Changes to say service:**

When `base_url` is not set or it is the same as the resolved URL, set media content ID to a TTS media source ID.

Otherwise, log a warning and fall back to the old behavior.

Eventually we can remove the base_url option and make sure there is a single way. It also makes sure that people creating media player entities will work with the media browser and not just the TTS integration.

Dev blog post: https://github.com/home-assistant/developers.home-assistant/pull/1302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
