### PR TITLE
Ensure SimpliSafe re-auth only looks at SimpliSafe config entries

### DIFF
--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -126,7 +126,8 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if existing_entries := [
                 entry
                 for entry in self.hass.config_entries.async_entries()
-                if entry.unique_id in (self._username, user_id)
+                if entry.domain == DOMAIN
+                and entry.unique_id in (self._username, user_id)
             ]:
                 existing_entry = existing_entries[0]
                 self.hass.config_entries.async_update_entry(

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
 
+from tests.common import MockConfigEntry
+
 from .common import REFRESH_TOKEN, USER_ID, USERNAME
 
 CONF_USER_ID = "user_id"
@@ -57,9 +59,15 @@ async def test_options_flow(hass, config_entry):
 
 @pytest.mark.parametrize("unique_id", [USERNAME, USER_ID])
 async def test_step_reauth(
-    hass, config, config_entry, reauth_config, setup_simplisafe, sms_config
+    hass, config, config_entry, reauth_config, setup_simplisafe, sms_config, unique_id
 ):
     """Test the re-auth step (testing both username and user ID as unique ID)."""
+    # Add a second config entry (tied to a random domain, but with the same unique ID as
+    # the SimpliSafe entry) to ensure that this reauth process only touches the
+    # SimpliSafe entry:
+    entry = MockConfigEntry(domain="random", unique_id=USERNAME, data={"some": "data"})
+    entry.add_to_hass(hass)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config
     )
@@ -78,10 +86,17 @@ async def test_step_reauth(
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "reauth_successful"
 
-    assert len(hass.config_entries.async_entries()) == 1
+    assert len(hass.config_entries.async_entries()) == 2
+
+    # Test that the SimpliSafe config flow is updated:
     [config_entry] = hass.config_entries.async_entries(DOMAIN)
     assert config_entry.unique_id == USER_ID
     assert config_entry.data == config
+
+    # Test that the non-SimpliSafe config flow remains the same:
+    [config_entry] = hass.config_entries.async_entries("random")
+    assert config_entry.unique_id == USERNAME
+    assert config_entry.data == {"some": "data"}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -95,8 +95,7 @@ async def test_step_reauth(
 
     # Test that the non-SimpliSafe config flow remains the same:
     [config_entry] = hass.config_entries.async_entries("random")
-    assert config_entry.unique_id == USERNAME
-    assert config_entry.data == {"some": "data"}
+    assert config_entry == entry
 
 
 @pytest.mark.parametrize(

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -10,9 +10,9 @@ from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
 
-from tests.common import MockConfigEntry
-
 from .common import REFRESH_TOKEN, USER_ID, USERNAME
+
+from tests.common import MockConfigEntry
 
 CONF_USER_ID = "user_id"
 

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -62,9 +62,9 @@ async def test_step_reauth(
     hass, config, config_entry, reauth_config, setup_simplisafe, sms_config, unique_id
 ):
     """Test the re-auth step (testing both username and user ID as unique ID)."""
-    # Add a second config entry (tied to a random domain, but with the same unique ID as
-    # the SimpliSafe entry) to ensure that this reauth process only touches the
-    # SimpliSafe entry:
+    # Add a second config entry (tied to a random domain, but with the same unique ID
+    # that could exist in a SimpliSafe entry) to ensure that this reauth process only
+    # touches the SimpliSafe entry:
     entry = MockConfigEntry(domain="random", unique_id=USERNAME, data={"some": "data"})
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/70160 introduced a possibility where SimpliSafe re-auth would impact non-SimpliSafe config entries that had the same unique ID. This PR fixes things.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
