### PR TITLE
Rework Sonos battery and ping activity tracking

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     SONOS_VANISHED,
     UPNP_ST,
 )
+from .exception import SonosUpdateError
 from .favorites import SonosFavorites
 from .speaker import SonosSpeaker
 
@@ -264,18 +265,10 @@ class SonosDiscoveryManager:
                 self._create_visible_speakers(ip_addr)
             elif not known_speaker.available:
                 try:
-                    known_speaker.soco.renderingControl.GetVolume(
-                        [("InstanceID", 0), ("Channel", "Master")], timeout=1
-                    )
-                except OSError:
+                    known_speaker.ping()
+                except SonosUpdateError:
                     _LOGGER.debug(
                         "Manual poll to %s failed, keeping unavailable", ip_addr
-                    )
-                else:
-                    dispatcher_send(
-                        self.hass,
-                        f"{SONOS_SPEAKER_ACTIVITY}-{known_speaker.uid}",
-                        "manual rediscovery",
                     )
 
         self.data.hosts_heartbeat = call_later(

--- a/homeassistant/components/sonos/exception.py
+++ b/homeassistant/components/sonos/exception.py
@@ -9,3 +9,7 @@ class UnknownMediaType(BrowseError):
 
 class SonosUpdateError(HomeAssistantError):
     """Update failed."""
+
+
+class S1BatteryMissing(SonosUpdateError):
+    """Battery update failed on S1 firmware."""

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -57,6 +57,7 @@ from .const import (
     SONOS_VANISHED,
     SUBSCRIPTION_TIMEOUT,
 )
+from .exception import S1BatteryMissing, SonosUpdateError
 from .favorites import SonosFavorites
 from .helpers import soco_error
 from .media import SonosMedia
@@ -81,16 +82,6 @@ UNUSED_DEVICE_KEYS = ["SPID", "TargetRoomName"]
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def fetch_battery_info_or_none(soco: SoCo) -> dict[str, Any] | None:
-    """Fetch battery_info from the given SoCo object.
-
-    Returns None if the device doesn't support battery info
-    or if the device is offline.
-    """
-    with contextlib.suppress(ConnectionError, TimeoutError, SoCoException):
-        return soco.get_battery_info()
 
 
 class SonosSpeaker:
@@ -202,8 +193,11 @@ class SonosSpeaker:
                 self.hass, SONOS_CREATE_AUDIO_FORMAT_SENSOR, self, audio_format
             )
 
-        if battery_info := fetch_battery_info_or_none(self.soco):
-            self.battery_info = battery_info
+        try:
+            self.battery_info = self.fetch_battery_info()
+        except SonosUpdateError:
+            _LOGGER.debug("No battery available for %s", self.zone_name)
+        else:
             # Battery events can be infrequent, polling is still necessary
             self._battery_poll_timer = track_time_interval(
                 self.hass, self.async_poll_battery, BATTERY_SCAN_INTERVAL
@@ -502,6 +496,13 @@ class SonosSpeaker:
     #
     # Speaker availability methods
     #
+    @soco_error()
+    def ping(self) -> None:
+        """Test device availability. Failure will raise SonosUpdateError."""
+        self.soco.renderingControl.GetVolume(
+            [("InstanceID", 0), ("Channel", "Master")], timeout=1
+        )
+
     @callback
     def speaker_activity(self, source):
         """Track the last activity on this speaker, set availability and resubscribe."""
@@ -532,23 +533,13 @@ class SonosSpeaker:
             return
 
         try:
-            # Make a short-timeout call as a final check
-            # before marking this speaker as unavailable
-            await self.hass.async_add_executor_job(
-                partial(
-                    self.soco.renderingControl.GetVolume,
-                    [("InstanceID", 0), ("Channel", "Master")],
-                    timeout=1,
-                )
-            )
-        except OSError:
+            await self.hass.async_add_executor_job(self.ping)
+        except SonosUpdateError:
             _LOGGER.warning(
                 "No recent activity and cannot reach %s, marking unavailable",
                 self.zone_name,
             )
             await self.async_offline()
-        else:
-            self.speaker_activity("timeout poll")
 
     async def async_offline(self) -> None:
         """Handle removal of speaker when unavailable."""
@@ -591,6 +582,15 @@ class SonosSpeaker:
     #
     # Battery management
     #
+    @soco_error()
+    def fetch_battery_info(self) -> dict[str, Any]:
+        """Fetch battery_info for the speaker."""
+        battery_info = self.soco.get_battery_info()
+        if not battery_info:
+            # S1 firmware returns an empty payload
+            raise S1BatteryMissing
+        return battery_info
+
     async def async_update_battery_info(self, more_info: str) -> None:
         """Update battery info using a SonosEvent payload value."""
         battery_dict = dict(x.split(":") for x in more_info.split(","))
@@ -630,11 +630,17 @@ class SonosSpeaker:
 
         if is_charging == self.charging:
             self.battery_info.update({"Level": int(battery_dict["BattPct"])})
+        elif not is_charging:
+            # Avoid polling the speaker if possible
+            self.battery_info["PowerSource"] = "BATTERY"
         else:
-            if battery_info := await self.hass.async_add_executor_job(
-                fetch_battery_info_or_none, self.soco
-            ):
-                self.battery_info = battery_info
+            # Poll to obtain current power source not provided by event
+            try:
+                self.battery_info = await self.hass.async_add_executor_job(
+                    self.fetch_battery_info
+                )
+            except SonosUpdateError as err:
+                _LOGGER.debug("Could not request current power source: %s", err)
 
     @property
     def power_source(self) -> str | None:
@@ -664,10 +670,13 @@ class SonosSpeaker:
         ):
             return
 
-        if battery_info := await self.hass.async_add_executor_job(
-            fetch_battery_info_or_none, self.soco
-        ):
-            self.battery_info = battery_info
+        try:
+            self.battery_info = await self.hass.async_add_executor_job(
+                self.fetch_battery_info
+            )
+        except SonosUpdateError as err:
+            _LOGGER.debug("Could not poll battery info: %s", err)
+        else:
             self.async_write_entity_states()
 
     #


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Battery tracking and last-chance pings were odd special cases. This change makes dedicated methods for each and routes them through the integration's common activity tracking (i.e., the `@soco_error` decorator).

This also adds a minor optimization which avoids a network call when a battery-operated device is removed from its charger.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
