### PR TITLE
Add UniqueID to AsusWRT config entry

### DIFF
--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -152,10 +152,6 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
         # if exist one entry without unique ID, we abort config flow
         for unique_id in self._async_current_ids():
             if unique_id is None:
-                _LOGGER.warning(
-                    "A device without a valid UniqueID is already configured."
-                    " Configuration of multiple instance is not possible"
-                )
                 return self.async_abort(reason="not_unique_id_exist")
 
         if user_input is None:

--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
     CONF_DNSMASQ,
@@ -41,11 +42,13 @@ from .const import (
     PROTOCOL_SSH,
     PROTOCOL_TELNET,
 )
-from .router import get_api
+from .router import get_api, get_nvram_info
+
+LABEL_MAC = "LABEL_MAC"
 
 RESULT_CONN_ERROR = "cannot_connect"
-RESULT_UNKNOWN = "unknown"
 RESULT_SUCCESS = "success"
+RESULT_UNKNOWN = "unknown"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +110,9 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
-    async def _async_check_connection(user_input: dict[str, Any]) -> str:
+    async def _async_check_connection(
+        user_input: dict[str, Any]
+    ) -> tuple[str, str | None]:
         """Attempt to connect the AsusWrt router."""
 
         host: str = user_input[CONF_HOST]
@@ -117,29 +122,41 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
 
         except OSError:
             _LOGGER.error("Error connecting to the AsusWrt router at %s", host)
-            return RESULT_CONN_ERROR
+            return RESULT_CONN_ERROR, None
 
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception(
                 "Unknown error connecting with AsusWrt router at %s", host
             )
-            return RESULT_UNKNOWN
+            return RESULT_UNKNOWN, None
 
         if not api.is_connected:
             _LOGGER.error("Error connecting to the AsusWrt router at %s", host)
-            return RESULT_CONN_ERROR
+            return RESULT_CONN_ERROR, None
 
+        label_mac = await get_nvram_info(api, LABEL_MAC)
         conf_protocol = user_input[CONF_PROTOCOL]
         if conf_protocol == PROTOCOL_TELNET:
             api.connection.disconnect()
-        return RESULT_SUCCESS
+
+        unique_id = None
+        if label_mac and "label_mac" in label_mac:
+            unique_id = format_mac(label_mac["label_mac"])
+        return RESULT_SUCCESS, unique_id
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initiated by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
+
+        # if exist one entry without unique ID, we abort config flow
+        for unique_id in self._async_current_ids():
+            if unique_id is None:
+                _LOGGER.warning(
+                    "A device without a valid UniqueID is already configured."
+                    " Configuration of multiple instance is not possible"
+                )
+                return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
             return self._show_setup_form(user_input)
@@ -166,17 +183,28 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_host"
 
         if not errors:
-            result = await self._async_check_connection(user_input)
-            if result != RESULT_SUCCESS:
-                errors["base"] = result
+            result, unique_id = await self._async_check_connection(user_input)
+            if result == RESULT_SUCCESS:
+                if unique_id:
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
+                # we allow configure a single instance without unique id
+                elif self._async_current_entries():
+                    return self.async_abort(reason="invalid_unique_id")
+                else:
+                    _LOGGER.warning(
+                        "This device do not provide a valid Unique ID."
+                        " Configuration of multiple instance will not be possible"
+                    )
 
-        if errors:
-            return self._show_setup_form(user_input, errors)
+                return self.async_create_entry(
+                    title=host,
+                    data=user_input,
+                )
 
-        return self.async_create_entry(
-            title=host,
-            data=user_input,
-        )
+            errors["base"] = result
+
+        return self._show_setup_form(user_input, errors)
 
     @staticmethod
     @callback

--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -156,7 +156,7 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
                     "A device without a valid UniqueID is already configured."
                     " Configuration of multiple instance is not possible"
                 )
-                return self.async_abort(reason="single_instance_allowed")
+                return self.async_abort(reason="not_unique_id_exist")
 
         if user_input is None:
             return self._show_setup_form(user_input)
