### PR TITLE
Coerce int in Flo set sleep mode service

### DIFF
--- a/homeassistant/components/flo/switch.py
+++ b/homeassistant/components/flo/switch.py
@@ -51,7 +51,10 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_SET_SLEEP_MODE,
         {
-            vol.Required(ATTR_SLEEP_MINUTES, default=120): vol.In(SLEEP_MINUTE_OPTIONS),
+            vol.Required(ATTR_SLEEP_MINUTES, default=120): vol.All(
+                vol.Coerce(int),
+                vol.In(SLEEP_MINUTE_OPTIONS),
+            ),
             vol.Required(ATTR_REVERT_TO_MODE, default=SYSTEM_MODE_HOME): vol.In(
                 SYSTEM_REVERT_MODES
             ),

--- a/tests/components/flo/test_services.py
+++ b/tests/components/flo/test_services.py
@@ -67,3 +67,17 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
     )
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 12
+
+    # test calling with a string value to ensure it is converted to int
+    await hass.services.async_call(
+        FLO_DOMAIN,
+        SERVICE_SET_SLEEP_MODE,
+        {
+            ATTR_ENTITY_ID: SWITCH_ENTITY_ID,
+            ATTR_REVERT_TO_MODE: SYSTEM_MODE_HOME,
+            ATTR_SLEEP_MINUTES: "120",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert aioclient_mock.call_count == 13

--- a/tests/components/flo/test_services.py
+++ b/tests/components/flo/test_services.py
@@ -1,4 +1,7 @@
 """Test the services for the Flo by Moen integration."""
+import pytest
+from voluptuous.error import MultipleInvalid
+
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.flo.switch import (
     ATTR_REVERT_TO_MODE,
@@ -81,3 +84,18 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
     )
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 13
+
+    # test calling with a non string -> int value and ensure exception is thrown
+    with pytest.raises(MultipleInvalid):
+        await hass.services.async_call(
+            FLO_DOMAIN,
+            SERVICE_SET_SLEEP_MODE,
+            {
+                ATTR_ENTITY_ID: SWITCH_ENTITY_ID,
+                ATTR_REVERT_TO_MODE: SYSTEM_MODE_HOME,
+                ATTR_SLEEP_MINUTES: "test",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert aioclient_mock.call_count == 13


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will coerce a string value to int to fix an issue when calling the service from the UI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68971
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
