### PR TITLE
Skip translations when integration no longer exists

### DIFF
--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -70,7 +70,7 @@ def get_component_path(lang, component):
         return os.path.join(
             "homeassistant", "components", component, "translations", f"{lang}.json"
         )
-    raise ExitApp(f"Integration {component} not found under homeassistant/components/")
+    return None
 
 
 def get_platform_path(lang, component, platform):
@@ -98,7 +98,11 @@ def save_language_translations(lang, translations):
     for component, component_translations in components.items():
         base_translations = get_component_translations(component_translations)
         if base_translations:
-            path = get_component_path(lang, component)
+            if (path := get_component_path(lang, component)) is None:
+                print(
+                    f"Skipping {lang} for {component}, as the integration doesn't seem to exists."
+                )
+                continue
             os.makedirs(os.path.dirname(path), exist_ok=True)
             save_json(path, base_translations)
 

--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -100,7 +100,7 @@ def save_language_translations(lang, translations):
         if base_translations:
             if (path := get_component_path(lang, component)) is None:
                 print(
-                    f"Skipping {lang} for {component}, as the integration doesn't seem to exists."
+                    f"Skipping {lang} for {component}, as the integration doesn't seem to exist."
                 )
                 continue
             os.makedirs(os.path.dirname(path), exist_ok=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Because of this issue report #70982, I quickly glanced at our translations download workflows and discovered:

![image](https://user-images.githubusercontent.com/195327/165766518-00b9dde4-ef09-43eb-9b84-4df18281243a.png)

Our last successful translations download is 2 months ago! 😨

It is caused by removed integrations:

![CleanShot 2022-04-28 at 15 46 23](https://user-images.githubusercontent.com/195327/165766709-954a7a29-2762-4976-9a20-0666c74aae47.png)


This PR adjusts the behavior of the translations download script to report missing translations but continues as usual.

It is good to know what to clean up; but it should not stall an automated process.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
