### PR TITLE
Only apply color from light profile if no color specified

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -706,8 +706,21 @@ class Profiles:
         if (profile := self.data.get(name)) is None:
             return
 
-        if profile.hs_color is not None:
-            params.setdefault(ATTR_HS_COLOR, profile.hs_color)
+        color_attributes = (
+            ATTR_COLOR_NAME,
+            ATTR_COLOR_TEMP,
+            ATTR_HS_COLOR,
+            ATTR_RGB_COLOR,
+            ATTR_RGBW_COLOR,
+            ATTR_RGBWW_COLOR,
+            ATTR_XY_COLOR,
+            ATTR_WHITE,
+        )
+
+        if profile.hs_color is not None and not any(
+            color_attribute in params for color_attribute in color_attributes
+        ):
+            params[ATTR_HS_COLOR] = profile.hs_color
         if profile.brightness is not None:
             params.setdefault(ATTR_BRIGHTNESS, profile.brightness)
         if profile.transition is not None:

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -595,6 +595,7 @@ async def test_default_profiles_group(
     "extra_call_params, expected_params_state_was_off, expected_params_state_was_on",
     (
         (
+            # No turn on params, should apply profile
             {},
             {
                 light.ATTR_HS_COLOR: (50.353, 100),
@@ -608,6 +609,7 @@ async def test_default_profiles_group(
             },
         ),
         (
+            # Brightness in turn on params, brightness from profile ignored
             {light.ATTR_BRIGHTNESS: 22},
             {
                 light.ATTR_HS_COLOR: (50.353, 100),
@@ -620,6 +622,7 @@ async def test_default_profiles_group(
             },
         ),
         (
+            # Transition in turn on params, transition from profile ignored
             {light.ATTR_TRANSITION: 22},
             {
                 light.ATTR_HS_COLOR: (50.353, 100),
@@ -631,23 +634,115 @@ async def test_default_profiles_group(
             },
         ),
         (
+            # Color temp in turn on params, color from profile ignored
+            {
+                light.ATTR_COLOR_TEMP: 600,
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_COLOR_TEMP: 600,
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_COLOR_TEMP: 600,
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+        ),
+        (
+            # HS-color in turn on params, color from profile ignored
+            {
+                light.ATTR_HS_COLOR: [70, 80],
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_HS_COLOR: (70, 80),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_HS_COLOR: (70, 80),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+        ),
+        (
+            # RGB-color in turn on params, color from profile ignored
+            {
+                light.ATTR_RGB_COLOR: [1, 2, 3],
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_RGB_COLOR: (1, 2, 3),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_RGB_COLOR: (1, 2, 3),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+        ),
+        (
+            # RGBW-color in turn on params, color from profile ignored
+            {
+                light.ATTR_RGBW_COLOR: [1, 2, 3, 4],
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_RGBW_COLOR: (1, 2, 3, 4),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_RGBW_COLOR: (1, 2, 3, 4),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+        ),
+        (
+            # RGBWW-color in turn on params, color from profile ignored
+            {
+                light.ATTR_RGBWW_COLOR: [1, 2, 3, 4, 5],
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_RGBWW_COLOR: (1, 2, 3, 4, 5),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+            {
+                light.ATTR_RGBWW_COLOR: (1, 2, 3, 4, 5),
+                light.ATTR_BRIGHTNESS: 11,
+                light.ATTR_TRANSITION: 1,
+            },
+        ),
+        (
+            # XY-color in turn on params, color from profile ignored
             {
                 light.ATTR_XY_COLOR: [0.4448, 0.4066],
                 light.ATTR_BRIGHTNESS: 11,
                 light.ATTR_TRANSITION: 1,
             },
             {
-                light.ATTR_HS_COLOR: (38.88, 49.02),
+                light.ATTR_XY_COLOR: (0.4448, 0.4066),
                 light.ATTR_BRIGHTNESS: 11,
                 light.ATTR_TRANSITION: 1,
             },
             {
-                light.ATTR_HS_COLOR: (38.88, 49.02),
+                light.ATTR_XY_COLOR: (0.4448, 0.4066),
                 light.ATTR_BRIGHTNESS: 11,
                 light.ATTR_TRANSITION: 1,
             },
         ),
         (
+            # Brightness + transition in turn on params
             {light.ATTR_BRIGHTNESS: 11, light.ATTR_TRANSITION: 1},
             {
                 light.ATTR_HS_COLOR: (50.353, 100),
@@ -684,7 +779,14 @@ async def test_default_profiles_light(
     mock_light_profiles[profile.name] = profile
 
     dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES))
-    dev.supported_color_modes = [light.ColorMode.HS]
+    dev.supported_color_modes = {
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
+        light.ColorMode.RGB,
+        light.ColorMode.RGBW,
+        light.ColorMode.RGBWW,
+        light.ColorMode.XY,
+    }
     dev.supported_features = light.LightEntityFeature.TRANSITION
     await hass.services.async_call(
         light.DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only apply color from light profile if no color is specified

The color from a light profile will only be applied if none of the following parameters are present in the turn on call:
`color_name`, `color_temp`, `hs_color`, `rgb_color`, `rgbw_color`, `rgbww_color`, `xy_color`, `white`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/69499
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
