### PR TITLE
Add Cancel helper class

### DIFF
--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -24,4 +24,4 @@ def async_at_start(
         """Call the callback when Home Assistant started."""
         hass.async_run_hass_job(at_start_job, hass)
 
-    return hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _matched_event)
+    return hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _matched_event).cancel

--- a/tests/helpers/test_start.py
+++ b/tests/helpers/test_start.py
@@ -27,7 +27,7 @@ async def test_at_start_when_running_awaitable(hass):
     assert len(calls) == 2
 
 
-async def test_at_start_when_running_callback(hass):
+async def test_at_start_when_running_callback(hass, caplog):
     """Test at start when already running."""
     assert hass.state == core.CoreState.running
     assert hass.is_running
@@ -39,14 +39,18 @@ async def test_at_start_when_running_callback(hass):
         """Home Assistant is started."""
         calls.append(1)
 
-    start.async_at_start(hass, cb_at_start)
+    start.async_at_start(hass, cb_at_start)()
     assert len(calls) == 1
 
     hass.state = core.CoreState.starting
     assert hass.is_running
 
-    start.async_at_start(hass, cb_at_start)
+    start.async_at_start(hass, cb_at_start)()
     assert len(calls) == 2
+
+    # Check the unnecessary cancel did not generate warnings or errors
+    for record in caplog.records:
+        assert record.levelname in ("DEBUG", "INFO")
 
 
 async def test_at_start_when_starting_awaitable(hass):
@@ -69,7 +73,7 @@ async def test_at_start_when_starting_awaitable(hass):
     assert len(calls) == 1
 
 
-async def test_at_start_when_starting_callback(hass):
+async def test_at_start_when_starting_callback(hass, caplog):
     """Test at start when yet to start."""
     hass.state = core.CoreState.not_running
     assert not hass.is_running
@@ -81,7 +85,7 @@ async def test_at_start_when_starting_callback(hass):
         """Home Assistant is started."""
         calls.append(1)
 
-    start.async_at_start(hass, cb_at_start)
+    cancel = start.async_at_start(hass, cb_at_start)
     await hass.async_block_till_done()
     assert len(calls) == 0
 
@@ -89,8 +93,14 @@ async def test_at_start_when_starting_callback(hass):
     await hass.async_block_till_done()
     assert len(calls) == 1
 
+    cancel()
 
-async def test_cancelling_when_running(hass):
+    # Check the unnecessary cancel did not generate warnings or errors
+    for record in caplog.records:
+        assert record.levelname in ("DEBUG", "INFO")
+
+
+async def test_cancelling_when_running(hass, caplog):
     """Test cancelling at start when already running."""
     assert hass.state == core.CoreState.running
     assert hass.is_running
@@ -104,6 +114,10 @@ async def test_cancelling_when_running(hass):
     start.async_at_start(hass, cb_at_start)()
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+    # Check the unnecessary cancel did not generate warnings or errors
+    for record in caplog.records:
+        assert record.levelname in ("DEBUG", "INFO")
 
 
 async def test_cancelling_when_starting(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `Cancel` helper class which can be used as an alternative to returning closure functions to help unsubscribe from events, signals etc.

The `Cancel` class has its `__run__` method overloaded for backwards compatibility.

This PR modifies `async_listen_once` to return a `Cancel` object, but if this idea is deemed valid it should be extended to other functions allowing cancellation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
