### PR TITLE
Generic camera handle template adjacent to portnumber

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -168,16 +168,20 @@ async def async_test_still(hass, info) -> tuple[dict[str, str], str | None]:
     return {}, f"image/{fmt}"
 
 
-def slug_url(hass, url) -> str | None:
+def slug(hass, template) -> str | None:
     """Convert a camera url into a string suitable for a camera name."""
-    if not url:
+    if not template:
         return None
-    if not isinstance(url, template_helper.Template):
-        url = cv.template(url)
-        url.hass = hass
-    # We shouldn't have any exceptions here, because we verified the url earlier
-    url = url.async_render(parse_result=False)
-    return slugify(yarl.URL(url).host)
+    if not isinstance(template, template_helper.Template):
+        template = template_helper.Template(template, hass)
+    try:
+        url = template.async_render(parse_result=False)
+        return slugify(yarl.URL(url).host)
+    except TemplateError as err:
+        _LOGGER.error("Syntax error in '%s': %s", template.template, err)
+    except (ValueError, TypeError) as err:
+        _LOGGER.error("Syntax error in '%s': %s", url, err)
+    return None
 
 
 async def async_test_stream(hass, info) -> dict[str, str]:
@@ -257,6 +261,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the start of the config flow."""
         errors = {}
+        hass = self.hass
         if user_input:
             # Secondary validation because serialised vol can't seem to handle this complexity:
             if not user_input.get(CONF_STILL_IMAGE_URL) and not user_input.get(
@@ -268,12 +273,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors = errors | await async_test_stream(self.hass, user_input)
                 still_url = user_input.get(CONF_STILL_IMAGE_URL)
                 stream_url = user_input.get(CONF_STREAM_SOURCE)
-                name = (
-                    slug_url(self.hass, still_url)
-                    or slug_url(self.hass, stream_url)
-                    or DEFAULT_NAME
-                )
-
+                name = slug(hass, still_url) or slug(hass, stream_url) or DEFAULT_NAME
                 if not errors:
                     user_input[CONF_CONTENT_TYPE] = still_format
                     user_input[CONF_LIMIT_REFETCH_TO_URL_CHANGE] = False
@@ -305,9 +305,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         stream_url = import_config.get(CONF_STREAM_SOURCE)
         name = import_config.get(
             CONF_NAME,
-            slug_url(self.hass, still_url)
-            or slug_url(self.hass, stream_url)
-            or DEFAULT_NAME,
+            slug(self.hass, still_url) or slug(self.hass, stream_url) or DEFAULT_NAME,
         )
         if CONF_LIMIT_REFETCH_TO_URL_CHANGE not in import_config:
             import_config[CONF_LIMIT_REFETCH_TO_URL_CHANGE] = False
@@ -330,6 +328,7 @@ class GenericOptionsFlowHandler(OptionsFlow):
     ) -> FlowResult:
         """Manage Generic IP Camera options."""
         errors: dict[str, str] = {}
+        hass = self.hass
 
         if user_input is not None:
             errors, still_format = await async_test_still(
@@ -339,11 +338,7 @@ class GenericOptionsFlowHandler(OptionsFlow):
             still_url = user_input.get(CONF_STILL_IMAGE_URL)
             stream_url = user_input.get(CONF_STREAM_SOURCE)
             if not errors:
-                title = (
-                    slug_url(self.hass, still_url)
-                    or slug_url(self.hass, stream_url)
-                    or DEFAULT_NAME
-                )
+                title = slug(hass, still_url) or slug(hass, stream_url) or DEFAULT_NAME
                 if still_url is None:
                     # If user didn't specify a still image URL,
                     # The automatically generated still image that stream generates

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -268,11 +268,11 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
             ):
                 errors["base"] = "no_still_image_or_stream_url"
             else:
+                errors, still_format = await async_test_still(self.hass, user_input)
+                errors = errors | await async_test_stream(self.hass, user_input)
                 still_url = user_input.get(CONF_STILL_IMAGE_URL)
                 stream_url = user_input.get(CONF_STREAM_SOURCE)
                 name = slug(hass, still_url) or slug(hass, stream_url) or DEFAULT_NAME
-                errors, still_format = await async_test_still(self.hass, user_input)
-                errors = errors | await async_test_stream(self.hass, user_input)
                 if not errors:
                     user_input[CONF_CONTENT_TYPE] = still_format
                     user_input[CONF_LIMIT_REFETCH_TO_URL_CHANGE] = False

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -166,6 +166,23 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
 
 
 @respx.mock
+async def test_template_immediately_following_port(
+    hass, user_flow, fakeimgbytes_png
+) -> None:
+    """Test we can handle templates in strange parts of the url, #70961."""
+    url = "http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png"
+    respx.get(url).respond(stream=fakeimgbytes_png)
+    data = TESTDATA.copy()
+    data.pop(CONF_STREAM_SOURCE)
+    data[CONF_STILL_IMAGE_URL] = url
+    result2 = await hass.config_entries.flow.async_configure(
+        user_flow["flow_id"],
+        data,
+    )
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+@respx.mock
 async def test_form_rtsp_mode(hass, fakeimg_png, mock_av_open, user_flow):
     """Test we complete ok if the user enters a stream url."""
     with mock_av_open as mock_setup:

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -167,17 +167,34 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
 
 @respx.mock
 @pytest.mark.parametrize(
-    ("template", "url"),
+    ("template", "url", "expected_result"),
     [
         # Test we can handle templates in strange parts of the url, #70961.
         (
             "http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png",
             "http://localhost:8123/static/icons/favicon-apple-180x180.png",
+            data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
         ),
-        ("{% if 1 %}https://bla{% else %}https://yo{% endif %}", "https://bla/"),
+        (
+            "{% if 1 %}https://bla{% else %}https://yo{% endif %}",
+            "https://bla/",
+            data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+        ),
+        (
+            "http://{{example.org",
+            "http://example.org",
+            data_entry_flow.RESULT_TYPE_FORM,
+        ),
+        (
+            "invalid1://invalid:4\\1",
+            "invalid1://invalid:4%5c1",
+            data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+        ),
     ],
 )
