### PR TITLE
Add logging to UniFi device tracker for help debugging client status

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -1,5 +1,7 @@
 """Track both clients and devices using UniFi Network."""
+
 from datetime import timedelta
+import logging
 
 from aiounifi.api import SOURCE_DATA
 from aiounifi.events import (
@@ -27,6 +29,8 @@ import homeassistant.util.dt as dt_util
 from .const import DOMAIN as UNIFI_DOMAIN
 from .unifi_client import UniFiClient
 from .unifi_entity_base import UniFiBase
+
+LOGGER = logging.getLogger(__name__)
 
 CLIENT_TRACKER = "client"
 DEVICE_TRACKER = "device"
@@ -150,14 +154,29 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         """Set up tracked client."""
         super().__init__(client, controller)
 
-        self.heartbeat_check = False
         self._controller_connection_state_changed = False
 
-        self._last_seen = client.last_seen or 0
+        last_seen = client.last_seen or 0
         self.schedule_update = self._is_connected = (
             self.is_wired == client.is_wired
-            and dt_util.utcnow() - dt_util.utc_from_timestamp(float(self._last_seen))
+            and dt_util.utcnow() - dt_util.utc_from_timestamp(float(last_seen))
             < controller.option_detection_time
+        )
+
+    @callback
+    def _async_log_debug_data(self, method: str) -> None:
+        """Print debug data about entity."""
+        last_seen = self.client.last_seen or 0
+        LOGGER.debug(
+            "[%s, %s] %s [%s %s] [%s] %s (%s)",
+            self.entity_id,
+            self.client.mac,
+            method,
+            self.schedule_update,
+            self._is_connected,
+            dt_util.utc_from_timestamp(float(last_seen)),
+            dt_util.utcnow() - dt_util.utc_from_timestamp(float(last_seen)),
+            last_seen,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -170,6 +189,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
             )
         )
         await super().async_added_to_hass()
+        self._async_log_debug_data("added_to_hass")
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect object when removed."""
@@ -200,16 +220,16 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
             self.client.last_updated == SOURCE_DATA
             and self.is_wired == self.client.is_wired
         ):
-            self._last_seen = self.client.last_seen
             self._is_connected = True
             self.schedule_update = True
+
+        self._async_log_debug_data("update_callback")
 
         if self.schedule_update:
             self.schedule_update = False
             self.controller.async_heartbeat(
                 self.unique_id, dt_util.utcnow() + self.controller.option_detection_time
             )
-            self.heartbeat_check = True
 
             super().async_update_callback()
 
@@ -218,6 +238,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         """No heart beat by device."""
         self._is_connected = False
         self.async_write_ha_state()
+        self._async_log_debug_data("make_disconnected")
 
     @property
     def device_info(self) -> None:

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -166,12 +166,14 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
     @callback
     def _async_log_debug_data(self, method: str) -> None:
         """Print debug data about entity."""
+        if not LOGGER.isEnabledFor(logging.DEBUG):
+            return
         last_seen = self.client.last_seen or 0
         LOGGER.debug(
-            "[%s, %s] %s [%s %s] [%s] %s (%s)",
+            "%s [%s, %s] [%s %s] [%s] %s (%s)",
+            method,
             self.entity_id,
             self.client.mac,
-            method,
             self.schedule_update,
             self._is_connected,
             dt_util.utc_from_timestamp(float(last_seen)),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding some debug logging to help in investigating instability issues of the UniFi client tracker.
These debug prints will be removed in the future.

I also found two unused variables I removed.

```
logger:
  default: warning
  logs:
    homeassistant.components.unifi.device_tracker: debug
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