@@ -187,7 +187,6 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
             if result == RESULT_SUCCESS:
                 if unique_id:
                     await self.async_set_unique_id(unique_id)
-                    self._abort_if_unique_id_configured()
                 # we allow configure a single instance without unique id
                 elif self._async_current_entries():
                     return self.async_abort(reason="invalid_unique_id")

--- a/homeassistant/components/asuswrt/diagnostics.py
+++ b/homeassistant/components/asuswrt/diagnostics.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_CONNECTIONS,
     ATTR_IDENTIFIERS,
     CONF_PASSWORD,
+    CONF_UNIQUE_ID,
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
@@ -19,7 +20,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from .const import DATA_ASUSWRT, DOMAIN
 from .router import AsusWrtRouter
 
-TO_REDACT = {CONF_PASSWORD, CONF_USERNAME}
+TO_REDACT = {CONF_PASSWORD, CONF_UNIQUE_ID, CONF_USERNAME}
 TO_REDACT_DEV = {ATTR_CONNECTIONS, ATTR_IDENTIFIERS}
 
 

--- a/homeassistant/components/asuswrt/sensor.py
+++ b/homeassistant/components/asuswrt/sensor.py
@@ -43,7 +43,6 @@ class AsusWrtSensorEntityDescription(SensorEntityDescription):
     precision: int = 2
 
 
-DEFAULT_PREFIX = "Asuswrt"
 UNIT_DEVICES = "Devices"
 
 CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
@@ -190,8 +189,11 @@ class AsusWrtSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description: AsusWrtSensorEntityDescription = description
 
-        self._attr_name = f"{DEFAULT_PREFIX} {description.name}"
-        self._attr_unique_id = f"{DOMAIN} {self.name}"
+        self._attr_name = f"{router.name} {description.name}"
+        if router.unique_id:
+            self._attr_unique_id = f"{DOMAIN} {router.unique_id} {description.name}"
+        else:
+            self._attr_unique_id = f"{DOMAIN} {self.name}"
         self._attr_device_info = router.device_info
         self._attr_extra_state_attributes = {"hostname": router.host}
 

--- a/homeassistant/components/asuswrt/strings.json
+++ b/homeassistant/components/asuswrt/strings.json
@@ -25,9 +25,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "invalid_unique_id": "Impossible to determine a valid unique id for the device",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "not_unique_id_exist": "A device without a valid UniqueID is already configured. Configuration of multiple instance is not possible"
     }
   },
   "options": {

--- a/homeassistant/components/asuswrt/strings.json
+++ b/homeassistant/components/asuswrt/strings.json
@@ -25,6 +25,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "invalid_unique_id": "Impossible to determine a valid unique id for the device",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },

