### PR TITLE
New KinCony Hx component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -527,6 +527,7 @@ build.json @home-assistant/supervisor
 /tests/components/keenetic_ndms2/ @foxel
 /homeassistant/components/kef/ @basnijholt
 /homeassistant/components/keyboard_remote/ @bendavid @lanrat
+/homeassistant/components/kincony_hx/ @kgkolev
 /homeassistant/components/kmtronic/ @dgomes
 /tests/components/kmtronic/ @dgomes
 /homeassistant/components/knx/ @Julius2342 @farmio @marvin-w

--- a/homeassistant/components/kincony_hx/__init__.py
+++ b/homeassistant/components/kincony_hx/__init__.py
@@ -1,0 +1,204 @@
+"""The KinCony Hx integration."""
+from __future__ import annotations
+
+import logging
+import socket
+import threading
+from types import MappingProxyType
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+
+from .const import (
+    CONF_SO_TIMEOUT,
+    DATA_KCBOARD,
+    DEFAULT_PORT,
+    DEFAULT_SO_TIMEOUT,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+
+PLATFORMS: list[Platform] = [Platform.SWITCH]
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class ResponseError(HomeAssistantError):
+    """Error to indicate protocol error."""
+
+
+def _status_from_resp(resp: str) -> bool:
+    """Retrieve that response status on success, raises ResponseError otherwise."""
+    resp_parts = resp.split(",")
+    succ = resp_parts.pop(-1).strip().lower()
+    status = int(resp_parts.pop(-1))
+
+    if not succ.startswith("ok"):
+        raise ResponseError(succ, status, resp)
+
+    _LOGGER.debug("Got response %s with status %s", succ, status)
+    return 1 == status
+
+
+class KCBoard:
+    """Wrapper over raw socket to remote KinCony Board."""
+
+    _socket: socket.socket
+    _sn: str | None = None
+    _relays_count: int | None = None
+
+    def __init__(
+        self,
+        host: str,
+        port: int = DEFAULT_PORT,
+        so_timeout: float = DEFAULT_SO_TIMEOUT,
+    ) -> None:
+        """Create a remote client for KinCony Board endpoint."""
+        self._host = host
+        self._port = port
+        self._so_timeout = so_timeout
+        self._lock = threading.Lock()
+
+    def connect(self):
+        """Request remote connection at init time."""
+        remote_ip = self._host
+        try:
+            remote_ip = socket.gethostbyname(self._host)
+            _LOGGER.info("Hostname %s resolved to IP %s", self._host, remote_ip)
+        except socket.gaierror:
+            _LOGGER.warning("Hostname %s could not be resolved", self._host)
+
+        if hasattr(self, "_socket"):
+            try:
+                self._socket.close()
+            except OSError:
+                pass
+
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.settimeout(self._so_timeout)
+        self._socket.connect((remote_ip, self._port))
+        _LOGGER.info("Connection successful to %s:%s", self._host, self._port)
+
+    def dispose(self):
+        """Close remote connection and invalidates this instance."""
+        if hasattr(self, "_socket"):
+            try:
+                self._socket.close()
+            finally:
+                self._socket = None
+
+    def _send(self, command: str) -> None:
+        self._socket.send(command.encode("utf-8"))
+
+    def _receive(self) -> str:
+        return self._socket.recv(1024).decode("utf-8")
+
+    def _request(self, command: str, retry_count: int = 3) -> str:
+        """Make a request to remote board with specified command."""
+
+        with self._lock:
+            try:
+                self._send(command)
+                # time.sleep(1)
+                return self._receive()
+            except OSError as err:
+                if retry_count > 0:
+                    # reconnect and retry
+                    # time.sleep(3)
+                    self.connect()
+                    return self._request(command, retry_count=retry_count - 1)
+                raise CannotConnect from err
+
+    def get_board_host(self) -> str:
+        """Get the board Host/IP endpoint address."""
+        return self._host
+
+    def read_serial_num(self) -> str:
+        """Get the board identifier note, this starts testing of all ports."""
+
+        if self._sn is None:
+            self._sn = self._request("RELAY-HOST-NOW").split("-").pop()
+
+        return self._sn
+
+    def read_relays_count(self) -> int:
+        """Make a request to find the max number of relay switches."""
+
+        if self._relays_count is None:
+            self._relays_count = int(
+                self._request("RELAY-SCAN_DEVICE-NOW")
+                .split(",")
+                .pop(0)
+                .split("_")
+                .pop()
+            )
+
+        return self._relays_count
+
+    def read_relay_status(self, index: int) -> bool:
+        """Retrieve the status of a Relay Switch - index is 0-based."""
+        _LOGGER.debug("Reading SW %s status", index + 1)
+        return _status_from_resp(self._request(f"RELAY-READ-255,{index + 1}"))
+
+    def write_relay_status(self, index: int, status: bool = True) -> bool:
+        """Set the status of a Relay Switch - index is 0-based."""
+        _LOGGER.debug("Setting SW %s to status %s", index + 1, status)
+        return _status_from_resp(
+            self._request(f"RELAY-SET-255,{index + 1},{1 if status else 0}")
+        )
+
+    @staticmethod
+    def from_data(data: dict[str, Any] | MappingProxyType[str, Any]) -> KCBoard:
+        """Create new instance from a data dict using this factory method."""
+        host = data[CONF_HOST]
+        port = data[CONF_PORT]
+        so_timeout = data[CONF_SO_TIMEOUT]
+        return KCBoard(host, port, so_timeout)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up KinCony Hx from a config entry."""
+
+    client = KCBoard.from_data(entry.data)
+
+    try:
+        client.connect()
+    except OSError as exception:
+        raise PlatformNotReady from exception
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_KCBOARD: client}
+
+    # Setup components
+    entry.title = entry.data[CONF_NAME]
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+class KCSwitch:
+    """Base KinKony Switch class."""
+
+    def __init__(self, board: KCBoard, index: int) -> None:
+        """Create a switch instance."""
+        super().__init__()
+        self._board = board
+        self._index = index
+
+    def get_uuid(self):
+        """Get a unique identifier for this entity."""
+        return f"{self._board.get_board_host()}/sw.{self._index}"

--- a/homeassistant/components/kincony_hx/config_flow.py
+++ b/homeassistant/components/kincony_hx/config_flow.py
@@ -1,0 +1,114 @@
+"""Config flow for KinCony Hx integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
+
+from . import CannotConnect, KCBoard
+from .const import (
+    CONF_REFRESH,
+    CONF_SO_TIMEOUT,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_REFRESH,
+    DEFAULT_SO_TIMEOUT,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_schema_with_data(data: dict[str, Any] | None = None) -> vol.Schema:
+    """Retrieve the schema with updateable defaults from data."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_HOST,
+                default=data.get(CONF_HOST, None) if data else None,
+            ): cv.string,
+            vol.Optional(
+                CONF_NAME,
+                default=data.get(CONF_NAME, DEFAULT_NAME) if data else DEFAULT_NAME,
+            ): cv.string,
+            vol.Optional(
+                CONF_PORT,
+                default=data.get(CONF_PORT, DEFAULT_PORT) if data else DEFAULT_PORT,
+            ): cv.port,
+            vol.Optional(
+                CONF_REFRESH,
+                default=data.get(CONF_REFRESH, DEFAULT_REFRESH)
+                if data
+                else DEFAULT_REFRESH,
+            ): cv.positive_int,
+            vol.Optional(
+                CONF_SO_TIMEOUT,
+                default=data.get(CONF_SO_TIMEOUT, DEFAULT_SO_TIMEOUT)
+                if data
+                else DEFAULT_SO_TIMEOUT,
+            ): cv.positive_int,
+        }
+    )
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the specified endpoint is accessible."""
+    client = KCBoard.from_data(data)
+
+    relays_count = 0
+    try:
+        client.connect()
+        relays_count = client.read_relays_count()
+        client.dispose()
+    except ConnectionRefusedError:
+        raise
+    except OSError as exception:
+        raise CannotConnect from exception
+
+    # Return info that you want to store in the config entry.
+    return {
+        "title": data.get(CONF_NAME, DEFAULT_NAME),
+        "desc": f"KinCony Board with {relays_count} relays at {data[CONF_HOST]}",
+    }
+
+
+class KCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for KinCony Hx."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=get_schema_with_data()
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except ConnectionRefusedError:
+            errors["base"] = "connect_refused"
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(
+                title=info["title"], description=info["desc"], data=user_input
+            )
+
+        return self.async_show_form(
+            step_id="user", data_schema=get_schema_with_data(user_input), errors=errors
+        )

--- a/homeassistant/components/kincony_hx/const.py
+++ b/homeassistant/components/kincony_hx/const.py
@@ -1,0 +1,13 @@
+"""Constants for the KinCony Hx integration."""
+
+DOMAIN = "kincony_hx"
+
+DATA_KCBOARD = "board_client"
+
+CONF_REFRESH = "refresh_interval"
+CONF_SO_TIMEOUT = "so_timeout"
+
+DEFAULT_NAME = "Relay Board"
+DEFAULT_PORT = 4196
+DEFAULT_REFRESH = 300
+DEFAULT_SO_TIMEOUT = 10

--- a/homeassistant/components/kincony_hx/manifest.json
+++ b/homeassistant/components/kincony_hx/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "kincony_hx",
+  "name": "KinCony Hx",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/kincony_hx",
+  "requirements": [],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": ["@kgkolev"],
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/kincony_hx/strings.json
+++ b/homeassistant/components/kincony_hx/strings.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connecting to a KinCony Hx Board",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "so_timeout": "Network Timeout",
+          "refresh_interval": "Refresh Interval"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "connect_refused": "Target endpoint refused connection"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/kincony_hx/switch.py
+++ b/homeassistant/components/kincony_hx/switch.py
@@ -1,0 +1,76 @@
+"""WiZ integration switch platform."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import KCBoard, KCSwitch
+from .const import CONF_REFRESH, DATA_KCBOARD, DEFAULT_REFRESH, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the KinCony switch platform."""
+    board: KCBoard = hass.data[DOMAIN][entry.entry_id][DATA_KCBOARD]
+    relays_len = board.read_relays_count()
+
+    refresh_interval: int = (
+        entry.data[CONF_REFRESH] if hasattr(entry, CONF_REFRESH) else DEFAULT_REFRESH
+    )
+
+    switches: list[KCSwitchEntity] = []
+    for i in range(relays_len):
+        switches.append(KCSwitchEntity(board, i, refresh_interval))
+
+    async_add_entities(switches, True)
+
+
+class KCSwitchEntity(KCSwitch, SwitchEntity):
+    """Representation of KinCony Relay switch."""
+
+    _cached_last_refresh_time: datetime
+    _refresh_interval: int
+
+    def __init__(
+        self, board: KCBoard, index: int, refresh_interval: int, name: str = None
+    ) -> None:
+        """Create the entity."""
+        super().__init__(board, index)
+        self._attr_unique_id = self.get_uuid()
+        self._attr_name = name if name is not None else f"SW {index + 1:02d}"
+        self._attr_is_on = False
+        self._refresh_interval = refresh_interval
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        self._board.write_relay_status(self._index, True)
+        self._attr_is_on = True
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        self._board.write_relay_status(self._index, False)
+        self._attr_is_on = False
+
+    def update(self) -> None:
+        """Fetch from cache or live the latest state for this relay."""
+
+        now = datetime.utcnow()
+        if not hasattr(
+            self, "_cached_last_refresh_time"
+        ) or now - self._cached_last_refresh_time > timedelta(
+            seconds=self._refresh_interval
+        ):
+            self._cached_last_refresh_time = now
+            self._attr_is_on = self._board.read_relay_status(self._index)

--- a/homeassistant/components/kincony_hx/translations/en.json
+++ b/homeassistant/components/kincony_hx/translations/en.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connecting to a KinCony Hx Board",
+        "data": {
+          "name": "Title",
+          "host": "Host",
+          "port": "Port",
+          "so_timeout": "Network Timeout",
+          "refresh_interval": "Refresh Interval"
+        }
+      }
+    },
+    "error": {
+      "connect_refused": "Target endpoint refused connection",
+      "cannot_connect": "Failed to connect to endpoint",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -175,6 +175,7 @@ FLOWS = {
         "juicenet",
         "kaleidescape",
         "keenetic_ndms2",
+        "kincony_hx",
         "kmtronic",
         "knx",
         "kodi",


### PR DESCRIPTION
## Proposed change
This is a best-effort unification and harmonization of various approaches for integrating a KinCony H8/16/32 boards in a more native HASS component way for easier consumption by the general public. It should be considered as a functional code, but not a fully polished (unit tested, community tested, documented, branded, etc) integration as it is not of direct value to me at this time.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Background user issues observed:
- https://community.home-assistant.io/t/32-channel-ethernet-relay-module-kincony-kc868-h32/155647
- https://community.home-assistant.io/t/kincony-kc868-h4-and-h8/303417

Existing approaches for integration:
- quick-component, requires manual install for users and no config flow - https://gist.github.com/shamruk/284e2f31fd2c2cfd236218a04aa1f0ab
- via external mqtt-bridge that might bring more complexity down the road - https://github.com/hzkincony/ethernet-relay-control-board-TCP-Socket-to-MQTT-protocol-kit-for-home-assistant/blob/master/HADemoL.py

Out of scope changes/PRs:
- KinCony PyPi library not planned/included
- Test Cases not planned/included
- Documentation not planned/included
- Logos/Branding not planned/included

## Checklist
- [X] The code change is tested and works locally. - using KinCony KC868-H32 Board 
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist] - **All but the pypi Library**
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] - ** Doc page not added **
- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
