### PR TITLE
Improve and fix Airzone config flow

### DIFF
--- a/homeassistant/components/airzone/config_flow.py
+++ b/homeassistant/components/airzone/config_flow.py
@@ -39,22 +39,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            system_id = user_input.get(CONF_ID, DEFAULT_SYSTEM_ID)
-            entry_data: dict[str, Any] = {
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_PORT: user_input[CONF_PORT],
-            }
-
-            if system_id != DEFAULT_SYSTEM_ID:
-                entry_data[CONF_ID] = system_id
-            self._async_abort_entries_match(entry_data)
+            self._async_abort_entries_match(user_input)
 
             airzone = AirzoneLocalApi(
                 aiohttp_client.async_get_clientsession(self.hass),
                 ConnectionOptions(
                     user_input[CONF_HOST],
                     user_input[CONF_PORT],
-                    system_id,
+                    user_input.get(CONF_ID, DEFAULT_SYSTEM_ID),
                 ),
             )
 
@@ -67,7 +59,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             else:
                 title = f"Airzone {user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
-                return self.async_create_entry(title=title, data=entry_data)
+                return self.async_create_entry(title=title, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT
 from homeassistant.core import HomeAssistant
 
-from .util import CONFIG, CONFIG_ID1, CONFIG_NO_ID, HVAC_MOCK
+from .util import CONFIG, CONFIG_ID1, HVAC_MOCK
 
 from tests.common import MockConfigEntry
 
@@ -46,7 +46,7 @@ async def test_form(hass: HomeAssistant) -> None:
         assert result["errors"] == {}
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], CONFIG_NO_ID
+            result["flow_id"], CONFIG
         )
 
         await hass.async_block_till_done()
@@ -81,7 +81,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
         side_effect=InvalidMethod,
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=CONFIG_NO_ID
+            DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -86,7 +86,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == SOURCE_USER
-        assert result["errors"] == {"base": "invalid_system_id"}
+        assert result["errors"] == {CONF_ID: "invalid_system_id"}
 
         mock_hvac.return_value = HVAC_MOCK[API_SYSTEMS][0]
         mock_hvac.side_effect = None

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -39,17 +39,10 @@ from tests.common import MockConfigEntry
 CONFIG = {
     CONF_HOST: "192.168.1.100",
     CONF_PORT: 3000,
-    CONF_ID: 0,
-}
-
-CONFIG_NO_ID = {
-    CONF_HOST: CONFIG[CONF_HOST],
-    CONF_PORT: CONFIG[CONF_PORT],
 }
 
 CONFIG_ID1 = {
-    CONF_HOST: CONFIG[CONF_HOST],
-    CONF_PORT: CONFIG[CONF_PORT],
+    **CONFIG,
     CONF_ID: 1,
 }
 


### PR DESCRIPTION
## Proposed change
Improve and fix Airzone config flow:
- A user can add multiple config entries for the same Airzone device for those Airzone devices that support all systems listing (systemID=0) since _async_abort_entries_match is being checked with CONF_ID always set, but if the Airzone device supports systemID=0, CONF_ID won't be set. This bug was introduced in https://github.com/home-assistant/core/pull/69751 c76b21e24ee959c66e9bdec4d626d2d2bf81e2d0.
- Extend SYSTEM_ID_SCHEMA from CONFIG_SCHEMA.
- invalid_system_id error refers to CONF_ID.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
