### PR TITLE
Review AndroidTV tests for media player entity

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -58,7 +58,6 @@ omit =
     homeassistant/components/amcrest/*
     homeassistant/components/ampio/*
     homeassistant/components/android_ip_webcam/*
-    homeassistant/components/androidtv/__init__.py
     homeassistant/components/androidtv/diagnostics.py
     homeassistant/components/anel_pwrctrl/switch.py
     homeassistant/components/anthemav/media_player.py

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -3,7 +3,11 @@ from unittest.mock import patch
 
 from androidtv.constants import CMD_DEVICE_PROPERTIES, CMD_MAC_ETH0, CMD_MAC_WLAN0
 
-from homeassistant.components.androidtv.const import DEVICE_ANDROIDTV, DEVICE_FIRETV
+from homeassistant.components.androidtv.const import (
+    DEFAULT_ADB_SERVER_PORT,
+    DEVICE_ANDROIDTV,
+    DEVICE_FIRETV,
+)
 
 ADB_SERVER_HOST = "127.0.0.1"
 KEY_PYTHON = "python"
@@ -39,7 +43,7 @@ class AdbDeviceTcpAsyncFake:
 class ClientAsyncFakeSuccess:
     """A fake of the `ClientAsync` class when the connection and shell commands succeed."""
 
-    def __init__(self, host=ADB_SERVER_HOST, port=5037):
+    def __init__(self, host=ADB_SERVER_HOST, port=DEFAULT_ADB_SERVER_PORT):
         """Initialize a `ClientAsyncFakeSuccess` instance."""
         self._devices = []
 
@@ -53,7 +57,7 @@ class ClientAsyncFakeSuccess:
 class ClientAsyncFakeFail:
     """A fake of the `ClientAsync` class when the connection and shell commands fail."""
 
-    def __init__(self, host=ADB_SERVER_HOST, port=5037):
+    def __init__(self, host=ADB_SERVER_HOST, port=DEFAULT_ADB_SERVER_PORT):
         """Initialize a `ClientAsyncFakeFail` instance."""
         self._devices = []
 

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -1,8 +1,11 @@
 """Define patches used for androidtv tests."""
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 from androidtv.constants import CMD_DEVICE_PROPERTIES, CMD_MAC_ETH0, CMD_MAC_WLAN0
 
+from homeassistant.components.androidtv.const import DEVICE_ANDROIDTV, DEVICE_FIRETV
+
+ADB_SERVER_HOST = "127.0.0.1"
 KEY_PYTHON = "python"
 KEY_SERVER = "server"
 
@@ -36,7 +39,7 @@ class AdbDeviceTcpAsyncFake:
 class ClientAsyncFakeSuccess:
     """A fake of the `ClientAsync` class when the connection and shell commands succeed."""
 
-    def __init__(self, host="127.0.0.1", port=5037):
+    def __init__(self, host=ADB_SERVER_HOST, port=5037):
         """Initialize a `ClientAsyncFakeSuccess` instance."""
         self._devices = []
 
@@ -50,7 +53,7 @@ class ClientAsyncFakeSuccess:
 class ClientAsyncFakeFail:
     """A fake of the `ClientAsync` class when the connection and shell commands fail."""
 
-    def __init__(self, host="127.0.0.1", port=5037):
+    def __init__(self, host=ADB_SERVER_HOST, port=5037):
         """Initialize a `ClientAsyncFakeFail` instance."""
         self._devices = []
 
@@ -143,48 +146,39 @@ def patch_shell(response=None, error=False, mac_eth=False):
     }
 
 
-PATCH_ADB_DEVICE_TCP = patch(
-    "androidtv.adb_manager.adb_manager_async.AdbDeviceTcpAsync", AdbDeviceTcpAsyncFake
-)
-PATCH_ANDROIDTV_OPEN = patch(
-    "homeassistant.components.androidtv.media_player.open", mock_open()
-)
-PATCH_KEYGEN = patch("homeassistant.components.androidtv.keygen")
-PATCH_SIGNER = patch(
-    "homeassistant.components.androidtv.ADBPythonSync.load_adbkey",
-    return_value="signer for testing",
-)
-
-
 def isfile(filepath):
     """Mock `os.path.isfile`."""
     return filepath.endswith("adbkey")
 
 
-def patch_firetv_update(state, current_app, running_apps, hdmi_input):
-    """Patch the `FireTV.update()` method."""
-    return patch(
-        "androidtv.firetv.firetv_async.FireTVAsync.update",
-        return_value=(state, current_app, running_apps, hdmi_input),
-    )
-
-
 def patch_androidtv_update(
-    state, current_app, running_apps, device, is_volume_muted, volume_level, hdmi_input
+    state,
+    current_app,
+    running_apps,
+    device,
+    is_volume_muted,
+    volume_level,
+    hdmi_input,
 ):
     """Patch the `AndroidTV.update()` method."""
-    return patch(
-        "androidtv.androidtv.androidtv_async.AndroidTVAsync.update",
-        return_value=(
-            state,
-            current_app,
-            running_apps,
-            device,
-            is_volume_muted,
-            volume_level,
-            hdmi_input,
+    return {
+        DEVICE_ANDROIDTV: patch(
+            "androidtv.androidtv.androidtv_async.AndroidTVAsync.update",
+            return_value=(
+                state,
+                current_app,
+                running_apps,
+                device,
+                is_volume_muted,
+                volume_level,
+                hdmi_input,
+            ),
         ),
-    )
+        DEVICE_FIRETV: patch(
+            "androidtv.firetv.firetv_async.FireTVAsync.update",
+            return_value=(state, current_app, running_apps, hdmi_input),
+        ),
+    }
 
 
 PATCH_LAUNCH_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.launch_app")

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -150,11 +150,6 @@ def patch_shell(response=None, error=False, mac_eth=False):
     }
 
 
-def isfile(filepath):
-    """Mock `os.path.isfile`."""
-    return filepath.endswith("adbkey")
-
-
 def patch_androidtv_update(
     state,
     current_app,
@@ -185,6 +180,17 @@ def patch_androidtv_update(
     }
 
 
+def isfile(filepath):
+    """Mock `os.path.isfile`."""
+    return filepath.endswith("adbkey")
+
+
+PATCH_SETUP_ENTRY = patch(
+    "homeassistant.components.androidtv.async_setup_entry",
+    return_value=True,
+)
+PATCH_ACCESS = patch("homeassistant.components.androidtv.os.access", return_value=True)
+PATCH_ISFILE = patch("homeassistant.components.androidtv.os.path.isfile", isfile)
 PATCH_LAUNCH_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.launch_app")
 PATCH_STOP_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.stop_app")
 

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -36,7 +36,7 @@ from homeassistant.components.androidtv.const import (
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_HOST, CONF_PORT
 
-from .patchers import isfile
+from .patchers import PATCH_ACCESS, PATCH_ISFILE, PATCH_SETUP_ENTRY
 
 from tests.common import MockConfigEntry
 
@@ -65,16 +65,6 @@ CONFIG_ADB_SERVER = {
 
 CONNECT_METHOD = (
     "homeassistant.components.androidtv.config_flow.async_connect_androidtv"
-)
-PATCH_ACCESS = patch(
-    "homeassistant.components.androidtv.config_flow.os.access", return_value=True
-)
-PATCH_ISFILE = patch(
-    "homeassistant.components.androidtv.config_flow.os.path.isfile", isfile
-)
-PATCH_SETUP_ENTRY = patch(
-    "homeassistant.components.androidtv.async_setup_entry",
-    return_value=True,
 )
 
 

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -2,7 +2,7 @@
 import base64
 import copy
 import logging
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from androidtv.constants import APPS as ANDROIDTV_APPS, KEYS
 from androidtv.exceptions import LockNotAcquiredException
@@ -14,6 +14,7 @@ from homeassistant.components.androidtv.const import (
     CONF_ADBKEY,
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
+    CONF_SCREENCAP,
     CONF_TURN_OFF_COMMAND,
     CONF_TURN_ON_COMMAND,
     DEFAULT_ADB_SERVER_PORT,
@@ -77,6 +78,11 @@ HOST = "127.0.0.1"
 
 ADB_PATCH_KEY = "patch_key"
 TEST_ENTITY_NAME = "entity_name"
+
+MSG_RECONNECT = {
+    patchers.KEY_PYTHON: f"ADB connection to {HOST}:5555 successfully established",
+    patchers.KEY_SERVER: f"ADB connection to {HOST}:5555 via ADB server {patchers.ADB_SERVER_HOST}:5037 successfully established",
+}
 
 PATCH_ACCESS = patch("homeassistant.components.androidtv.os.access", return_value=True)
 PATCH_ISFILE = patch(
@@ -144,6 +150,39 @@ CONFIG_FIRETV_ADB_SERVER = {
     },
 }
 
+CONFIG_ANDROIDTV_DEFAULT = CONFIG_ANDROIDTV_PYTHON_ADB
+CONFIG_FIRETV_DEFAULT = CONFIG_FIRETV_PYTHON_ADB
+
+
+@pytest.fixture(autouse=True)
+def adb_device_tcp_fixture() -> None:
+    """Patch ADB Device TCP."""
+    with patch(
+        "androidtv.adb_manager.adb_manager_async.AdbDeviceTcpAsync",
+        patchers.AdbDeviceTcpAsyncFake,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def load_adbkey_fixture() -> None:
+    """Patch load_adbkey."""
+    with patch(
+        "homeassistant.components.androidtv.ADBPythonSync.load_adbkey",
+        return_value="signer for testing",
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def keygen_fixture() -> None:
+    """Patch keygen."""
+    with patch(
+        "homeassistant.components.androidtv.keygen",
+        return_value=Mock(),
+    ):
+        yield
+
 
 def _setup(config):
     """Perform common setup tasks for the tests."""
@@ -180,11 +219,9 @@ async def test_reconnect(hass, caplog, config):
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
-        patch_key
-    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -198,7 +235,7 @@ async def test_reconnect(hass, caplog, config):
 
     with patchers.patch_connect(False)[patch_key], patchers.patch_shell(error=True)[
         patch_key
-    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    ]:
         for _ in range(5):
             await async_update_entity(hass, entity_id)
             state = hass.states.get(entity_id)
@@ -212,23 +249,13 @@ async def test_reconnect(hass, caplog, config):
     caplog.set_level(logging.DEBUG)
     with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
         SHELL_RESPONSE_STANDBY
-    )[patch_key], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    )[patch_key]:
         await async_update_entity(hass, entity_id)
 
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_STANDBY
-
-    if patch_key == "python":
-        assert (
-            "ADB connection to 127.0.0.1:5555 successfully established"
-            in caplog.record_tuples[2]
-        )
-    else:
-        assert (
-            "ADB connection to 127.0.0.1:5555 via ADB server 127.0.0.1:5037 successfully established"
-            in caplog.record_tuples[2]
-        )
+        assert MSG_RECONNECT[patch_key] in caplog.record_tuples[2]
 
 
 @pytest.mark.parametrize(
@@ -248,11 +275,9 @@ async def test_adb_shell_returns_none(hass, config):
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
-        patch_key
-    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -263,7 +288,7 @@ async def test_adb_shell_returns_none(hass, config):
 
     with patchers.patch_shell(None)[patch_key], patchers.patch_shell(error=True)[
         patch_key
-    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    ]:
         await async_update_entity(hass, entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -272,16 +297,14 @@ async def test_adb_shell_returns_none(hass, config):
 
 async def test_setup_with_adbkey(hass):
     """Test that setup succeeds when using an ADB key."""
-    config = copy.deepcopy(CONFIG_ANDROIDTV_PYTHON_ADB)
+    config = copy.deepcopy(CONFIG_ANDROIDTV_DEFAULT)
     config[DOMAIN][CONF_ADBKEY] = hass.config.path("user_provided_adbkey")
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
-        patch_key
-    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER, PATCH_ISFILE, PATCH_ACCESS:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key], PATCH_ISFILE, PATCH_ACCESS:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -292,30 +315,26 @@ async def test_setup_with_adbkey(hass):
 
 
 @pytest.mark.parametrize(
-    "config0",
+    "config",
     [
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        CONFIG_FIRETV_ADB_SERVER,
+        CONFIG_ANDROIDTV_DEFAULT,
+        CONFIG_FIRETV_DEFAULT,
     ],
 )
-async def test_sources(hass, config0):
+async def test_sources(hass, config):
     """Test that sources (i.e., apps) are handled correctly for Android TV and Fire TV devices."""
-    config = copy.deepcopy(config0)
-    config[DOMAIN].setdefault(CONF_OPTIONS, {}).update(
-        {
-            CONF_APPS: {
-                "com.app.test1": "TEST 1",
-                "com.app.test3": None,
-                "com.app.test4": SHELL_RESPONSE_OFF,
-            }
-        }
-    )
+    conf_apps = {
+        "com.app.test1": "TEST 1",
+        "com.app.test3": None,
+        "com.app.test4": SHELL_RESPONSE_OFF,
+    }
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(config_entry, options={CONF_APPS: conf_apps})
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -324,25 +343,17 @@ async def test_sources(hass, config0):
         assert state is not None
         assert state.state == STATE_OFF
 
-    if config[DOMAIN].get(CONF_DEVICE_CLASS) != DEVICE_FIRETV:
-        patch_update = patchers.patch_androidtv_update(
-            "playing",
-            "com.app.test1",
-            ["com.app.test1", "com.app.test2", "com.app.test3", "com.app.test4"],
-            "hdmi",
-            False,
-            1,
-            "HW5",
-        )
-    else:
-        patch_update = patchers.patch_firetv_update(
-            "playing",
-            "com.app.test1",
-            ["com.app.test1", "com.app.test2", "com.app.test3", "com.app.test4"],
-            "HW5",
-        )
+    patch_update = patchers.patch_androidtv_update(
+        "playing",
+        "com.app.test1",
+        ["com.app.test1", "com.app.test2", "com.app.test3", "com.app.test4"],
+        "hdmi",
+        False,
+        1,
+        "HW5",
+    )
 
-    with patch_update:
+    with patch_update[config[DOMAIN][CONF_DEVICE_CLASS]]:
         await async_update_entity(hass, entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -350,25 +361,17 @@ async def test_sources(hass, config0):
         assert state.attributes["source"] == "TEST 1"
         assert sorted(state.attributes["source_list"]) == ["TEST 1", "com.app.test2"]
 
-    if config[DOMAIN].get(CONF_DEVICE_CLASS) != DEVICE_FIRETV:
-        patch_update = patchers.patch_androidtv_update(
-            "playing",
-            "com.app.test2",
-            ["com.app.test2", "com.app.test1", "com.app.test3", "com.app.test4"],
-            "hdmi",
-            True,
-            0,
-            "HW5",
-        )
-    else:
-        patch_update = patchers.patch_firetv_update(
-            "playing",
-            "com.app.test2",
-            ["com.app.test2", "com.app.test1", "com.app.test3", "com.app.test4"],
-            "HW5",
-        )
+    patch_update = patchers.patch_androidtv_update(
+        "playing",
+        "com.app.test2",
+        ["com.app.test2", "com.app.test1", "com.app.test3", "com.app.test4"],
+        "hdmi",
+        True,
+        0,
+        "HW5",
+    )
 
-    with patch_update:
+    with patch_update[config[DOMAIN][CONF_DEVICE_CLASS]]:
         await async_update_entity(hass, entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -377,24 +380,29 @@ async def test_sources(hass, config0):
         assert sorted(state.attributes["source_list"]) == ["TEST 1", "com.app.test2"]
 
 
-async def _test_exclude_sources(hass, config0, expected_sources):
+@pytest.mark.parametrize(
+    ["config", "expected_sources"],
+    [
+        (CONFIG_ANDROIDTV_DEFAULT, ["TEST 1"]),
+        (CONFIG_FIRETV_DEFAULT, ["TEST 1"]),
+    ],
+)
+async def test_exclude_sources(hass, config, expected_sources):
     """Test that sources (i.e., apps) are handled correctly when the `exclude_unnamed_apps` config parameter is provided."""
-    config = copy.deepcopy(config0)
-    config[DOMAIN].setdefault(CONF_OPTIONS, {}).update(
-        {
-            CONF_APPS: {
-                "com.app.test1": "TEST 1",
-                "com.app.test3": None,
-                "com.app.test4": SHELL_RESPONSE_OFF,
-            }
-        }
-    )
+    conf_apps = {
+        "com.app.test1": "TEST 1",
+        "com.app.test3": None,
+        "com.app.test4": SHELL_RESPONSE_OFF,
+    }
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        config_entry, options={CONF_EXCLUDE_UNNAMED_APPS: True, CONF_APPS: conf_apps}
+    )
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -403,37 +411,23 @@ async def _test_exclude_sources(hass, config0, expected_sources):
         assert state is not None
         assert state.state == STATE_OFF
 
-    if config[DOMAIN].get(CONF_DEVICE_CLASS) != DEVICE_FIRETV:
-        patch_update = patchers.patch_androidtv_update(
-            "playing",
+    patch_update = patchers.patch_androidtv_update(
+        "playing",
+        "com.app.test1",
+        [
             "com.app.test1",
-            [
-                "com.app.test1",
-                "com.app.test2",
-                "com.app.test3",
-                "com.app.test4",
-                "com.app.test5",
-            ],
-            "hdmi",
-            False,
-            1,
-            "HW5",
-        )
-    else:
-        patch_update = patchers.patch_firetv_update(
-            "playing",
-            "com.app.test1",
-            [
-                "com.app.test1",
-                "com.app.test2",
-                "com.app.test3",
-                "com.app.test4",
-                "com.app.test5",
-            ],
-            "HW5",
-        )
+            "com.app.test2",
+            "com.app.test3",
+            "com.app.test4",
+            "com.app.test5",
+        ],
+        "hdmi",
+        False,
+        1,
+        "HW5",
+    )
 
-    with patch_update:
+    with patch_update[config[DOMAIN][CONF_DEVICE_CLASS]]:
         await async_update_entity(hass, entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -441,41 +435,18 @@ async def _test_exclude_sources(hass, config0, expected_sources):
         assert state.attributes["source"] == "TEST 1"
         assert sorted(state.attributes["source_list"]) == expected_sources
 
-    return True
 
-
-async def test_androidtv_exclude_sources(hass):
-    """Test that sources (i.e., apps) are handled correctly for Android TV devices when the `exclude_unnamed_apps` config parameter is provided as true."""
-    config = copy.deepcopy(CONFIG_ANDROIDTV_ADB_SERVER)
-    config[DOMAIN][CONF_OPTIONS] = {CONF_EXCLUDE_UNNAMED_APPS: True}
-    assert await _test_exclude_sources(hass, config, ["TEST 1"])
-
-
-async def test_firetv_exclude_sources(hass):
-    """Test that sources (i.e., apps) are handled correctly for Fire TV devices when the `exclude_unnamed_apps` config parameter is provided as true."""
-    config = copy.deepcopy(CONFIG_FIRETV_ADB_SERVER)
-    config[DOMAIN][CONF_OPTIONS] = {CONF_EXCLUDE_UNNAMED_APPS: True}
-    assert await _test_exclude_sources(hass, config, ["TEST 1"])
-
-
-async def _test_select_source(hass, config0, source, expected_arg, method_patch):
+async def _test_select_source(
+    hass, config, conf_apps, source, expected_arg, method_patch
+):
     """Test that the methods for launching and stopping apps are called correctly when selecting a source."""
-    config = copy.deepcopy(config0)
-    config[DOMAIN].setdefault(CONF_OPTIONS, {}).update(
-        {
-            CONF_APPS: {
-                "com.app.test1": "TEST 1",
-                "com.app.test3": None,
-                "com.youtube.test": "YouTube",
-            }
-        }
-    )
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(config_entry, options={CONF_APPS: conf_apps})
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -484,213 +455,87 @@ async def _test_select_source(hass, config0, source, expected_arg, method_patch)
         assert state is not None
         assert state.state == STATE_OFF
 
-    with method_patch as method_patch_:
+    with method_patch as method_patch_used:
         await hass.services.async_call(
             MP_DOMAIN,
             SERVICE_SELECT_SOURCE,
             {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: source},
             blocking=True,
         )
-        method_patch_.assert_called_with(expected_arg)
-
-    return True
+        method_patch_used.assert_called_with(expected_arg)
 
 
-async def test_androidtv_select_source_launch_app_id(hass):
-    """Test that an app can be launched using its app ID."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "com.app.test1",
-        "com.app.test1",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_androidtv_select_source_launch_app_name(hass):
-    """Test that an app can be launched using its friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "TEST 1",
-        "com.app.test1",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_androidtv_select_source_launch_app_id_no_name(hass):
-    """Test that an app can be launched using its app ID when it has no friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "com.app.test2",
-        "com.app.test2",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_androidtv_select_source_launch_app_hidden(hass):
-    """Test that an app can be launched using its app ID when it is hidden from the sources list."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "com.app.test3",
-        "com.app.test3",
-        patchers.PATCH_LAUNCH_APP,
+@pytest.mark.parametrize(
+    ["source", "expected_arg", "method_patch"],
+    [
+        ("com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
+        ("TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
+        ("com.app.test2", "com.app.test2", patchers.PATCH_LAUNCH_APP),
+        ("com.app.test3", "com.app.test3", patchers.PATCH_LAUNCH_APP),
+        ("!com.app.test1", "com.app.test1", patchers.PATCH_STOP_APP),
+        ("!TEST 1", "com.app.test1", patchers.PATCH_STOP_APP),
+        ("!com.app.test2", "com.app.test2", patchers.PATCH_STOP_APP),
+        ("!com.app.test3", "com.app.test3", patchers.PATCH_STOP_APP),
+    ],
+)
+async def test_select_source_androidtv(hass, source, expected_arg, method_patch):
+    """Test that an app can be launched for AndroidTV."""
+    conf_apps = {
+        "com.app.test1": "TEST 1",
+        "com.app.test3": None,
+    }
+    await _test_select_source(
+        hass, CONFIG_ANDROIDTV_DEFAULT, conf_apps, source, expected_arg, method_patch
     )
 
 
 async def test_androidtv_select_source_overridden_app_name(hass):
     """Test that when an app name is overridden via the `apps` configuration parameter, the app is launched correctly."""
     # Evidence that the default YouTube app ID will be overridden
+    conf_apps = {
+        "com.youtube.test": "YouTube",
+    }
     assert "YouTube" in ANDROIDTV_APPS.values()
     assert "com.youtube.test" not in ANDROIDTV_APPS
-    assert await _test_select_source(
+    await _test_select_source(
         hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
+        CONFIG_ANDROIDTV_PYTHON_ADB,
+        conf_apps,
         "YouTube",
         "com.youtube.test",
         patchers.PATCH_LAUNCH_APP,
     )
 
 
-async def test_androidtv_select_source_stop_app_id(hass):
-    """Test that an app can be stopped using its app ID."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "!com.app.test1",
-        "com.app.test1",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_androidtv_select_source_stop_app_name(hass):
-    """Test that an app can be stopped using its friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "!TEST 1",
-        "com.app.test1",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_androidtv_select_source_stop_app_id_no_name(hass):
-    """Test that an app can be stopped using its app ID when it has no friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "!com.app.test2",
-        "com.app.test2",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_androidtv_select_source_stop_app_hidden(hass):
-    """Test that an app can be stopped using its app ID when it is hidden from the sources list."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_ANDROIDTV_ADB_SERVER,
-        "!com.app.test3",
-        "com.app.test3",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_firetv_select_source_launch_app_id(hass):
-    """Test that an app can be launched using its app ID."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "com.app.test1",
-        "com.app.test1",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_firetv_select_source_launch_app_name(hass):
-    """Test that an app can be launched using its friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "TEST 1",
-        "com.app.test1",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_firetv_select_source_launch_app_id_no_name(hass):
-    """Test that an app can be launched using its app ID when it has no friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "com.app.test2",
-        "com.app.test2",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_firetv_select_source_launch_app_hidden(hass):
-    """Test that an app can be launched using its app ID when it is hidden from the sources list."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "com.app.test3",
-        "com.app.test3",
-        patchers.PATCH_LAUNCH_APP,
-    )
-
-
-async def test_firetv_select_source_stop_app_id(hass):
-    """Test that an app can be stopped using its app ID."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "!com.app.test1",
-        "com.app.test1",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_firetv_select_source_stop_app_name(hass):
-    """Test that an app can be stopped using its friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "!TEST 1",
-        "com.app.test1",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_firetv_select_source_stop_app_id_no_name(hass):
-    """Test that an app can be stopped using its app ID when it has no friendly name."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "!com.app.test2",
-        "com.app.test2",
-        patchers.PATCH_STOP_APP,
-    )
-
-
-async def test_firetv_select_source_stop_hidden(hass):
-    """Test that an app can be stopped using its app ID when it is hidden from the sources list."""
-    assert await _test_select_source(
-        hass,
-        CONFIG_FIRETV_ADB_SERVER,
-        "!com.app.test3",
-        "com.app.test3",
-        patchers.PATCH_STOP_APP,
+@pytest.mark.parametrize(
+    ["source", "expected_arg", "method_patch"],
+    [
+        ("com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
+        ("TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
+        ("com.app.test2", "com.app.test2", patchers.PATCH_LAUNCH_APP),
+        ("com.app.test3", "com.app.test3", patchers.PATCH_LAUNCH_APP),
+        ("!com.app.test1", "com.app.test1", patchers.PATCH_STOP_APP),
+        ("!TEST 1", "com.app.test1", patchers.PATCH_STOP_APP),
+        ("!com.app.test2", "com.app.test2", patchers.PATCH_STOP_APP),
+        ("!com.app.test3", "com.app.test3", patchers.PATCH_STOP_APP),
+    ],
+)
+async def test_select_source_firetv(hass, source, expected_arg, method_patch):
+    """Test that an app can be launched for FireTV."""
+    conf_apps = {
+        "com.app.test1": "TEST 1",
+        "com.app.test3": None,
+    }
+    await _test_select_source(
+        hass, CONFIG_FIRETV_DEFAULT, conf_apps, source, expected_arg, method_patch
     )
 
 
 @pytest.mark.parametrize(
     "config",
     [
-        CONFIG_ANDROIDTV_PYTHON_ADB,
-        CONFIG_FIRETV_PYTHON_ADB,
+        CONFIG_ANDROIDTV_DEFAULT,
+        CONFIG_FIRETV_DEFAULT,
     ],
 )
 async def test_setup_fail(hass, config):
@@ -698,11 +543,9 @@ async def test_setup_fail(hass, config):
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(False)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
-        patch_key
-    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    with patchers.patch_connect(False)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id) is False
         await hass.async_block_till_done()
 
@@ -713,14 +556,14 @@ async def test_setup_fail(hass, config):
 
 async def test_adb_command(hass):
     """Test sending a command via the `androidtv.adb_command` service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     command = "test command"
     response = "test response"
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -742,14 +585,14 @@ async def test_adb_command(hass):
 
 async def test_adb_command_unicode_decode_error(hass):
     """Test sending a command via the `androidtv.adb_command` service that raises a UnicodeDecodeError exception."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     command = "test command"
     response = b"test response"
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -771,14 +614,14 @@ async def test_adb_command_unicode_decode_error(hass):
 
 async def test_adb_command_key(hass):
     """Test sending a key command via the `androidtv.adb_command` service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     command = "HOME"
     response = None
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -800,14 +643,14 @@ async def test_adb_command_key(hass):
 
 async def test_adb_command_get_properties(hass):
     """Test sending the "GET_PROPERTIES" command via the `androidtv.adb_command` service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     command = "GET_PROPERTIES"
     response = {"test key": "test value"}
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -830,13 +673,13 @@ async def test_adb_command_get_properties(hass):
 
 async def test_learn_sendevent(hass):
     """Test the `androidtv.learn_sendevent` service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     response = "sendevent 1 2 3 4"
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -859,12 +702,12 @@ async def test_learn_sendevent(hass):
 
 async def test_update_lock_not_acquired(hass):
     """Test that the state does not get updated when a `LockNotAcquiredException` is raised."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -892,14 +735,14 @@ async def test_update_lock_not_acquired(hass):
 
 async def test_download(hass):
     """Test the `androidtv.download` service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     device_path = "device/path"
     local_path = "local/path"
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -938,14 +781,14 @@ async def test_download(hass):
 
 async def test_upload(hass):
     """Test the `androidtv.upload` service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
     device_path = "device/path"
     local_path = "local/path"
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -984,12 +827,12 @@ async def test_upload(hass):
 
 async def test_androidtv_volume_set(hass):
     """Test setting the volume for an Android TV device."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1011,12 +854,12 @@ async def test_get_image(hass, hass_ws_client):
 
     This is based on `test_get_image` in tests/components/media_player/test_init.py.
     """
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1042,7 +885,7 @@ async def test_get_image(hass, hass_ws_client):
 
     with patch(
         "androidtv.basetv.basetv_async.BaseTVAsync.adb_screencap",
-        side_effect=RuntimeError,
+        side_effect=ConnectionResetError,
     ):
         await client.send_json(
             {"id": 6, "type": "media_player_thumbnail", "entity_id": entity_id}
@@ -1054,6 +897,39 @@ async def test_get_image(hass, hass_ws_client):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
+
+
+async def test_get_image_disabled(hass, hass_ws_client):
+    """Test taking a screen capture with screencap option disabled.
+
+    This is based on `test_get_image` in tests/components/media_player/test_init.py.
+    """
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
+    config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        config_entry, options={CONF_SCREENCAP: False}
+    )
+
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patchers.patch_shell("11")[patch_key]:
+        await async_update_entity(hass, entity_id)
+
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "androidtv.basetv.basetv_async.BaseTVAsync.adb_screencap", return_value=b"image"
+    ) as screen_cap:
+        await client.send_json(
+            {"id": 5, "type": "media_player_thumbnail", "entity_id": entity_id}
+        )
+
+        await client.receive_json()
+        assert not screen_cap.called
 
 
 async def _test_service(
@@ -1088,10 +964,10 @@ async def _test_service(
 
 async def test_services_androidtv(hass):
     """Test media player services for an Android TV device."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
+    with patchers.patch_connect(True)[patch_key]:
         with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()
@@ -1129,7 +1005,7 @@ async def test_services_androidtv(hass):
 
 async def test_services_firetv(hass):
     """Test media player services for a Fire TV device."""
-    config = copy.deepcopy(CONFIG_FIRETV_ADB_SERVER)
+    config = copy.deepcopy(CONFIG_FIRETV_DEFAULT)
     config[DOMAIN][CONF_OPTIONS] = {
         CONF_TURN_OFF_COMMAND: "test off",
         CONF_TURN_ON_COMMAND: "test on",
@@ -1137,7 +1013,7 @@ async def test_services_firetv(hass):
     patch_key, entity_id, config_entry = _setup(config)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
+    with patchers.patch_connect(True)[patch_key]:
         with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()
@@ -1150,10 +1026,10 @@ async def test_services_firetv(hass):
 
 async def test_volume_mute(hass):
     """Test the volume mute service."""
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
+    with patchers.patch_connect(True)[patch_key]:
         with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()
@@ -1193,18 +1069,16 @@ async def test_volume_mute(hass):
 
 async def test_connection_closed_on_ha_stop(hass):
     """Test that the ADB socket connection is closed when HA stops."""
-    patch_key, _, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    patch_key, _, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        with patch(
-            "androidtv.androidtv.androidtv_async.AndroidTVAsync.adb_close"
-        ) as adb_close:
+        with patch("androidtv.basetv.basetv_async.BaseTVAsync.adb_close") as adb_close:
             hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
             await hass.async_block_till_done()
             assert adb_close.called
@@ -1215,14 +1089,12 @@ async def test_exception(hass):
 
     HA will attempt to reconnect on the next update.
     """
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_PYTHON_ADB)
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
 
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
-        patch_key
-    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell(
+        SHELL_RESPONSE_OFF
+    )[patch_key]:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Review AndroidTV tests for media player entity:
- remove `if` conditions in tests
- use `pytest.fixture` and `pytest..mark.parametrize` where possible

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
