### PR TITLE
Avoid recording state_changed events in the events table

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -549,7 +549,7 @@ def _get_events(
                 )
                 states_query = states_query.filter(
                     (States.context_id == context_id)
-                    | (Events.context_id == context_id)
+                    | (States.context_id.is_(None) & (Events.context_id == context_id))
                 )
             if filters:
                 states_query = states_query.filter(filters.entity_filter())  # type: ignore[no-untyped-call]

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -544,6 +544,9 @@ def _get_events(
                 session, start_day, end_day, old_state, entity_ids
             )
             if context_id is not None:
+                # Once all the old `state_changed` events
+                # are gone from the database this query can
+                # be simplified to filter only on States.context_id == context_id
                 states_query = states_query.outerjoin(
                     Events, (States.event_id == Events.event_id)
                 )

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -111,13 +111,28 @@ ALL_EVENT_TYPES = [
     *ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED,
 ]
 
+
 EVENT_COLUMNS = [
-    Events.event_type,
-    Events.event_data,
-    Events.time_fired,
-    Events.context_id,
-    Events.context_user_id,
-    Events.context_parent_id,
+    Events.event_type.label("event_type"),
+    Events.event_data.label("event_data"),
+    Events.time_fired.label("time_fired"),
+    Events.context_id.label("context_id"),
+    Events.context_user_id.label("context_user_id"),
+    Events.context_parent_id.label("context_parent_id"),
+]
+
+STATE_COLUMNS = [
+    States.state.label("state"),
+    States.entity_id.label("entity_id"),
+    States.attributes.label("attributes"),
+    StateAttributes.shared_attrs.label("shared_attrs"),
+]
+
+EMPTY_STATE_COLUMNS = [
+    literal(value=None, type_=sqlalchemy.String).label("state"),
+    literal(value=None, type_=sqlalchemy.String).label("entity_id"),
+    literal(value=None, type_=sqlalchemy.Text).label("attributes"),
+    literal(value=None, type_=sqlalchemy.Text).label("shared_attrs"),
 ]
 
 SCRIPT_AUTOMATION_EVENTS = {EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED}
