### PR TITLE
Add reauth flow for devolo_home_network

### DIFF
--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -10,7 +10,7 @@ from devolo_plc_api.exceptions.device import DeviceNotFound, DeviceUnavailable
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_IP_ADDRESS, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import get_async_client
@@ -39,6 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device = Device(
             ip=entry.data[CONF_IP_ADDRESS], zeroconf_instance=zeroconf_instance
         )
+        device.password = entry.data[CONF_PASSWORD]
         await device.async_connect(session_instance=async_client)
     except DeviceNotFound as err:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -39,7 +39,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device = Device(
             ip=entry.data[CONF_IP_ADDRESS], zeroconf_instance=zeroconf_instance
         )
-        device.password = entry.data.get(CONF_PASSWORD, "")
+        device.password = entry.data.get(
+            CONF_PASSWORD, ""  # This key was added in HA Core 2022.6
+        )
         await device.async_connect(session_instance=async_client)
     except DeviceNotFound as err:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -39,10 +39,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device = Device(
             ip=entry.data[CONF_IP_ADDRESS], zeroconf_instance=zeroconf_instance
         )
+        await device.async_connect(session_instance=async_client)
         device.password = entry.data.get(
             CONF_PASSWORD, ""  # This key was added in HA Core 2022.6
         )
-        await device.async_connect(session_instance=async_client)
     except DeviceNotFound as err:
         raise ConfigEntryNotReady(
             f"Unable to connect to {entry.data[CONF_IP_ADDRESS]}"

--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device = Device(
             ip=entry.data[CONF_IP_ADDRESS], zeroconf_instance=zeroconf_instance
         )
-        device.password = entry.data[CONF_PASSWORD]
+        device.password = entry.data.get(CONF_PASSWORD, "")
         await device.async_connect(session_instance=async_client)
     except DeviceNotFound as err:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/devolo_home_network/config_flow.py
+++ b/homeassistant/components/devolo_home_network/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for devolo Home Network integration."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -109,9 +110,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={"host_name": title},
         )
 
-    async def async_step_reauth(self, user_input: dict[str, Any]) -> FlowResult:
+    async def async_step_reauth(self, data: Mapping[str, Any]) -> FlowResult:
         """Handle reauthentication."""
-        self.context[CONF_HOST] = user_input[CONF_IP_ADDRESS]
+        self.context[CONF_HOST] = data[CONF_IP_ADDRESS]
         self.context["title_placeholders"][PRODUCT] = self.hass.data[DOMAIN][
             self.context["entry_id"]
         ]["device"].product

--- a/homeassistant/components/devolo_home_network/config_flow.py
+++ b/homeassistant/components/devolo_home_network/config_flow.py
@@ -70,6 +70,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             await self.async_set_unique_id(info[SERIAL_NUMBER], raise_on_progress=False)
             self._abort_if_unique_id_configured()
