### PR TITLE
Disable no-self-use [pylint]

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -147,9 +147,7 @@ class Data:
         if not bcrypt.checkpw(password.encode(), user_hash):
             raise InvalidAuth
 
-    def hash_password(  # pylint: disable=no-self-use
-        self, password: str, for_storage: bool = False
-    ) -> bytes:
+    def hash_password(self, password: str, for_storage: bool = False) -> bytes:
         """Encode a password."""
         hashed: bytes = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12))
 

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -73,8 +73,6 @@ class AlexaCapability:
     https://developer.amazon.com/docs/device-apis/message-guide.html
     """
 
-    # pylint: disable=no-self-use
-
     supported_locales = {"en-US"}
 
     def __init__(self, entity: State, instance: str | None = None) -> None:

--- a/homeassistant/components/alexa/config.py
+++ b/homeassistant/components/alexa/config.py
@@ -84,7 +84,6 @@ class AbstractConfig(ABC):
     @callback
     def should_expose(self, entity_id):
         """If an entity should be exposed."""
-        # pylint: disable=no-self-use
         return False
 
     @callback

--- a/homeassistant/components/alexa/resources.py
+++ b/homeassistant/components/alexa/resources.py
@@ -200,8 +200,6 @@ class AlexaCapabilityResource:
     https://developer.amazon.com/docs/device-apis/resources-and-assets.html#capability-resources
     """
 
-    # pylint: disable=no-self-use
-
     def __init__(self, labels):
         """Initialize an Alexa resource."""
         self._resource_labels = []

--- a/homeassistant/components/ambiclimate/config_flow.py
+++ b/homeassistant/components/ambiclimate/config_flow.py
@@ -140,7 +140,6 @@ class AmbiclimateAuthCallbackView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> str:
         """Receive authorization token."""
-        # pylint: disable=no-self-use
         if (code := request.query.get("code")) is None:
             return "No code"
         hass = request.app["hass"]

--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -89,7 +89,6 @@ class APIEventStream(HomeAssistantView):
 
     async def get(self, request):
         """Provide a streaming interface for the event bus."""
-        # pylint: disable=no-self-use
         if not request["hass_user"].is_admin:
             raise Unauthorized()
         hass = request.app["hass"]
@@ -379,7 +378,6 @@ class APIErrorLog(HomeAssistantView):
 
     async def get(self, request):
         """Retrieve API error log."""
-        # pylint: disable=no-self-use
         if not request["hass_user"].is_admin:
             raise Unauthorized()
         return web.FileResponse(request.app["hass"].data[DATA_LOGGING])

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -271,7 +271,6 @@ class TokenView(HomeAssistantView):
 
     async def _async_handle_revoke_token(self, hass, data):
         """Handle revoke token request."""
-        # pylint: disable=no-self-use
 
         # OAuth 2.0 Token Revocation [RFC7009]
         # 2.2 The authorization server responds with HTTP status code 200

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -198,7 +198,6 @@ class LoginFlowIndexView(LoginFlowBaseView):
 
     async def get(self, request):
         """Do not allow index of flows in progress."""
