### PR TITLE
Rename bound TypeVars

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -61,18 +61,20 @@ from .data import EventListenAddr, get_domain_data
 
 PARALLEL_UPDATES = 0
 
-_T = TypeVar("_T", bound="DlnaDmrEntity")
+_DlnaDmrEntityT = TypeVar("_DlnaDmrEntityT", bound="DlnaDmrEntity")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 
 def catch_request_errors(
-    func: Callable[Concatenate[_T, _P], Awaitable[_R]]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R | None]]:
+    func: Callable[Concatenate[_DlnaDmrEntityT, _P], Awaitable[_R]]
+) -> Callable[Concatenate[_DlnaDmrEntityT, _P], Coroutine[Any, Any, _R | None]]:
     """Catch UpnpError errors."""
 
     @functools.wraps(func)
-    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
+    async def wrapper(
+        self: _DlnaDmrEntityT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R | None:
         """Catch UpnpError errors and check availability before and after request."""
         if not self.available:
             _LOGGER.warning(

--- a/homeassistant/components/evil_genius_labs/util.py
+++ b/homeassistant/components/evil_genius_labs/util.py
@@ -9,18 +9,20 @@ from typing_extensions import Concatenate, ParamSpec
 
 from . import EvilGeniusEntity
 
-_T = TypeVar("_T", bound=EvilGeniusEntity)
+_EvilGeniusEntityT = TypeVar("_EvilGeniusEntityT", bound=EvilGeniusEntity)
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 
 def update_when_done(
-    func: Callable[Concatenate[_T, _P], Awaitable[_R]]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
+    func: Callable[Concatenate[_EvilGeniusEntityT, _P], Awaitable[_R]]
+) -> Callable[Concatenate[_EvilGeniusEntityT, _P], Coroutine[Any, Any, _R]]:
     """Decorate function to trigger update when function is done."""
 
     @wraps(func)
-    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    async def wrapper(
+        self: _EvilGeniusEntityT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R:
         """Wrap function."""
         result = await func(self, *args, **kwargs)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/plugwise/util.py
+++ b/homeassistant/components/plugwise/util.py
@@ -9,21 +9,23 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .entity import PlugwiseEntity
 
-_P = ParamSpec("_P")
+_PlugwiseEntityT = TypeVar("_PlugwiseEntityT", bound=PlugwiseEntity)
 _R = TypeVar("_R")
-_T = TypeVar("_T", bound=PlugwiseEntity)
+_P = ParamSpec("_P")
 
 
 def plugwise_command(
-    func: Callable[Concatenate[_T, _P], Awaitable[_R]]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
+    func: Callable[Concatenate[_PlugwiseEntityT, _P], Awaitable[_R]]
+) -> Callable[Concatenate[_PlugwiseEntityT, _P], Coroutine[Any, Any, _R]]:
     """Decorate Plugwise calls that send commands/make changes to the device.
 
     A decorator that wraps the passed in function, catches Plugwise errors,
     and requests an coordinator update to update status of the devices asap.
     """
 
-    async def handler(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    async def handler(
+        self: _PlugwiseEntityT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R:
         try:
             return await func(self, *args, **kwargs)
         except PlugwiseException as error:

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -76,7 +76,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
-_T = TypeVar("_T", bound="SonarrSensor")
+_SonarrSensorT = TypeVar("_SonarrSensorT", bound="SonarrSensor")
 _P = ParamSpec("_P")
 
 
@@ -109,8 +109,8 @@ async def async_setup_entry(
 
 
 def sonarr_exception_handler(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
+    func: Callable[Concatenate[_SonarrSensorT, _P], Awaitable[None]]
+) -> Callable[Concatenate[_SonarrSensorT, _P], Coroutine[Any, Any, None]]:
     """Decorate Sonarr calls to handle Sonarr exceptions.
 
     A decorator that wraps the passed in function, catches Sonarr errors,
@@ -118,7 +118,9 @@ def sonarr_exception_handler(
     """
 
     @wraps(func)
-    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
+    async def wrapper(
+        self: _SonarrSensorT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> None:
         try:
             await func(self, *args, **kwargs)
             self.last_update_success = True

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -31,7 +31,7 @@ from .const import DATA_AVAILABLE, DATA_VLC, DEFAULT_NAME, DOMAIN, LOGGER
 
 MAX_VOLUME = 500
 
-_T = TypeVar("_T", bound="VlcDevice")
+_VlcDeviceT = TypeVar("_VlcDeviceT", bound="VlcDevice")
 _P = ParamSpec("_P")
 
 
@@ -48,12 +48,12 @@ async def async_setup_entry(
 
 
 def catch_vlc_errors(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
+    func: Callable[Concatenate[_VlcDeviceT, _P], Awaitable[None]]
+) -> Callable[Concatenate[_VlcDeviceT, _P], Coroutine[Any, Any, None]]:
     """Catch VLC errors."""
 
     @wraps(func)
-    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
+    async def wrapper(self: _VlcDeviceT, *args: _P.args, **kwargs: _P.kwargs) -> None:
         """Catch VLC errors and modify availability."""
         try:
             await func(self, *args, **kwargs)


### PR DESCRIPTION
## Proposed change
Rename some TypeVars to better indicate their bound type.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
