### PR TITLE
Update Mypy to 0.950

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -67,8 +67,8 @@ _P = ParamSpec("_P")
 
 
 def catch_request_errors(
-    func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R | None]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R | None]]:
     """Catch UpnpError errors."""
 
     @functools.wraps(func)
@@ -80,7 +80,7 @@ def catch_request_errors(
             )
             return None
         try:
-            return await func(self, *args, **kwargs)  # type: ignore[no-any-return]  # mypy can't yet infer 'func'
+            return await func(self, *args, **kwargs)
         except UpnpError as err:
             self.check_available = True
             _LOGGER.error("Error during call %s: %r", func.__name__, err)

--- a/homeassistant/components/evil_genius_labs/util.py
+++ b/homeassistant/components/evil_genius_labs/util.py
@@ -15,8 +15,8 @@ _P = ParamSpec("_P")
 
 
 def update_when_done(
-    func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
     """Decorate function to trigger update when function is done."""
 
     @wraps(func)
@@ -24,6 +24,6 @@ def update_when_done(
         """Wrap function."""
         result = await func(self, *args, **kwargs)
         await self.coordinator.async_request_refresh()
-        return result  # type: ignore[no-any-return]  # mypy can't yet infer 'func'
+        return result
 
     return wrapper

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -96,7 +96,7 @@ def async_user_not_allowed_do_auth(
             return "User is local only"
 
     try:
-        remote = ip_address(request.remote)
+        remote = ip_address(request.remote)  # type: ignore[arg-type]
     except ValueError:
         return "Invalid remote IP"
 

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -67,7 +67,7 @@ async def ban_middleware(
         return await handler(request)
 
     # Verify if IP is not banned
-    ip_address_ = ip_address(request.remote)
+    ip_address_ = ip_address(request.remote)  # type: ignore[arg-type]
     is_banned = any(
         ip_ban.ip_address == ip_address_ for ip_ban in request.app[KEY_BANNED_IPS]
     )
@@ -107,7 +107,7 @@ async def process_wrong_login(request: Request) -> None:
     """
     hass = request.app["hass"]
 
-    remote_addr = ip_address(request.remote)
+    remote_addr = ip_address(request.remote)  # type: ignore[arg-type]
     remote_host = request.remote
     with suppress(herror):
         remote_host, _, _ = await hass.async_add_executor_job(
@@ -170,7 +170,7 @@ async def process_success_login(request: Request) -> None:
     No release IP address from banned list function, it can only be done by
     manual modify ip bans config file.
     """
-    remote_addr = ip_address(request.remote)
+    remote_addr = ip_address(request.remote)  # type: ignore[arg-type]
 
     # Check if ban middleware is loaded
     if KEY_BANNED_IPS not in request.app or request.app[KEY_LOGIN_THRESHOLD] < 1:

--- a/homeassistant/components/plugwise/util.py
+++ b/homeassistant/components/plugwise/util.py
@@ -15,8 +15,8 @@ _T = TypeVar("_T", bound=PlugwiseEntity)
 
 
 def plugwise_command(
-    func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
     """Decorate Plugwise calls that send commands/make changes to the device.
 
     A decorator that wraps the passed in function, catches Plugwise errors,

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -29,8 +29,8 @@ def roku_exception_handler(ignore_timeout: bool = False) -> Callable[..., Callab
     """Decorate Roku calls to handle Roku exceptions."""
 
     def decorator(
-        func: Callable[Concatenate[_T, _P], Awaitable[None]],  # type: ignore[misc]
-    ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
+        func: Callable[Concatenate[_T, _P], Awaitable[None]],
+    ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
         @wraps(func)
         async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
             try:

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -79,7 +79,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ),
         }
 
-    sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
+    # pylint: disable-next=abstract-class-instantiated
+    sentry_sdk.init(  # type: ignore[abstract]
         dsn=entry.data[CONF_DSN],
         environment=entry.options.get(CONF_ENVIRONMENT),
         integrations=[sentry_logging, AioHttpIntegration(), SqlalchemyIntegration()],

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -109,8 +109,8 @@ async def async_setup_entry(
 
 
 def sonarr_exception_handler(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[None]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Decorate Sonarr calls to handle Sonarr exceptions.
 
     A decorator that wraps the passed in function, catches Sonarr errors,

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -35,16 +35,14 @@ _P = ParamSpec("_P")
 @overload
 def soco_error(
     errorcodes: None = ...,
-) -> Callable[  # type: ignore[misc]
-    [Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R]
-]:
+) -> Callable[[Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R]]:
     ...
 
 
 @overload
 def soco_error(
     errorcodes: list[str],
-) -> Callable[  # type: ignore[misc]
+) -> Callable[
     [Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R | None]
 ]:
     ...
@@ -52,14 +50,14 @@ def soco_error(
 
 def soco_error(
     errorcodes: list[str] | None = None,
-) -> Callable[  # type: ignore[misc]
+) -> Callable[
     [Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R | None]
 ]:
     """Filter out specified UPnP errors and raise exceptions for service calls."""
 
     def decorator(
-        funct: Callable[Concatenate[_T, _P], _R]  # type: ignore[misc]
-    ) -> Callable[Concatenate[_T, _P], _R | None]:  # type: ignore[misc]
+        funct: Callable[Concatenate[_T, _P], _R]
+    ) -> Callable[Concatenate[_T, _P], _R | None]:
         """Decorate functions."""
 
         def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -135,7 +135,7 @@ class SonosMedia:
         self.title = track_info.get("title")
         self.image_url = track_info.get("album_art")
 
-        playlist_position = int(track_info.get("playlist_position"))
+        playlist_position = int(track_info.get("playlist_position", -1))
         if playlist_position > 0:
             self.queue_position = playlist_position
 

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -19,8 +19,8 @@ _P = ParamSpec("_P")
 
 
 def async_refresh_after(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[None]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Define a wrapper to refresh after."""
 
     async def _async_wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -48,8 +48,8 @@ async def async_setup_entry(
 
 
 def catch_vlc_errors(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[None]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Catch VLC errors."""
 
     @wraps(func)

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -108,7 +108,7 @@ async def async_handle_webhook(
 
     if webhook["local_only"]:
         try:
-            remote = ip_address(request.remote)
+            remote = ip_address(request.remote)  # type: ignore[arg-type]
         except ValueError:
             _LOGGER.debug("Unable to parse remote ip %s", request.remote)
             return Response(status=HTTPStatus.OK)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -87,8 +87,8 @@ _P = ParamSpec("_P")
 
 
 def cmd(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[None]]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Catch command exceptions."""
 
     @wraps(func)

--- a/homeassistant/components/zabbix/__init__.py
+++ b/homeassistant/components/zabbix/__init__.py
@@ -90,7 +90,11 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.error("HTTPError when connecting to Zabbix API: %s", http_error)
         zapi = None
         _LOGGER.error(RETRY_MESSAGE, http_error)
-        event_helper.call_later(hass, RETRY_INTERVAL, lambda _: setup(hass, config))
+        event_helper.call_later(
+            hass,
+            RETRY_INTERVAL,
+            lambda _: setup(hass, config),  # type: ignore[arg-type,return-value]
+        )
         return True
 
     hass.data[DOMAIN] = zapi

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -111,8 +111,8 @@ class TrackTemplateResult:
 
 
 def threaded_listener_factory(
-    async_factory: Callable[Concatenate[HomeAssistant, _P], Any]  # type: ignore[misc]
-) -> Callable[Concatenate[HomeAssistant, _P], CALLBACK_TYPE]:  # type: ignore[misc]
+    async_factory: Callable[Concatenate[HomeAssistant, _P], Any]
+) -> Callable[Concatenate[HomeAssistant, _P], CALLBACK_TYPE]:
     """Convert an async event helper to a threaded one."""
 
     @ft.wraps(async_factory)

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -48,7 +48,7 @@ async def _async_process_single_integration_platform_component(
         return
 
     try:
-        await integration_platform.process_platform(hass, component_name, platform)  # type: ignore[misc,operator] # https://github.com/python/mypy/issues/5485
+        await integration_platform.process_platform(hass, component_name, platform)
     except Exception:  # pylint: disable=broad-except
         _LOGGER.exception(
             "Error processing platform %s.%s", component_name, platform_name

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -48,7 +48,7 @@ class RuntimeConfig:
     open_ui: bool = False
 
 
-class HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore[valid-type,misc]
+class HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     """Event loop policy for Home Assistant."""
 
     def __init__(self, debug: bool) -> None:
@@ -59,7 +59,7 @@ class HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore[valid
     @property
     def loop_name(self) -> str:
         """Return name of the loop."""
-        return self._loop_factory.__name__  # type: ignore[no-any-return]
+        return self._loop_factory.__name__  # type: ignore[no-any-return,attr-defined]
 
     def new_event_loop(self) -> asyncio.AbstractEventLoop:
         """Get the event loop."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,7 @@ warn_redundant_casts = true
 warn_unused_configs = true
 warn_unused_ignores = true
 enable_error_code = ignore-without-code
+strict_concatenate = false
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_subclassing_any = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ codecov==2.1.12
 coverage==6.3.2
 freezegun==1.2.1
 mock-open==1.4.0
-mypy==0.942
+mypy==0.950
 pre-commit==2.17.0
 pylint==2.13.7
 pipdeptree==2.2.1

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -221,6 +221,8 @@ GENERAL_SETTINGS: Final[dict[str, str]] = {
     "warn_unused_configs": "true",
     "warn_unused_ignores": "true",
     "enable_error_code": "ignore-without-code",
+    # Strict_concatenate breaks passthrough ParamSpec typing
+    "strict_concatenate": "false",
 }
 
 # This is basically the list of checks which is enabled for "strict=true".


### PR DESCRIPTION
## Proposed change
I've waited a long time but it's finally here, mypy `0.950` 🎉
This release finally adds support for generic ParamSpec and most importantly `Concatenate`. A while ago, I started adding ParamSpec to the first decorators and now we can take full advantage of it. I've addressed almost all "new" issues because of it in previous PRs already but it will definitely help to improve our typing and catch even more bugs that way in the future. For reference, I'll include a good example of how `ParamSpec` and `Concatenate` can be used for an error decorator below (the most common use case for us so far).

Changelog: http://mypy-lang.blogspot.com/2022/04/mypy-0950-released.html
A short summary of noteworthy improvements
* Support for generic `ParamSpec` and `Concatenate`. Although technical the implementation is still experimental, most cases are already covered and it's definitely useable. There can still be the occasional bug though. For example, it's not yet possible to use ParamSpec type variables or Concatenate in TypeAliases. Furthermore `P.args` and `P.kwargs` are not yet interpreted as `tuple[object, ...]` and `dict[str, object]` respectively. I.e. something like this still causes an error `args[0]` (if `*args: P.args`).
* Mypy can now detect if `Coroutines` aren't used. This most likely indicates a missing `await`.
```py
async def async_func(): ...

async def f() -> None:
    async_func()  # error: Value of type "Coroutine[Any, Any, None]" must be used  [unused-coroutine]
```
* It's also now possible to emit an error for unused awaitables. However, that causes many false-positives and has thus been disabled by default. We would have 350+ "errors" currently. [mypy doc - unused-awaitable](https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-awaitable-return-value-is-used-unused-awaitable)

---

**ParamSpec example**

https://github.com/home-assistant/core/blob/603c7c89802cf40ce8e77553eef1d4c7c5702bde/homeassistant/components/evil_genius_labs/util.py#L12-L26

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
