### PR TITLE
Fix Sonos races related to grouping and startup

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -263,7 +263,11 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     @property
     def available(self) -> bool:
         """Return if the media_player is available."""
-        return self.speaker.available and self.speaker.sonos_group_entities
+        return (
+            self.speaker.available
+            and self.speaker.sonos_group_entities
+            and self.media.playback_status
+        )
 
     @property
     def coordinator(self) -> SonosSpeaker:

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -261,6 +261,11 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             self.async_write_ha_state()
 
     @property
+    def available(self) -> bool:
+        """Return if the media_player is available."""
+        return self.speaker.available and self.speaker.sonos_group_entities
+
+    @property
     def coordinator(self) -> SonosSpeaker:
         """Return the current coordinator SonosSpeaker."""
         return self.speaker.coordinator or self.speaker

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -189,7 +189,10 @@ class SonosSpeaker:
 
     def setup(self, entry: ConfigEntry) -> None:
         """Run initial setup of the speaker."""
-        self.set_basic_info()
+        self.media.play_mode = self.soco.play_mode
+        self.update_volume()
+        self.update_groups()
+
         future = asyncio.run_coroutine_threadsafe(
             self.async_setup_dispatchers(entry), self.hass.loop
         )
@@ -246,11 +249,6 @@ class SonosSpeaker:
     def async_write_entity_states(self) -> None:
         """Write states for associated SonosEntity instances."""
         async_dispatcher_send(self.hass, f"{SONOS_STATE_UPDATED}-{self.soco.uid}")
-
-    def set_basic_info(self) -> None:
-        """Set basic information when speaker is reconnected."""
-        self.media.play_mode = self.soco.play_mode
-        self.update_volume()
 
     #
     # Properties
@@ -456,6 +454,34 @@ class SonosSpeaker:
     @callback
     def async_dispatch_media_update(self, event: SonosEvent) -> None:
         """Update information about currently playing media from an event."""
+        # The new coordinator can be provided in a media update event but
+        # before the ZoneGroupState updates. If this happens the playback
+        # state will be incorrect and should be ignored. Switching to the
+        # new coordinator will use its media. The regrouping process will
+        # be completed during the next ZoneGroupState update.
+        av_transport_uri = event.variables.get("av_transport_uri", "")
+        current_track_uri = event.variables.get("current_track_uri", "")
+        if av_transport_uri == current_track_uri and av_transport_uri.startswith(
+            "x-rincon:"
+        ):
+            new_coordinator_uid = av_transport_uri.split(":")[-1]
+            if new_coordinator_speaker := self.hass.data[DATA_SONOS].discovered.get(
+                new_coordinator_uid
+            ):
+                _LOGGER.debug(
+                    "Media update coordinator (%s) received for %s",
+                    new_coordinator_speaker.zone_name,
+                    self.zone_name,
+                )
+                self.coordinator = new_coordinator_speaker
+            else:
+                _LOGGER.debug(
+                    "Media update coordinator (%s) for %s not yet available",
+                    new_coordinator_uid,
+                    self.zone_name,
+                )
+            return
+
         if crossfade := event.variables.get("current_crossfade_mode"):
             self.cross_fade = bool(int(crossfade))
 
@@ -774,6 +800,7 @@ class SonosSpeaker:
                         self.zone_name,
                         uid,
                     )
+                    return
 
             if self.sonos_group_entities == sonos_group_entities:
                 # Useful in polling mode for speakers with stereo pairs or surrounds

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -192,6 +192,8 @@ class SonosSpeaker:
         self.media.play_mode = self.soco.play_mode
         self.update_volume()
         self.update_groups()
+        if self.is_coordinator:
+            self.media.poll_media()
 
         future = asyncio.run_coroutine_threadsafe(
             self.async_setup_dispatchers(entry), self.hass.loop

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -120,6 +120,7 @@ def soco_fixture(
         mock_soco.get_battery_info.return_value = battery_info
         mock_soco.all_zones = {mock_soco}
         mock_soco.visible_zones = {mock_soco}
+        mock_soco.group.coordinator = mock_soco
         yield mock_soco
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This addresses some race conditions related to grouping:
* On startup, wait until group structures and playback state are known before marking speakers as available
* Use regroup "hints" during media metadata updates to avoid using invalid states (e.g., marking idle speakers as "playing" while they're being moved to a group)
* Defer writing groups during startup if some members have not been created yet

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
