### PR TITLE
Handle removed entites in collection.sync_entity_lifecycle

### DIFF
--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -351,6 +351,8 @@ def sync_entity_lifecycle(
             ent_reg.async_remove(ent_to_remove)
         elif change_set.item_id in entities:
             await entities[change_set.item_id].async_remove(force_remove=True)
+        # Unconditionally pop the entity from the entity list to avoid racing against
+        # the entity registry event handled by Entity._async_registry_updated
         if change_set.item_id in entities:
             entities.pop(change_set.item_id)
 

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -334,7 +334,13 @@ def sync_entity_lifecycle(
     ent_reg = entity_registry.async_get(hass)
 
     async def _add_entity(change_set: CollectionChangeSet) -> Entity:
+        def entity_removed() -> None:
+            """Remove entity from entities if it's removed or not added."""
+            if change_set.item_id in entities:
+                entities.pop(change_set.item_id)
+
         entities[change_set.item_id] = create_entity(change_set.item)
+        entities[change_set.item_id].async_on_remove(entity_removed)
         return entities[change_set.item_id]
 
     async def _remove_entity(change_set: CollectionChangeSet) -> None:
@@ -343,11 +349,14 @@ def sync_entity_lifecycle(
         )
         if ent_to_remove is not None:
             ent_reg.async_remove(ent_to_remove)
-        else:
+        elif change_set.item_id in entities:
             await entities[change_set.item_id].async_remove(force_remove=True)
-        entities.pop(change_set.item_id)
+        if change_set.item_id in entities:
+            entities.pop(change_set.item_id)
 
     async def _update_entity(change_set: CollectionChangeSet) -> None:
+        if change_set.item_id not in entities:
+            return
         await entities[change_set.item_id].async_update_config(change_set.item)  # type: ignore[attr-defined]
 
     _func_map: dict[

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -611,7 +611,7 @@ class EntityPlatform:
             self.hass.states.async_reserve(entity.entity_id)
 
         def remove_entity_cb() -> None:
-            """Remove entity from entities list."""
+            """Remove entity from entities dict."""
             self.entities.pop(entity_id)
 
         entity.async_on_remove(remove_entity_cb)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle removed entites in `collection.sync_entity_lifecycle`

This is implemented by `collection.sync_entity_lifecycle` adding an on_remove-callback to its entities.

Note:
Callbacks registered by `Entity.async_on_remove` are now called *also if adding of the entity is aborted*.

A review of all calls to `Entity.async_on_remove` shows that this should not create any unwanted behavior.

The only calls to `Entity.async_on_remove` before `Entity.async_added_to_hass` I could find are:
- A call from `homeassistant.components.threshold.binary_sensor.ThresholdSensor.__init__`; this call should be moved to `homeassistant.components.threshold.binary_sensor.ThresholdSensor.async_added_to_hass` in a separate PR.
- A call from entity_platform so it can keep track of its entities, this is only called if adding the entity is NOT aborted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