-        # pylint: disable=no-self-use
         return web.Response(status=HTTPStatus.METHOD_NOT_ALLOWED)
 
     @RequestDataValidator(

--- a/homeassistant/components/awair/__init__.py
+++ b/homeassistant/components/awair/__init__.py
@@ -76,7 +76,6 @@ class AwairDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _fetch_air_data(self, device):
         """Fetch latest air quality data."""
-        # pylint: disable=no-self-use
         LOGGER.debug("Fetching data for %s", device.uuid)
         air_data = await device.air_data_latest()
         LOGGER.debug(air_data)

--- a/homeassistant/components/backup/http.py
+++ b/homeassistant/components/backup/http.py
@@ -26,7 +26,7 @@ class DownloadBackupView(HomeAssistantView):
     url = "/api/backup/download/{slug}"
     name = "api:backup:download"
 
-    async def get(  # pylint: disable=no-self-use
+    async def get(
         self,
         request: Request,
         slug: str,

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -549,7 +549,6 @@ class Camera(Entity):
         This is used by cameras with CameraEntityFeature.STREAM
         and StreamType.HLS.
         """
-        # pylint: disable=no-self-use
         return None
 
     async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -160,7 +160,6 @@ class ConfigManagerFlowIndexView(FlowManagerIndexView):
 
     async def get(self, request):
         """Not implemented."""
-        # pylint: disable=no-self-use
         raise aiohttp.web_exceptions.HTTPMethodNotAllowed("GET", ["POST"])
 
     # pylint: disable=arguments-differ

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -17,12 +17,10 @@ class AbstractConversationAgent(ABC):
 
     async def async_get_onboarding(self):
         """Get onboard data."""
-        # pylint: disable=no-self-use
         return None
 
     async def async_set_onboarding(self, shown):
         """Set onboard data."""
-        # pylint: disable=no-self-use
         return True
 
     @abstractmethod

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -180,7 +180,7 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
     extra_urls = ["/api/diagnostics/{d_type}/{d_id}/{sub_type}/{sub_id}"]
     name = "api:diagnostics"
 
-    async def get(  # pylint: disable=no-self-use
+    async def get(
         self,
         request: web.Request,
         d_type: str,

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -336,7 +336,6 @@ class DoorBirdRequestView(HomeAssistantView):
 
     async def get(self, request, event):
         """Respond to requests from the device."""
-        # pylint: disable=no-self-use
         hass = request.app["hass"]
 
         token = request.query.get("token")

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -127,7 +127,7 @@ class UPNPResponderProtocol:
         _LOGGER.debug("UPNP Responder responding with: %s", response)
         self.transport.sendto(response, addr)
 
-    def error_received(self, exc):  # pylint: disable=no-self-use
+    def error_received(self, exc):
         """Log UPNP errors."""
         _LOGGER.error("UPNP Error received: %s", exc)
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -611,7 +611,7 @@ class ManifestJSONView(HomeAssistantView):
     name = "manifestjson"
 
     @callback
-    def get(self, request: web.Request) -> web.Response:  # pylint: disable=no-self-use
+    def get(self, request: web.Request) -> web.Response:
         """Return the manifest.json."""
         return web.Response(
             text=MANIFEST_JSON.json, content_type="application/manifest+json"

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -167,7 +167,6 @@ class AbstractConfig(ABC):
 
     def should_2fa(self, state):
         """If an entity should have 2FA checked."""
-        # pylint: disable=no-self-use
         return True
 
     async def async_report_state(self, message, agent_user_id: str):

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -1004,7 +1004,6 @@ class HomeKitPairingQRView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Retrieve the pairing QRCode image."""
-        # pylint: disable=no-self-use
         if not request.query_string:
             raise Unauthorized()
         entry_id, secret = request.query_string.split("-")

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -60,7 +60,6 @@ class HomematicipAuth:
 
     async def get_auth(self, hass: HomeAssistant, hapid, pin):
         """Create a HomematicIP access point object."""
-        # pylint: disable=no-self-use
         auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
         try:
             await auth.init(hapid)

--- a/homeassistant/components/huisbaasje/config_flow.py
+++ b/homeassistant/components/huisbaasje/config_flow.py
@@ -69,7 +69,6 @@ class HuisbaasjeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         Data has the keys from DATA_SCHEMA with values provided by the user.
         """
-        # pylint: disable=no-self-use
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
 

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -485,7 +485,6 @@ class HyperionBaseLight(LightEntity):
         priority: dict[str, Any] | None = self._client.visible_priority
         return priority
 
-    # pylint: disable=no-self-use
     def _allow_priority_update(self, priority: dict[str, Any] | None = None) -> bool:
         """Determine whether to allow a priority to update internal state."""
         return True

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -69,12 +69,10 @@ class LovelaceConfig(ABC):
 
     async def async_save(self, config):
         """Save config."""
-        # pylint: disable=no-self-use
         raise HomeAssistantError("Not supported")
 
     async def async_delete(self):
         """Delete config."""
-        # pylint: disable=no-self-use
         raise HomeAssistantError("Not supported")
 
     @callback

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -540,7 +540,6 @@ class MediaPlayerEntity(Entity):
 
         Must be implemented by integration.
         """
-        # pylint: disable=no-self-use
         return None, None
 
     @property

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -301,9 +301,7 @@ class UploadMediaView(http.HomeAssistantView):
             {"media_content_id": f"{data['media_content_id']}/{uploaded_file.filename}"}
         )
 
-    def _move_file(  # pylint: disable=no-self-use
-        self, target_dir: Path, uploaded_file: FileField
-    ) -> None:
+    def _move_file(self, target_dir: Path, uploaded_file: FileField) -> None:
         """Move file to target."""
         if not target_dir.is_dir():
             raise ValueError("Target is not an existing directory")

--- a/homeassistant/components/numato/__init__.py
+++ b/homeassistant/components/numato/__init__.py
@@ -168,7 +168,6 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-# pylint: disable=no-self-use
 class NumatoAPI:
     """Home-Assistant specific API for numato device access."""
 

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -420,7 +420,6 @@ class PlexAuthorizationCallbackView(HomeAssistantView):
 
     async def get(self, request):
         """Receive authorization confirmation."""
-        # pylint: disable=no-self-use
         hass = request.app["hass"]
         await hass.config_entries.flow.async_configure(
             flow_id=request.query["flow_id"], user_input=None

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -22,7 +22,7 @@ class PlexImageView(HomeAssistantView):
     name = "api:plex:image"
     url = "/api/plex_image_proxy/{server_id}/{media_content_id}"
 
-    async def get(  # pylint: disable=no-self-use
+    async def get(
         self,
         request: web.Request,
         server_id: str,

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -236,7 +236,6 @@ class StubPrinter:
 
     def _call_print(self, *objects, **kwargs):
         """Print text."""
-        # pylint: disable=no-self-use
         _LOGGER.warning("Don't use print() inside scripts. Use logger.info() instead")
 
 
@@ -246,7 +245,6 @@ class TimeWrapper:
     # Class variable, only going to warn once per Home Assistant run
     warned = False
 
-    # pylint: disable=no-self-use
     def sleep(self, *args, **kwargs):
         """Sleep method that warns once."""
         if not TimeWrapper.warned:

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -124,7 +124,7 @@ class IRobotEntity(Entity):
         """Register callback function."""
         self.vacuum.register_on_message_callback(self.on_message)
 
-    def new_state_filter(self, new_state):  # pylint: disable=no-self-use
+    def new_state_filter(self, new_state):
         """Filter out wifi state messages."""
         return len(new_state) > 1 or "signal" not in new_state
 

--- a/homeassistant/components/smarttub/controller.py
+++ b/homeassistant/components/smarttub/controller.py
@@ -94,7 +94,6 @@ class SmartTubController:
         return data
 
     async def _get_spa_data(self, spa):
-        # pylint: disable=no-self-use
         full_status, reminders, errors = await asyncio.gather(
             spa.get_status_full(),
             spa.get_reminders(),

--- a/homeassistant/components/sms/gateway.py
+++ b/homeassistant/components/sms/gateway.py
@@ -73,7 +73,6 @@ class Gateway:
 
         self._hass.add_job(self._notify_incoming_sms, data)
 
-    # pylint: disable=no-self-use
     def get_and_delete_all_sms(self, state_machine, force=False):
         """Read and delete all SMS in the modem."""
         # Read SMS memory status ...

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -145,7 +145,6 @@ class WebhookView(HomeAssistantView):
 
     async def _handle(self, request: Request, webhook_id: str) -> Response:
         """Handle webhook call."""
-        # pylint: disable=no-self-use
         _LOGGER.debug("Handling webhook %s payload for %s", request.method, webhook_id)
         hass = request.app["hass"]
         return await async_handle_webhook(hass, webhook_id, request)

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -42,7 +42,6 @@ class WebsocketAPIView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.WebSocketResponse:
         """Handle an incoming websocket connection."""
-        # pylint: disable=no-self-use
         return await WebSocketHandler(request.app["hass"], request).async_handle()
 
 

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -186,7 +186,6 @@ class WirelessTagBaseSensor(Entity):
         """
         return self.decorate_value(self.principal_value)
 
-    # pylint: disable=no-self-use
     def decorate_value(self, value):
         """Decorate input value to be well presented for end user."""
         return f"{value:.1f}"

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -641,7 +641,6 @@ class DataManager:
 
         Withings' API occasionally and incorrectly throws errors. Retrying the call tends to work.
         """
-        # pylint: disable=no-self-use
         exception = None
         for attempt in range(1, attempts + 1):
             _LOGGER.debug("Attempt %s of %s", attempt, attempts)

--- a/homeassistant/components/xmpp/notify.py
+++ b/homeassistant/components/xmpp/notify.py
@@ -347,7 +347,6 @@ async def async_send_message(  # noqa: C901
             except NotConnectedError as ex:
                 _LOGGER.error("Connection error %s", ex)
 
-        # pylint: disable=no-self-use
         def get_random_filename(self, filename, extension=None):
             """Return a random filename, leaving the extension intact."""
             if extension is None:

--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -60,7 +60,6 @@ class ZWaveNodePingButton(ButtonEntity):
 
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
-        # pylint: disable=no-self-use
         LOGGER.error(
             "There is no value to refresh for this entity so the zwave_js.refresh_value "
             "service won't work for it"

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -240,7 +240,6 @@ class BaseDiscoverySchemaDataTemplate:
         Can optionally be implemented by subclasses if input data needs to be
         transformed once discovered Value is available.
         """
-        # pylint: disable=no-self-use
         return {}
 
     def values_to_watch(self, resolved_data: Any) -> Iterable[ZwaveValue]:
@@ -249,7 +248,6 @@ class BaseDiscoverySchemaDataTemplate:
 
         Should be implemented by subclasses only if there are values to watch.
         """
-        # pylint: disable=no-self-use
         return []
 
     def value_ids_to_watch(self, resolved_data: Any) -> set[str]:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -487,7 +487,6 @@ class ZWaveNodeStatusSensor(SensorEntity):
 
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
-        # pylint: disable=no-self-use
         LOGGER.error(
             "There is no value to refresh for this entity so the zwave_js.refresh_value "
             "service won't work for it"

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -328,7 +328,6 @@ class ZWaveServices:
 
     async def async_set_config_parameter(self, service: ServiceCall) -> None:
         """Set a config value on a node."""
-        # pylint: disable=no-self-use
         nodes = service.data[const.ATTR_NODES]
         property_or_property_name = service.data[const.ATTR_CONFIG_PARAMETER]
         property_key = service.data.get(const.ATTR_CONFIG_PARAMETER_BITMASK)
@@ -356,7 +355,6 @@ class ZWaveServices:
         self, service: ServiceCall
     ) -> None:
         """Bulk set multiple partial config values on a node."""
-        # pylint: disable=no-self-use
         nodes = service.data[const.ATTR_NODES]
         property_ = service.data[const.ATTR_CONFIG_PARAMETER]
         new_value = service.data[const.ATTR_CONFIG_VALUE]
@@ -391,7 +389,6 @@ class ZWaveServices:
 
     async def async_set_value(self, service: ServiceCall) -> None:
         """Set a value on a node."""
-        # pylint: disable=no-self-use
         nodes: set[ZwaveNode] = service.data[const.ATTR_NODES]
         command_class = service.data[const.ATTR_COMMAND_CLASS]
         property_ = service.data[const.ATTR_PROPERTY]
@@ -503,7 +500,6 @@ class ZWaveServices:
 
     async def async_ping(self, service: ServiceCall) -> None:
         """Ping node(s)."""
-        # pylint: disable=no-self-use
         const.LOGGER.warning(
             "This service is deprecated in favor of the ping button entity. Service "
             "calls will still work for now but the service will be removed in a "

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -602,7 +602,6 @@ class HomeAssistant:
 
     async def _await_and_log_pending(self, pending: Iterable[Awaitable[Any]]) -> None:
         """Await and log tasks that take a long time."""
-        # pylint: disable=no-self-use
         wait_time = 0
         while pending:
             _, pending = await asyncio.wait(pending, timeout=BLOCK_LOG_TIMEOUT)

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -394,7 +394,6 @@ class OAuth2AuthorizeCallbackView(http.HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Receive authorization code."""
-        # pylint: disable=no-self-use
         if "code" not in request.query or "state" not in request.query:
             return web.Response(
                 text=f"Missing code or state parameter in {request.url}"

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -22,7 +22,6 @@ class _BaseFlowManagerView(HomeAssistantView):
         """Initialize the flow manager index view."""
         self._flow_mgr = flow_mgr
 
-    # pylint: disable=no-self-use
     def _prepare_result_json(
         self, result: data_entry_flow.FlowResult
     ) -> data_entry_flow.FlowResult:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -417,7 +417,7 @@ class Template:
 
         return self._parse_result(render_result)
 
-    def _parse_result(self, render_result: str) -> Any:  # pylint: disable=no-self-use
+    def _parse_result(self, render_result: str) -> Any:
         """Parse the result."""
         try:
             result = literal_eval(render_result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ good-names = [
 # too-many-ancestors - it's too strict.
 # wrong-import-order - isort guards this
 # consider-using-f-string - str.format sometimes more readable
+# no-self-use - little added value with too many false-positives
 # ---
 # Enable once current issues are fixed:
 # consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
@@ -111,6 +112,7 @@ disable = [
     "unused-argument",
     "wrong-import-order",
     "consider-using-f-string",
+    "no-self-use",
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
 ]

--- a/tests/components/aws/test_init.py
+++ b/tests/components/aws/test_init.py
@@ -14,7 +14,7 @@ class MockAioSession:
         self.publish = AsyncMock()
         self.send_message = AsyncMock()
 
-    def create_client(self, *args, **kwargs):  # pylint: disable=no-self-use
+    def create_client(self, *args, **kwargs):
         """Create a mocked client."""
         return MagicMock(
             __aenter__=AsyncMock(

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -232,7 +232,6 @@ def test_process_custom_logbook_entries(hass_):
     assert_entry(entries[0], name=name, message=message, entity_id=entity_id)
 
 
-# pylint: disable=no-self-use
 def assert_entry(
     entry, when=None, name=None, message=None, domain=None, entity_id=None
 ):
@@ -261,7 +260,6 @@ def create_state_changed_event(
     )
 
 
-# pylint: disable=no-self-use
 def create_state_changed_event_from_old_new(
     entity_id, event_time_fired, old_state, new_state
 ):

--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -36,7 +36,7 @@ class PilightDaemonSim:
     def __init__(self, host, port):
         """Init pilight client, ignore parameters."""
 
-    def send_code(self, call):  # pylint: disable=no-self-use
+    def send_code(self, call):
         """Handle pilight.send service callback."""
         _LOGGER.error("PilightDaemonSim payload: %s", call)
 
@@ -51,7 +51,7 @@ class PilightDaemonSim:
             self.callback(self.test_message)
             self.called = True
 
-    def stop(self):  # pylint: disable=no-self-use
+    def stop(self):
         """Handle homeassistant.stop callback."""
         _LOGGER.error("PilightDaemonSim stop")
 


### PR DESCRIPTION
## Proposed change
The pylint `no-self-use` check provides very little added value with many false-positive.
It can also leads to bad code which doesn't account for subclassing when users want to avoid the error message and annotate a method with `staticmethod` just because the base implementation doesn't use `self`. See: https://github.com/home-assistant/core/pull/68656#discussion_r835062168

For more details, see the pylint issue here: https://github.com/PyCQA/pylint/issues/5502

With the next pylint release, the check will be moved to an optional extension. However, we can choose to `disable` it already.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
