### PR TITLE
Remove deprecated YAML configuration from ONVIF

### DIFF
--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_RTSP_TRANSPORT,
@@ -21,11 +20,6 @@ from .const import (
     RTSP_TRANS_PROTOCOLS,
 )
 from .device import ONVIFDevice
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the ONVIF component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -2,13 +2,8 @@
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
 
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
@@ -16,17 +11,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_per_platform
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_RTSP_TRANSPORT,
     CONF_SNAPSHOT_AUTH,
     DEFAULT_ARGUMENTS,
-    DEFAULT_NAME,
-    DEFAULT_PASSWORD,
-    DEFAULT_PORT,
-    DEFAULT_USERNAME,
     DOMAIN,
     RTSP_TRANS_PROTOCOLS,
 )
@@ -35,29 +25,6 @@ from .device import ONVIFDevice
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the ONVIF component."""
-    # Import from yaml
-    configs = {}
-    for p_type, p_config in config_per_platform(config, "camera"):
-        if p_type != DOMAIN:
-            continue
-
-        config = p_config.copy()
-        if config[CONF_HOST] not in configs:
-            configs[config[CONF_HOST]] = {
-                CONF_HOST: config[CONF_HOST],
-                CONF_NAME: config.get(CONF_NAME, DEFAULT_NAME),
-                CONF_PASSWORD: config.get(CONF_PASSWORD, DEFAULT_PASSWORD),
-                CONF_PORT: config.get(CONF_PORT, DEFAULT_PORT),
-                CONF_USERNAME: config.get(CONF_USERNAME, DEFAULT_USERNAME),
-            }
-
-    for conf in configs.values():
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-            )
-        )
-
     return True
 
 

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -261,10 +261,6 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         finally:
             await device.close()
 
-    async def async_step_import(self, user_input):
-        """Handle import."""
-        return await self.async_step_configure(user_input)
-
 
 class OnvifOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle ONVIF options."""

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -5,10 +5,7 @@ LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "onvif"
 
-DEFAULT_NAME = "ONVIF Camera"
-DEFAULT_PORT = 5000
-DEFAULT_USERNAME = "admin"
-DEFAULT_PASSWORD = "888888"
+DEFAULT_PORT = 80
 DEFAULT_ARGUMENTS = "-pred 1"
 
 CONF_DEVICE_ID = "deviceid"

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -1,9 +1,6 @@
 """Test ONVIF config flow."""
 from unittest.mock import MagicMock, patch
 
-from onvif.exceptions import ONVIFError
-from zeep.exceptions import Fault
-
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.onvif import config_flow
 
@@ -13,7 +10,6 @@ from . import (
     NAME,
     PASSWORD,
     PORT,
-    SERIAL_NUMBER,
     URN,
     USERNAME,
     setup_mock_device,
@@ -318,189 +314,6 @@ async def test_flow_manual_entry(hass):
             config_flow.CONF_USERNAME: USERNAME,
             config_flow.CONF_PASSWORD: PASSWORD,
         }
