### PR TITLE
Revert "tts.say to use media source URLs"

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -27,7 +27,6 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
 )
-from homeassistant.components.media_source import generate_media_source_id
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DESCRIPTION,
@@ -142,10 +141,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         cache_dir = conf.get(CONF_CACHE_DIR, DEFAULT_CACHE_DIR)
         time_memory = conf.get(CONF_TIME_MEMORY, DEFAULT_TIME_MEMORY)
         base_url = conf.get(CONF_BASE_URL)
-        if base_url is not None:
-            _LOGGER.warning(
-                "TTS base_url option is deprecated. Configure internal/external URL instead"
-            )
         hass.data[BASE_URL_KEY] = base_url
 
         await tts.async_init_cache(use_cache, cache_dir, time_memory, base_url)
@@ -202,34 +197,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             cache = service.data.get(ATTR_CACHE)
             language = service.data.get(ATTR_LANGUAGE)
             options = service.data.get(ATTR_OPTIONS)
-
-            if tts.base_url is None or tts.base_url == get_url(hass):
-                tts.process_options(p_type, language, options)
-                params = {
-                    "message": message,
-                }
-                if cache is not None:
-                    params["cache"] = "true" if cache else "false"
-                if language is not None:
-                    params["language"] = language
-                if options is not None:
-                    params.update(options)
-
-                await hass.services.async_call(
-                    DOMAIN_MP,
-                    SERVICE_PLAY_MEDIA,
-                    {
-                        ATTR_ENTITY_ID: entity_ids,
-                        ATTR_MEDIA_CONTENT_ID: generate_media_source_id(
-                            DOMAIN,
-                            str(yarl.URL.build(path=p_type, query=params)),
-                        ),
-                        ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
-                    },
-                    blocking=True,
-                    context=service.context,
-                )
-                return
 
             try:
                 url = await tts.async_get_url_path(
@@ -377,16 +344,23 @@ class SpeechManager:
             PLATFORM_FORMAT.format(domain=engine, platform=DOMAIN)
         )
 
-    @callback
-    def process_options(
+    async def async_get_url_path(
         self,
         engine: str,
+        message: str,
+        cache: bool | None = None,
         language: str | None = None,
         options: dict | None = None,
-    ) -> tuple[str, dict | None]:
-        """Validate and process options."""
+    ) -> str:
+        """Get URL for play message.
+
+        This method is a coroutine.
+        """
         if (provider := self.providers.get(engine)) is None:
             raise HomeAssistantError(f"Provider {engine} not found")
+
+        msg_hash = hashlib.sha1(bytes(message, "utf-8")).hexdigest()
+        use_cache = cache if cache is not None else self.use_cache
 
         # Languages
         language = language or provider.default_language
@@ -408,25 +382,9 @@ class SpeechManager:
             ]
             if invalid_opts:
                 raise HomeAssistantError(f"Invalid options found: {invalid_opts}")
-
-        return language, options
-
-    async def async_get_url_path(
-        self,
-        engine: str,
-        message: str,
-        cache: bool | None = None,
-        language: str | None = None,
-        options: dict | None = None,
-    ) -> str:
-        """Get URL for play message.
-
-        This method is a coroutine.
-        """
-        language, options = self.process_options(engine, language, options)
-        options_key = _hash_options(options) if options else "-"
-        msg_hash = hashlib.sha1(bytes(message, "utf-8")).hexdigest()
-        use_cache = cache if cache is not None else self.use_cache
+            options_key = _hash_options(options)
+        else:
+            options_key = "-"
 
         key = KEY_PATTERN.format(
             msg_hash, language.replace("_", "-"), options_key, engine

--- a/homeassistant/components/tts/media_source.py
+++ b/homeassistant/components/tts/media_source.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import mimetypes
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from yarl import URL
 
@@ -46,19 +46,17 @@ class TTSMediaSource(MediaSource):
             raise Unresolvable("No message specified.")
 
         options = dict(parsed.query)
-        kwargs: dict[str, Any] = {
+        kwargs = {
             "engine": parsed.name,
             "message": options.pop("message"),
             "language": options.pop("language", None),
             "options": options,
         }
-        if "cache" in options:
-            kwargs["cache"] = options.pop("cache") == "true"
 
         manager: SpeechManager = self.hass.data[DOMAIN]
 
         try:
-            url = await manager.async_get_url_path(**kwargs)
+            url = await manager.async_get_url_path(**kwargs)  # type: ignore[arg-type]
         except HomeAssistantError as err:
             raise Unresolvable(str(err)) from err
 

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -6,27 +6,17 @@ from unittest.mock import patch
 from gtts import gTTSError
 import pytest
 
-from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
+import homeassistant.components.tts as tts
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
 from tests.components.tts.conftest import mutagen_mock  # noqa: F401
-
-
-async def get_media_source_url(hass, media_content_id):
-    """Get the media source url."""
-    if media_source.DOMAIN not in hass.config.components:
-        assert await async_setup_component(hass, media_source.DOMAIN, {})
-
-    resolved = await media_source.async_resolve_media(hass, media_content_id)
-    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -77,9 +67,8 @@ async def test_service_say(hass, mock_gtts, calls):
     )
 
     assert len(calls) == 1
-    url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2
-    assert url.endswith(".mp3")
+    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
 
     assert mock_gtts.mock_calls[0][2] == {
         "text": "There is a person at the front door.",
@@ -107,7 +96,6 @@ async def test_service_say_german_config(hass, mock_gtts, calls):
     )
 
     assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
         "text": "There is a person at the front door.",
@@ -136,7 +124,6 @@ async def test_service_say_german_service(hass, mock_gtts, calls):
     )
 
     assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
         "text": "There is a person at the front door.",
