### PR TITLE
Remove "sonos" prefix for Sonos switch entity_ids

### DIFF
--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -150,9 +150,6 @@ class SonosSwitchEntity(SonosPollingEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(speaker)
         self.feature_type = feature_type
-        self.entity_id = ENTITY_ID_FORMAT.format(
-            f"sonos_{speaker.zone_name}_{FRIENDLY_NAMES[feature_type]}"
-        )
         self.needs_coordinator = feature_type in COORDINATOR_FEATURES
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_name = f"{speaker.zone_name} {FRIENDLY_NAMES[feature_type]}"

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -28,12 +28,12 @@ async def test_entity_registry(hass, async_autosetup_sonos):
 
     assert "media_player.zone_a" in entity_registry.entities
     assert "switch.sonos_alarm_14" in entity_registry.entities
-    assert "switch.sonos_zone_a_status_light" in entity_registry.entities
-    assert "switch.sonos_zone_a_night_sound" in entity_registry.entities
-    assert "switch.sonos_zone_a_speech_enhancement" in entity_registry.entities
-    assert "switch.sonos_zone_a_subwoofer_enabled" in entity_registry.entities
-    assert "switch.sonos_zone_a_surround_enabled" in entity_registry.entities
-    assert "switch.sonos_zone_a_touch_controls" in entity_registry.entities
+    assert "switch.zone_a_status_light" in entity_registry.entities
+    assert "switch.zone_a_night_sound" in entity_registry.entities
+    assert "switch.zone_a_speech_enhancement" in entity_registry.entities
+    assert "switch.zone_a_subwoofer_enabled" in entity_registry.entities
+    assert "switch.zone_a_surround_enabled" in entity_registry.entities
+    assert "switch.zone_a_touch_controls" in entity_registry.entities
 
 
 async def test_switch_attributes(hass, async_autosetup_sonos, soco):
@@ -51,32 +51,30 @@ async def test_switch_attributes(hass, async_autosetup_sonos, soco):
     assert alarm_state.attributes.get(ATTR_PLAY_MODE) == "SHUFFLE_NOREPEAT"
     assert not alarm_state.attributes.get(ATTR_INCLUDE_LINKED_ZONES)
 
-    night_sound = entity_registry.entities["switch.sonos_zone_a_night_sound"]
+    night_sound = entity_registry.entities["switch.zone_a_night_sound"]
     night_sound_state = hass.states.get(night_sound.entity_id)
     assert night_sound_state.state == STATE_ON
 
-    speech_enhancement = entity_registry.entities[
-        "switch.sonos_zone_a_speech_enhancement"
-    ]
+    speech_enhancement = entity_registry.entities["switch.zone_a_speech_enhancement"]
     speech_enhancement_state = hass.states.get(speech_enhancement.entity_id)
     assert speech_enhancement_state.state == STATE_ON
 
-    crossfade = entity_registry.entities["switch.sonos_zone_a_crossfade"]
+    crossfade = entity_registry.entities["switch.zone_a_crossfade"]
     crossfade_state = hass.states.get(crossfade.entity_id)
     assert crossfade_state.state == STATE_ON
 
     # Ensure switches are disabled
-    status_light = entity_registry.entities["switch.sonos_zone_a_status_light"]
+    status_light = entity_registry.entities["switch.zone_a_status_light"]
     assert hass.states.get(status_light.entity_id) is None
 
-    touch_controls = entity_registry.entities["switch.sonos_zone_a_touch_controls"]
+    touch_controls = entity_registry.entities["switch.zone_a_touch_controls"]
     assert hass.states.get(touch_controls.entity_id) is None
 
-    sub_switch = entity_registry.entities["switch.sonos_zone_a_subwoofer_enabled"]
+    sub_switch = entity_registry.entities["switch.zone_a_subwoofer_enabled"]
     sub_switch_state = hass.states.get(sub_switch.entity_id)
     assert sub_switch_state.state == STATE_OFF
 
-    surround_switch = entity_registry.entities["switch.sonos_zone_a_surround_enabled"]
+    surround_switch = entity_registry.entities["switch.zone_a_surround_enabled"]
     surround_switch_state = hass.states.get(surround_switch.entity_id)
     assert surround_switch_state.state == STATE_ON
 
@@ -106,7 +104,7 @@ async def test_switch_attributes(hass, async_autosetup_sonos, soco):
     status_light_state = hass.states.get(status_light.entity_id)
     assert status_light_state.state == STATE_ON
 
-    touch_controls = entity_registry.entities["switch.sonos_zone_a_touch_controls"]
+    touch_controls = entity_registry.entities["switch.zone_a_touch_controls"]
     touch_controls_state = hass.states.get(touch_controls.entity_id)
     assert touch_controls_state.state == STATE_ON
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the "sonos_" prefix from switch `entity_id` values to match other Sonos platforms. Alarm switches are the exception and retain the prefix as they're less obviously identifiable.

Will not cause a breaking change as the entity registry will keep the `entity_id` values stable for existing users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69975
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
