### PR TITLE
Fix state_changes_during_period bakery caching for limit and descending

### DIFF
--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -343,15 +343,22 @@ def state_changes_during_period(
                 StateAttributes, States.attributes_id == StateAttributes.attributes_id
             )
 
-        last_updated = States.last_updated.desc() if descending else States.last_updated
-        baked_query += lambda q: q.order_by(States.entity_id, last_updated)
+        if descending:
+            baked_query += lambda q: q.order_by(
+                States.entity_id, States.last_updated.desc()
+            )
+        else:
+            baked_query += lambda q: q.order_by(States.entity_id, States.last_updated)
 
         if limit:
-            baked_query += lambda q: q.limit(limit)
+            baked_query += lambda q: q.limit(bindparam("limit"))
 
         states = execute(
             baked_query(session).params(
-                start_time=start_time, end_time=end_time, entity_id=entity_id
+                start_time=start_time,
+                end_time=end_time,
+                entity_id=entity_id,
+                limit=limit,
             )
         )
 

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -268,6 +268,63 @@ def test_state_changes_during_period(hass_recorder, attributes, no_attributes, l
     assert states[:limit] == hist[entity_id]
 
 
+@pytest.mark.parametrize(
+    "attributes, no_attributes, descending",
+    [
+        ({"attr": True}, False, True),
+        ({}, True, True),
+        ({"attr": True}, False, False),
+        ({}, True, False),
+    ],
+)
+def test_state_changes_during_period_descending(
+    hass_recorder, attributes, no_attributes, descending
+):
+    """Test state change during period descending."""
+    hass = hass_recorder()
+    entity_id = "media_player.test"
+
+    def set_state(state):
+        """Set the state."""
+        hass.states.set(entity_id, state, attributes)
+        wait_recording_done(hass)
+        return hass.states.get(entity_id)
+
+    start = dt_util.utcnow()
+    point = start + timedelta(seconds=1)
+    end = point + timedelta(seconds=1)
+
+    with patch("homeassistant.components.recorder.dt_util.utcnow", return_value=start):
+        set_state("idle")
+        set_state("YouTube")
+
+    with patch("homeassistant.components.recorder.dt_util.utcnow", return_value=point):
+        states = [
+            set_state("idle"),
+            set_state("Netflix"),
+            set_state("Plex"),
+            set_state("YouTube"),
+        ]
+
+    with patch("homeassistant.components.recorder.dt_util.utcnow", return_value=end):
+        set_state("Netflix")
+        set_state("Plex")
+
+    hist = history.state_changes_during_period(
+        hass, start, end, entity_id, no_attributes, descending=descending
+    )
+    history_states = list(hist[entity_id])
+
+    # Normally we do not want to branch in tests, but
+    # in this case since we are validating that the sqlalchemy
+    # bakery caching is not caching the incorrect descending
+    # value, we have to do it all in one test
+    if descending:
+        history_states = list(reversed(history_states))
+
+    assert states == history_states
+
+
 def test_get_last_state_changes(hass_recorder):
     """Test number of state changes."""
     hass = hass_recorder()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix state_changes_during_period bakery caching for limit and descending

The bakery calls needed to use `bindparam`s and separate lambda to
avoid the bakery caching the previous query

This fixes a violate of point 5 on https://docs.sqlalchemy.org/en/14/orm/extensions/baked.html
> The caching is achieved by storing references to the lambda objects themselves in order to formulate a cache key; that is, the fact that the Python interpreter assigns an in-Python identity to these functions is what determines how to identify the query on successive runs. For those invocations of search_for_user() where the email parameter is specified, the callable lambda q: q.filter(User.email == bindparam('email')) will be part of the cache key that’s retrieved; when email is None, this callable is not part of the cache key.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: probably also solves #70011
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
