### PR TITLE
Fix linking issue when deCONZ gateway is not unlocked

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from urllib.parse import urlparse
 
 import async_timeout
-from pydeconz.errors import RequestError, ResponseError
+from pydeconz.errors import LinkButtonNotPressed, RequestError, ResponseError
 from pydeconz.gateway import DeconzSession
 from pydeconz.utils import (
     DiscoveredBridge,
@@ -159,6 +159,9 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
             try:
                 async with async_timeout.timeout(10):
                     api_key = await deconz_session.get_api_key()
+
+            except LinkButtonNotPressed:
+                errors["base"] = "linking_not_possible"
 
             except (ResponseError, RequestError, asyncio.TimeoutError):
                 errors["base"] = "no_key"

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -23,6 +23,7 @@
       }
     },
     "error": {
+      "linking_not_possible": "Couldn't link with the gateway",
       "no_key": "Couldn't get an API key"
     },
     "abort": {

--- a/homeassistant/components/deconz/translations/en.json
+++ b/homeassistant/components/deconz/translations/en.json
@@ -9,6 +9,7 @@
             "updated_instance": "Updated deCONZ instance with new host address"
         },
         "error": {
+            "linking_not_possible": "Couldn't link with the gateway",
             "no_key": "Couldn't get an API key"
         },
         "flow_title": "{host}",

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import patch
 
 import pydeconz
+import pytest
 
 from homeassistant.components import ssdp
 from homeassistant.components.deconz.config_flow import (
@@ -341,7 +342,16 @@ async def test_manual_configuration_timeout_get_bridge(hass, aioclient_mock):
     assert result["reason"] == "no_bridges"
 
 
-async def test_link_get_api_key_ResponseError(hass, aioclient_mock):
+@pytest.mark.parametrize(
+    "raised_error, error_string",
+    [
+        (pydeconz.errors.LinkButtonNotPressed, "linking_not_possible"),
+        (asyncio.TimeoutError, "no_key"),
+        (pydeconz.errors.ResponseError, "no_key"),
+        (pydeconz.errors.RequestError, "no_key"),
+    ],
+)
+async def test_link_step_fails(hass, aioclient_mock, raised_error, error_string):
     """Test config flow should abort if no API key was possible to retrieve."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
@@ -360,7 +370,7 @@ async def test_link_get_api_key_ResponseError(hass, aioclient_mock):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "link"
 
-    aioclient_mock.post("http://1.2.3.4:80/api", exc=pydeconz.errors.ResponseError)
+    aioclient_mock.post("http://1.2.3.4:80/api", exc=raised_error)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
@@ -368,7 +378,7 @@ async def test_link_get_api_key_ResponseError(hass, aioclient_mock):
 
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "link"
-    assert result["errors"] == {"base": "no_key"}
+    assert result["errors"] == {"base": error_string}
 
 
 async def test_reauth_flow_update_configuration(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68165
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
