### PR TITLE
Use ColorMode enum in broadlink

### DIFF
--- a/homeassistant/components/broadlink/light.py
+++ b/homeassistant/components/broadlink/light.py
@@ -8,10 +8,7 @@ from homeassistant.components.light import (
     ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
-    COLOR_MODE_BRIGHTNESS,
-    COLOR_MODE_COLOR_TEMP,
-    COLOR_MODE_HS,
-    COLOR_MODE_UNKNOWN,
+    ColorMode,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -56,11 +53,11 @@ class BroadlinkLight(BroadlinkEntity, LightEntity):
         data = self._coordinator.data
 
         if {"hue", "saturation"}.issubset(data):
-            self._attr_supported_color_modes.add(COLOR_MODE_HS)
+            self._attr_supported_color_modes.add(ColorMode.HS)
         if "colortemp" in data:
-            self._attr_supported_color_modes.add(COLOR_MODE_COLOR_TEMP)
+            self._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
         if not self.supported_color_modes:
-            self._attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
         self._update_state(data)
 
@@ -72,8 +69,8 @@ class BroadlinkLight(BroadlinkEntity, LightEntity):
         if "brightness" in data:
             self._attr_brightness = round(data["brightness"] * 2.55)
 
-        if self.supported_color_modes == {COLOR_MODE_BRIGHTNESS}:
-            self._attr_color_mode = COLOR_MODE_BRIGHTNESS
+        if self.supported_color_modes == {ColorMode.BRIGHTNESS}:
+            self._attr_color_mode = ColorMode.BRIGHTNESS
             return
 
         if {"hue", "saturation"}.issubset(data):
@@ -84,12 +81,12 @@ class BroadlinkLight(BroadlinkEntity, LightEntity):
 
         if "bulb_colormode" in data:
             if data["bulb_colormode"] == BROADLINK_COLOR_MODE_RGB:
-                self._attr_color_mode = COLOR_MODE_HS
+                self._attr_color_mode = ColorMode.HS
             elif data["bulb_colormode"] == BROADLINK_COLOR_MODE_WHITE:
-                self._attr_color_mode = COLOR_MODE_COLOR_TEMP
+                self._attr_color_mode = ColorMode.COLOR_TEMP
             else:
                 # Scenes are not yet supported.
-                self._attr_color_mode = COLOR_MODE_UNKNOWN
+                self._attr_color_mode = ColorMode.UNKNOWN
 
     async def async_turn_on(self, **kwargs):
         """Turn on the light."""
@@ -99,7 +96,7 @@ class BroadlinkLight(BroadlinkEntity, LightEntity):
             brightness = kwargs[ATTR_BRIGHTNESS]
             state["brightness"] = round(brightness / 2.55)
 
-        if self.supported_color_modes == {COLOR_MODE_BRIGHTNESS}:
+        if self.supported_color_modes == {ColorMode.BRIGHTNESS}:
             state["bulb_colormode"] = BROADLINK_COLOR_MODE_WHITE
 
         elif ATTR_HS_COLOR in kwargs:
@@ -115,9 +112,9 @@ class BroadlinkLight(BroadlinkEntity, LightEntity):
 
         elif ATTR_COLOR_MODE in kwargs:
             color_mode = kwargs[ATTR_COLOR_MODE]
-            if color_mode == COLOR_MODE_HS:
+            if color_mode == ColorMode.HS:
                 state["bulb_colormode"] = BROADLINK_COLOR_MODE_RGB
-            elif color_mode == COLOR_MODE_COLOR_TEMP:
+            elif color_mode == ColorMode.COLOR_TEMP:
                 state["bulb_colormode"] = BROADLINK_COLOR_MODE_WHITE
             else:
                 # Scenes are not yet supported.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use ColorMode enum in broadlink
Follow-up to #69223, and required for #69302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
