### PR TITLE
Update ZHA switch entities to leverage Zigpy cache appropriately

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -6,6 +6,7 @@ from collections.abc import Coroutine
 from typing import Any
 
 import zigpy.exceptions
+import zigpy.types as t
 from zigpy.zcl.clusters import general
 from zigpy.zcl.foundation import Status
 
@@ -300,7 +301,6 @@ class OnOffChannel(ZigbeeChannel):
     ) -> None:
         """Initialize OnOffChannel."""
         super().__init__(cluster, ch_pool)
-        self._state = None
         self._off_listener = None
 
     @property
@@ -314,9 +314,9 @@ class OnOffChannel(ZigbeeChannel):
         cmd = parse_and_log_command(self, tsn, command_id, args)
 
         if cmd in ("off", "off_with_effect"):
-            self.attribute_updated(self.ON_OFF, False)
+            self.cluster.update_attribute(self.ON_OFF, t.Bool.false)
         elif cmd in ("on", "on_with_recall_global_scene"):
-            self.attribute_updated(self.ON_OFF, True)
+            self.cluster.update_attribute(self.ON_OFF, t.Bool.true)
         elif cmd == "on_with_timed_off":
             should_accept = args[0]
             on_time = args[1]
@@ -325,7 +325,7 @@ class OnOffChannel(ZigbeeChannel):
                 if self._off_listener is not None:
                     self._off_listener()
                     self._off_listener = None
-                self.attribute_updated(self.ON_OFF, True)
+                self.cluster.update_attribute(self.ON_OFF, t.Bool.true)
                 if on_time > 0:
                     self._off_listener = async_call_later(
                         self._ch_pool.hass,
@@ -333,13 +333,13 @@ class OnOffChannel(ZigbeeChannel):
                         self.set_to_off,
                     )
         elif cmd == "toggle":
-            self.attribute_updated(self.ON_OFF, not bool(self._state))
+            self.cluster.update_attribute(self.ON_OFF, not bool(self.on_off))
 
     @callback
     def set_to_off(self, *_):
         """Set the state to off."""
         self._off_listener = None
-        self.attribute_updated(self.ON_OFF, False)
+        self.cluster.update_attribute(self.ON_OFF, t.Bool.false)
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -348,11 +348,6 @@ class OnOffChannel(ZigbeeChannel):
             self.async_send_signal(
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, "on_off", value
             )
-            self._state = bool(value)
-
-    async def async_initialize_channel_specific(self, from_cache: bool) -> None:
-        """Initialize channel."""
-        self._state = self.on_off
 
     async def async_update(self):
         """Initialize channel."""
@@ -360,9 +355,7 @@ class OnOffChannel(ZigbeeChannel):
             return
         from_cache = not self._ch_pool.is_mains_powered
         self.debug("attempting to update onoff state - from cache: %s", from_cache)
-        state = await self.get_attribute_value(self.ON_OFF, from_cache=from_cache)
-        if state is not None:
-            self._state = bool(state)
+        await self.get_attribute_value(self.ON_OFF, from_cache=from_cache)
         await super().async_update()
 
 

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -113,9 +113,17 @@ class SwitchGroup(BaseSwitch, ZhaGroupEntity):
     ) -> None:
         """Initialize a switch group."""
         super().__init__(entity_ids, unique_id, group_id, zha_device, **kwargs)
-        self._available: bool = False
+        self._available: bool
+        self._state: bool
         group = self.zha_device.gateway.get_group(self._group_id)
         self._on_off_channel = group.endpoint[OnOff.cluster_id]
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the switch is on based on the statemachine."""
+        if self._state is None:
+            return False
+        return self._state
 
     async def async_update(self) -> None:
         """Query all members and determine the light group state."""

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -52,22 +52,20 @@ class BaseSwitch(SwitchEntity):
     def __init__(self, *args, **kwargs):
         """Initialize the ZHA switch."""
         self._on_off_channel = None
-        self._state = None
         super().__init__(*args, **kwargs)
 
     @property
     def is_on(self) -> bool:
         """Return if the switch is on based on the statemachine."""
-        if self._state is None:
+        if self._on_off_channel.on_off is None:
             return False
-        return self._state
+        return self._on_off_channel.on_off
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
         result = await self._on_off_channel.on()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
             return
-        self._state = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -75,7 +73,6 @@ class BaseSwitch(SwitchEntity):
         result = await self._on_off_channel.off()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
             return
-        self._state = False
         self.async_write_ha_state()
 
 
@@ -91,7 +88,6 @@ class Switch(BaseSwitch, ZhaEntity):
     @callback
     def async_set_state(self, attr_id: int, attr_name: str, value: Any):
         """Handle state update from channel."""
-        self._state = bool(value)
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
@@ -101,18 +97,11 @@ class Switch(BaseSwitch, ZhaEntity):
             self._on_off_channel, SIGNAL_ATTR_UPDATED, self.async_set_state
         )
 
-    @callback
-    def async_restore_last_state(self, last_state) -> None:
-        """Restore previous state."""
-        self._state = last_state.state == STATE_ON
-
     async def async_update(self) -> None:
         """Attempt to retrieve on off state from the switch."""
         await super().async_update()
         if self._on_off_channel:
-            state = await self._on_off_channel.get_attribute_value("on_off")
-            if state is not None:
-                self._state = state
+            await self._on_off_channel.get_attribute_value("on_off", from_cache=False)
 
 
 @GROUP_MATCH()

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -112,9 +112,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return if the switch is on based on the statemachine."""
-        if self._state is None:
-            return False
-        return self._state
+        return bool(self._state)
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates ZHA switch entities to leverage the cache from Zigpy correctly. Other entities and channels have already done this. This should prevent / fix erroneous state flipping for switches after a restart. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