-
-
-async def test_flow_import_not_implemented(hass):
-    """Test that config flow uses Serial Number when no MAC available."""
-    with patch(
-        "homeassistant.components.onvif.config_flow.get_device"
-    ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.ONVIFDevice"
-    ) as mock_device, patch(
-        "homeassistant.components.onvif.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.onvif.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        setup_mock_onvif_camera(mock_onvif_camera, with_interfaces_not_implemented=True)
-        setup_mock_device(mock_device)
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                config_flow.CONF_NAME: NAME,
-                config_flow.CONF_HOST: HOST,
-                config_flow.CONF_PORT: PORT,
-                config_flow.CONF_USERNAME: USERNAME,
-                config_flow.CONF_PASSWORD: PASSWORD,
-            },
-        )
-
-        await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
-        assert len(mock_setup_entry.mock_calls) == 1
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == f"{NAME} - {SERIAL_NUMBER}"
-        assert result["data"] == {
-            config_flow.CONF_NAME: NAME,
-            config_flow.CONF_HOST: HOST,
-            config_flow.CONF_PORT: PORT,
-            config_flow.CONF_USERNAME: USERNAME,
-            config_flow.CONF_PASSWORD: PASSWORD,
-        }
-
-
-async def test_flow_import_no_mac(hass):
-    """Test that config flow uses Serial Number when no MAC available."""
-    with patch(
-        "homeassistant.components.onvif.config_flow.get_device"
-    ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.ONVIFDevice"
-    ) as mock_device, patch(
-        "homeassistant.components.onvif.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.onvif.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        setup_mock_onvif_camera(mock_onvif_camera, with_interfaces=False)
-        setup_mock_device(mock_device)
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                config_flow.CONF_NAME: NAME,
-                config_flow.CONF_HOST: HOST,
-                config_flow.CONF_PORT: PORT,
-                config_flow.CONF_USERNAME: USERNAME,
-                config_flow.CONF_PASSWORD: PASSWORD,
-            },
-        )
-
-        await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
-        assert len(mock_setup_entry.mock_calls) == 1
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == f"{NAME} - {SERIAL_NUMBER}"
-        assert result["data"] == {
-            config_flow.CONF_NAME: NAME,
-            config_flow.CONF_HOST: HOST,
-            config_flow.CONF_PORT: PORT,
-            config_flow.CONF_USERNAME: USERNAME,
-            config_flow.CONF_PASSWORD: PASSWORD,
-        }
-
-
-async def test_flow_import_no_mac_or_serial(hass):
-    """Test that config flow fails when no MAC or Serial Number available."""
-    with patch(
-        "homeassistant.components.onvif.config_flow.get_device"
-    ) as mock_onvif_camera:
-        setup_mock_onvif_camera(
-            mock_onvif_camera, with_interfaces=False, with_serial=False
-        )
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                config_flow.CONF_NAME: NAME,
-                config_flow.CONF_HOST: HOST,
-                config_flow.CONF_PORT: PORT,
-                config_flow.CONF_USERNAME: USERNAME,
-                config_flow.CONF_PASSWORD: PASSWORD,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "no_mac"
-
-
-async def test_flow_import_no_h264(hass):
-    """Test that config flow fails when no MAC available."""
-    with patch(
-        "homeassistant.components.onvif.config_flow.get_device"
-    ) as mock_onvif_camera:
-        setup_mock_onvif_camera(mock_onvif_camera, with_h264=False)
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                config_flow.CONF_NAME: NAME,
-                config_flow.CONF_HOST: HOST,
-                config_flow.CONF_PORT: PORT,
-                config_flow.CONF_USERNAME: USERNAME,
-                config_flow.CONF_PASSWORD: PASSWORD,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "no_h264"
-
-
-async def test_flow_import_onvif_api_error(hass):
-    """Test that config flow fails when ONVIF API fails."""
-    with patch(
-        "homeassistant.components.onvif.config_flow.get_device"
-    ) as mock_onvif_camera:
-        setup_mock_onvif_camera(mock_onvif_camera)
-        mock_onvif_camera.create_devicemgmt_service = MagicMock(
-            side_effect=ONVIFError("Could not get device mgmt service")
-        )
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                config_flow.CONF_NAME: NAME,
-                config_flow.CONF_HOST: HOST,
-                config_flow.CONF_PORT: PORT,
-                config_flow.CONF_USERNAME: USERNAME,
-                config_flow.CONF_PASSWORD: PASSWORD,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "onvif_error"
-
-
-async def test_flow_import_onvif_auth_error(hass):
-    """Test that config flow fails when ONVIF API fails."""
-    with patch(
-        "homeassistant.components.onvif.config_flow.get_device"
-    ) as mock_onvif_camera:
-        setup_mock_onvif_camera(mock_onvif_camera)
-        mock_onvif_camera.create_devicemgmt_service = MagicMock(
-            side_effect=Fault("Auth Error")
-        )
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                config_flow.CONF_NAME: NAME,
-                config_flow.CONF_HOST: HOST,
-                config_flow.CONF_PORT: PORT,
-                config_flow.CONF_USERNAME: USERNAME,
-                config_flow.CONF_PASSWORD: PASSWORD,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "configure"
-        assert result["errors"]["base"] == "cannot_connect"
 
 
 async def test_option_flow(hass):

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -103,8 +103,6 @@ async def test_flow_discovered_devices(hass):
         assert result["step_id"] == "configure"
 
         with patch(
-            "homeassistant.components.onvif.async_setup", return_value=True
-        ) as mock_setup, patch(
             "homeassistant.components.onvif.async_setup_entry", return_value=True
         ) as mock_setup_entry:
             result = await hass.config_entries.flow.async_configure(
@@ -116,7 +114,6 @@ async def test_flow_discovered_devices(hass):
             )
 
             await hass.async_block_till_done()
-            assert len(mock_setup.mock_calls) == 1
             assert len(mock_setup_entry.mock_calls) == 1
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -286,8 +283,6 @@ async def test_flow_manual_entry(hass):
         assert result["step_id"] == "configure"
 
         with patch(
-            "homeassistant.components.onvif.async_setup", return_value=True
-        ) as mock_setup, patch(
             "homeassistant.components.onvif.async_setup_entry", return_value=True
         ) as mock_setup_entry:
             result = await hass.config_entries.flow.async_configure(
@@ -302,7 +297,6 @@ async def test_flow_manual_entry(hass):
             )
 
             await hass.async_block_till_done()
-            assert len(mock_setup.mock_calls) == 1
             assert len(mock_setup_entry.mock_calls) == 1
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Removes previously deprecated YAML configuration/import from ONVIF.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Originally deprecated in May 2020: https://github.com/home-assistant/core/pull/34520

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
