### PR TITLE
Revert "Improve ZHA startup performance (#70111)"

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import zigpy.endpoint
@@ -49,6 +50,7 @@ class Channels:
         self._pools: list[ChannelPool] = []
         self._power_config: base.ZigbeeChannel | None = None
         self._identify: base.ZigbeeChannel | None = None
+        self._semaphore = asyncio.Semaphore(3)
         self._unique_id = str(zha_device.ieee)
         self._zdo_channel = base.ZDOChannel(zha_device.device.endpoints[0], zha_device)
         self._zha_device = zha_device
@@ -79,6 +81,11 @@ class Channels:
         """Power configuration channel setter."""
         if self._identify is None:
             self._identify = channel
+
+    @property
+    def semaphore(self) -> asyncio.Semaphore:
+        """Return semaphore for concurrent tasks."""
+        return self._semaphore
 
     @property
     def zdo_channel(self) -> base.ZDOChannel:
@@ -329,8 +336,13 @@ class ChannelPool:
 
     async def _execute_channel_tasks(self, func_name: str, *args: Any) -> None:
         """Add a throttled channel task and swallow exceptions."""
+
+        async def _throttle(coro: Coroutine[Any, Any, None]) -> None:
+            async with self._channels.semaphore:
+                return await coro
+
         channels = [*self.claimed_channels.values(), *self.client_channels.values()]
-        tasks = [getattr(ch, func_name)(*args) for ch in channels]
+        tasks = [_throttle(getattr(ch, func_name)(*args)) for ch in channels]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for channel, outcome in zip(channels, results):
             if isinstance(outcome, Exception):

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -310,14 +310,11 @@ class ZigbeeChannel(LogMixin):
         """Set cluster binding and attribute reporting."""
         if not self._ch_pool.skip_configuration:
             if self.BIND:
-                self.debug("Performing cluster binding")
                 await self.bind()
             if self.cluster.is_server:
-                self.debug("Configuring cluster attribute reporting")
                 await self.configure_reporting()
             ch_specific_cfg = getattr(self, "async_configure_channel_specific", None)
             if ch_specific_cfg:
-                self.debug("Performing channel specific configuration")
                 await ch_specific_cfg()
             self.debug("finished channel configuration")
         else:
@@ -328,7 +325,6 @@ class ZigbeeChannel(LogMixin):
     async def async_initialize(self, from_cache: bool) -> None:
         """Initialize channel."""
         if not from_cache and self._ch_pool.skip_configuration:
-            self.debug("Skipping channel initialization")
             self._status = ChannelStatus.INITIALIZED
             return
 
@@ -338,23 +334,12 @@ class ZigbeeChannel(LogMixin):
         uncached.extend([cfg["attr"] for cfg in self.REPORT_CONFIG])
 
         if cached:
-            self.debug("initializing cached channel attributes: %s", cached)
-            await self._get_attributes(
-                True, cached, from_cache=True, only_cache=from_cache
-            )
+            await self._get_attributes(True, cached, from_cache=True)
         if uncached:
-            self.debug(
-                "initializing uncached channel attributes: %s - from cache[%s]",
-                uncached,
-                from_cache,
-            )
-            await self._get_attributes(
-                True, uncached, from_cache=from_cache, only_cache=from_cache
-            )
+            await self._get_attributes(True, uncached, from_cache=from_cache)
 
         ch_specific_init = getattr(self, "async_initialize_channel_specific", None)
         if ch_specific_init:
-            self.debug("Performing channel specific initialization: %s", uncached)
             await ch_specific_init(from_cache=from_cache)
 
         self.debug("finished channel initialization")
@@ -422,7 +407,7 @@ class ZigbeeChannel(LogMixin):
             self._cluster,
             [attribute],
             allow_cache=from_cache,
-            only_cache=from_cache,
+            only_cache=from_cache and not self._ch_pool.is_mains_powered,
             manufacturer=manufacturer,
         )
         return result.get(attribute)
@@ -432,7 +417,6 @@ class ZigbeeChannel(LogMixin):
         raise_exceptions: bool,
         attributes: list[int | str],
         from_cache: bool = True,
-        only_cache: bool = True,
     ) -> dict[int | str, Any]:
         """Get the values for a list of attributes."""
         manufacturer = None
@@ -444,18 +428,17 @@ class ZigbeeChannel(LogMixin):
         result = {}
         while chunk:
             try:
-                self.debug("Reading attributes in chunks: %s", chunk)
                 read, _ = await self.cluster.read_attributes(
                     attributes,
                     allow_cache=from_cache,
-                    only_cache=only_cache,
+                    only_cache=from_cache and not self._ch_pool.is_mains_powered,
                     manufacturer=manufacturer,
                 )
                 result.update(read)
             except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
                 self.debug(
                     "failed to get attributes '%s' on '%s' cluster: %s",
-                    chunk,
+                    attributes,
                     self.cluster.ep_attribute,
                     str(ex),
                 )

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -463,9 +463,7 @@ class PowerConfigurationChannel(ZigbeeChannel):
             "battery_size",
             "battery_quantity",
         ]
-        return self.get_attributes(
-            attributes, from_cache=from_cache, only_cache=from_cache
-        )
+        return self.get_attributes(attributes, from_cache=from_cache)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.PowerProfile.cluster_id)

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -97,7 +97,7 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
             for a in self.REPORT_CONFIG
             if a["attr"] not in self.cluster.unsupported_attributes
         ]