+            user_input[CONF_PASSWORD] = ""
             return self.async_create_entry(title=info[TITLE], data=user_input)
 
         return self.async_show_form(
@@ -140,9 +141,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.hass.config_entries.async_update_entry(
             reauth_entry,
             data=data,
-            unique_id=self.hass.data[DOMAIN][self.context["entry_id"]][
-                "device"
-            ].serial_number,
         )
         self.hass.async_create_task(
             self.hass.config_entries.async_reload(reauth_entry.entry_id)

--- a/homeassistant/components/devolo_home_network/config_flow.py
+++ b/homeassistant/components/devolo_home_network/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.components import zeroconf
-from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS, CONF_NAME, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.httpx_client import get_async_client
 
@@ -19,6 +19,7 @@ from .const import DOMAIN, PRODUCT, SERIAL_NUMBER, TITLE
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_IP_ADDRESS): str})
+STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Optional(CONF_PASSWORD): str})
 
 
 async def validate_input(
@@ -100,9 +101,49 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             data = {
                 CONF_IP_ADDRESS: self.context[CONF_HOST],
+                CONF_PASSWORD: "",
             }
             return self.async_create_entry(title=title, data=data)
         return self.async_show_form(
             step_id="zeroconf_confirm",
             description_placeholders={"host_name": title},
         )
+
+    async def async_step_reauth(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle reauthentication."""
+        self.context[CONF_HOST] = user_input[CONF_IP_ADDRESS]
+        self.context["title_placeholders"][PRODUCT] = self.hass.data[DOMAIN][
+            self.context["entry_id"]
+        ]["device"].product
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initiated by reauthentication."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=STEP_REAUTH_DATA_SCHEMA,
+            )
+
+        reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        assert reauth_entry is not None
+
+        data = {
+            CONF_IP_ADDRESS: self.context[CONF_HOST],
+            CONF_PASSWORD: user_input[CONF_PASSWORD],
+        }
+        self.hass.config_entries.async_update_entry(
+            reauth_entry,
+            data=data,
+            unique_id=self.hass.data[DOMAIN][self.context["entry_id"]][
+                "device"
+            ].serial_number,
+        )
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(reauth_entry.entry_id)
+        )
+        return self.async_abort(reason="reauth_successful")

--- a/homeassistant/components/devolo_home_network/strings.json
+++ b/homeassistant/components/devolo_home_network/strings.json
@@ -8,6 +8,11 @@
           "ip_address": "[%key:common::config_flow::data::ip%]"
         }
       },
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
       "zeroconf_confirm": {
         "description": "Do you want to add the devolo home network device with the hostname `{host_name}` to Home Assistant?",
         "title": "Discovered devolo home network device"
@@ -19,7 +24,8 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "home_control": "The devolo Home Control Central Unit does not work with this integration."
+      "home_control": "The devolo Home Control Central Unit does not work with this integration.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/homeassistant/components/devolo_home_network/translations/en.json
+++ b/homeassistant/components/devolo_home_network/translations/en.json
@@ -2,7 +2,8 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "home_control": "The devolo Home Control Central Unit does not work with this integration."
+            "home_control": "The devolo Home Control Central Unit does not work with this integration.",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -10,6 +11,11 @@
         },
         "flow_title": "{product} ({name})",
         "step": {
+            "reauth_confirm": {
+                "data": {
+                    "password": "Password"
+                }
+            },
             "user": {
                 "data": {
                     "ip_address": "IP Address"

--- a/tests/components/devolo_home_network/__init__.py
+++ b/tests/components/devolo_home_network/__init__.py
@@ -1,6 +1,6 @@
 """Tests for the devolo Home Network integration."""
 from homeassistant.components.devolo_home_network.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 from .const import IP
@@ -12,6 +12,7 @@ def configure_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Configure the integration."""
     config = {
         CONF_IP_ADDRESS: IP,
+        CONF_PASSWORD: "",
     }
     entry = MockConfigEntry(domain=DOMAIN, data=config)
     entry.add_to_hass(hass)

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -48,6 +48,7 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]):
     assert result2["title"] == info["title"]
     assert result2["data"] == {
         CONF_IP_ADDRESS: IP,
+        CONF_PASSWORD: "",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -7,17 +7,18 @@ from unittest.mock import patch
 from devolo_plc_api.exceptions.device import DeviceNotFound
 import pytest
 
-from homeassistant import config_entries
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.devolo_home_network import config_flow
 from homeassistant.components.devolo_home_network.const import (
     DOMAIN,
     SERIAL_NUMBER,
     TITLE,
 )
-from homeassistant.const import CONF_BASE, CONF_IP_ADDRESS, CONF_NAME
+from homeassistant.const import CONF_BASE, CONF_IP_ADDRESS, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from . import configure_integration
 from .const import DISCOVERY_INFO, DISCOVERY_INFO_WRONG_DEVICE, IP
 from .mock import MockDevice
 
@@ -112,6 +113,7 @@ async def test_zeroconf(hass: HomeAssistant):
     assert result2["title"] == "test"
     assert result2["data"] == {
         CONF_IP_ADDRESS: IP,
+        CONF_PASSWORD: "",
     }
 
 
@@ -168,6 +170,47 @@ async def test_abort_if_configued(hass: HomeAssistant):
     assert result3["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_device")
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_reauth(hass: HomeAssistant):
+    """Test that the reauth confirmation form is served."""
+    entry = configure_integration(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+            "title_placeholders": {
+                CONF_NAME: DISCOVERY_INFO.hostname.split(".")[0],
+            },
+        },
+        data=entry.data,
+    )
+
+    assert result["step_id"] == "reauth_confirm"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    with patch(
+        "homeassistant.components.devolo_home_network.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_PASSWORD: "test-password-new"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_device")
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_validate_input(hass: HomeAssistant):
     """Test input validation."""
     with patch(

--- a/tests/components/devolo_home_network/test_init.py
+++ b/tests/components/devolo_home_network/test_init.py
@@ -4,18 +4,38 @@ from unittest.mock import patch
 from devolo_plc_api.exceptions.device import DeviceNotFound
 import pytest
 
+from homeassistant.components.devolo_home_network.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_IP_ADDRESS, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 
 from . import configure_integration
+from .const import IP
 from .mock import MockDevice
+
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("mock_device")
 async def test_setup_entry(hass: HomeAssistant):
     """Test setup entry."""
     entry = configure_integration(hass)
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
+        return_value=True,
+    ), patch("homeassistant.core.EventBus.async_listen_once"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("mock_device")
+async def test_setup_without_password(hass: HomeAssistant):
+    """Test setup entry without a device password set like used before HA Core 2022.06."""
+    config = {
+        CONF_IP_ADDRESS: IP,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config)
+    entry.add_to_hass(hass)
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
         return_value=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
devolo Home Network devices are a bit weird as they optionally support protecting changing settings with a password but getting their state is still possible without authorization. On top, there is no way to ensure the right password is used without really changing a setting. This MR adds the reauth flow to react on protected devices. Currently only unprotected endpoints are implemented, but that will change in future by adding additional platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
