### PR TITLE
Hue config flow to guard ipv6

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import ipaddress
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -22,6 +21,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client, device_registry
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.network import is_ipv6_address
 
 from .const import (
     CONF_ALLOW_HUE_GROUPS,
@@ -232,11 +232,8 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_hue_bridge")
 
         # Ignore if host is IPv6
-        try:
-            if ipaddress.ip_address(url.hostname).version == 6:
-                return self.async_abort(reason="invalid_host")
-        except ValueError:
-            pass
+        if is_ipv6_address(url.hostname):
+            return self.async_abort(reason="invalid_host")
 
         # abort if we already have exactly this bridge id/host
         # reload the integration if the host got updated
@@ -260,11 +257,8 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         host is already configured and delegate to the import step if not.
         """
         # Ignore if host is IPv6
-        try:
-            if ipaddress.ip_address(discovery_info.host).version == 6:
-                return self.async_abort(reason="invalid_host")
-        except ValueError:
-            pass
+        if is_ipv6_address(discovery_info.host):
+            return self.async_abort(reason="invalid_host")
 
         # abort if we already have exactly this bridge id/host
         # reload the integration if the host got updated

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -230,6 +231,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not url.hostname:
             return self.async_abort(reason="not_hue_bridge")
 
+        # Ignore if host is IPv6
+        try:
+            if ipaddress.ip_address(url.hostname).version == 6:
+                return self.async_abort(reason="invalid_host")
+        except ValueError:
+            pass
+
         # abort if we already have exactly this bridge id/host
         # reload the integration if the host got updated
         bridge_id = normalize_bridge_id(discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL])
@@ -251,6 +259,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         This flow is triggered by the Zeroconf component. It will check if the
         host is already configured and delegate to the import step if not.
         """
+        # Ignore if host is IPv6
+        try:
+            if ipaddress.ip_address(discovery_info.host).version == 6:
+                return self.async_abort(reason="invalid_host")
+        except ValueError:
+            pass
+
         # abort if we already have exactly this bridge id/host
         # reload the integration if the host got updated
         bridge_id = normalize_bridge_id(discovery_info.properties["bridgeid"])

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -30,7 +30,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "not_hue_bridge": "Not a Hue bridge"
+      "not_hue_bridge": "Not a Hue bridge",
+      "invalid_host": "Invalid host"
     }
   },
   "device_automation": {

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -424,7 +424,14 @@ async def test_bridge_ssdp_missing_serial(hass):
     assert result["reason"] == "not_hue_bridge"
 
 
-async def test_bridge_ssdp_invalid_location(hass):
+@pytest.mark.parametrize(
+    "location,reason",
+    (
+        ("http:///", "not_hue_bridge"),
+        ("http://[fd00::eeb5:faff:fe84:b17d]/description.xml", "invalid_host"),
+    ),
+)
+async def test_bridge_ssdp_invalid_location(hass, location, reason):
     """Test if discovery info is a serial attribute."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -432,7 +439,7 @@ async def test_bridge_ssdp_invalid_location(hass):
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="http:///",
+            ssdp_location=location,
             upnp={
                 ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL[0],
                 ssdp.ATTR_UPNP_SERIAL: "1234",
@@ -441,7 +448,7 @@ async def test_bridge_ssdp_invalid_location(hass):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "not_hue_bridge"
+    assert result["reason"] == reason
 
 
 async def test_bridge_ssdp_espalexa(hass):
@@ -791,3 +798,27 @@ async def test_bridge_zeroconf_already_exists(hass, aioclient_mock):
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     assert entry.data["host"] == "192.168.1.217"
+
+
+async def test_bridge_zeroconf_ipv6(hass):
+    """Test a bridge being discovered by zeroconf and ipv6 address."""
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="fd00::eeb5:faff:fe84:b17d",
+            addresses=["fd00::eeb5:faff:fe84:b17d"],
+            port=443,
+            hostname="Philips-hue.local",
+            type="_hue._tcp.local.",
+            name="Philips Hue - ABCABC._hue._tcp.local.",
+            properties={
+                "_raw": {"bridgeid": b"ecb5faabcabc", "modelid": b"BSB002"},
+                "bridgeid": "ecb5faabcabc",
+                "modelid": "BSB002",
+            },
+        ),
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "invalid_host"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hue apparently will braodcast IPv6 addresses if it was without internet.

Fixes #70086

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
