### PR TITLE
Remove deprecated yaml schema [fritzbox_callmonitor]

### DIFF
--- a/homeassistant/components/fritzbox_callmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_callmonitor/config_flow.py
@@ -141,12 +141,6 @@ class FritzBoxCallMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return FritzBoxCallMonitorOptionsFlowHandler(config_entry)
 
-    async def async_step_import(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle configuration by yaml file."""
-        return await self.async_step_user(user_input)
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -10,35 +10,20 @@ from time import sleep
 from typing import Any, cast
 
 from fritzconnection.core.fritzmonitor import FritzMonitor
-import voluptuous as vol
 
 from homeassistant.backports.enum import StrEnum
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .base import FritzBoxPhonebook
 from .const import (
     ATTR_PREFIXES,
     CONF_PHONEBOOK,
     CONF_PREFIXES,
-    DEFAULT_HOST,
-    DEFAULT_NAME,
-    DEFAULT_PHONEBOOK,
-    DEFAULT_PORT,
-    DEFAULT_USERNAME,
     DOMAIN,
     FRITZBOX_PHONEBOOK,
     ICON_PHONE,
@@ -59,40 +44,6 @@ class CallState(StrEnum):
     DIALING = "dialing"
     TALKING = "talking"
     IDLE = "idle"
-
-
-# Deprecated in Home Assistant 2022.3
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PHONEBOOK, default=DEFAULT_PHONEBOOK): cv.positive_int,
-        vol.Optional(CONF_PREFIXES): vol.All(cv.ensure_list, [cv.string]),
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Import the platform into a config entry."""
-    _LOGGER.warning(
-        "Configuration of the AVM FRITZ!Box Call Monitor sensor platform in YAML "
-        "is deprecated and will be removed in Home Assistant 2022.5; "
-        "Your existing configuration has been imported into the UI automatically "
-        "and can be safely removed from your configuration.yaml file"
-    )
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/fritzbox_callmonitor/test_config_flow.py
+++ b/tests/components/fritzbox_callmonitor/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.fritzbox_callmonitor.const import (
     FRITZ_ATTR_SERIAL_NUMBER,
     SERIAL_NUMBER,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -66,44 +66,6 @@ MOCK_DEVICE_INFO = {FRITZ_ATTR_SERIAL_NUMBER: MOCK_SERIAL_NUMBER}
 MOCK_PHONEBOOK_INFO_1 = {FRITZ_ATTR_NAME: MOCK_PHONEBOOK_NAME_1}
 MOCK_PHONEBOOK_INFO_2 = {FRITZ_ATTR_NAME: MOCK_PHONEBOOK_NAME_2}
 MOCK_UNIQUE_ID = f"{MOCK_SERIAL_NUMBER}-{MOCK_PHONEBOOK_ID}"
-
-
-async def test_yaml_import(hass: HomeAssistant) -> None:
-    """Test configuration.yaml import."""
-
-    with patch(
-        "homeassistant.components.fritzbox_callmonitor.base.FritzPhonebook.__init__",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.base.FritzPhonebook.phonebook_ids",
-        new_callable=PropertyMock,
-        return_value=[0],
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.base.FritzPhonebook.phonebook_info",
-        return_value=MOCK_PHONEBOOK_INFO_1,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.base.FritzPhonebook.modelname",
-        return_value=MOCK_PHONEBOOK_NAME_1,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzConnection.__init__",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzConnection.call_action",
-        return_value=MOCK_DEVICE_INFO,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=MOCK_YAML_CONFIG,
-        )
-
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == MOCK_NAME
-        assert result["data"] == MOCK_CONFIG_ENTRY
-        assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_setup_one_phonebook(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change
Fritzbox_callmonitor YAML import has been removed after being deprecated for 2 releases.

## Proposed change
The YAML import was deprecated in #61762 for `v2022.3.0`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
