### PR TITLE
Add backup.purge service

### DIFF
--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -3,7 +3,7 @@ from homeassistant.components.hassio import is_hassio
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, LOGGER
+from .const import ATTR_KEEP_RECENT, DOMAIN, LOGGER
 from .http import async_register_http_views
 from .manager import BackupManager
 from .websocket import async_register_websocket_handlers
@@ -25,7 +25,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Service handler for creating backups."""
         await backup_manager.generate_backup()
 
+    async def async_handle_purge_service(call: ServiceCall) -> None:
+        """Service handler for purging old backups."""
+        await backup_manager.purge_backups(keep_recent=call.data[ATTR_KEEP_RECENT])
+
     hass.services.async_register(DOMAIN, "create", async_handle_create_service)
+    hass.services.async_register(DOMAIN, "purge", async_handle_purge_service)
 
     async_register_websocket_handlers(hass)
     async_register_http_views(hass)

--- a/homeassistant/components/backup/const.py
+++ b/homeassistant/components/backup/const.py
@@ -4,6 +4,8 @@ from logging import getLogger
 DOMAIN = "backup"
 LOGGER = getLogger(__package__)
 
+ATTR_KEEP_RECENT = "keep_recent"
+
 EXCLUDE_FROM_BACKUP = [
     "__pycache__/*",
     ".DS_Store",

--- a/homeassistant/components/backup/services.yaml
+++ b/homeassistant/components/backup/services.yaml
@@ -1,3 +1,17 @@
 create:
   name: Create backup
   description: Create a new backup.
+
+purge:
+  name: Purge old backups
+  description: Purge old backups, keeping the given number of recent backups.
+  fields:
+    keep_recent:
+      name: Keep recent
+      description: Number of recent backups to keep
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 1000
+          mode: box

--- a/tests/components/backup/test_init.py
+++ b/tests/components/backup/test_init.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.backup.const import DOMAIN
+from homeassistant.components.backup.const import ATTR_KEEP_RECENT, DOMAIN
 from homeassistant.core import HomeAssistant
 
 from .common import setup_backup_integration
@@ -37,3 +37,24 @@ async def test_create_service(
         )
 
     assert generate_backup.called
+
+
+async def test_purge_service(
+    hass: HomeAssistant,
+) -> None:
+    """Test purge backups."""
+    await setup_backup_integration(hass)
+
+    data = {ATTR_KEEP_RECENT: 3}
+
+    with patch(
+        "homeassistant.components.backup.websocket.BackupManager.purge_backups",
+    ) as purge_backups:
+        await hass.services.async_call(
+            DOMAIN,
+            "purge",
+            service_data=data,
+            blocking=True,
+        )
+
+    assert purge_backups.called


### PR DESCRIPTION
## Proposed change

Adds a new service to the backup integration: `backup.purge`.

Inspired by #70118, this allows users of Home Assistant Container and Core installation types to purge old backups on a schedule using automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: Will open a PR with documentation if/when this one is deemed ok

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