--- a/homeassistant/components/asuswrt/translations/en.json
+++ b/homeassistant/components/asuswrt/translations/en.json
@@ -1,6 +1,8 @@
 {
     "config": {
         "abort": {
+            "already_configured": "Device is already configured",
+            "invalid_unique_id": "Impossible to determine a valid unique id for the device",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },
         "error": {

--- a/homeassistant/components/asuswrt/translations/en.json
+++ b/homeassistant/components/asuswrt/translations/en.json
@@ -1,9 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured",
             "invalid_unique_id": "Impossible to determine a valid unique id for the device",
-            "single_instance_allowed": "Already configured. Only a single configuration possible."
+            "not_unique_id_exist": "A device without a valid UniqueID is already configured. Configuration of multiple instance is not possible"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -28,6 +28,7 @@ from tests.common import MockConfigEntry
 
 HOST = "myrouter.asuswrt.com"
 IP_ADDRESS = "192.168.1.1"
+MAC_ADDR = "a1:b1:c1:d1:e1:f1"
 SSH_KEY = "1234"
 
 CONFIG_DATA = {
@@ -39,19 +40,44 @@ CONFIG_DATA = {
     CONF_MODE: "ap",
 }
 
+PATCH_GET_HOST = patch(
+    "homeassistant.components.asuswrt.config_flow.socket.gethostbyname",
+    return_value=IP_ADDRESS,
+)
+
+PATCH_SETUP_ENTRY = patch(
+    "homeassistant.components.asuswrt.async_setup_entry",
+    return_value=True,
+)
+
+
+@pytest.fixture(name="mock_unique_id")
+def mock_unique_id_fixture():
+    """Mock returned unique id."""
+    return {}
+
 
 @pytest.fixture(name="connect")
-def mock_controller_connect():
+def mock_controller_connect(mock_unique_id):
     """Mock a successful connection."""
     with patch("homeassistant.components.asuswrt.router.AsusWrt") as service_mock:
         service_mock.return_value.connection.async_connect = AsyncMock()
         service_mock.return_value.is_connected = True
         service_mock.return_value.connection.disconnect = Mock()
+        service_mock.return_value.async_get_nvram = AsyncMock(
+            return_value=mock_unique_id
+        )
         yield service_mock
 
 
-async def test_user(hass, connect):
+@pytest.mark.usefixtures("connect")
+@pytest.mark.parametrize(
+    "unique_id",
+    [{}, {"label_mac": MAC_ADDR}],
+)
+async def test_user(hass, mock_unique_id, unique_id):
     """Test user config."""
+    mock_unique_id.update(unique_id)
     flow_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER, "show_advanced_options": True}
     )
@@ -59,15 +85,10 @@ async def test_user(hass, connect):
     assert flow_result["step_id"] == "user"
 
     # test with all provided
-    with patch(
-        "homeassistant.components.asuswrt.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry, patch(
-        "homeassistant.components.asuswrt.config_flow.socket.gethostbyname",
-        return_value=IP_ADDRESS,
-    ):
+    with PATCH_GET_HOST, PATCH_SETUP_ENTRY as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
-            flow_result["flow_id"], user_input=CONFIG_DATA
+            flow_result["flow_id"],
+            user_input=CONFIG_DATA,
         )
         await hass.async_block_till_done()
 
@@ -78,10 +99,17 @@ async def test_user(hass, connect):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_error_no_password_ssh(hass):
-    """Test we abort if component is already setup."""
+@pytest.mark.parametrize(
+    ["config", "error"],
+    [
+        ({CONF_PASSWORD: None}, "pwd_or_ssh"),
+        ({CONF_SSH_KEY: SSH_KEY}, "pwd_and_ssh"),
+    ],
+)
+async def test_error_wrong_password_ssh(hass, config, error):
+    """Test we abort for wrong password and ssh file combination."""
     config_data = CONFIG_DATA.copy()
-    config_data.pop(CONF_PASSWORD)
+    config_data.update(config)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER, "show_advanced_options": True},
@@ -89,36 +117,27 @@ async def test_error_no_password_ssh(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "pwd_or_ssh"}
-
-
-async def test_error_both_password_ssh(hass):
-    """Test we abort if component is already setup."""
-    config_data = CONFIG_DATA.copy()
-    config_data[CONF_SSH_KEY] = SSH_KEY
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
-        data=config_data,
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "pwd_and_ssh"}
+    assert result["errors"] == {"base": error}
 
 
 async def test_error_invalid_ssh(hass):
-    """Test we abort if component is already setup."""
+    """Test we abort if invalid ssh file is provided."""
     config_data = CONFIG_DATA.copy()
     config_data.pop(CONF_PASSWORD)
     config_data[CONF_SSH_KEY] = SSH_KEY
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
-        data=config_data,
-    )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "ssh_not_file"}
+    with patch(
+        "homeassistant.components.asuswrt.config_flow.os.path.isfile",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER, "show_advanced_options": True},
+            data=config_data,
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "ssh_not_file"}
 
 
 async def test_error_invalid_host(hass):