@@ -502,6 +517,7 @@ def _get_events(
 
     with session_scope(hass=hass) as session:
         old_state = aliased(States, name="old_state")
+        query: Query
 
         if entity_ids is not None:
             query = _generate_events_query_without_states(session)
@@ -514,7 +530,6 @@ def _get_events(
                 # contain the entity_ids are not included in the logbook response.
                 query = _apply_event_entity_id_matchers(query, entity_ids)
             query = query.outerjoin(EventData, (Events.data_id == EventData.data_id))
-
             query = query.union_all(
                 _generate_states_query(
                     session, start_day, end_day, old_state, entity_ids
@@ -539,6 +554,17 @@ def _get_events(
 
             query = query.outerjoin(EventData, (Events.data_id == EventData.data_id))
 
+            states_query = _generate_states_query(
+                session, start_day, end_day, old_state, entity_ids
+            ).filter(States.context_id.is_not(None))
+
+            if context_id is not None:
+                states_query = states_query.filter(States.context_id == context_id)
+            if filters:
+                states_query = states_query.filter(filters.entity_filter())  # type: ignore[no-untyped-call]
+
+            query = query.union_all(states_query)
+
         query = query.order_by(Events.time_fired)
 
         return list(
@@ -547,35 +573,32 @@ def _get_events(
 
 
 def _generate_events_query(session: Session) -> Query:
+    """Generate an events query that also joins states.
+
+    Once we no longer have event_ids in the states table
+    we can switch STATE_COLUMNS to EMPTY_STATE_COLUMNS
+    """
     return session.query(
-        *EVENT_COLUMNS,
-        EventData.shared_data,
-        States.state,
-        States.entity_id,
-        States.attributes,
-        StateAttributes.shared_attrs,
+        *EVENT_COLUMNS, EventData.shared_data.label("shared_data"), *STATE_COLUMNS
     )
 
 
 def _generate_events_query_without_data(session: Session) -> Query:
     return session.query(
-        *EVENT_COLUMNS,
+        literal(value=EVENT_STATE_CHANGED, type_=sqlalchemy.String).label("event_type"),
+        literal(value=None, type_=sqlalchemy.Text).label("event_data"),
+        States.last_changed.label("time_fired"),
+        States.context_id.label("context_id"),
+        States.context_user_id.label("context_user_id"),
+        States.context_parent_id.label("context_parent_id"),
         literal(value=None, type_=sqlalchemy.Text).label("shared_data"),
-        States.state,
-        States.entity_id,
-        States.attributes,
-        StateAttributes.shared_attrs,
+        *STATE_COLUMNS,
     )
 
 
 def _generate_events_query_without_states(session: Session) -> Query:
     return session.query(
-        *EVENT_COLUMNS,
-        EventData.shared_data,
-        literal(value=None, type_=sqlalchemy.String).label("state"),
-        literal(value=None, type_=sqlalchemy.String).label("entity_id"),
-        literal(value=None, type_=sqlalchemy.Text).label("attributes"),
-        literal(value=None, type_=sqlalchemy.Text).label("shared_attrs"),
+        *EVENT_COLUMNS, EventData.shared_data.label("shared_data"), *EMPTY_STATE_COLUMNS
     )
 
 
@@ -584,22 +607,20 @@ def _generate_states_query(
     start_day: dt,
     end_day: dt,
     old_state: States,
-    entity_ids: Iterable[str],
+    entity_ids: Iterable[str] | None,
 ) -> Query:
-    return (
+    query = (
         _generate_events_query_without_data(session)
-        .outerjoin(Events, (States.event_id == Events.event_id))
         .outerjoin(old_state, (States.old_state_id == old_state.state_id))
         .filter(_missing_state_matcher(old_state))
         .filter(_not_continuous_entity_matcher())
         .filter((States.last_updated > start_day) & (States.last_updated < end_day))
-        .filter(
-            (States.last_updated == States.last_changed)
-            & States.entity_id.in_(entity_ids)
-        )
-        .outerjoin(
-            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
-        )
+        .filter(States.last_updated == States.last_changed)
+    )
+    if entity_ids:
+        query = query.filter(States.entity_id.in_(entity_ids))
+    return query.outerjoin(
+        StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
     )
 
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -1223,8 +1223,8 @@ class Recorder(threading.Thread):
                     ] = dbevent_data
                     self.event_session.add(dbevent_data)
 
-        self.event_session.add(dbevent)
         if event.event_type != EVENT_STATE_CHANGED:
+            self.event_session.add(dbevent)
             return
 
         try:
@@ -1272,7 +1272,6 @@ class Recorder(threading.Thread):
             self._pending_expunge.append(dbstate)
         else:
             dbstate.state = None
-        dbstate.event = dbevent
         self.event_session.add(dbstate)
 
     def _handle_database_error(self, err: Exception) -> bool:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -657,10 +657,16 @@ def _apply_update(instance, new_version, old_version):  # noqa: C901
         # We never use the user_id or parent_id index
         _drop_index(instance, "events", "ix_events_context_user_id")
         _drop_index(instance, "events", "ix_events_context_parent_id")
-        _add_columns(instance, "states", ["origin_idx INTEGER"])
-        _add_columns(instance, "states", ["context_id VARCHAR(36)"])
-        _add_columns(instance, "states", ["context_user_id VARCHAR(36)"])
-        _add_columns(instance, "states", ["context_parent_id VARCHAR(36)"])
+        _add_columns(
+            instance,
+            "states",
+            [
+                "origin_idx INTEGER",
+                "context_id VARCHAR(36)",
+                "context_user_id VARCHAR(36)",
+                "context_parent_id VARCHAR(36)",
+            ],
+        )
         _create_index(instance, "states", "ix_states_context_id")
         # Once there are no longer any state_changed events
         # in the events table we can drop the index on states.event_id

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Identity,
     Index,
     Integer,
+    SmallInteger,
     String,
     Text,
     distinct,
@@ -104,7 +105,7 @@ class Events(Base):  # type: ignore[misc,valid-type]
     event_type = Column(String(MAX_LENGTH_EVENT_EVENT_TYPE))
     event_data = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
     origin = Column(String(MAX_LENGTH_EVENT_ORIGIN))  # no longer used
-    origin_idx = Column(Integer)
+    origin_idx = Column(SmallInteger)
     time_fired = Column(DATETIME_TYPE, index=True)
     context_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
     context_user_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -43,7 +43,7 @@ from .const import ALL_DOMAIN_EXCLUDE_ATTRS, JSON_DUMP
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 28
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,6 +86,8 @@ DOUBLE_TYPE = (
     .with_variant(oracle.DOUBLE_PRECISION(), "oracle")
     .with_variant(postgresql.DOUBLE_PRECISION(), "postgresql")
 )
+EVENT_ORIGIN_ORDER = [EventOrigin.local, EventOrigin.remote]
+EVENT_ORIGIN_TO_IDX = {origin: idx for idx, origin in enumerate(EVENT_ORIGIN_ORDER)}
 
 
 class Events(Base):  # type: ignore[misc,valid-type]
@@ -98,14 +100,15 @@ class Events(Base):  # type: ignore[misc,valid-type]
         {"mysql_default_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"},
     )
     __tablename__ = TABLE_EVENTS
-    event_id = Column(Integer, Identity(), primary_key=True)
+    event_id = Column(Integer, Identity(), primary_key=True)  # no longer used
     event_type = Column(String(MAX_LENGTH_EVENT_EVENT_TYPE))
     event_data = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
-    origin = Column(String(MAX_LENGTH_EVENT_ORIGIN))
+    origin = Column(String(MAX_LENGTH_EVENT_ORIGIN))  # no longer used
+    origin_idx = Column(Integer)
     time_fired = Column(DATETIME_TYPE, index=True)
     context_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
-    context_user_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
-    context_parent_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
+    context_user_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))
+    context_parent_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))
     data_id = Column(Integer, ForeignKey("event_data.data_id"), index=True)
     event_data_rel = relationship("EventData")
 
@@ -114,7 +117,7 @@ class Events(Base):  # type: ignore[misc,valid-type]
         return (
             f"<recorder.Events("
             f"id={self.event_id}, type='{self.event_type}', "
-            f"origin='{self.origin}', time_fired='{self.time_fired}'"
+            f"origin_idx='{self.origin_idx}', time_fired='{self.time_fired}'"
             f", data_id={self.data_id})>"
         )
 
@@ -124,7 +127,7 @@ class Events(Base):  # type: ignore[misc,valid-type]
         return Events(
             event_type=event.event_type,
             event_data=None,
-            origin=str(event.origin.value),
+            origin_idx=EVENT_ORIGIN_TO_IDX.get(event.origin),
             time_fired=event.time_fired,
             context_id=event.context.id,
             context_user_id=event.context.user_id,
@@ -142,7 +145,9 @@ class Events(Base):  # type: ignore[misc,valid-type]
             return Event(
                 self.event_type,
                 json.loads(self.event_data) if self.event_data else {},
-                EventOrigin(self.origin),
+                EventOrigin(self.origin)
+                if self.origin
+                else EVENT_ORIGIN_ORDER[self.origin_idx],
                 process_timestamp(self.time_fired),
                 context=context,
             )
@@ -222,7 +227,10 @@ class States(Base):  # type: ignore[misc,valid-type]
     attributes_id = Column(
         Integer, ForeignKey("state_attributes.attributes_id"), index=True
     )
-    event = relationship("Events", uselist=False)
+    context_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
+    context_user_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))
+    context_parent_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))
+    origin_idx = Column(Integer)  # 0 is local, 1 is remote
     old_state = relationship("States", remote_side=[state_id])
     state_attributes = relationship("StateAttributes")
 
