### PR TITLE
Ensure that email-based 2FA in SimpliSafe shows the progress UI

### DIFF
--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -109,21 +109,22 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_get_email_2fa(self) -> None:
         """Define a task to wait for email-based 2FA."""
-        assert self._simplisafe
+        # assert self._simplisafe
 
-        async with async_timeout.timeout(DEFAULT_EMAIL_2FA_TIMEOUT):
-            while True:
-                try:
-                    await self._simplisafe.async_verify_2fa_email()
-                except Verify2FAPending:
-                    LOGGER.info("Email-based 2FA pending; trying again")
-                    await asyncio.sleep(DEFAULT_EMAIL_2FA_SLEEP)
-                else:
-                    break
-
-        self.hass.async_create_task(
-            self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
-        )
+        try:
+            async with async_timeout.timeout(DEFAULT_EMAIL_2FA_TIMEOUT):
+                while True:
+                    try:
+                        await self._simplisafe.async_verify_2fa_email()
+                    except Verify2FAPending:
+                        LOGGER.info("Email-based 2FA pending; trying again")
+                        await asyncio.sleep(DEFAULT_EMAIL_2FA_SLEEP)
+                    else:
+                        break
+        finally:
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+            )
 
     async def async_step_email_2fa(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -52,7 +52,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._email_2fa_task: asyncio.Task | None = None
         self._password: str | None = None
         self._reauth: bool = False
-        self._simplisafe: API = None
+        self._simplisafe: API | None = None
         self._username: str | None = None
 
     async def _async_authenticate(

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -109,7 +109,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_get_email_2fa(self) -> None:
         """Define a task to wait for email-based 2FA."""
-        # assert self._simplisafe
+        assert self._simplisafe
 
         try:
             async with async_timeout.timeout(DEFAULT_EMAIL_2FA_TIMEOUT):

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from .const import DOMAIN, LOGGER
 
 DEFAULT_EMAIL_2FA_SLEEP = 3
-DEFAULT_EMAIL_2FA_TIMEOUT = 300
+DEFAULT_EMAIL_2FA_TIMEOUT = 5
 
 STEP_REAUTH_SCHEMA = vol.Schema(
     {
@@ -49,13 +49,15 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
+        self._email_2fa_error: str | None = None
+        self._email_2fa_task: asyncio.Task | None = None
         self._password: str | None = None
         self._reauth: bool = False
-        self._simplisafe: API | None = None
+        self._simplisafe: API = None
         self._username: str | None = None
 
     async def _async_authenticate(
-        self, error_step_id: str, error_schema: vol.Schema
+        self, originating_step_id: str, originating_step_schema: vol.Schema
     ) -> FlowResult:
         """Attempt to authenticate to the SimpliSafe API."""
         assert self._password
@@ -76,16 +78,39 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if errors:
             return self.async_show_form(
-                step_id=error_step_id,
-                data_schema=error_schema,
+                step_id=originating_step_id,
+                data_schema=originating_step_schema,
                 errors=errors,
                 description_placeholders={CONF_USERNAME: self._username},
             )
 
-        assert self._simplisafe
-
         if self._simplisafe.auth_state == AuthStates.PENDING_2FA_SMS:
             return await self.async_step_sms_2fa()
+        return await self.async_step_email_2fa()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> SimpliSafeOptionsFlowHandler:
+        """Define the config flow to handle options."""
+        return SimpliSafeOptionsFlowHandler(config_entry)
+
+    async def async_step_reauth(self, config: dict[str, Any]) -> FlowResult:
+        """Handle configuration by re-auth."""
+        self._reauth = True
+
+        if CONF_USERNAME not in config:
+            # Old versions of the config flow may not have the username by this point;
+            # in that case, we reauth them by making them go through the user flow:
+            return await self.async_step_user()
+
+        self._username = config[CONF_USERNAME]
+        return await self.async_step_reauth_confirm()
+
+    async def _async_get_email_2fa(self) -> None:
+        """Define a task to wait for email-based 2FA."""
+        assert self._simplisafe
 
         try:
             async with async_timeout.timeout(DEFAULT_EMAIL_2FA_TIMEOUT):
@@ -98,16 +123,41 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     else:
                         break
         except asyncio.TimeoutError:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=STEP_USER_SCHEMA,
-                errors={"base": "2fa_timed_out"},
+            self._email_2fa_error = "email_2fa_timed_out"
+
+        if self._simplisafe.auth_state != AuthStates.AUTHENTICATED:
+            self._email_2fa_error = "email_2fa_unknown"
+
+        self.hass.async_create_task(
+            self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+        )
+
+    async def async_step_email_2fa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle email-based two-factor authentication."""
+        if not self._email_2fa_task:
+            self._email_2fa_task = self.hass.async_create_task(
+                self._async_get_email_2fa()
+            )
+            return self.async_show_progress(
+                step_id="email_2fa", progress_action="email_2fa"
             )
 
-        return await self._async_finish_setup()
+        if self._email_2fa_error:
+            return self.async_show_progress_done(next_step_id="email_2fa_error")
+        return self.async_show_progress_done(next_step_id="finish")
 
-    async def _async_finish_setup(self) -> FlowResult:
-        """Complete setup with an authenticated API object."""
+    async def async_step_email_2fa_error(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle an error during email-based two-factor authentication."""
+        return self.async_abort(reason=self._email_2fa_error)
+
+    async def async_step_finish(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the final step."""
         assert self._simplisafe
         assert self._username
 
@@ -141,26 +191,6 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(user_id)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title=self._username, data=data)
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> SimpliSafeOptionsFlowHandler:
-        """Define the config flow to handle options."""
-        return SimpliSafeOptionsFlowHandler(config_entry)
-
-    async def async_step_reauth(self, config: dict[str, Any]) -> FlowResult:
-        """Handle configuration by re-auth."""
-        self._reauth = True
-
-        if CONF_USERNAME not in config:
-            # Old versions of the config flow may not have the username by this point;
-            # in that case, we reauth them by making them go through the user flow:
-            return await self.async_step_user()
-
-        self._username = config[CONF_USERNAME]
-        return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -197,7 +227,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors={CONF_CODE: "invalid_auth"},
             )
 
-        return await self._async_finish_setup()
+        return await self.async_step_finish()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -83,6 +83,8 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 description_placeholders={CONF_USERNAME: self._username},
             )
 
+        assert self._simplisafe
+
         if self._simplisafe.auth_state == AuthStates.PENDING_2FA_SMS:
             return await self.async_step_sms_2fa()
         return await self.async_step_email_2fa()

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -23,13 +23,17 @@
       }
     },
     "error": {
-      "2fa_timed_out": "Timed out while waiting for two-factor authentication",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "This SimpliSafe account is already in use.",
+      "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
+      "email_2fa_unknown": "Unknown error while authenticating email-based two-factor authentication.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    },
+    "progress": {
+      "email_2fa": "Input the two-factor authentication code\nsent to you via email."
     }
   },
   "options": {

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -29,7 +29,6 @@
     "abort": {
       "already_configured": "This SimpliSafe account is already in use.",
       "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
-      "email_2fa_unknown": "Unknown error while authenticating email-based two-factor authentication.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "progress": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -3,7 +3,6 @@
         "abort": {
             "already_configured": "This SimpliSafe account is already in use.",
             "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
-            "email_2fa_unknown": "Unknown error while authenticating email-based two-factor authentication.",
             "reauth_successful": "Re-authentication was successful"
         },
         "error": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -2,12 +2,16 @@
     "config": {
         "abort": {
             "already_configured": "This SimpliSafe account is already in use.",
+            "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
+            "email_2fa_unknown": "Unknown error while authenticating email-based two-factor authentication.",
             "reauth_successful": "Re-authentication was successful"
         },
         "error": {
-            "2fa_timed_out": "Timed out while waiting for two-factor authentication",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
+        },
+        "progress": {
+            "email_2fa": "Input the two-factor authentication code\nsent to you via email."
         },
         "step": {
             "reauth_confirm": {

--- a/tests/components/simplisafe/conftest.py
+++ b/tests/components/simplisafe/conftest.py
@@ -102,6 +102,8 @@ def reauth_config_fixture():
 async def setup_simplisafe_fixture(hass, api, config):
     """Define a fixture to set up SimpliSafe."""
     with patch(
+        "homeassistant.components.simplisafe.config_flow.DEFAULT_EMAIL_2FA_SLEEP", 0
+    ), patch(
         "homeassistant.components.simplisafe.config_flow.API.async_from_credentials",
         return_value=api,
     ), patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on @MartinHjelmare's [suggestion](https://github.com/home-assistant/core/pull/70160#discussion_r859638279) in https://github.com/home-assistant/core/pull/70160, this PR utilizes the progress UI during the email-based Simplisafe 2FA flow.

Unfortunately, I've migrated my SimpliSafe account to SMS-based 2FA and there's no way to revert, so I'm flying a bit blind on this one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/70160
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