@@ -144,53 +163,82 @@ async def test_abort_if_already_setup(hass):
         data=CONFIG_DATA,
     ).add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.asuswrt.config_flow.socket.gethostbyname",
-        return_value=IP_ADDRESS,
-    ):
-        # Should fail, same HOST (flow)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=CONFIG_DATA,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+@pytest.mark.usefixtures("connect")
+async def test_abort_if_unique_exist(hass, mock_unique_id):
+    """Test we abort if uniqueid is already configured."""
+    mock_unique_id.update({"label_mac": MAC_ADDR})
+    MockConfigEntry(
+        domain=DOMAIN,
+        data=CONFIG_DATA,
+        unique_id=MAC_ADDR,
+    ).add_to_hass(hass)
+
+    with PATCH_GET_HOST:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
             data=CONFIG_DATA,
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "single_instance_allowed"
+        assert result["reason"] == "already_configured"
 
 
-async def test_on_connect_failed(hass):
+@pytest.mark.usefixtures("connect")
+async def test_abort_invalid_unique_id(hass):
+    """Test we abort if uniqueid not available."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        data=CONFIG_DATA,
+        unique_id=MAC_ADDR,
+    ).add_to_hass(hass)
+
+    with PATCH_GET_HOST:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=CONFIG_DATA,
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "invalid_unique_id"
+
+
+@pytest.mark.parametrize(
+    ["side_effect", "error"],
+    [
+        (OSError, "cannot_connect"),
+        (TypeError, "unknown"),
+        (None, "cannot_connect"),
+    ],
+)
+async def test_on_connect_failed(hass, side_effect, error):
     """Test when we have errors connecting the router."""
     flow_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER, "show_advanced_options": True},
     )
 
-    with patch("homeassistant.components.asuswrt.router.AsusWrt") as asus_wrt:
-        asus_wrt.return_value.connection.async_connect = AsyncMock()
-        asus_wrt.return_value.is_connected = False
-        result = await hass.config_entries.flow.async_configure(
-            flow_result["flow_id"], user_input=CONFIG_DATA
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "cannot_connect"}
-
-    with patch("homeassistant.components.asuswrt.router.AsusWrt") as asus_wrt:
-        asus_wrt.return_value.connection.async_connect = AsyncMock(side_effect=OSError)
-        result = await hass.config_entries.flow.async_configure(
-            flow_result["flow_id"], user_input=CONFIG_DATA
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "cannot_connect"}
-
-    with patch("homeassistant.components.asuswrt.router.AsusWrt") as asus_wrt:
+    with PATCH_GET_HOST, patch(
+        "homeassistant.components.asuswrt.router.AsusWrt"
+    ) as asus_wrt:
         asus_wrt.return_value.connection.async_connect = AsyncMock(
-            side_effect=TypeError
+            side_effect=side_effect
         )
+        asus_wrt.return_value.is_connected = False
+
         result = await hass.config_entries.flow.async_configure(
             flow_result["flow_id"], user_input=CONFIG_DATA
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "unknown"}
+        assert result["errors"] == {"base": error}
 
 
 async def test_options_flow(hass):
@@ -202,7 +250,7 @@ async def test_options_flow(hass):
     )
     config_entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.asuswrt.async_setup_entry", return_value=True):
+    with PATCH_SETUP_ENTRY:
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is to add UniqueID to AsusWRT config entry and allow configuration of multiple instance. It use as UniqueID the device Mac Address retrieved from nvram
To not break compatibility with existing configuration and in case that we are not able to retrieve mac-address from nvram, I implemented this logic in config flow:

- if a device without UniqueID is configured, flow abort with error "single instance allowed"
- if during configuration is not possible to determinate device UniqueID there are 2 options:
    - if another device with a valid UniqueID is configured, flow is aborted
    - if no devices are configured, configuration complete without UniqueID (and we come back to check at first point if user try to configure a second device) 

I do not implemented any automatic migration of existing configurations because it would cause names change for existing entities.  


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
