### PR TITLE
Add entity id to template error logging

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -207,8 +207,9 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
             return
 
         _LOGGER.error(
-            "Received invalid alarm panel state: %s. Expected: %s",
+            "Received invalid alarm panel state: %s for entity %s. Expected: %s",
             result,
+            self.entity_id,
             ", ".join(_VALID_STATES),
         )
         self._state = None

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -222,8 +222,9 @@ class CoverTemplate(TemplateEntity, CoverEntity):
             self._is_closing = state == STATE_CLOSING
         else:
             _LOGGER.error(
-                "Received invalid cover is_on state: %s. Expected: %s",
+                "Received invalid cover is_on state: %s for entity %s. Expected: %s",
                 state,
+                self.entity_id,
                 ", ".join(_VALID_STATES),
             )
             if not self._position_template:

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -285,8 +285,9 @@ class TemplateFan(TemplateEntity, FanEntity):
         """Set the preset_mode of the fan."""
         if self.preset_modes and preset_mode not in self.preset_modes:
             _LOGGER.error(
-                "Received invalid preset_mode: %s. Expected: %s",
+                "Received invalid preset_mode: %s for entity %s. Expected: %s",
                 preset_mode,
+                self.entity_id,
                 self.preset_modes,
             )
             return
@@ -322,8 +323,9 @@ class TemplateFan(TemplateEntity, FanEntity):
             )
         else:
             _LOGGER.error(
-                "Received invalid direction: %s. Expected: %s",
+                "Received invalid direction: %s for entity %s. Expected: %s",
                 direction,
+                self.entity_id,
                 ", ".join(_VALID_DIRECTIONS),
             )
 
@@ -341,8 +343,9 @@ class TemplateFan(TemplateEntity, FanEntity):
             self._state = None
         else:
             _LOGGER.error(
-                "Received invalid fan is_on state: %s. Expected: %s",
+                "Received invalid fan is_on state: %s for entity %s. Expected: %s",
                 result,
+                self.entity_id,
                 ", ".join(_VALID_STATES),
             )
             self._state = None
@@ -390,7 +393,11 @@ class TemplateFan(TemplateEntity, FanEntity):
         try:
             percentage = int(float(percentage))
         except ValueError:
-            _LOGGER.error("Received invalid percentage: %s", percentage)
+            _LOGGER.error(
+                "Received invalid percentage: %s for entity %s",
+                percentage,
+                self.entity_id,
+            )
             self._percentage = 0
             self._preset_mode = None
             return
@@ -399,7 +406,11 @@ class TemplateFan(TemplateEntity, FanEntity):
             self._percentage = percentage
             self._preset_mode = None
         else:
-            _LOGGER.error("Received invalid percentage: %s", percentage)
+            _LOGGER.error(
+                "Received invalid percentage: %s for entity %s",
+                percentage,
+                self.entity_id,
+            )
             self._percentage = 0
             self._preset_mode = None
 
@@ -416,8 +427,9 @@ class TemplateFan(TemplateEntity, FanEntity):
             self._preset_mode = None
         else:
             _LOGGER.error(
-                "Received invalid preset_mode: %s. Expected: %s",
+                "Received invalid preset_mode: %s for entity %s. Expected: %s",
                 preset_mode,
+                self.entity_id,
                 self.preset_mode,
             )
             self._percentage = None
@@ -434,8 +446,9 @@ class TemplateFan(TemplateEntity, FanEntity):
             self._oscillating = None
         else:
             _LOGGER.error(
-                "Received invalid oscillating: %s. Expected: True/False",
+                "Received invalid oscillating: %s for entity %s. Expected: True/False",
                 oscillating,
+                self.entity_id,
             )
             self._oscillating = None
 
@@ -448,8 +461,9 @@ class TemplateFan(TemplateEntity, FanEntity):
             self._direction = None
         else:
             _LOGGER.error(
-                "Received invalid direction: %s. Expected: %s",
+                "Received invalid direction: %s for entity %s. Expected: %s",
                 direction,
+                self.entity_id,
                 ", ".join(_VALID_DIRECTIONS),
             )
             self._direction = None

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -397,8 +397,9 @@ class LightTemplate(TemplateEntity, LightEntity):
             effect = kwargs[ATTR_EFFECT]
             if effect not in self._effect_list:
                 _LOGGER.error(
-                    "Received invalid effect: %s. Expected one of: %s",
+                    "Received invalid effect: %s for entity %s. Expected one of: %s",
                     effect,
+                    self.entity_id,
                     self._effect_list,
                     exc_info=True,
                 )
@@ -447,7 +448,9 @@ class LightTemplate(TemplateEntity, LightEntity):
                 self._brightness = int(brightness)
             else:
                 _LOGGER.error(
-                    "Received invalid brightness : %s. Expected: 0-255", brightness
+                    "Received invalid brightness : %s for entity %s. Expected: 0-255",
+                    brightness,
+                    self.entity_id,
                 )
                 self._brightness = None
         except ValueError:
