### PR TITLE
Fix history_stats for timezones with a positive offset from UTC

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -11,6 +11,11 @@ import homeassistant.util.dt as dt_util
 
 from .helpers import async_calculate_period, floored_timestamp
 
+# Add 24 hours to min time since min time is min time UTC
+# and we want min time that can be represented in the configured
+# time zone
+MIN_TIME = datetime.datetime.min + datetime.timedelta(hours=24)
+
 
 @dataclass
 class HistoryStatsState:
@@ -36,7 +41,7 @@ class HistoryStats:
         """Init the history stats manager."""
         self.hass = hass
         self.entity_id = entity_id
-        self._period = (datetime.datetime.min, datetime.datetime.min)
+        self._period = (MIN_TIME, MIN_TIME)
         self._state: HistoryStatsState = HistoryStatsState(None, None, self._period)
         self._history_current_period: list[State] = []
         self._previous_run_before_start = False

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -11,10 +11,7 @@ import homeassistant.util.dt as dt_util
 
 from .helpers import async_calculate_period, floored_timestamp
 
-# Add 24 hours to min time since min time is min time UTC
-# and we want min time that can be represented in the configured
-# time zone
-MIN_TIME = datetime.datetime.min + datetime.timedelta(hours=24)
+MIN_TIME_UTC = datetime.datetime.min.replace(tzinfo=dt_util.UTC)
 
 
 @dataclass
@@ -41,7 +38,7 @@ class HistoryStats:
         """Init the history stats manager."""
         self.hass = hass
         self.entity_id = entity_id
-        self._period = (MIN_TIME, MIN_TIME)
+        self._period = (MIN_TIME_UTC, MIN_TIME_UTC)
         self._state: HistoryStatsState = HistoryStatsState(None, None, self._period)
         self._history_current_period: list[State] = []
         self._previous_run_before_start = False


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

datetime.min doesn't have a timezone so when we converted it to utc it was a time before python could represent

Fixes
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 191, in _async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/components/history_stats/coordinator.py", line 94, in _async_update_data
    return await self._history_stats.async_update(None)
  File "/usr/src/homeassistant/homeassistant/components/history_stats/data.py", line 60, in async_update
    previous_period_start = dt_util.as_utc(previous_period_start)
  File "/usr/src/homeassistant/homeassistant/util/dt.py", line 71, in as_utc
    return dattim.astimezone(UTC)
OverflowError: date value out of range
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71007
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
