### PR TITLE
Add media source support to AppleTV

### DIFF
--- a/homeassistant/components/apple_tv/browse_media.py
+++ b/homeassistant/components/apple_tv/browse_media.py
@@ -18,7 +18,7 @@ def build_app_list(app_list):
 
     return BrowseMedia(
         media_class=MEDIA_CLASS_DIRECTORY,
-        media_content_id=None,
+        media_content_id="apps",
         media_content_type=MEDIA_TYPE_APPS,
         title="Apps",
         can_play=True,

--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -13,10 +13,14 @@ from pyatv.const import (
 )
 from pyatv.helpers import is_streamable
 
+from homeassistant.components import media_source
 from homeassistant.components.media_player import (
     BrowseMedia,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
+)
+from homeassistant.components.media_player.browse_media import (
+    async_process_play_media_url,
 )
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_APP,
@@ -73,7 +77,8 @@ SUPPORT_APPLE_TV = (
 
 # Map features in pyatv to Home Assistant
 SUPPORT_FEATURE_MAPPING = {
-    FeatureName.PlayUrl: MediaPlayerEntityFeature.PLAY_MEDIA,
+    FeatureName.PlayUrl: MediaPlayerEntityFeature.BROWSE_MEDIA
+    | MediaPlayerEntityFeature.PLAY_MEDIA,
     FeatureName.StreamFile: MediaPlayerEntityFeature.PLAY_MEDIA,
     FeatureName.Pause: MediaPlayerEntityFeature.PAUSE,
     FeatureName.Play: MediaPlayerEntityFeature.PLAY,
@@ -276,12 +281,24 @@ class AppleTvMediaPlayer(AppleTVEntity, MediaPlayerEntity):
         # RAOP. Otherwise try to play it with regular AirPlay.
         if media_type == MEDIA_TYPE_APP:
             await self.atv.apps.launch_app(media_id)
-        elif self._is_feature_available(FeatureName.StreamFile) and (
-            await is_streamable(media_id) or media_type == MEDIA_TYPE_MUSIC
+
+        is_media_source_id = media_source.is_media_source_id(media_id)
+
+        if (
+            not is_media_source_id
+            and self._is_feature_available(FeatureName.StreamFile)
+            and (await is_streamable(media_id) or media_type == MEDIA_TYPE_MUSIC)
         ):
             _LOGGER.debug("Streaming %s via RAOP", media_id)
             await self.atv.stream.stream_file(media_id)
-        elif self._is_feature_available(FeatureName.PlayUrl):
+
+        if self._is_feature_available(FeatureName.PlayUrl):
+            if is_media_source_id:
+                play_item = await media_source.async_resolve_media(self.hass, media_id)
+                media_id = play_item.url
+
+            media_id = async_process_play_media_url(self.hass, media_id)
+
             _LOGGER.debug("Playing %s via AirPlay", media_id)
             await self.atv.stream.play_url(media_id)
         else:
@@ -380,7 +397,34 @@ class AppleTvMediaPlayer(AppleTVEntity, MediaPlayerEntity):
         media_content_id=None,
     ) -> BrowseMedia:
         """Implement the websocket media browsing helper."""
-        return build_app_list(self._app_list)
+        # If we can't stream URLs, we can't browse media.
+        # In that case the `BROWSE_MEDIA` feature was added because of AppList/LaunchApp
+        if not self._is_feature_available(FeatureName.PlayUrl):
+            return build_app_list(self._app_list)
+
+        if self._app_list:
+            kwargs = {}
+        else:
+            # If it has no apps, assume it has no display
+            kwargs = {
+                "content_filter": lambda item: item.media_content_type.startswith(
+                    "audio/"
+                ),
+            }
+
+        cur_item = await media_source.async_browse_media(
+            self.hass, media_content_id, **kwargs
+        )
+
+        # If media content id is not None, we're browsing into a media source
+        if media_content_id is not None:
+            return cur_item
+
+        # Add app item if we have one
+        if self._app_list and cur_item.children:
+            cur_item.children.insert(0, build_app_list(self._app_list))
+
+        return cur_item
 
     async def async_turn_on(self):
         """Turn the media player on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add media source support to AppleTV. This issue became apparent because TTS now uses media sources. So if a media player can work with TTS, it should use media sources.

Fixes #71159

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
