### PR TITLE
Revert changes from #70300 part 2

### DIFF
--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.common import async_fire_time_changed, load_fixture
 from tests.components.accuweather import init_integration
@@ -693,8 +694,9 @@ async def test_manual_update_entity(hass):
         assert mock_forecast.call_count == 1
 
 
-async def test_sensor_imperial_units(hass, units_imperial):
+async def test_sensor_imperial_units(hass):
     """Test states of the sensor without forecast."""
+    hass.config.units = IMPERIAL_SYSTEM
     await init_integration(hass)
 
     state = hass.states.get("sensor.home_cloud_ceiling")

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -4,9 +4,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.core import HomeAssistant
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
-
 
 @pytest.fixture(scope="session", autouse=True)
 def patch_zeroconf_multiple_catcher():
@@ -36,10 +33,3 @@ def entity_registry_enabled_by_default() -> Generator[AsyncMock, None, None]:
         return_value=True,
     ) as mock_entity_registry_enabled_by_default:
         yield mock_entity_registry_enabled_by_default
-
-
-@pytest.fixture
-def units_imperial(hass: HomeAssistant) -> Generator[None, None, None]:
-    """Fixture to temporary change units to imperial."""
-    with patch.object(hass.config, "units", IMPERIAL_SYSTEM):
-        yield

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -4,6 +4,7 @@ import voluptuous as vol
 
 from homeassistant.components import water_heater
 from homeassistant.setup import async_setup_component
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.components.water_heater import common
 
@@ -12,8 +13,9 @@ ENTITY_WATER_HEATER_CELSIUS = "water_heater.demo_water_heater_celsius"
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass, units_imperial):
+async def setup_comp(hass):
     """Set up demo component."""
+    hass.config.units = IMPERIAL_SYSTEM
     assert await async_setup_component(
         hass, water_heater.DOMAIN, {"water_heater": {"platform": "demo"}}
     )

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.common import async_fire_time_changed
 from tests.components.gdacs import _generate_mock_feed_entry
@@ -204,8 +205,9 @@ async def test_setup(hass):
         assert len(entity_registry.entities) == 1
 
 
-async def test_setup_imperial(hass, units_imperial):
+async def test_setup_imperial(hass):
     """Test the setup of the integration using imperial unit system."""
+    hass.config.units = IMPERIAL_SYSTEM
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
         "1234",

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -39,7 +39,7 @@ from homeassistant.core import DOMAIN as HASS_DOMAIN, CoreState, State, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_system import METRIC_SYSTEM
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 from tests.common import (
     assert_setup_component,
@@ -1201,8 +1201,9 @@ async def setup_comp_9(hass):
     await hass.async_block_till_done()
 
 
-async def test_precision(hass, units_imperial, setup_comp_9):
+async def test_precision(hass, setup_comp_9):
     """Test that setting precision to tenths works as intended."""
+    hass.config.units = IMPERIAL_SYSTEM
     await common.async_set_temperature(hass, 23.27)
     state = hass.states.get(ENTITY)
     assert state.attributes.get("temperature") == 23.3

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.common import async_fire_time_changed
 from tests.components.geonetnz_quakes import _generate_mock_feed_entry
@@ -167,8 +168,9 @@ async def test_setup(hass):
         assert len(entity_registry.entities) == 1
 
 
-async def test_setup_imperial(hass, units_imperial):
+async def test_setup_imperial(hass):
     """Test the setup of the integration using imperial unit system."""
+    hass.config.units = IMPERIAL_SYSTEM
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 15.5, (38.0, -3.0))
 

--- a/tests/components/geonetnz_volcano/test_sensor.py
+++ b/tests/components/geonetnz_volcano/test_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.common import async_fire_time_changed
 from tests.components.geonetnz_volcano import _generate_mock_feed_entry
@@ -146,8 +147,9 @@ async def test_setup(hass):
         )
 
 
-async def test_setup_imperial(hass, units_imperial):
+async def test_setup_imperial(hass):
     """Test the setup of the integration using imperial unit system."""
+    hass.config.units = IMPERIAL_SYSTEM
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 1, 15.5, (38.0, -3.0))
 

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     PRESSURE_PSI,
 )
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from . import init_integration
 
@@ -125,8 +126,10 @@ async def test_sensors(hass):
     assert entry.unique_id == "JM000000000000000_rear_right_tire_pressure"
 
 
-async def test_sensors_imperial_units(hass, units_imperial):
+async def test_sensors_imperial_units(hass):
     """Test that the sensors work properly with imperial units."""
+    hass.config.units = IMPERIAL_SYSTEM
+
     await init_integration(hass)
 
     # Fuel Distance Remaining

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.subaru.sensor import (
     SENSOR_TYPE,
 )
 from homeassistant.util import slugify
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from .api_responses import (
     EXPECTED_STATE_EV_IMPERIAL,
@@ -29,8 +30,10 @@ from tests.components.subaru.conftest import (
 VEHICLE_NAME = VEHICLE_DATA[TEST_VIN_2_EV][VEHICLE_NAME]
 
 
-async def test_sensors_ev_imperial(hass, ev_entry, units_imperial):
+async def test_sensors_ev_imperial(hass, ev_entry):
     """Test sensors supporting imperial units."""
+    hass.config.units = IMPERIAL_SYSTEM
+
     with patch(MOCK_API_FETCH), patch(
         MOCK_API_GET_DATA, return_value=VEHICLE_STATUS_EV
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,7 +269,6 @@ def hass(loop, load_registries, hass_storage, request):
 
     exceptions = []
     hass = loop.run_until_complete(async_test_home_assistant(loop, load_registries))
-    orig_units = hass.config.units
     orig_exception_handler = loop.get_exception_handler()
     loop.set_exception_handler(exc_handle)
 
@@ -279,8 +278,6 @@ def hass(loop, load_registries, hass_storage, request):
 
     # Restore timezone, it is set when creating the hass object
     dt_util.DEFAULT_TIME_ZONE = orig_tz
-    # Restore the units as well
-    hass.config.units = orig_units
 
     for ex in exceptions:
         if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,7 @@ def hass(loop, load_registries, hass_storage, request):
 
     exceptions = []
     hass = loop.run_until_complete(async_test_home_assistant(loop, load_registries))
+    orig_units = hass.config.units
     orig_exception_handler = loop.get_exception_handler()
     loop.set_exception_handler(exc_handle)
 
@@ -278,6 +279,8 @@ def hass(loop, load_registries, hass_storage, request):
 
     # Restore timezone, it is set when creating the hass object
     dt_util.DEFAULT_TIME_ZONE = orig_tz
+    # Restore the units as well
+    hass.config.units = orig_units
 
     for ex in exceptions:
         if (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part 1 is https://github.com/home-assistant/core/pull/70385

These changes were not needed since the original problem was
actually the METRIC_SYSTEM objects internals being mutated

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
…)"

This reverts commit 309424d.