@@ -161,7 +148,5 @@ async def test_service_say_error(hass, mock_gtts, calls):
         blocking=True,
     )
 
-    assert len(calls) == 1
-    with pytest.raises(HomeAssistantError):
-        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(calls) == 0
     assert len(mock_gtts.mock_calls) == 2

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -5,24 +5,15 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
+import homeassistant.components.tts as tts
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
-
-
-async def get_media_source_url(hass, media_content_id):
-    """Get the media source url."""
-    if media_source.DOMAIN not in hass.config.components:
-        assert await async_setup_component(hass, media_source.DOMAIN, {})
-
-    resolved = await media_source.async_resolve_media(hass, media_content_id)
-    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -67,13 +58,11 @@ async def test_service_say(hass):
             blocking=True,
         )
 
-        url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-
     mock_speak.assert_called_once()
     mock_speak.assert_called_with("HomeAssistant", {})
 
     assert len(calls) == 1
-    assert url.endswith(".wav")
+    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".wav") != -1
 
 
 async def test_service_say_with_effect(hass):
@@ -100,13 +89,11 @@ async def test_service_say_with_effect(hass):
             blocking=True,
         )
 
-        url = await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-
     mock_speak.assert_called_once()
     mock_speak.assert_called_with("HomeAssistant", {"Volume": "amount:2.0;"})
 
     assert len(calls) == 1
-    assert url.endswith(".wav")
+    assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".wav") != -1
 
 
 async def test_service_say_http_error(hass):
@@ -133,7 +120,5 @@ async def test_service_say_http_error(hass):
         )
         await hass.async_block_till_done()
 
-        with pytest.raises(Exception):
-            await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-
     mock_speak.assert_called_once()
+    assert len(calls) == 0

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -6,12 +6,11 @@ import shutil
 
 import pytest
 
-from homeassistant.components import media_source, tts
 from homeassistant.components.media_player.const import (
-    ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
+import homeassistant.components.tts as tts
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
@@ -20,15 +19,6 @@ from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unuse
 )
 
 URL = "https://tts.voicetech.yandex.net/generate?"
-
-
-async def get_media_source_url(hass, media_content_id):
-    """Get the media source url."""
-    if media_source.DOMAIN not in hass.config.components:
-        assert await async_setup_component(hass, media_source.DOMAIN, {})
-
-    resolved = await media_source.async_resolve_media(hass, media_content_id)
-    return resolved.url
 
 
 @pytest.fixture(autouse=True)
@@ -83,11 +73,11 @@ async def test_service_say(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
+
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_russian_config(hass, aioclient_mock):
@@ -121,12 +111,11 @@ async def test_service_say_russian_config(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
+    await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_russian_service(hass, aioclient_mock):
@@ -158,11 +147,11 @@ async def test_service_say_russian_service(hass, aioclient_mock):
             tts.ATTR_MESSAGE: "HomeAssistant",
             tts.ATTR_LANGUAGE: "ru-RU",
         },
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
+
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_timeout(hass, aioclient_mock):
@@ -195,13 +184,10 @@ async def test_service_say_timeout(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    with pytest.raises(media_source.Unresolvable):
-        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(calls) == 0
     assert len(aioclient_mock.mock_calls) == 1
 
 
@@ -235,12 +221,10 @@ async def test_service_say_http_error(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
+    await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    with pytest.raises(media_source.Unresolvable):
-        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    assert len(calls) == 0
 
 
 async def test_service_say_specified_speaker(hass, aioclient_mock):
@@ -274,11 +258,11 @@ async def test_service_say_specified_speaker(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
+
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_specified_emotion(hass, aioclient_mock):
@@ -312,12 +296,11 @@ async def test_service_say_specified_emotion(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_specified_low_speed(hass, aioclient_mock):
@@ -347,12 +330,11 @@ async def test_service_say_specified_low_speed(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_specified_speed(hass, aioclient_mock):
@@ -380,12 +362,11 @@ async def test_service_say_specified_speed(hass, aioclient_mock):
         tts.DOMAIN,
         "yandextts_say",
         {"entity_id": "media_player.something", tts.ATTR_MESSAGE: "HomeAssistant"},
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1
 
 
 async def test_service_say_specified_options(hass, aioclient_mock):
@@ -416,9 +397,8 @@ async def test_service_say_specified_options(hass, aioclient_mock):
             tts.ATTR_MESSAGE: "HomeAssistant",
             "options": {"emotion": "evil", "speed": 2},
         },
-        blocking=True,
     )
-    assert len(calls) == 1
-    await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+    await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 1
+    assert len(calls) == 1


### PR DESCRIPTION
This PR Reverts home-assistant/core#70382

It should not have been merged, as it breaks split DNS setups or setups that run their own local DNS server providing local hosts/domains when using TTS on Google Assistant capable devices.

Google devices simply ignore any DNS and only uses their own public DNS servers (and thus ignore any local knowledge).

This option was the only way out of that.

CC @balloob 