### PR TITLE
Move deCONZ group and scene imports to reflect the changes in pydeconz

### DIFF
--- a/homeassistant/components/deconz/button.py
+++ b/homeassistant/components/deconz/button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pydeconz.group import Scene as PydeconzScene
+from pydeconz.models.scene import Scene as PydeconzScene
 
 from homeassistant.components.button import (
     DOMAIN,

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from pydeconz.group import Group as DeconzGroup, Scene as PydeconzScene
+from pydeconz.group import Group as DeconzGroup
 from pydeconz.light import LightBase as DeconzLight
+from pydeconz.models.scene import Scene as PydeconzScene
 from pydeconz.models.sensor import SensorBase as DeconzSensor
 
 from homeassistant.core import callback

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pydeconz.group import Group as DeconzGroup
 from pydeconz.light import LightBase as DeconzLight
+from pydeconz.models.group import Group as DeconzGroup
 from pydeconz.models.scene import Scene as PydeconzScene
 from pydeconz.models.sensor import SensorBase as DeconzSensor
 

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -7,12 +7,11 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
 
 import async_timeout
-from pydeconz import DeconzSession, errors, group, light
+from pydeconz import DeconzSession, errors, light
 from pydeconz.alarm_system import AlarmSystem as DeconzAlarmSystem
-from pydeconz.group import Group as DeconzGroup
 from pydeconz.light import LightBase as DeconzLight
-from pydeconz.models import scene
-from pydeconz.models import sensor
+from pydeconz.models import group, scene, sensor
+from pydeconz.models.group import Group as DeconzGroup
 from pydeconz.models.sensor import SensorBase as DeconzSensor
 
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -7,10 +7,10 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
 
 import async_timeout
-from pydeconz import DeconzSession, errors, light
+from pydeconz import DeconzSession, errors
 from pydeconz.alarm_system import AlarmSystem as DeconzAlarmSystem
 from pydeconz.light import LightBase as DeconzLight
-from pydeconz.models import group, scene, sensor
+from pydeconz.models import ResourceGroup
 from pydeconz.models.group import Group as DeconzGroup
 from pydeconz.models.sensor import SensorBase as DeconzSensor
 
@@ -69,10 +69,10 @@ class DeconzGateway:
         self.signal_new_sensor = f"deconz_new_sensor_{config_entry.entry_id}"
 
         self.deconz_resource_type_to_signal_new_device = {
-            group.RESOURCE_TYPE: self.signal_new_group,
-            light.RESOURCE_TYPE: self.signal_new_light,
-            scene.RESOURCE_TYPE: self.signal_new_scene,
-            sensor.RESOURCE_TYPE: self.signal_new_sensor,
+            ResourceGroup.GROUP.value: self.signal_new_group,
+            ResourceGroup.LIGHT.value: self.signal_new_light,
+            ResourceGroup.SCENE.value: self.signal_new_scene,
+            ResourceGroup.SENSOR.value: self.signal_new_sensor,
         }
 
         self.deconz_ids: dict[str, str] = {}
@@ -210,7 +210,7 @@ class DeconzGateway:
         deconz_ids = []
 
         if self.option_allow_clip_sensor:
-            self.async_add_device_callback(sensor.RESOURCE_TYPE)
+            self.async_add_device_callback(ResourceGroup.SENSOR.value)
 
         else:
             deconz_ids += [
@@ -220,7 +220,7 @@ class DeconzGateway:
             ]
 
         if self.option_allow_deconz_groups:
-            self.async_add_device_callback(group.RESOURCE_TYPE)
+            self.async_add_device_callback(ResourceGroup.GROUP.value)
 
         else:
             deconz_ids += [group.deconz_id for group in self.api.groups.values()]

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -11,6 +11,7 @@ from pydeconz import DeconzSession, errors, group, light
 from pydeconz.alarm_system import AlarmSystem as DeconzAlarmSystem
 from pydeconz.group import Group as DeconzGroup
 from pydeconz.light import LightBase as DeconzLight
+from pydeconz.models import scene
 from pydeconz.models import sensor
 from pydeconz.models.sensor import SensorBase as DeconzSensor
 
@@ -71,7 +72,7 @@ class DeconzGateway:
         self.deconz_resource_type_to_signal_new_device = {
             group.RESOURCE_TYPE: self.signal_new_group,
             light.RESOURCE_TYPE: self.signal_new_light,
-            group.RESOURCE_TYPE_SCENE: self.signal_new_scene,
+            scene.RESOURCE_TYPE: self.signal_new_scene,
             sensor.RESOURCE_TYPE: self.signal_new_sensor,
         }
 

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any, Generic, TypedDict, TypeVar
 
-from pydeconz.group import Group
 from pydeconz.light import (
     ALERT_LONG,
     ALERT_SHORT,
@@ -12,6 +11,7 @@ from pydeconz.light import (
     Light,
     LightResources,
 )
+from pydeconz.models.group import Group
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,

--- a/homeassistant/components/deconz/scene.py
+++ b/homeassistant/components/deconz/scene.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydeconz.group import Scene as PydeconzScene
+from pydeconz.models.scene import Scene as PydeconzScene
 
 from homeassistant.components.scene import DOMAIN, Scene
 from homeassistant.config_entries import ConfigEntry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Old import paths was kept during the refactorization of pydeconz v88
Now I move them to the new paths
Import cleanup in library as a result of this PR https://github.com/Kane610/deconz/pull/245

- https://github.com/home-assistant/core/pull/70453
- https://github.com/home-assistant/core/pull/70469
- https://github.com/home-assistant/core/pull/70471

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
