### PR TITLE
Prepare for upcoming mypy update

### DIFF
--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -130,7 +130,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
         )
         self.context[CONF_HOST] = self._host
 
-        if ipaddress.ip_address(self._host).is_link_local:
+        if not self._host or ipaddress.ip_address(self._host).is_link_local:
             return self.async_abort(reason="ignore_ip6_link_local")
 
         if uuid := discovery_info.upnp.get(ssdp.ATTR_UPNP_UDN):

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -236,7 +236,7 @@ class StatisticsSensor(SensorEntity):
         samples_max_age: timedelta | None,
         precision: int,
         quantile_intervals: int,
-        quantile_method: str,
+        quantile_method: Literal["exclusive", "inclusive"],
     ) -> None:
         """Initialize the Statistics sensor."""
         self._attr_icon: str = ICON
@@ -252,7 +252,7 @@ class StatisticsSensor(SensorEntity):
         self._samples_max_age: timedelta | None = samples_max_age
         self._precision: int = precision
         self._quantile_intervals: int = quantile_intervals
-        self._quantile_method: str = quantile_method
+        self._quantile_method: Literal["exclusive", "inclusive"] = quantile_method
         self._value: StateType | datetime = None
         self._unit_of_measurement: str | None = None
         self._available: bool = False

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -109,7 +109,7 @@ def report_integration(
         integration,
         found_frame.filename[index:],
         found_frame.lineno,
-        found_frame.line.strip(),
+        (found_frame.line or "?").strip(),
     )
 
 

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -236,7 +236,8 @@ def _get_internal_url(
             scheme="http", host=hass.config.api.local_ip, port=hass.config.api.port
         )
         if (
-            not is_loopback(ip_address(ip_url.host))
+            ip_url.host
+            and not is_loopback(ip_address(ip_url.host))
             and (not require_current_request or ip_url.host == _get_request_host())
             and (not require_standard_port or ip_url.is_default_port())
         ):

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -155,13 +155,13 @@ def check_loop(func: Callable[..., Any], strict: bool = True) -> None:
         integration,
         found_frame.filename[index:],
         found_frame.lineno,
-        found_frame.line.strip(),
+        (found_frame.line or "?").strip(),
     )
     if strict:
         raise RuntimeError(
             "Blocking calls must be done in the executor or a separate thread; "
             "Use `await hass.async_add_executor_job()` "
-            f"at {found_frame.filename[index:]}, line {found_frame.lineno}: {found_frame.line.strip()}"
+            f"at {found_frame.filename[index:]}, line {found_frame.lineno}: {(found_frame.line or '?').strip()}"
         )
 
 


### PR DESCRIPTION
## Proposed change
The next mypy version will be released soon (1-2 weeks).
This PR implements some of the recent Typeshed changes to make the update a bit easier.

**Changes**
* `statistics.quantiles` will no longer accept `str` for the `method` argument. It must be `Literal["exclusive", "inclusive"]`, which is already validated by the config schema.
https://github.com/home-assistant/core/blob/fe0120b65a5e685b1aed06e8bd3cf10b561a710b/homeassistant/components/statistics/sensor.py#L187-L189
* The `lineno` attribute for `traceback.FrameSummary` will change from `int` to `int | None`.
* The input type for `ip_address` was changed from `object` to `int | str | bytes | IPv4Address | IPv6Address`. Most importantly, that means `None` doesn't type check anymore. The function itself would emit a `ValueError` in case `None` is passed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
