### PR TITLE
Add type information to panel_custom

### DIFF
--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -1,4 +1,6 @@
 """Register a custom front end panel."""
+from __future__ import annotations
+
 import logging
 
 import voluptuous as vol
@@ -70,27 +72,27 @@ CONFIG_SCHEMA = vol.Schema(
 
 @bind_hass
 async def async_register_panel(
-    hass,
+    hass: HomeAssistant,
     # The url to serve the panel
-    frontend_url_path,
+    frontend_url_path: str,
     # The webcomponent name that loads your panel
-    webcomponent_name,
+    webcomponent_name: str,
     # Title/icon for sidebar
-    sidebar_title=None,
-    sidebar_icon=None,
+    sidebar_title: str | None = None,
+    sidebar_icon: str | None = None,
     # JS source of your panel
-    js_url=None,
+    js_url: str | None = None,
     # JS module of your panel
-    module_url=None,
+    module_url: str | None = None,
     # If your panel should be run inside an iframe
-    embed_iframe=DEFAULT_EMBED_IFRAME,
+    embed_iframe: bool = DEFAULT_EMBED_IFRAME,
     # Should user be asked for confirmation when loading external source
-    trust_external=DEFAULT_TRUST_EXTERNAL,
+    trust_external: bool = DEFAULT_TRUST_EXTERNAL,
     # Configuration to be passed to the panel
-    config=None,
+    config: ConfigType | None = None,
     # If your panel should only be shown to admin users
-    require_admin=False,
-):
+    require_admin: bool = False,
+) -> None:
     """Register a new custom panel."""
     if js_url is None and module_url is None:
         raise ValueError("Either js_url, module_url or html_url is required.")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While implementing https://github.com/home-assistant/core/pull/71018 I got errors due to missing type information for the `async_register_panel` method since KNX is strictly typed. 
This PR adds the type information in order to avoid using ignore comments for untyped calls to this method.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