-async def test_still_template(hass, user_flow, fakeimgbytes_png, template, url) -> None:
+async def test_still_template(
+    hass, user_flow, fakeimgbytes_png, template, url, expected_result
+) -> None:
     """Test we can handle various templates."""
     respx.get(url).respond(stream=fakeimgbytes_png)
     data = TESTDATA.copy()
@@ -187,7 +204,7 @@ async def test_still_template(hass, user_flow, fakeimgbytes_png, template, url) 
         user_flow["flow_id"],
         data,
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == expected_result
 
 
 @respx.mock

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -166,15 +166,23 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
 
 
 @respx.mock
-async def test_template_immediately_following_port(
-    hass, user_flow, fakeimgbytes_png
-) -> None:
-    """Test we can handle templates in strange parts of the url, #70961."""
-    url = "http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png"
+@pytest.mark.parametrize(
+    ("template", "url"),
+    [
+        # Test we can handle templates in strange parts of the url, #70961.
+        (
+            "http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png",
+            "http://localhost:8123/static/icons/favicon-apple-180x180.png",
+        ),
+        ("{% if 1 %}https://bla{% else %}https://yo{% endif %}", "https://bla/"),
+    ],
+)
+async def test_still_template(hass, user_flow, fakeimgbytes_png, template, url) -> None:
+    """Test we can handle various templates."""
     respx.get(url).respond(stream=fakeimgbytes_png)
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
-    data[CONF_STILL_IMAGE_URL] = url
+    data[CONF_STILL_IMAGE_URL] = template
     result2 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
         data,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While setting up a generic camera (yaml import or UI), still image URLs such as `http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png` were enough to confuse yarl when it attempted to create a default name based on the provided url.

This is because the templates were not being rendered during the slugify, and yarl deems a port number invalid if it is not an integer followed by `/`.

This PR resolves the issue by rendering the template prior to slugifying.  

It has the side effect that if the url uses a template to define any part of the hostname, the default name of the camera entity will be based on what the template rendered to at the time of setup.  If the user doesn't like this, they can rename it manually.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #70961
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