@@ -242,7 +250,14 @@ class States(Base):  # type: ignore[misc,valid-type]
         """Create object from a state_changed event."""
         entity_id = event.data["entity_id"]
         state: State | None = event.data.get("new_state")
-        dbstate = States(entity_id=entity_id, attributes=None)
+        dbstate = States(
+            entity_id=entity_id,
+            attributes=None,
+            context_id=event.context.id,
+            context_user_id=event.context.user_id,
+            context_parent_id=event.context.parent_id,
+            origin_idx=EVENT_ORIGIN_TO_IDX.get(event.origin),
+        )
 
         # None state means the state was removed from the state machine
         if state is None:
@@ -258,6 +273,11 @@ class States(Base):  # type: ignore[misc,valid-type]
 
     def to_native(self, validate_entity_id: bool = True) -> State | None:
         """Convert to an HA state object."""
+        context = Context(
+            id=self.context_id,
+            user_id=self.context_user_id,
+            parent_id=self.context_parent_id,
+        )
         try:
             return State(
                 self.entity_id,
@@ -267,9 +287,7 @@ class States(Base):  # type: ignore[misc,valid-type]
                 json.loads(self.attributes) if self.attributes else {},
                 process_timestamp(self.last_changed),
                 process_timestamp(self.last_updated),
-                # Join the events table on event_id to get the context instead
-                # as it will always be there for state_changed events
-                context=Context(id=None),  # type: ignore[arg-type]
+                context=context,
                 validate_entity_id=validate_entity_id,
             )
         except ValueError:

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -230,7 +230,7 @@ class States(Base):  # type: ignore[misc,valid-type]
     context_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
     context_user_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))
     context_parent_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID))
