### PR TITLE
deCONZ dependency exports type hints

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -163,7 +163,7 @@ ENTITY_DESCRIPTIONS = {
 BINARY_SENSOR_DESCRIPTIONS = [
     DeconzBinarySensorDescription(
         key="tampered",
-        value_fn=lambda device: device.tampered,  # type: ignore[no-any-return]
+        value_fn=lambda device: device.tampered,
         suffix="Tampered",
         update_key="tampered",
         device_class=BinarySensorDeviceClass.TAMPER,
@@ -171,7 +171,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
     ),
     DeconzBinarySensorDescription(
         key="low_battery",
-        value_fn=lambda device: device.low_battery,  # type: ignore[no-any-return]
+        value_fn=lambda device: device.low_battery,
         suffix="Low Battery",
         update_key="lowbattery",
         device_class=BinarySensorDeviceClass.BATTERY,

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -228,16 +228,16 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def current_temperature(self) -> float:
         """Return the current temperature."""
-        return self._device.scaled_temperature  # type: ignore[no-any-return]
+        return self._device.scaled_temperature
 
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
         if self._device.mode == THERMOSTAT_MODE_COOL and self._device.cooling_setpoint:
-            return self._device.cooling_setpoint  # type: ignore[no-any-return]
+            return self._device.cooling_setpoint
 
         if self._device.heating_setpoint:
-            return self._device.heating_setpoint  # type: ignore[no-any-return]
+            return self._device.heating_setpoint
 
         return None
 

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -92,7 +92,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
     @property
     def current_cover_position(self) -> int:
         """Return the current position of the cover."""
-        return 100 - self._device.lift  # type: ignore[no-any-return]
+        return 100 - self._device.lift
 
     @property
     def is_closed(self) -> bool:
@@ -120,7 +120,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
     def current_cover_tilt_position(self) -> int | None:
         """Return the current tilt position of the cover."""
         if self._device.tilt is not None:
-            return 100 - self._device.tilt  # type: ignore[no-any-return]
+            return 100 - self._device.tilt
         return None
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -31,7 +31,7 @@ class DeconzBase:
     def unique_id(self) -> str:
         """Return a unique identifier for this device."""
         assert not isinstance(self._device, PydeconzScene)
-        return self._device.unique_id  # type: ignore[no-any-return]
+        return self._device.unique_id
 
     @property
     def serial(self) -> str | None:
@@ -39,7 +39,7 @@ class DeconzBase:
         assert not isinstance(self._device, PydeconzScene)
         if not self._device.unique_id or self._device.unique_id.count(":") != 7:
             return None
-        return self._device.unique_id.split("-", 1)[0]  # type: ignore[no-any-return]
+        return self._device.unique_id.split("-", 1)[0]
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -92,7 +92,7 @@ class DeconzFan(DeconzDevice, FanEntity):
     @property
     def is_on(self) -> bool:
         """Return true if fan is on."""
-        return self._device.speed != FAN_SPEED_OFF  # type: ignore[no-any-return]
+        return self._device.speed != FAN_SPEED_OFF
 
     @property
     def percentage(self) -> int | None:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -186,12 +186,12 @@ class DeconzBaseLight(Generic[_L], DeconzDevice, LightEntity):
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return self._device.brightness  # type: ignore[no-any-return]
+        return self._device.brightness
 
     @property
     def color_temp(self) -> int | None:
         """Return the CT color value."""
-        return self._device.color_temp  # type: ignore[no-any-return]
+        return self._device.color_temp
 
     @property
     def hs_color(self) -> tuple[float, float] | None:
@@ -203,12 +203,12 @@ class DeconzBaseLight(Generic[_L], DeconzDevice, LightEntity):
     @property
     def xy_color(self) -> tuple[float, float] | None:
         """Return the XY color value."""
-        return self._device.xy  # type: ignore[no-any-return]
+        return self._device.xy
 
     @property
     def is_on(self) -> bool | None:
         """Return true if light is on."""
-        return self._device.state  # type: ignore[no-any-return]
+        return self._device.state
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on light."""

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -93,7 +93,7 @@ class DeconzLock(DeconzDevice, LockEntity):
     @property
     def is_locked(self) -> bool:
         """Return true if lock is on."""
-        return self._device.is_locked  # type: ignore[no-any-return]
+        return self._device.is_locked
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==88"],
+  "requirements": ["pydeconz==90"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -28,7 +28,7 @@ class DeconzNumberDescriptionMixin:
 
     suffix: str
     update_key: str
-    value_fn: Callable[[Presence], float]
+    value_fn: Callable[[Presence], float | None]
 
 
 @dataclass
@@ -40,7 +40,7 @@ ENTITY_DESCRIPTIONS = {
     Presence: [
         DeconzNumberDescription(
             key="delay",
-            value_fn=lambda device: device.delay,  # type: ignore[no-any-return]
+            value_fn=lambda device: device.delay,
             suffix="Delay",
             update_key=PRESENCE_DELAY,
             max_value=65535,
@@ -100,7 +100,7 @@ async def async_setup_entry(
 
     async_add_sensor(
         [
-            gateway.api.sensors[key]
+            gateway.api.sensors.presence[key]
             for key in sorted(gateway.api.sensors.presence, key=int)
         ]
     )
@@ -132,7 +132,7 @@ class DeconzNumber(DeconzDevice, NumberEntity):
             super().async_update_callback()
 
     @property
-    def value(self) -> float:
+    def value(self) -> float | None:
         """Return the value of the sensor property."""
         return self.entity_description.value_fn(self._device)
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -216,7 +216,7 @@ ENTITY_DESCRIPTIONS = {
 SENSOR_DESCRIPTIONS = [
     DeconzSensorDescription(
         key="battery",
-        value_fn=lambda device: device.battery,  # type: ignore[no-any-return]
+        value_fn=lambda device: device.battery,
         suffix="Battery",
         update_key="battery",
         device_class=SensorDeviceClass.BATTERY,
@@ -226,7 +226,7 @@ SENSOR_DESCRIPTIONS = [
     ),
     DeconzSensorDescription(
         key="secondary_temperature",
-        value_fn=lambda device: device.secondary_temperature,  # type: ignore[no-any-return]
+        value_fn=lambda device: device.secondary_temperature,
         suffix="Temperature",
         update_key="temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -354,9 +354,9 @@ class DeconzSensor(DeconzDevice, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         if self.entity_description.device_class is SensorDeviceClass.TIMESTAMP:
-            return dt_util.parse_datetime(
-                self.entity_description.value_fn(self._device)  # type: ignore[arg-type]
-            )
+            value = self.entity_description.value_fn(self._device)
+            assert isinstance(value, str)
+            return dt_util.parse_datetime(value)
         return self.entity_description.value_fn(self._device)
 
     @property

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -73,7 +73,7 @@ class DeconzSiren(DeconzDevice, SirenEntity):
     @property
     def is_on(self) -> bool:
         """Return true if siren is on."""
-        return self._device.is_on  # type: ignore[no-any-return]
+        return self._device.is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on siren."""

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -80,7 +80,7 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        return self._device.on  # type: ignore[no-any-return]
+        return self._device.on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1426,7 +1426,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==88
+pydeconz==90
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -947,7 +947,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==88
+pydeconz==90
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove all unnecessary type: ignore comments and fix a final detail in number platform.
Finalizing this long excursion of adding type hinting to deCONZ integration and library.
Full typing was done here https://github.com/home-assistant/core/pull/58968 and part of it split out to this PR.

https://github.com/Kane610/deconz/compare/v88...v90

```
❯ mypy homeassistant/components/deconz
homeassistant/components/deconz/deconz_device.py:34: error: Unused "type: ignore" comment
homeassistant/components/deconz/deconz_device.py:42: error: Unused "type: ignore" comment
homeassistant/components/deconz/switch.py:83: error: Unused "type: ignore" comment
homeassistant/components/deconz/siren.py:76: error: Unused "type: ignore" comment
homeassistant/components/deconz/sensor.py:219: error: Unused "type: ignore" comment
homeassistant/components/deconz/sensor.py:229: error: Unused "type: ignore" comment
homeassistant/components/deconz/number.py:43: error: Unused "type: ignore" comment
homeassistant/components/deconz/number.py:43: error: Argument "value_fn" to "DeconzNumberDescription" has incompatible type "Callable[[Presence], Optional[int]]"; expected "Callable[[Presence], float]"  [arg-type]
homeassistant/components/deconz/number.py:43: note: Error code "arg-type" not covered by "type: ignore" comment
homeassistant/components/deconz/number.py:43: error: Incompatible return value type (got "Optional[int]", expected "float")  [return-value]
homeassistant/components/deconz/number.py:43: note: Error code "return-value" not covered by "type: ignore" comment
homeassistant/components/deconz/number.py:103: error: List comprehension has incompatible type List[Union[AirQuality, Alarm, AncillaryControl, Battery, CarbonMonoxide, Consumption, Daylight, DoorLock, Fire, GenericFlag, GenericStatus, Humidity, LightLevel, OpenClose, Power, Presence, Pressure, Switch, Temperature, Thermostat, Time, Vibration, Water]]; expected List[Presence]  [misc]
homeassistant/components/deconz/lock.py:96: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:189: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:194: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:206: error: Unused "type: ignore" comment
homeassistant/components/deconz/light.py:211: error: Unused "type: ignore" comment
homeassistant/components/deconz/fan.py:95: error: Unused "type: ignore" comment
homeassistant/components/deconz/cover.py:95: error: Unused "type: ignore" comment
homeassistant/components/deconz/cover.py:123: error: Unused "type: ignore" comment
homeassistant/components/deconz/climate.py:231: error: Unused "type: ignore" comment
homeassistant/components/deconz/climate.py:237: error: Unused "type: ignore" comment
homeassistant/components/deconz/climate.py:240: error: Unused "type: ignore" comment
homeassistant/components/deconz/binary_sensor.py:166: error: Unused "type: ignore" comment
homeassistant/components/deconz/binary_sensor.py:174: error: Unused "type: ignore" comment
Found 23 errors in 11 files (checked 24 source files)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
