### PR TITLE
2022.4.7

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -118,8 +118,8 @@ async def async_setup_entry(
 
 
 def format_target_temperature(target_temperature):
-    """Format target temperature to be sent to the Daikin unit, taking care of keeping at most 1 decimal digit."""
-    return str(round(float(target_temperature), 1)).rstrip("0").rstrip(".")
+    """Format target temperature to be sent to the Daikin unit, rounding to nearest half degree."""
+    return str(round(float(target_temperature) * 2, 0) / 2).rstrip("0").rstrip(".")
 
 
 class DaikinClimate(ClimateEntity):

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dhcp",
   "name": "DHCP Discovery",
   "documentation": "https://www.home-assistant.io/integrations/dhcp",
-  "requirements": ["scapy==2.4.5", "aiodiscover==1.4.10"],
+  "requirements": ["scapy==2.4.5", "aiodiscover==1.4.11"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",
   "iot_class": "local_push",

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dhcp",
   "name": "DHCP Discovery",
   "documentation": "https://www.home-assistant.io/integrations/dhcp",
-  "requirements": ["scapy==2.4.5", "aiodiscover==1.4.9"],
+  "requirements": ["scapy==2.4.5", "aiodiscover==1.4.10"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",
   "iot_class": "local_push",

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -3,7 +3,7 @@
   "name": "KNX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.20.3"],
+  "requirements": ["xknx==0.20.4"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver",
   "iot_class": "local_push",

--- a/homeassistant/components/plaato/manifest.json
+++ b/homeassistant/components/plaato/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["webhook"],
   "after_dependencies": ["cloud"],
   "codeowners": ["@JohNan"],
-  "requirements": ["pyplaato==0.0.16"],
+  "requirements": ["pyplaato==0.0.18"],
   "iot_class": "cloud_push",
   "loggers": ["pyplaato"]
 }

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -132,7 +132,7 @@ class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 # access token without using the IP address and password, so we have to
                 # store it:
                 return self.async_create_entry(
-                    title=controller.name,
+                    title=str(controller.name),
                     data={
                         CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -395,7 +395,7 @@ def _get_states_with_session(
 
     if (
         run is None
-        and (run := (recorder.run_information_from_instance(hass, utc_point_in_time)))
+        and (run := (recorder.run_information_with_session(session, utc_point_in_time)))
         is None
     ):
         # History did not run before utc_point_in_time

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -544,7 +544,7 @@ def _apply_update(instance, new_version, old_version):  # noqa: C901
                             # https://github.com/home-assistant/core/issues/56104
                             text(
                                 f"ALTER TABLE {table} CONVERT TO "
-                                "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci LOCK=EXCLUSIVE"
+                                "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci, LOCK=EXCLUSIVE"
                             )
                         )
     elif new_version == 22:

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.35.2"],
+  "requirements": ["zwave-js-server-python==0.35.3"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["usb", "http", "websocket_api"],
   "iot_class": "local_push",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 4
-PATCH_VERSION: Final = "6"
+PATCH_VERSION: Final = "7"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==2.3.0
 PyNaCl==1.5.0
-aiodiscover==1.4.9
+aiodiscover==1.4.10
 aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==2.3.0
 PyNaCl==1.5.0
-aiodiscover==1.4.10
+aiodiscover==1.4.11
 aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1723,7 +1723,7 @@ pypck==0.7.14
 pypjlink2==1.2.1
 
 # homeassistant.components.plaato
-pyplaato==0.0.16
+pyplaato==0.0.18
 
 # homeassistant.components.point
 pypoint==2.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2500,7 +2500,7 @@ zigpy==0.44.2
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.35.2
+zwave-js-server-python==0.35.3
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2435,7 +2435,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.knx
-xknx==0.20.3
+xknx==0.20.4
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -128,7 +128,7 @@ aioazuredevops==1.3.5
 aiobotocore==2.1.0
 
 # homeassistant.components.dhcp
-aiodiscover==1.4.9
+aiodiscover==1.4.10
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -128,7 +128,7 @@ aioazuredevops==1.3.5
 aiobotocore==2.1.0
 
 # homeassistant.components.dhcp
-aiodiscover==1.4.10
+aiodiscover==1.4.11
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -112,7 +112,7 @@ aioazuredevops==1.3.5
 aiobotocore==2.1.0
 
 # homeassistant.components.dhcp
-aiodiscover==1.4.10
+aiodiscover==1.4.11
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1154,7 +1154,7 @@ pyownet==0.10.0.post1
 pypck==0.7.14
 
 # homeassistant.components.plaato
-pyplaato==0.0.16
+pyplaato==0.0.18
 
 # homeassistant.components.point
 pypoint==2.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -112,7 +112,7 @@ aioazuredevops==1.3.5
 aiobotocore==2.1.0
 
 # homeassistant.components.dhcp
-aiodiscover==1.4.9
+aiodiscover==1.4.10
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1619,7 +1619,7 @@ zigpy-znp==0.7.0
 zigpy==0.44.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.35.2
+zwave-js-server-python==0.35.3
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1575,7 +1575,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.knx
-xknx==0.20.3
+xknx==0.20.4
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name         = homeassistant
-version      = 2022.4.6
+version      = 2022.4.7
 author       = The Home Assistant Authors
 author_email = hello@home-assistant.io
 license      = Apache-2.0

--- a/tests/components/daikin/test_temperature_format.py
+++ b/tests/components/daikin/test_temperature_format.py
@@ -8,13 +8,13 @@ def test_int_conversion():
     assert formatted == "16"
 
 
-def test_decimal_conversion():
+def test_rounding():
     """Check 1 decimal is kept when target temp is a decimal."""
     formatted = format_target_temperature("16.1")
-    assert formatted == "16.1"
-
-
-def test_decimal_conversion_more_digits():
-    """Check at most 1 decimal is kept when target temp is a decimal with more than 1 decimal."""
-    formatted = format_target_temperature("16.09")
-    assert formatted == "16.1"
+    assert formatted == "16"
+    formatted = format_target_temperature("16.3")
+    assert formatted == "16.5"
+    formatted = format_target_temperature("16.65")
+    assert formatted == "16.5"
+    formatted = format_target_temperature("16.9")
+    assert formatted == "17"

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -49,7 +49,9 @@ def controller_fixture(
     controller = AsyncMock()
     controller.api_version = "4.5.0"
     controller.hardware_version = 3
-    controller.name = "My RainMachine"
+    # The api returns a controller with all numbers as numeric
+    # instead of a string
+    controller.name = 12345
     controller.mac = controller_mac
     controller.software_version = "4.0.925"
 

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_step_user(hass, config, setup_rainmachine):
         data=config,
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "My RainMachine"
+    assert result["title"] == "12345"
     assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
         CONF_PASSWORD: "password",
@@ -232,7 +232,7 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(
         await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "My RainMachine"
+    assert result2["title"] == "12345"
     assert result2["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
         CONF_PASSWORD: "password",

--- a/tests/components/rainmachine/test_diagnostics.py
+++ b/tests/components/rainmachine/test_diagnostics.py
@@ -585,7 +585,7 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_rainmach
             "controller": {
                 "api_version": "4.5.0",
                 "hardware_version": 3,
-                "name": "My RainMachine",
+                "name": 12345,
                 "software_version": "4.0.925",
             },
         },

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -307,3 +307,26 @@ async def test_unknown_notification(hass, hank_binary_switch, integration, clien
     notification_obj.node = node
     with pytest.raises(TypeError):
         node.emit("notification", {"notification": notification_obj})
+
+    notification_events = async_capture_events(hass, "zwave_js_notification")
+
+    # Test a valid notification with an unsupported command class
+    event = Event(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": node.node_id,
+            "ccId": 0,
+            "args": {
+                "commandClassName": "No Operation",
+                "commandClass": 0,
+                "testNodeId": 1,
+                "status": 0,
+                "acknowledgedFrames": 2,
+            },
+        },
+    )
+    node.receive_event(event)
+
+    assert not notification_events


### PR DESCRIPTION
- Fixed syntax error in ALTER TABLE statement (#70304) ([@dmak] - [#70336]) ([recorder docs])
- Update xknx to version 0.20.4 ([@marvin-w] - [#70342]) ([knx docs])
- Bump aiodiscover to 1.4.10 ([@bdraco] - [#70348]) ([dhcp docs])
- Bump zwave-js-server-python to 0.35.3 ([@raman325] - [#70357]) ([zwave_js docs])
- Bump pyplaato to 0.0.18 ([@JohNan] - [#70391]) ([plaato docs])
- Bump aiodiscover to 1.4.11 ([@bdraco] - [#70413]) ([dhcp docs])
- Ensure rainmachine creates config entry titles as strings ([@bdraco] - [#70417]) ([rainmachine docs])
- Fix history not including start time state ([@bdraco] - [#70447]) ([recorder docs])
- Daikin AC : Round to nearest half degree (#70446) ([@vanackej] - [#70452]) ([daikin docs])

[#70336]: https://github.com/home-assistant/core/pull/70336
[#70342]: https://github.com/home-assistant/core/pull/70342
[#70348]: https://github.com/home-assistant/core/pull/70348
[#70357]: https://github.com/home-assistant/core/pull/70357
[#70391]: https://github.com/home-assistant/core/pull/70391
[#70413]: https://github.com/home-assistant/core/pull/70413
[#70417]: https://github.com/home-assistant/core/pull/70417
[#70447]: https://github.com/home-assistant/core/pull/70447
[#70452]: https://github.com/home-assistant/core/pull/70452
[@JohNan]: https://github.com/JohNan
[@bdraco]: https://github.com/bdraco
[@dmak]: https://github.com/dmak
[@marvin-w]: https://github.com/marvin-w
[@raman325]: https://github.com/raman325
[@vanackej]: https://github.com/vanackej
[daikin docs]: https://www.home-assistant.io/integrations/daikin/
[dhcp docs]: https://www.home-assistant.io/integrations/dhcp/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[plaato docs]: https://www.home-assistant.io/integrations/plaato/
[rainmachine docs]: https://www.home-assistant.io/integrations/rainmachine/
[recorder docs]: https://www.home-assistant.io/integrations/recorder/
[zwave_js docs]: https://www.home-assistant.io/integrations/zwave_js/