### PR TITLE
Remove unnecessary update_before_add from ZHA

### DIFF
--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -41,7 +41,6 @@ async def async_setup_entry(
             discovery.async_add_entities,
             async_add_entities,
             entities_to_create,
-            update_before_add=False,
         ),
     )
     config_entry.async_on_unload(unsub)

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -54,14 +54,13 @@ async def async_add_entities(
             tuple[str, ZHADevice, list[base.ZigbeeChannel]],
         ]
     ],
-    update_before_add: bool = True,
 ) -> None:
     """Add entities helper."""
     if not entities:
         return
     to_add = [ent_cls.create_entity(*args) for ent_cls, args in entities]
     entities_to_add = [entity for entity in to_add if entity is not None]
-    _async_add_entities(entities_to_add, update_before_add=update_before_add)
+    _async_add_entities(entities_to_add, update_before_add=False)
     entities.clear()
 
 

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -291,6 +291,7 @@ class ZhaGroupEntity(BaseZhaEntity):
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()
+        await self.async_update()
 
         self.async_accept_signal(
             None,

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -67,7 +67,6 @@ async def async_setup_entry(
             discovery.async_add_entities,
             async_add_entities,
             entities_to_create,
-            update_before_add=False,
         ),
     )
     config_entry.async_on_unload(unsub)

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -250,7 +250,6 @@ async def async_setup_entry(
             discovery.async_add_entities,
             async_add_entities,
             entities_to_create,
-            update_before_add=False,
         ),
     )
     config_entry.async_on_unload(unsub)

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -103,7 +103,6 @@ async def async_setup_entry(
             discovery.async_add_entities,
             async_add_entities,
             entities_to_create,
-            update_before_add=False,
         ),
     )
     config_entry.async_on_unload(unsub)

--- a/homeassistant/components/zha/siren.py
+++ b/homeassistant/components/zha/siren.py
@@ -60,7 +60,6 @@ async def async_setup_entry(
             discovery.async_add_entities,
             async_add_entities,
             entities_to_create,
-            update_before_add=False,
         ),
     )
     config_entry.async_on_unload(unsub)

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -104,17 +104,14 @@ def zigpy_keen_vent(zigpy_device_mock):
     )
 
 
-@patch(
-    "homeassistant.components.zha.core.channels.closures.WindowCovering.async_initialize"
-)
-async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
+async def test_cover(hass, zha_device_joined_restored, zigpy_cover_device):
     """Test zha cover platform."""
 
     # load up cover domain
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
     cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 100}
     zha_device = await zha_device_joined_restored(zigpy_cover_device)
-    assert cluster.read_attributes.call_count == 2
+    assert cluster.read_attributes.call_count == 1
     assert "current_position_lift_percentage" in cluster.read_attributes.call_args[0][0]
 
     entity_id = await find_entity_id(Platform.COVER, zha_device, hass)
@@ -193,6 +190,7 @@ async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
         assert cluster.request.call_args[1]["expect_reply"] is True
 
     # test rejoin
+    cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 0}
     await async_test_rejoin(hass, zigpy_cover_device, [cluster], (1,))
     assert hass.states.get(entity_id).state == STATE_OPEN
 

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -52,7 +52,7 @@ async def test_device_tracker(hass, zha_device_joined_restored, zigpy_device_dt)
     entity_id = await find_entity_id(Platform.DEVICE_TRACKER, zha_device, hass)
     assert entity_id is not None
 
-    assert hass.states.get(entity_id).state == STATE_HOME
+    assert hass.states.get(entity_id).state == STATE_NOT_HOME
     await async_enable_traffic(hass, [zha_device], enabled=False)
     # test that the device tracker was created and that it is unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -1,5 +1,7 @@
 """Test ZHA select entities."""
 
+from unittest.mock import call
+
 import pytest
 from zigpy.const import SIG_EP_PROFILE
 import zigpy.profiles.zha as zha
@@ -50,6 +52,7 @@ async def light(hass, zigpy_device_mock):
                 SIG_EP_OUTPUT: [general.Ota.cluster_id],
             }
         },
+        node_descriptor=b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00",
     )
 
     return zigpy_device
