### PR TITLE
Fix flaky ZHA tests

### DIFF
--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -1,5 +1,6 @@
 """Test ZHA Gateway."""
 import asyncio
+import math
 import time
 from unittest.mock import patch
 
@@ -207,14 +208,14 @@ async def test_updating_device_store(hass, zigpy_dev_basic, zha_dev_basic):
 
     assert zha_dev_basic.last_seen is not None
     entry = zha_gateway.zha_storage.async_get_or_create_device(zha_dev_basic)
-    assert entry.last_seen == zha_dev_basic.last_seen
+    assert math.isclose(entry.last_seen, zha_dev_basic.last_seen, rel_tol=1e-06)
 
     assert zha_dev_basic.last_seen is not None
     last_seen = zha_dev_basic.last_seen
 
     # test that we can't set None as last seen any more
     zha_dev_basic.async_update_last_seen(None)
-    assert last_seen == zha_dev_basic.last_seen
+    assert math.isclose(last_seen, zha_dev_basic.last_seen, rel_tol=1e-06)
 
     # test that we won't put None in storage
     zigpy_dev_basic.last_seen = None
@@ -222,18 +223,18 @@ async def test_updating_device_store(hass, zigpy_dev_basic, zha_dev_basic):
     await zha_gateway.async_update_device_storage()
     await hass.async_block_till_done()
     entry = zha_gateway.zha_storage.async_get_or_create_device(zha_dev_basic)
-    assert entry.last_seen == last_seen
+    assert math.isclose(entry.last_seen, last_seen, rel_tol=1e-06)
 
     # test that we can still set a good last_seen
     last_seen = time.time()
     zha_dev_basic.async_update_last_seen(last_seen)
-    assert last_seen == zha_dev_basic.last_seen
+    assert math.isclose(last_seen, zha_dev_basic.last_seen, rel_tol=1e-06)
 
     # test that we still put good values in storage
     await zha_gateway.async_update_device_storage()
     await hass.async_block_till_done()
     entry = zha_gateway.zha_storage.async_get_or_create_device(zha_dev_basic)
-    assert entry.last_seen == last_seen
+    assert math.isclose(entry.last_seen, last_seen, rel_tol=1e-06)
 
 
 async def test_cleaning_up_storage(hass, zigpy_dev_basic, zha_dev_basic, hass_storage):

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -193,7 +193,11 @@ async def test_on_off_select(hass, light, zha_device_joined_restored):
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_UNKNOWN
+    if zha_device_joined_restored.name == "zha_device_joined":
+        assert state.state == general.OnOff.StartUpOnOff.On.name
+    else:
+        assert state.state == STATE_UNKNOWN
+
     assert state.attributes["options"] == ["Off", "On", "Toggle", "PreviousValue"]
 
     entity_entry = entity_registry.async_get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Two ZHA tests had issues that needed to be addressed. 

test_gateway.py:

This test update should fix a flaky ZHA test that is the result of precision lost from data conversion. We now use math.isclose  instead of a direct comparison to the restored last_seen time for a device when we start ZHA. In the next release of HA this entire restoration of last_seen from ZHA store and the store itself will go away because Zigpy will be persisting this in its storage.

test_select.py:

This test had an issue caused by the differences from the quick init change we made. The PR that added this test and the quick init pr were independent and the issue was only apparent once the tests were combined. The quick init PR had to account for this change in another test as well. 

Sorry for the wackiness here!!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