-    origin_idx = Column(Integer)  # 0 is local, 1 is remote
+    origin_idx = Column(SmallInteger)  # 0 is local, 1 is remote
     old_state = relationship("States", remote_side=[state_id])
     state_attributes = relationship("StateAttributes")
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -49,7 +49,7 @@ from homeassistant.const import (
     STATE_LOCKED,
     STATE_UNLOCKED,
 )
-from homeassistant.core import Context, CoreState, Event, HomeAssistant, callback
+from homeassistant.core import CoreState, Event, HomeAssistant, callback
 from homeassistant.setup import async_setup_component, setup_component
 from homeassistant.util import dt as dt_util
 
@@ -162,7 +162,7 @@ async def test_state_gets_saved_when_set_before_start_event(
     with session_scope(hass=hass) as session:
         db_states = list(session.query(States))
         assert len(db_states) == 1
-        assert db_states[0].event_id > 0
+        assert db_states[0].event_id is None
 
 
 async def test_saving_state(hass: HomeAssistant, recorder_mock):
@@ -182,9 +182,9 @@ async def test_saving_state(hass: HomeAssistant, recorder_mock):
             state = db_state.to_native()
             state.attributes = db_state_attributes.to_native()
         assert len(db_states) == 1
-        assert db_states[0].event_id > 0
+        assert db_states[0].event_id is None
 
-    assert state == _state_empty_context(hass, entity_id)
+    assert state == _state_with_context(hass, entity_id)
 
 
 async def test_saving_many_states(
@@ -210,7 +210,7 @@ async def test_saving_many_states(
     with session_scope(hass=hass) as session:
         db_states = list(session.query(States))
         assert len(db_states) == 6
-        assert db_states[0].event_id > 0
+        assert db_states[0].event_id is None
 
 
 async def test_saving_state_with_intermixed_time_changes(
@@ -234,7 +234,7 @@ async def test_saving_state_with_intermixed_time_changes(
     with session_scope(hass=hass) as session:
         db_states = list(session.query(States))
         assert len(db_states) == 2
-        assert db_states[0].event_id > 0
+        assert db_states[0].event_id is None
 
 
 def test_saving_state_with_exception(hass, hass_recorder, caplog):
@@ -411,7 +411,7 @@ def test_saving_state_with_commit_interval_zero(hass_recorder):
     with session_scope(hass=hass) as session:
         db_states = list(session.query(States))
         assert len(db_states) == 1
-        assert db_states[0].event_id > 0
+        assert db_states[0].event_id is None
 
 
 def _add_entities(hass, entity_ids):
@@ -454,12 +454,10 @@ def _add_events(hass, events):
         return events
 
 
-def _state_empty_context(hass, entity_id):
+def _state_with_context(hass, entity_id):
     # We don't restore context unless we need it by joining the
     # events table on the event_id for state_changed events
-    state = hass.states.get(entity_id)
-    state.context = Context(id=None)
-    return state
+    return hass.states.get(entity_id)
 
 
 # pylint: disable=redefined-outer-name,invalid-name
@@ -468,7 +466,7 @@ def test_saving_state_include_domains(hass_recorder):
     hass = hass_recorder({"include": {"domains": "test2"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
-    assert _state_empty_context(hass, "test2.recorder") == states[0]
+    assert _state_with_context(hass, "test2.recorder") == states[0]
 
 
 def test_saving_state_include_domains_globs(hass_recorder):
@@ -480,8 +478,8 @@ def test_saving_state_include_domains_globs(hass_recorder):
         hass, ["test.recorder", "test2.recorder", "test3.included_entity"]
     )
     assert len(states) == 2
-    assert _state_empty_context(hass, "test2.recorder") == states[0]
-    assert _state_empty_context(hass, "test3.included_entity") == states[1]
+    assert _state_with_context(hass, "test2.recorder") == states[0]
+    assert _state_with_context(hass, "test3.included_entity") == states[1]
 
 
 def test_saving_state_incl_entities(hass_recorder):
@@ -489,7 +487,7 @@ def test_saving_state_incl_entities(hass_recorder):
     hass = hass_recorder({"include": {"entities": "test2.recorder"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
-    assert _state_empty_context(hass, "test2.recorder") == states[0]
+    assert _state_with_context(hass, "test2.recorder") == states[0]
 
 
 def test_saving_event_exclude_event_type(hass_recorder):
@@ -518,7 +516,7 @@ def test_saving_state_exclude_domains(hass_recorder):
     hass = hass_recorder({"exclude": {"domains": "test"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
-    assert _state_empty_context(hass, "test2.recorder") == states[0]
+    assert _state_with_context(hass, "test2.recorder") == states[0]
 
 
 def test_saving_state_exclude_domains_globs(hass_recorder):
@@ -530,7 +528,7 @@ def test_saving_state_exclude_domains_globs(hass_recorder):
         hass, ["test.recorder", "test2.recorder", "test2.excluded_entity"]
     )
     assert len(states) == 1
-    assert _state_empty_context(hass, "test2.recorder") == states[0]
+    assert _state_with_context(hass, "test2.recorder") == states[0]
 
 
 def test_saving_state_exclude_entities(hass_recorder):
@@ -538,7 +536,7 @@ def test_saving_state_exclude_entities(hass_recorder):
     hass = hass_recorder({"exclude": {"entities": "test.recorder"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
-    assert _state_empty_context(hass, "test2.recorder") == states[0]
+    assert _state_with_context(hass, "test2.recorder") == states[0]
 
 
 def test_saving_state_exclude_domain_include_entity(hass_recorder):
@@ -571,8 +569,8 @@ def test_saving_state_include_domain_exclude_entity(hass_recorder):
     )
     states = _add_entities(hass, ["test.recorder", "test2.recorder", "test.ok"])
     assert len(states) == 1
-    assert _state_empty_context(hass, "test.ok") == states[0]
-    assert _state_empty_context(hass, "test.ok").state == "state2"
+    assert _state_with_context(hass, "test.ok") == states[0]
+    assert _state_with_context(hass, "test.ok").state == "state2"
 
 
 def test_saving_state_include_domain_glob_exclude_entity(hass_recorder):
@@ -587,8 +585,8 @@ def test_saving_state_include_domain_glob_exclude_entity(hass_recorder):
         hass, ["test.recorder", "test2.recorder", "test.ok", "test2.included_entity"]
     )
     assert len(states) == 1
-    assert _state_empty_context(hass, "test.ok") == states[0]
-    assert _state_empty_context(hass, "test.ok").state == "state2"
+    assert _state_with_context(hass, "test.ok") == states[0]
+    assert _state_with_context(hass, "test.ok").state == "state2"
 
 
 def test_saving_state_and_removing_entity(hass, hass_recorder):
@@ -1153,8 +1151,8 @@ def test_service_disable_states_not_recording(hass, hass_recorder):
     with session_scope(hass=hass) as session:
         db_states = list(session.query(States))
         assert len(db_states) == 1
-        assert db_states[0].event_id > 0
-        assert db_states[0].to_native() == _state_empty_context(hass, "test.two")
+        assert db_states[0].event_id is None
+        assert db_states[0].to_native() == _state_with_context(hass, "test.two")
 
 
 def test_service_disable_run_information_recorded(tmpdir):
@@ -1257,7 +1255,7 @@ async def test_database_corruption_while_running(hass, tmpdir, caplog):
         with session_scope(hass=hass) as session:
             db_states = list(session.query(States))
             assert len(db_states) == 1
-            assert db_states[0].event_id > 0
+            assert db_states[0].event_id is None
             return db_states[0].to_native()
 
     state = await hass.async_add_executor_job(_get_last_state)

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -39,9 +39,6 @@ def test_from_event_to_db_state():
         {"entity_id": "sensor.temperature", "old_state": None, "new_state": state},
         context=state.context,
     )
-    # We don't restore context unless we need it by joining the
-    # events table on the event_id for state_changed events
-    state.context = ha.Context(id=None)
     assert state == States.from_event(event).to_native()
 
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -64,14 +64,14 @@ async def test_purge_old_states(
         assert state_attributes.count() == 3
 
         events = session.query(Events).filter(Events.event_type == "state_changed")
-        assert events.count() == 6
+        assert events.count() == 0
         assert "test.recorder2" in instance._old_states
 
         purge_before = dt_util.utcnow() - timedelta(days=4)
 
         # run purge_old_data()
         finished = purge_old_data(instance, purge_before, repack=False)
-        assert not finished
+        # assert not finished
         assert states.count() == 2
         assert state_attributes.count() == 1
 
@@ -108,7 +108,7 @@ async def test_purge_old_states(
         assert states[5].old_state_id == states[4].state_id
 
         events = session.query(Events).filter(Events.event_type == "state_changed")
-        assert events.count() == 6
+        assert events.count() == 0
         assert "test.recorder2" in instance._old_states
 
         state_attributes = session.query(StateAttributes)
@@ -793,7 +793,6 @@ async def test_purge_filtered_states(
 
         assert session.query(StateAttributes).count() == 11
 
-    # Finally make sure we can delete them all except for the ones missing an event_id
     service_data = {"keep_days": 0}
     await hass.services.async_call(
         recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
@@ -805,8 +804,8 @@ async def test_purge_filtered_states(
         remaining = list(session.query(States))
         for state in remaining:
             assert state.event_id is None
-        assert len(remaining) == 3
-        assert session.query(StateAttributes).count() == 1
+        assert len(remaining) == 0
+        assert session.query(StateAttributes).count() == 0
 
 
 @pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -71,7 +71,7 @@ async def test_purge_old_states(
 
         # run purge_old_data()
         finished = purge_old_data(instance, purge_before, repack=False)
-        # assert not finished
+        assert not finished
         assert states.count() == 2
         assert state_attributes.count() == 1
 


### PR DESCRIPTION
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- All the data needed to fetch a `stated_changed` event is now available in the `states` table (along with `state_attributes` if needed)

- Reduces overall database size by ~27%

- Refactors logbook to work without the need for the `state_changed` `events` rows (fetched from `states`)

- Refactors purge to work without the need for linking the `state_changed` event

- Origin is now stored as an int

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/data.home-assistant/pull/209

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
