### PR TITLE
Only use scale sensor value if ordinary deCONZ value is not None

### DIFF
--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -112,7 +112,7 @@ ENTITY_DESCRIPTIONS = {
         DeconzSensorDescription(
             key="consumption",
             value_fn=lambda device: device.scaled_consumption
-            if isinstance(device, Consumption)
+            if isinstance(device, Consumption) and isinstance(device.consumption, int)
             else None,
             update_key="consumption",
             device_class=SensorDeviceClass.ENERGY,
@@ -144,7 +144,7 @@ ENTITY_DESCRIPTIONS = {
         DeconzSensorDescription(
             key="humidity",
             value_fn=lambda device: device.scaled_humidity
-            if isinstance(device, Humidity)
+            if isinstance(device, Humidity) and isinstance(device.humidity, int)
             else None,
             update_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
@@ -156,7 +156,7 @@ ENTITY_DESCRIPTIONS = {
         DeconzSensorDescription(
             key="light_level",
             value_fn=lambda device: device.scaled_light_level
-            if isinstance(device, LightLevel)
+            if isinstance(device, LightLevel) and isinstance(device.light_level, int)
             else None,
             update_key="lightlevel",
             device_class=SensorDeviceClass.ILLUMINANCE,
@@ -189,7 +189,7 @@ ENTITY_DESCRIPTIONS = {
         DeconzSensorDescription(
             key="temperature",
             value_fn=lambda device: device.scaled_temperature
-            if isinstance(device, Temperature)
+            if isinstance(device, Temperature) and isinstance(device.temperature, int)
             else None,
             update_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -785,6 +785,36 @@ async def test_add_new_sensor(hass, aioclient_mock, mock_deconz_websocket):
     assert hass.states.get("sensor.light_level_sensor").state == "999.8"
 
 
+BAD_SENSOR_DATA = [
+    ("ZHAConsumption", "consumption"),
+    ("ZHAHumidity", "humidity"),
+    ("ZHALightLevel", "lightlevel"),
+    ("ZHATemperature", "temperature"),
+]
+
+
+@pytest.mark.parametrize("sensor_type, sensor_property", BAD_SENSOR_DATA)
+async def test_dont_add_sensor_if_state_is_none(
+    hass, aioclient_mock, sensor_type, sensor_property
+):
+    """Test sensor with scaled data is not created if state is None."""
+    data = {
+        "sensors": {
+            "1": {
+                "name": "Sensor 1",
+                "type": sensor_type,
+                "state": {sensor_property: None},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 0
+
+
 async def test_add_battery_later(hass, aioclient_mock, mock_deconz_websocket):
     """Test that a sensor without an initial battery state creates a battery sensor once state exist."""
     data = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sure sensor state value is not None prior to trying to used the scaled value.
I know there is a lingering review comment from Martin in a previous PR related to not using lambdas on multi-line, and I intend to fix that as well, but I need to lay a bit more of groundwork prior to getting there.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71170
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