@@ -173,15 +176,15 @@ async def test_select_restore_state(
     assert state.state == security.IasWd.Warning.WarningMode.Burglar.name
 
 
-async def test_on_off_select(hass, light, zha_device_joined_restored):
-    """Test zha on off select."""
+async def test_on_off_select_new_join(hass, light, zha_device_joined):
+    """Test zha on off select - new join."""
 
     entity_registry = er.async_get(hass)
     on_off_cluster = light.endpoints[1].on_off
     on_off_cluster.PLUGGED_ATTR_READS = {
         "start_up_on_off": general.OnOff.StartUpOnOff.On
     }
-    zha_device = await zha_device_joined_restored(light)
+    zha_device = await zha_device_joined(light)
     select_name = general.OnOff.StartUpOnOff.__name__
     entity_id = await find_entity_id(
         Platform.SELECT,
@@ -191,12 +194,19 @@ async def test_on_off_select(hass, light, zha_device_joined_restored):
     )
     assert entity_id is not None
 
+    assert on_off_cluster.read_attributes.call_count == 2
+    assert (
+        call(["start_up_on_off"], allow_cache=True, only_cache=False, manufacturer=None)
+        in on_off_cluster.read_attributes.call_args_list
+    )
+    assert (
+        call(["on_off"], allow_cache=False, only_cache=False, manufacturer=None)
+        in on_off_cluster.read_attributes.call_args_list
+    )
+
     state = hass.states.get(entity_id)
     assert state
-    if zha_device_joined_restored.name == "zha_device_joined":
-        assert state.state == general.OnOff.StartUpOnOff.On.name
-    else:
-        assert state.state == STATE_UNKNOWN
+    assert state.state == general.OnOff.StartUpOnOff.On.name
 
     assert state.attributes["options"] == ["Off", "On", "Toggle", "PreviousValue"]
 
@@ -223,6 +233,58 @@ async def test_on_off_select(hass, light, zha_device_joined_restored):
     state = hass.states.get(entity_id)
     assert state
     assert state.state == general.OnOff.StartUpOnOff.Off.name
+
+
+async def test_on_off_select_restored(hass, light, zha_device_restored):
+    """Test zha on off select - restored."""
+
+    entity_registry = er.async_get(hass)
+    on_off_cluster = light.endpoints[1].on_off
+    on_off_cluster.PLUGGED_ATTR_READS = {
+        "start_up_on_off": general.OnOff.StartUpOnOff.On
+    }
+    zha_device = await zha_device_restored(light)
+
+    assert zha_device.is_mains_powered
+
+    assert on_off_cluster.read_attributes.call_count == 4
+    # first 2 calls hit cache only
+    assert (
+        call(["start_up_on_off"], allow_cache=True, only_cache=True, manufacturer=None)
+        in on_off_cluster.read_attributes.call_args_list
+    )
+    assert (
+        call(["on_off"], allow_cache=True, only_cache=True, manufacturer=None)
+        in on_off_cluster.read_attributes.call_args_list
+    )
+
+    # 2nd set of calls can actually read from the device
+    assert (
+        call(["start_up_on_off"], allow_cache=True, only_cache=False, manufacturer=None)
+        in on_off_cluster.read_attributes.call_args_list
+    )
+    assert (
+        call(["on_off"], allow_cache=False, only_cache=False, manufacturer=None)
+        in on_off_cluster.read_attributes.call_args_list
+    )
+
+    select_name = general.OnOff.StartUpOnOff.__name__
+    entity_id = await find_entity_id(
+        Platform.SELECT,
+        zha_device,
+        hass,
+        qualifier=select_name.lower(),
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == general.OnOff.StartUpOnOff.On.name
+    assert state.attributes["options"] == ["Off", "On", "Toggle", "PreviousValue"]
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category == ENTITY_CATEGORY_CONFIG
 
 
 async def test_on_off_select_unsupported(hass, light, zha_device_joined_restored):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Continuing the work on fixing ZHA initialization and while handling this comment: https://github.com/home-assistant/core/pull/70956#discussion_r860356194 I discovered that several platforms were still calling update_before_add in ZHA which causes additional unnecessary network reads. The only place the update is needed is for group entities since their state is derived from the member states. This PR fixes the test comment above and corrects the extra network reads. 


I am going to take an additional pass after the beta (for next months release) to verify all calls against all clusters in the tests to prevent something like this from happening again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
