### PR TITLE
Add optional `type` for KNX notify entity configuration

### DIFF
--- a/homeassistant/components/knx/notify.py
+++ b/homeassistant/components/knx/notify.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.devices import Notification as XknxNotification
 
 from homeassistant.components.notify import BaseNotificationService
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -34,6 +34,7 @@ async def async_get_service(
                     xknx,
                     name=device_config[CONF_NAME],
                     group_address=device_config[KNX_ADDRESS],
+                    value_type=device_config[CONF_TYPE],
                 )
             )
         return (

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from abc import ABC
 from collections import OrderedDict
+from collections.abc import Callable
 import ipaddress
 from typing import Any, ClassVar, Final
 
 import voluptuous as vol
 from xknx.devices.climate import SetpointShiftMode
-from xknx.dpt import DPTBase, DPTNumeric
+from xknx.dpt import DPTBase, DPTNumeric, DPTString
 from xknx.exceptions import ConversionError, CouldNotParseAddress
 from xknx.telegram.address import IndividualAddress, parse_device_group_address
 
@@ -52,6 +53,28 @@ from .const import (
 ##################
 # KNX VALIDATORS
 ##################
+
+
+def dpt_subclass_validator(dpt_base_class: type[DPTBase]) -> Callable[[Any], str | int]:
+    """Validate that value is parsable as given sensor type."""
+
+    def dpt_value_validator(value: Any) -> str | int:
+        """Validate that value is parsable as sensor type."""
+        if (
+            isinstance(value, (str, int))
+            and dpt_base_class.parse_transcoder(value) is not None
+        ):
+            return value
+        raise vol.Invalid(
+            f"type '{value}' is not a valid DPT identifier for {dpt_base_class.__name__}."
+        )
+
+    return dpt_value_validator
+
+
+numeric_type_validator = dpt_subclass_validator(DPTNumeric)  # type: ignore[misc]
+sensor_type_validator = dpt_subclass_validator(DPTBase)  # type: ignore[misc]
+string_type_validator = dpt_subclass_validator(DPTString)
 
 
 def ga_validator(value: Any) -> str | int:
@@ -131,13 +154,6 @@ def number_limit_sub_validator(entity_config: OrderedDict) -> OrderedDict:
     return entity_config
 
 
-def numeric_type_validator(value: Any) -> str | int:
-    """Validate that value is parsable as numeric sensor type."""
-    if isinstance(value, (str, int)) and DPTNumeric.parse_transcoder(value) is not None:
-        return value
-    raise vol.Invalid(f"value '{value}' is not a valid numeric sensor type.")
-
-
 def _max_payload_value(payload_length: int) -> int:
     if payload_length == 0:
         return 0x3F
@@ -192,13 +208,6 @@ def select_options_sub_validator(entity_config: OrderedDict) -> OrderedDict:
             raise vol.Invalid(f"duplicate item for 'payload' not allowed: {payload}")
         payloads_seen.add(payload)
     return entity_config
-
-
-def sensor_type_validator(value: Any) -> str | int:
-    """Validate that value is parsable as sensor type."""
-    if isinstance(value, (str, int)) and DPTBase.parse_transcoder(value) is not None:
-        return value
-    raise vol.Invalid(f"value '{value}' is not a valid sensor type.")
 
 
 sync_state_validator = vol.Any(
@@ -733,6 +742,7 @@ class NotifySchema(KNXPlatformSchema):
     ENTITY_SCHEMA = vol.Schema(
         {
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_TYPE, default="latin_1"): string_type_validator,
             vol.Required(KNX_ADDRESS): ga_validator,
         }
     )

--- a/tests/components/knx/test_notify.py
+++ b/tests/components/knx/test_notify.py
@@ -78,7 +78,7 @@ async def test_notify_simple(hass: HomeAssistant, knx: KNXTestKit):
 async def test_notify_multiple_sends_to_all_with_different_encodings(
     hass: HomeAssistant, knx: KNXTestKit
 ):
-    """Test KNX notify can send to all devices."""
+    """Test KNX notify `type` configuration."""
     await knx.setup_integration(
         {
             NotifySchema.PLATFORM: [

--- a/tests/components/knx/test_notify.py
+++ b/tests/components/knx/test_notify.py
@@ -2,7 +2,7 @@
 
 from homeassistant.components.knx.const import KNX_ADDRESS
 from homeassistant.components.knx.schema import NotifySchema
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
 
 from .conftest import KNXTestKit
@@ -75,18 +75,22 @@ async def test_notify_simple(hass: HomeAssistant, knx: KNXTestKit):
     )
 
 
-async def test_notify_multiple_sends_to_all(hass: HomeAssistant, knx: KNXTestKit):
+async def test_notify_multiple_sends_to_all_with_different_encodings(
+    hass: HomeAssistant, knx: KNXTestKit
+):
     """Test KNX notify can send to all devices."""
     await knx.setup_integration(
         {
             NotifySchema.PLATFORM: [
                 {
-                    CONF_NAME: "test",
+                    CONF_NAME: "ASCII",
                     KNX_ADDRESS: "1/0/0",
+                    CONF_TYPE: "string",
                 },
                 {
-                    CONF_NAME: "test2",
+                    CONF_NAME: "Latin-1",
                     KNX_ADDRESS: "1/0/1",
+                    CONF_TYPE: "latin_1",
                 },
             ]
         }
@@ -94,44 +98,15 @@ async def test_notify_multiple_sends_to_all(hass: HomeAssistant, knx: KNXTestKit
     await hass.async_block_till_done()
 
     await hass.services.async_call(
-        "notify", "notify", {"message": "I love KNX"}, blocking=True
+        "notify", "notify", {"message": "Gänsefüßchen"}, blocking=True
     )
 
     await knx.assert_write(
         "1/0/0",
-        (
-            0x49,
-            0x20,
-            0x6C,
-            0x6F,
-            0x76,
-            0x65,
-            0x20,
-            0x4B,
-            0x4E,
-            0x58,
-            0x0,
-            0x0,
-            0x0,
-            0x0,
-        ),
+        # "G?nsef??chen"
+        (71, 63, 110, 115, 101, 102, 63, 63, 99, 104, 101, 110, 0, 0),
     )
     await knx.assert_write(
         "1/0/1",
-        (
-            0x49,
-            0x20,
-            0x6C,
-            0x6F,
-            0x76,
-            0x65,
-            0x20,
-            0x4B,
-            0x4E,
-            0x58,
-            0x0,
-            0x0,
-            0x0,
-            0x0,
-        ),
+        (71, 228, 110, 115, 101, 102, 252, 223, 99, 104, 101, 110, 0, 0),
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add optional `type` for KNX notify entity configuration to enable selection of character encoding. Possible values are
- `string` for DPT 16.000 ASCII
- `latin_1` for DPT 16.001 Latin-1 (default)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/XKNX/xknx/issues/912
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22487

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
