### PR TITLE
Migrate zerproc light to ColorMode

### DIFF
--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -9,8 +9,7 @@ import pyzerproc
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
+    ColorMode,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -24,8 +23,6 @@ import homeassistant.util.color as color_util
 from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-SUPPORT_ZERPROC = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
 
 DISCOVERY_INTERVAL = timedelta(seconds=60)
 
@@ -81,6 +78,9 @@ async def async_setup_entry(
 class ZerprocLight(LightEntity):
     """Representation of an Zerproc Light."""
 
+    _attr_color_mode = ColorMode.HS
+    _attr_supported_color_modes = {ColorMode.HS}
+
     def __init__(self, light):
         """Initialize a Zerproc light."""
         self._light = light
@@ -130,11 +130,6 @@ class ZerprocLight(LightEntity):
     def icon(self) -> str | None:
         """Return the icon to use in the frontend."""
         return "mdi:string-lights"
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_ZERPROC
 
     @property
     def brightness(self):

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -12,8 +12,6 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_XY_COLOR,
     SCAN_INTERVAL,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
     ColorMode,
 )
 from homeassistant.components.zerproc.const import (
@@ -101,7 +99,7 @@ async def test_init(hass, mock_entry):
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
         ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
+        ATTR_SUPPORTED_FEATURES: 0,
         ATTR_ICON: "mdi:string-lights",
     }
 
@@ -110,7 +108,7 @@ async def test_init(hass, mock_entry):
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "LEDBlue-33445566",
         ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
+        ATTR_SUPPORTED_FEATURES: 0,
         ATTR_ICON: "mdi:string-lights",
         ATTR_COLOR_MODE: ColorMode.HS,
         ATTR_BRIGHTNESS: 255,
@@ -280,7 +278,7 @@ async def test_light_update(hass, mock_light):
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
         ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
+        ATTR_SUPPORTED_FEATURES: 0,
         ATTR_ICON: "mdi:string-lights",
     }
 
@@ -299,7 +297,7 @@ async def test_light_update(hass, mock_light):
         assert state.attributes == {
             ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
             ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS],
-            ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
+            ATTR_SUPPORTED_FEATURES: 0,
             ATTR_ICON: "mdi:string-lights",
         }
 
@@ -317,7 +315,7 @@ async def test_light_update(hass, mock_light):
         assert state.attributes == {
             ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
             ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS],
-            ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
+            ATTR_SUPPORTED_FEATURES: 0,
             ATTR_ICON: "mdi:string-lights",
         }
 
@@ -335,7 +333,7 @@ async def test_light_update(hass, mock_light):
         assert state.attributes == {
             ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
             ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS],
-            ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
+            ATTR_SUPPORTED_FEATURES: 0,
             ATTR_ICON: "mdi:string-lights",
             ATTR_COLOR_MODE: ColorMode.HS,
             ATTR_BRIGHTNESS: 220,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to https://github.com/home-assistant/core/pull/47720, needed for https://github.com/home-assistant/core/pull/69269

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
