### PR TITLE
Add `is_today` template function/filter

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1791,6 +1791,22 @@ def today_at(time_str: str = "") -> datetime:
     return datetime.combine(today, time_today, today.tzinfo)
 
 
+def is_today(value: Any) -> bool:
+    """Return true if the given datetime is today in the local time zone."""
+    if not isinstance(value, datetime):
+        if (value_dt := dt_util.parse_datetime(value)) is None:
+            raise ValueError(
+                f"could not convert {type(value).__name__} to datetime: '{value}'"
+            )
+    else:
+        value_dt = value
+
+    local_dt = dt_util.as_local(value_dt)
+    now_dt = dt_util.now()
+
+    return now_dt.date() == local_dt.date()
+
+
 def relative_time(value):
     """
     Take a datetime and return its "age" as a string.
@@ -1925,6 +1941,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["as_datetime"] = as_datetime
         self.filters["as_timestamp"] = forgiving_as_timestamp
         self.filters["today_at"] = today_at
+        self.filters["is_today"] = is_today
         self.filters["as_local"] = dt_util.as_local
         self.filters["timestamp_custom"] = timestamp_custom
         self.filters["timestamp_local"] = timestamp_local
@@ -1970,6 +1987,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["as_local"] = dt_util.as_local
         self.globals["as_timestamp"] = forgiving_as_timestamp
         self.globals["today_at"] = today_at
+        self.globals["is_today"] = is_today
         self.globals["relative_time"] = relative_time
         self.globals["timedelta"] = timedelta
         self.globals["strptime"] = strptime


### PR DESCRIPTION
## Proposed change

Add an `is_today` template function filter for testing if a timestamp is "today" in the local timezone. Timestamps coming from HA entities and attributes are sometimes in UTC, and checking if such a timestamp is today requires using e.g. `as_local(timestamp_in_utc)` before comparing `date()` of it and `now()`.

For example:

```yaml
- alias: Once per day
  trigger:
    platform: time_pattern
    minutes: '/1' 
  condition:
    - '{{ not is_today(this.attributes.last_triggered) }}'
```

instead of:

```yaml
- alias: Once per day
  trigger:
    platform: time_pattern
    minutes: '/1' 
  condition:
    - '{{ now().date() != as_local(this.attributes.last_triggered).date() }}'
```

A little bit of background: I hadn't realized that it's easy to make sure an automation is only triggered once per day until I reead [this tweet](https://twitter.com/Frenck/status/1516758257989210116) by @frenck:

<img width="588" alt="image" src="https://user-images.githubusercontent.com/1417619/166308846-90c958ae-9f64-442a-82d6-0ad01b2fa1aa.png">

What I didn't realize at that point was that the `last_triggered` attribute is in UTC, as [pointed out](https://discord.com/channels/330944238910963714/672220450977349653/970032129163534418) on Discord:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/1417619/166309025-49f8c1d8-8fea-47e3-a858-d72b17398803.png">

It's probably not a huge problem in this specific case, the automation will likely only be triggered once per day, but maybe at some slightly unexpected time depending on the triggers or other conditions. However, pointing users to this template function/filter for checking if a timestamp is today will hopefully be less error prone, as it will handle the comparison no matter the timezone of the input.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: not yet, will provide a documentation PR if/when the PR is deemed acceptable

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
