### PR TITLE
Fix missing device & entity references in automations

### DIFF
--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1079,6 +1079,7 @@ async def test_automation_restore_last_triggered_with_initial_state(hass):
 
 async def test_extraction_functions(hass):
     """Test extraction functions."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     assert await async_setup_component(
         hass,
         DOMAIN,
@@ -1086,7 +1087,24 @@ async def test_extraction_functions(hass):
             DOMAIN: [
                 {
                     "alias": "test1",
-                    "trigger": {"platform": "state", "entity_id": "sensor.trigger_1"},
+                    "trigger": [
+                        {"platform": "state", "entity_id": "sensor.trigger_state"},
+                        {
+                            "platform": "numeric_state",
+                            "entity_id": "sensor.trigger_numeric_state",
+                            "above": 10,
+                        },
+                        {
+                            "platform": "calendar",
+                            "entity_id": "calendar.trigger_calendar",
+                            "event": "start",
+                        },
+                        {
+                            "platform": "event",
+                            "event_type": "state_changed",
+                            "event_data": {"entity_id": "sensor.trigger_event"},
+                        },
+                    ],
                     "condition": {
                         "condition": "state",
                         "entity_id": "light.condition_state",
@@ -1111,13 +1129,30 @@ async def test_extraction_functions(hass):
                 },
                 {
                     "alias": "test2",
-                    "trigger": {
-                        "platform": "device",
-                        "domain": "light",
-                        "type": "turned_on",
-                        "entity_id": "light.trigger_2",
-                        "device_id": "trigger-device-2",
-                    },
+                    "trigger": [
+                        {
+                            "platform": "device",
+                            "domain": "light",
+                            "type": "turned_on",
+                            "entity_id": "light.trigger_2",
+                            "device_id": "trigger-device-2",
+                        },
+                        {
+                            "platform": "tag",
+                            "tag_id": "1234",
+                            "device_id": "device-trigger-tag1",
+                        },
+                        {
+                            "platform": "tag",
+                            "tag_id": "1234",
+                            "device_id": ["device-trigger-tag2", "device-trigger-tag3"],
+                        },
+                        {
+                            "platform": "event",
+                            "event_type": "esphome.button_pressed",
+                            "event_data": {"device_id": "device-trigger-event"},
+                        },
+                    ],
                     "condition": {
                         "condition": "device",
                         "device_id": "condition-device",
@@ -1159,7 +1194,10 @@ async def test_extraction_functions(hass):
         "automation.test2",
     }
     assert set(automation.entities_in_automation(hass, "automation.test1")) == {
-        "sensor.trigger_1",
+        "calendar.trigger_calendar",
+        "sensor.trigger_state",
+        "sensor.trigger_numeric_state",
+        "sensor.trigger_event",
         "light.condition_state",
         "light.in_both",
         "light.in_first",
@@ -1173,6 +1211,10 @@ async def test_extraction_functions(hass):
         "condition-device",
         "device-in-both",
         "device-in-last",
+        "device-trigger-event",
+        "device-trigger-tag1",
+        "device-trigger-tag2",
+        "device-trigger-tag3",
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes missing device & entity references that originate from automation triggers.

- Missing entity references for the new calendar trigger
- Missing device references for tag triggers
- Missing device references in events (e.g. from ESPHome, ZHA)
- Missing entity references in events (e.g. state changed events)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
