### PR TITLE
Use recorder test fixtures in tests

### DIFF
--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -18,11 +18,12 @@ from homeassistant.components.recorder.util import (
     session_scope,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .common import corrupt_db_file
 
-from tests.common import async_init_recorder_component, async_test_home_assistant
+from tests.common import SetupRecorderInstanceT, async_test_home_assistant
 
 
 def test_session_scope_not_setup(hass_recorder):
@@ -96,7 +97,9 @@ def test_validate_or_move_away_sqlite_database(hass, tmpdir, caplog):
     assert util.validate_or_move_away_sqlite_database(dburl) is True
 
 
-async def test_last_run_was_recently_clean(hass, tmp_path):
+async def test_last_run_was_recently_clean(
+    loop, async_setup_recorder_instance: SetupRecorderInstanceT, tmp_path
+):
     """Test we can check if the last recorder run was recently clean."""
     config = {
         recorder.CONF_DB_URL: "sqlite:///" + str(tmp_path / "pytest.db"),
@@ -116,7 +119,7 @@ async def test_last_run_was_recently_clean(hass, tmp_path):
         "homeassistant.components.recorder.util.last_run_was_recently_clean",
         wraps=_last_run_was_recently_clean,
     ) as last_run_was_recently_clean_mock:
-        await async_init_recorder_component(hass, config)
+        await async_setup_recorder_instance(hass, config)
         await hass.async_block_till_done()
         last_run_was_recently_clean_mock.assert_not_called()
 
@@ -130,7 +133,7 @@ async def test_last_run_was_recently_clean(hass, tmp_path):
         wraps=_last_run_was_recently_clean,
     ) as last_run_was_recently_clean_mock:
         hass = await async_test_home_assistant(None)
-        await async_init_recorder_component(hass, config)
+        await async_setup_recorder_instance(hass, config)
         last_run_was_recently_clean_mock.assert_called_once()
         assert return_values[-1] is True
 
@@ -149,7 +152,7 @@ async def test_last_run_was_recently_clean(hass, tmp_path):
         return_value=thirty_min_future_time,
     ):
         hass = await async_test_home_assistant(None)
-        await async_init_recorder_component(hass, config)
+        await async_setup_recorder_instance(hass, config)
         last_run_was_recently_clean_mock.assert_called_once()
         assert return_values[-1] is False
 
@@ -594,7 +597,9 @@ def test_periodic_db_cleanups(hass_recorder):
     assert str(text_obj) == "PRAGMA wal_checkpoint(TRUNCATE);"
 
 
-async def test_write_lock_db(hass, tmp_path):
+async def test_write_lock_db(
+    hass: HomeAssistant, async_setup_recorder_instance: SetupRecorderInstanceT, tmp_path
+):
     """Test database write lock."""
     from sqlalchemy.exc import OperationalError
 
@@ -602,7 +607,7 @@ async def test_write_lock_db(hass, tmp_path):
     config = {
         recorder.CONF_DB_URL: "sqlite:///" + str(tmp_path / "pytest.db?timeout=0.1")
     }
-    await async_init_recorder_component(hass, config)
+    await async_setup_recorder_instance(hass, config)
     await hass.async_block_till_done()
 
     instance = hass.data[DATA_INSTANCE]

--- a/tests/helpers/test_recorder.py
+++ b/tests/helpers/test_recorder.py
@@ -2,12 +2,15 @@
 
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import recorder
 
-from tests.common import async_init_recorder_component
+from tests.common import SetupRecorderInstanceT
 
 
-async def test_async_migration_in_progress(hass):
+async def test_async_migration_in_progress(
+    hass: HomeAssistant, async_setup_recorder_instance: SetupRecorderInstanceT
+):
     """Test async_migration_in_progress wraps the recorder."""
     with patch(
         "homeassistant.components.recorder.util.async_migration_in_progress",
@@ -22,7 +25,7 @@ async def test_async_migration_in_progress(hass):
     ):
         assert recorder.async_migration_in_progress(hass) is False
 
-    await async_init_recorder_component(hass)
+    await async_setup_recorder_instance(hass)
 
     # The recorder is now loaded
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `recorder_mock` and `async_setup_recorder_instance` fixtures in tests instead of setting up the recorder with test helper `async_init_recorder_component`
This helps prevent flaky tests because the fixtures disable statistics and nightly purge.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
