### PR TITLE
Speed up and isolate legacy logbook context_id query

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -597,7 +597,7 @@ def _generate_legacy_events_context_id_query(
         States.state,
         States.entity_id,
         States.attributes,
-        StateAttributes.shared_attrs,
+        literal(value=None, type_=sqlalchemy.String).label("shared_data"),
     )
     legacy_context_id_query = _apply_event_time_filter(
         legacy_context_id_query, start_day, end_day

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -550,14 +550,14 @@ def _get_events(
                 # _generate_legacy_events_context_id_query
                 unions.append(
                     _generate_legacy_events_context_id_query(
-                        session, context_id, start_day, end_day, filters
+                        session, context_id, start_day, end_day
                     )
                 )
                 states_query = states_query.outerjoin(
                     Events, (States.event_id == Events.event_id)
                 )
                 states_query = states_query.filter(States.context_id == context_id)
-            if filters:
+            elif filters:
                 states_query = states_query.filter(filters.entity_filter())  # type: ignore[no-untyped-call]
             unions.append(states_query)
             query = query.union_all(*unions)
@@ -587,7 +587,6 @@ def _generate_legacy_events_context_id_query(
     context_id: str,
     start_day: dt,
     end_day: dt,
-    filters: Filters | None = None,
 ) -> Query:
     """Generate a legacy events context id query that also joins states."""
     # This can be removed once we no longer have event_ids in the states table
@@ -602,7 +601,7 @@ def _generate_legacy_events_context_id_query(
     legacy_context_id_query = _apply_event_time_filter(
         legacy_context_id_query, start_day, end_day
     )
-    legacy_context_id_query = (
+    return (
         legacy_context_id_query.filter(Events.context_id == context_id)
         .outerjoin(States, (Events.event_id == States.event_id))
         .filter(States.last_updated == States.last_changed)
@@ -611,11 +610,6 @@ def _generate_legacy_events_context_id_query(
             StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
         )
     )
-    if filters:
-        legacy_context_id_query = legacy_context_id_query.filter(
-            filters.entity_filter()  # type: ignore[no-untyped-call]
-        )
-    return legacy_context_id_query
 
 
 def _generate_events_query_without_states(session: Session) -> Query:

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -593,7 +593,7 @@ def _generate_legacy_events_context_id_query(
     # This can be removed once we no longer have event_ids in the states table
     legacy_context_id_query = session.query(
         *EVENT_COLUMNS,
-        EventData.shared_data,
+        literal(value=None, type_=sqlalchemy.String).label("shared_data"),
         States.state,
         States.entity_id,
         States.attributes,

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -597,7 +597,7 @@ def _generate_legacy_events_context_id_query(
         States.state,
         States.entity_id,
         States.attributes,
-        literal(value=None, type_=sqlalchemy.String).label("shared_data"),
+        StateAttributes.shared_attrs,
     )
     legacy_context_id_query = _apply_event_time_filter(
         legacy_context_id_query, start_day, end_day

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -543,20 +543,24 @@ def _get_events(
             states_query = _generate_states_query(
                 session, start_day, end_day, old_state, entity_ids
             )
+            unions: list[Query] = []
             if context_id is not None:
                 # Once all the old `state_changed` events
-                # are gone from the database this query can
-                # be simplified to filter only on States.context_id == context_id
+                # are gone from the database remove the
+                # _generate_legacy_events_context_id_query
+                unions.append(
+                    _generate_legacy_events_context_id_query(
+                        session, context_id, start_day, end_day, filters
+                    )
+                )
                 states_query = states_query.outerjoin(
                     Events, (States.event_id == Events.event_id)
                 )
-                states_query = states_query.filter(
-                    (States.context_id == context_id)
-                    | (States.context_id.is_(None) & (Events.context_id == context_id))
-                )
+                states_query = states_query.filter(States.context_id == context_id)
             if filters:
                 states_query = states_query.filter(filters.entity_filter())  # type: ignore[no-untyped-call]
-            query = query.union_all(states_query)
+            unions.append(states_query)
+            query = query.union_all(*unions)
 
         query = query.order_by(Events.time_fired)
 
@@ -576,6 +580,42 @@ def _generate_events_query_without_data(session: Session) -> Query:
         literal(value=None, type_=sqlalchemy.Text).label("shared_data"),
         *STATE_COLUMNS,
     )
+
+
+def _generate_legacy_events_context_id_query(
+    session: Session,
+    context_id: str,
+    start_day: dt,
+    end_day: dt,
+    filters: Filters | None = None,
+) -> Query:
+    """Generate a legacy events context id query that also joins states."""
+    # This can be removed once we no longer have event_ids in the states table
+    legacy_context_id_query = session.query(
+        *EVENT_COLUMNS,
+        EventData.shared_data,
+        States.state,
+        States.entity_id,
+        States.attributes,
+        StateAttributes.shared_attrs,
+    )
+    legacy_context_id_query = _apply_event_time_filter(
+        legacy_context_id_query, start_day, end_day
+    )
+    legacy_context_id_query = (
+        legacy_context_id_query.filter(Events.context_id == context_id)
+        .outerjoin(States, (Events.event_id == States.event_id))
+        .filter(States.last_updated == States.last_changed)
+        .filter(_not_continuous_entity_matcher())
+        .outerjoin(
+            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
+        )
+    )
+    if filters:
+        legacy_context_id_query = legacy_context_id_query.filter(
+            filters.entity_filter()  # type: ignore[no-untyped-call]
+        )
+    return legacy_context_id_query
 
 
 def _generate_events_query_without_states(session: Session) -> Query:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The query to find the context_id in the old format as been moved
  to its own function so it can easily be removed later.

- The query is now much faster for looking up context ids
  that were recorded before the data change over

Verified ok with legacy database and `pytest -k test_context_filter tests/components/logbook`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