-        result = await self.get_attributes(attrs, from_cache=False, only_cache=False)
+        result = await self.get_attributes(attrs, from_cache=False)
         if result:
             for attr, value in result.items():
                 self.async_send_signal(

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -351,15 +351,11 @@ class ZHADevice(LogMixin):
         if self.is_coordinator:
             return
         if self.last_seen is None:
-            self.debug("last_seen is None, marking the device unavailable")
             self.update_available(False)
             return
 
         difference = time.time() - self.last_seen
         if difference < self.consider_unavailable_time:
-            self.debug(
-                "Device seen - marking the device available and resetting counter"
-            )
             self.update_available(True)
             self._checkins_missed_count = 0
             return
@@ -369,10 +365,6 @@ class ZHADevice(LogMixin):
             or self.manufacturer == "LUMI"
             or not self._channels.pools
         ):
-            self.debug(
-                "last_seen is %s seconds ago and ping attempts have been exhausted, marking the device unavailable",
-                difference,
-            )
             self.update_available(False)
             return
 
@@ -394,23 +386,13 @@ class ZHADevice(LogMixin):
 
     def update_available(self, available: bool) -> None:
         """Update device availability and signal entities."""
-        self.debug(
-            "Update device availability -  device available: %s - new availability: %s - changed: %s",
-            self.available,
-            available,
-            self.available ^ available,
-        )
         availability_changed = self.available ^ available
         self.available = available
         if availability_changed and available:
             # reinit channels then signal entities
-            self.debug(
-                "Device availability changed and device became available, reinitializing channels"
-            )
             self.hass.async_create_task(self._async_became_available())
             return
         if availability_changed and not available:
-            self.debug("Device availability changed and device became unavailable")
             self._channels.zha_send_event(
                 {
                     "device_event_type": "device_offline",

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -239,25 +239,29 @@ class ZHAGateway:
 
     async def async_initialize_devices_and_entities(self) -> None:
         """Initialize devices and load entities."""
+        semaphore = asyncio.Semaphore(2)
 
-        _LOGGER.warning("Loading all devices")
+        async def _throttle(zha_device: ZHADevice, cached: bool) -> None:
+            async with semaphore:
+                await zha_device.async_initialize(from_cache=cached)
+
+        _LOGGER.debug("Loading battery powered devices")
         await asyncio.gather(
-            *(dev.async_initialize(from_cache=True) for dev in self.devices.values())
+            *(
+                _throttle(dev, cached=True)
+                for dev in self.devices.values()
+                if not dev.is_mains_powered
+            )
         )
 
-        async def fetch_updated_state() -> None:
-            """Fetch updated state for mains powered devices."""
-            _LOGGER.warning("Fetching current state for mains powered devices")
-            await asyncio.gather(
-                *(
-                    dev.async_initialize(from_cache=False)
-                    for dev in self.devices.values()
-                    if dev.is_mains_powered
-                )
+        _LOGGER.debug("Loading mains powered devices")
+        await asyncio.gather(
+            *(
+                _throttle(dev, cached=False)
+                for dev in self.devices.values()
+                if dev.is_mains_powered
             )
-
-        # background the fetching of state for mains powered devices
-        asyncio.create_task(fetch_updated_state())
+        )
 
     def device_joined(self, device: zigpy.device.Device) -> None:
         """Handle device joined.

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -488,7 +488,7 @@ class Light(BaseLight, ZhaEntity):
             ]
 
             results = await self._color_channel.get_attributes(
-                attributes, from_cache=False, only_cache=False
+                attributes, from_cache=False
             )
 
             if (color_mode := results.get("color_mode")) is not None:

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -177,7 +177,6 @@ def zha_device_joined(hass, setup_zha):
     """Return a newly joined ZHA device."""
 
     async def _zha_device(zigpy_dev):
-        zigpy_dev.last_seen = time.time()
         await setup_zha()
         zha_gateway = common.get_zha_gateway(hass)
         await zha_gateway.async_device_initialized(zigpy_dev)

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -106,7 +106,7 @@ def _send_time_changed(hass, seconds):
 
 @patch(
     "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
-    new=mock.AsyncMock(),
+    new=mock.MagicMock(),
 )
 async def test_check_available_success(
     hass, device_with_basic_channel, zha_device_restored
@@ -160,7 +160,7 @@ async def test_check_available_success(
 
 @patch(
     "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
-    new=mock.AsyncMock(),
+    new=mock.MagicMock(),
 )
 async def test_check_available_unsuccessful(
     hass, device_with_basic_channel, zha_device_restored
@@ -203,7 +203,7 @@ async def test_check_available_unsuccessful(
 
 @patch(
     "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
-    new=mock.AsyncMock(),
+    new=mock.MagicMock(),
 )
 async def test_check_available_no_basic_channel(
     hass, device_without_basic_channel, zha_device_restored, caplog

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -471,10 +471,7 @@ async def test_fan_update_entity(
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 0
     assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
-    if zha_device_joined_restored.name == "zha_device_joined":
-        assert cluster.read_attributes.await_count == 2
-    else:
-        assert cluster.read_attributes.await_count == 4
+    assert cluster.read_attributes.await_count == 2
 
     await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
@@ -483,10 +480,7 @@ async def test_fan_update_entity(
         "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
     )
     assert hass.states.get(entity_id).state == STATE_OFF
-    if zha_device_joined_restored.name == "zha_device_joined":
-        assert cluster.read_attributes.await_count == 3
-    else:
-        assert cluster.read_attributes.await_count == 5
+    assert cluster.read_attributes.await_count == 3
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
     await hass.services.async_call(
@@ -496,7 +490,4 @@ async def test_fan_update_entity(
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 33
     assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
-    if zha_device_joined_restored.name == "zha_device_joined":
-        assert cluster.read_attributes.await_count == 4
-    else:
-        assert cluster.read_attributes.await_count == 6
+    assert cluster.read_attributes.await_count == 4


### PR DESCRIPTION
This reverts commit 361119d5c166be28f41966d0f9acf466e066a566.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert #70111 as I didn't notice it's dependencies were not done. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
