### PR TITLE
Fix TOD incorrectly determining state between sun events

### DIFF
--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, event
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.sun import get_astral_event_date, get_astral_event_next
+from homeassistant.helpers.sun import get_astral_event_next, get_astral_event_previous
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
@@ -150,63 +150,49 @@ class TodSensor(BinarySensorEntity):
     def _calculate_boundary_time(self):
         """Calculate internal absolute time boundaries."""
         nowutc = dt_util.utcnow()
-        # If after value is a sun event instead of absolute time
+        # Get the next after time
         if _is_sun_event(self._after):
-            # Calculate the today's event utc time or
-            # if not available take next
-            after_event_date = get_astral_event_date(
-                self.hass, self._after, nowutc
-            ) or get_astral_event_next(self.hass, self._after, nowutc)
+            # Get the next sun event of this type
+            print("next after event")
+            after_event_datetime = get_astral_event_next(self.hass, self._after, nowutc)
         else:
             # Convert local time provided to UTC today
             # datetime.combine(date, time, tzinfo) is not supported
             # in python 3.5. The self._after is provided
             # with hass configured TZ not system wide
-            after_event_date = self._naive_time_to_utc_datetime(self._after)
+            after_event_datetime = self._naive_time_to_utc_datetime(self._after)
 
-        self._time_after = after_event_date
-
-        # If before value is a sun event instead of absolute time
+        # Get the next before time
         if _is_sun_event(self._before):
-            # Calculate the today's event utc time or  if not available take
-            # next
-            before_event_date = get_astral_event_date(
+            # Calculate the next sun event utc time
+            print("next before event")
+            before_event_datetime = get_astral_event_next(
                 self.hass, self._before, nowutc
-            ) or get_astral_event_next(self.hass, self._before, nowutc)
-            # Before is earlier than after
-            if before_event_date < after_event_date:
-                # Take next day for before
-                before_event_date = get_astral_event_next(
-                    self.hass, self._before, after_event_date
-                )
+            )
         else:
             # Convert local time provided to UTC today, see above
-            before_event_date = self._naive_time_to_utc_datetime(self._before)
-
-            # It is safe to add timedelta days=1 to UTC as there is no DST
-            if before_event_date < after_event_date + self._after_offset:
-                before_event_date += timedelta(days=1)
-
-        self._time_before = before_event_date
-
-        # We are calculating the _time_after value assuming that it will happen today
-        # But that is not always true, e.g. after 23:00, before 12:00 and now is 10:00
-        # If _time_before and _time_after are ahead of nowutc:
-        # _time_before is set to 12:00 next day
-        # _time_after is set to 23:00 today
-        # nowutc is set to 10:00 today
-        if (
-            not _is_sun_event(self._after)
-            and self._time_after > nowutc
-            and self._time_before > nowutc + timedelta(days=1)
-        ):
-            # remove one day from _time_before and _time_after
-            self._time_after -= timedelta(days=1)
-            self._time_before -= timedelta(days=1)
+            before_event_datetime = self._naive_time_to_utc_datetime(self._before)
 
         # Add offset to utc boundaries according to the configuration
-        self._time_after += self._after_offset
-        self._time_before += self._before_offset
+        after_event_datetime += self._after_offset
+        before_event_datetime += self._before_offset
+
+        # Before is earlier than after, then revert the after time to the previous one
+        #   e.g. after 23:00, before 12:00 and now is 10:00
+        #    or after sunset 9pm, before sunrise 6am, now is 2am
+        if before_event_datetime < after_event_datetime:
+            if _is_sun_event(self._after):
+                # Take the previous instance for after
+                after_event_datetime = get_astral_event_previous(
+                    self.hass, self._after, nowutc
+                )
+                after_event_datetime += self._after_offset
+            else:
+                # remove one day from _time_after
+                after_event_datetime -= timedelta(days=1)
+
+        self._time_after = after_event_datetime
+        self._time_before = before_event_datetime
 
     def _turn_to_next_day(self):
         """Turn to to the next day."""
@@ -248,7 +234,7 @@ class TodSensor(BinarySensorEntity):
     def _calculate_next_update(self):
         """Datetime when the next update to the state."""
         now = dt_util.utcnow()
-        if now < self._time_after:
+        if (now < self._time_after) and (self._time_after < self._time_before):
             self._next_update = self._time_after
             return
         if now < self._time_before:

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
-from homeassistant.helpers.sun import get_astral_event_date, get_astral_event_next
+from homeassistant.helpers.sun import get_astral_event_next, get_astral_event_previous
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -156,6 +156,21 @@ async def test_after_happens_tomorrow(hass):
 
     state = hass.states.get("binary_sensor.night")
     assert state.state == STATE_ON
+
+
+# @freeze_time("2022-05-10 01:00:00-08:00")
+# async def test_start_after_midnight_sunset_sunrise(hass):
+#    """Test when both before and after are in the future, after midnight and before sunrise."""
+#    config = {
+#        "binary_sensor": [
+#            {"platform": "tod", "name": "Night", "after": "sunset", "before": "sunrise"}
+#        ]
+#    }
+#    await async_setup_component(hass, "binary_sensor", config)
+#    await hass.async_block_till_done()
+#
+#    state = hass.states.get("binary_sensor.night")
+#    assert state.state == STATE_ON
 
 
 async def test_midnight_turnover_after_midnight_outside_period(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Remove a conditional from #65884 so that the "between" code is correctly executed whether it's a sun event or a fixed time. This attempts to fix a bug where Time of Day is wrong if HA is restarted after midnight between sunset and sunrise. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #70206 #69288 #67039
- This PR is related to issue: #70206
- Link to documentation pull request: https://www.home-assistant.io/integrations/tod/

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