@@ -468,7 +471,9 @@ class LightTemplate(TemplateEntity, LightEntity):
                 self._white_value = int(white_value)
             else:
                 _LOGGER.error(
-                    "Received invalid white value: %s. Expected: 0-255", white_value
+                    "Received invalid white value: %s for entity %s. Expected: 0-255",
+                    white_value,
+                    self.entity_id,
                 )
                 self._white_value = None
         except ValueError:
@@ -487,8 +492,9 @@ class LightTemplate(TemplateEntity, LightEntity):
 
         if not isinstance(effect_list, list):
             _LOGGER.error(
-                "Received invalid effect list: %s. Expected list of strings",
+                "Received invalid effect list: %s for entity %s. Expected list of strings",
                 effect_list,
+                self.entity_id,
             )
             self._effect_list = None
             return
@@ -508,8 +514,9 @@ class LightTemplate(TemplateEntity, LightEntity):
 
         if effect not in self._effect_list:
             _LOGGER.error(
-                "Received invalid effect: %s. Expected one of: %s",
+                "Received invalid effect: %s for entity %s. Expected one of: %s",
                 effect,
+                self.entity_id,
                 self._effect_list,
             )
             self._effect = None
@@ -537,8 +544,9 @@ class LightTemplate(TemplateEntity, LightEntity):
             return
 
         _LOGGER.error(
-            "Received invalid light is_on state: %s. Expected: %s",
+            "Received invalid light is_on state: %s for entity %s. Expected: %s",
             state,
+            self.entity_id,
             ", ".join(_VALID_STATES),
         )
         self._state = None
@@ -555,8 +563,9 @@ class LightTemplate(TemplateEntity, LightEntity):
                 self._temperature = temperature
             else:
                 _LOGGER.error(
-                    "Received invalid color temperature : %s. Expected: %s-%s",
+                    "Received invalid color temperature : %s for entity %s. Expected: %s-%s",
                     temperature,
+                    self.entity_id,
                     self.min_mireds,
                     self.max_mireds,
                 )
@@ -595,13 +604,16 @@ class LightTemplate(TemplateEntity, LightEntity):
             self._color = (h_str, s_str)
         elif h_str is not None and s_str is not None:
             _LOGGER.error(
-                "Received invalid hs_color : (%s, %s). Expected: (0-360, 0-100)",
+                "Received invalid hs_color : (%s, %s) for entity %s. Expected: (0-360, 0-100)",
                 h_str,
                 s_str,
+                self.entity_id,
             )
             self._color = None
         else:
-            _LOGGER.error("Received invalid hs_color : (%s)", render)
+            _LOGGER.error(
+                "Received invalid hs_color : (%s) for entity %s", render, self.entity_id
+            )
             self._color = None
 
     @callback

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -253,8 +253,9 @@ class TemplateVacuum(TemplateEntity, StateVacuumEntity):
             )
         else:
             _LOGGER.error(
-                "Received invalid fan speed: %s. Expected: %s",
+                "Received invalid fan speed: %s for entity %s. Expected: %s",
                 fan_speed,
+                self.entity_id,
                 self._attr_fan_speed_list,
             )
 
@@ -298,8 +299,9 @@ class TemplateVacuum(TemplateEntity, StateVacuumEntity):
             self._state = None
         else:
             _LOGGER.error(
-                "Received invalid vacuum state: %s. Expected: %s",
+                "Received invalid vacuum state: %s for entity %s. Expected: %s",
                 result,
+                self.entity_id,
                 ", ".join(_VALID_STATES),
             )
             self._state = None
@@ -312,7 +314,9 @@ class TemplateVacuum(TemplateEntity, StateVacuumEntity):
                 raise ValueError
         except ValueError:
             _LOGGER.error(
-                "Received invalid battery level: %s. Expected: 0-100", battery_level
+                "Received invalid battery level: %s for entity %s. Expected: 0-100",
+                battery_level,
+                self.entity_id,
             )
             self._attr_battery_level = None
             return
@@ -333,8 +337,9 @@ class TemplateVacuum(TemplateEntity, StateVacuumEntity):
             self._attr_fan_speed = None
         else:
             _LOGGER.error(
-                "Received invalid fan speed: %s. Expected: %s",
+                "Received invalid fan speed: %s for entity %s. Expected: %s",
                 fan_speed,
+                self.entity_id,
                 self._attr_fan_speed_list,
             )
             self._attr_fan_speed = None

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1025,6 +1025,7 @@ async def test_color_action_no_template(hass, start_ha, calls):
         ((359.9, 99.9), {"replace6": '"{{(359.9, 99.9)}}"'}),
         (None, {"replace6": '"{{(361, 100)}}"'}),
         (None, {"replace6": '"{{(360, 101)}}"'}),
+        (None, {"replace6": '"[{{(360)}},{{null}}]"'}),
         (None, {"replace6": '"{{x - 12}}"'}),
         (None, {"replace6": '""'}),
         (None, {"replace6": '"{{ none }}"'}),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity ID to template error logging

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/71100
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
