### PR TITLE
Add use_wallclock_as_timestamps option to generic

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DEFAULT_NAME,
     FFMPEG_OPTION_MAP,
     GET_IMAGE_TIMEOUT,
@@ -63,6 +64,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ),
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
         vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS.keys()),
+        vol.Optional(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, default=False): cv.boolean,
     }
 )
 
@@ -94,6 +96,7 @@ async def async_setup_platform(
         CONF_CONTENT_TYPE: config.get(CONF_CONTENT_TYPE),
         CONF_FRAMERATE: config.get(CONF_FRAMERATE),
         CONF_VERIFY_SSL: config.get(CONF_VERIFY_SSL),
+        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: config.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS),
     }
 
     hass.async_create_task(
@@ -160,6 +163,10 @@ class GenericCamera(Camera):
                 CONF_RTSP_TRANSPORT
             ]
         self._auth = generate_auth(device_info)
+        if device_info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
+            self.stream_options[
+                FFMPEG_OPTION_MAP[CONF_USE_WALLCLOCK_AS_TIMESTAMPS]
+            ] = "1"
 
         self._last_url = None
         self._last_image = None

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -64,7 +64,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ),
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
         vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS.keys()),
-        vol.Optional(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, default=False): cv.boolean,
     }
 )
 
@@ -96,7 +95,6 @@ async def async_setup_platform(
         CONF_CONTENT_TYPE: config.get(CONF_CONTENT_TYPE),
         CONF_FRAMERATE: config.get(CONF_FRAMERATE),
         CONF_VERIFY_SSL: config.get(CONF_VERIFY_SSL),
-        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: config.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS),
     }
 
     hass.async_create_task(

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -365,9 +365,9 @@ class GenericOptionsFlowHandler(OptionsFlow):
                     ],
                     CONF_FRAMERATE: user_input[CONF_FRAMERATE],
                     CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
-                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: user_input.get(
+                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: user_input[
                         CONF_USE_WALLCLOCK_AS_TIMESTAMPS
-                    ),
+                    ],
                 }
                 return self.async_create_entry(
                     title=title,

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DEFAULT_NAME,
     DOMAIN,
     FFMPEG_OPTION_MAP,
@@ -79,6 +80,12 @@ def build_schema(
             CONF_RTSP_TRANSPORT,
             description={"suggested_value": user_input.get(CONF_RTSP_TRANSPORT)},
         ): vol.In(RTSP_TRANSPORTS),
+        vol.Optional(
+            CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+            description={
+                "suggested_value": user_input.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS)
+            },
+        ): bool,
         vol.Optional(
             CONF_AUTHENTICATION,
             description={"suggested_value": user_input.get(CONF_AUTHENTICATION)},
@@ -199,6 +206,8 @@ async def async_test_stream(hass, info) -> dict[str, str]:
             }
         if rtsp_transport := info.get(CONF_RTSP_TRANSPORT):
             stream_options[FFMPEG_OPTION_MAP[CONF_RTSP_TRANSPORT]] = rtsp_transport
+        if info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
+            stream_options[FFMPEG_OPTION_MAP[CONF_USE_WALLCLOCK_AS_TIMESTAMPS]] = "1"
         _LOGGER.debug("Attempting to open stream %s", stream_source)
         container = await hass.async_add_executor_job(
             partial(
@@ -356,6 +365,9 @@ class GenericOptionsFlowHandler(OptionsFlow):
                     ],
                     CONF_FRAMERATE: user_input[CONF_FRAMERATE],
                     CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: user_input.get(
+                        CONF_USE_WALLCLOCK_AS_TIMESTAMPS
+                    ),
                 }
                 return self.async_create_entry(
                     title=title,

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -65,6 +65,7 @@ SUPPORTED_IMAGE_TYPES = {"png", "jpeg", "gif", "svg+xml", "webp"}
 def build_schema(
     user_input: dict[str, Any] | MappingProxyType[str, Any],
     is_options_flow: bool = False,
+    show_advanced_options=False,
 ):
     """Create schema for camera config setup."""
     spec = {
@@ -107,12 +108,13 @@ def build_schema(
                 default=user_input.get(CONF_LIMIT_REFETCH_TO_URL_CHANGE, False),
             )
         ] = bool
-        spec[
-            vol.Required(
-                CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
-                default=user_input.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False),
-            )
-        ] = bool
+        if show_advanced_options:
+            spec[
+                vol.Required(
+                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+                    default=user_input.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False),
+                )
+            ] = bool
     return vol.Schema(spec)
 
 
@@ -365,9 +367,9 @@ class GenericOptionsFlowHandler(OptionsFlow):
                     ],
                     CONF_FRAMERATE: user_input[CONF_FRAMERATE],
                     CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
-                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: user_input[
+                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: user_input.get(
                         CONF_USE_WALLCLOCK_AS_TIMESTAMPS
-                    ],
+                    ),
                 }
                 return self.async_create_entry(
                     title=title,
@@ -375,6 +377,10 @@ class GenericOptionsFlowHandler(OptionsFlow):
                 )
         return self.async_show_form(
             step_id="init",
-            data_schema=build_schema(user_input or self.config_entry.options, True),
+            data_schema=build_schema(
+                user_input or self.config_entry.options,
+                True,
+                self.show_advanced_options,
+            ),
             errors=errors,
         )

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -81,12 +81,6 @@ def build_schema(
             description={"suggested_value": user_input.get(CONF_RTSP_TRANSPORT)},
         ): vol.In(RTSP_TRANSPORTS),
         vol.Optional(
-            CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
-            description={
-                "suggested_value": user_input.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS)
-            },
-        ): bool,
-        vol.Optional(
             CONF_AUTHENTICATION,
             description={"suggested_value": user_input.get(CONF_AUTHENTICATION)},
         ): vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
@@ -111,6 +105,12 @@ def build_schema(
             vol.Required(
                 CONF_LIMIT_REFETCH_TO_URL_CHANGE,
                 default=user_input.get(CONF_LIMIT_REFETCH_TO_URL_CHANGE, False),
+            )
+        ] = bool
+        spec[
+            vol.Required(
+                CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+                default=user_input.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False),
             )
         ] = bool
     return vol.Schema(spec)

--- a/homeassistant/components/generic/const.py
+++ b/homeassistant/components/generic/const.py
@@ -8,7 +8,11 @@ CONF_STILL_IMAGE_URL = "still_image_url"
 CONF_STREAM_SOURCE = "stream_source"
 CONF_FRAMERATE = "framerate"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
-FFMPEG_OPTION_MAP = {CONF_RTSP_TRANSPORT: "rtsp_transport"}
+CONF_USE_WALLCLOCK_AS_TIMESTAMPS = "use_wallclock_as_timestamps"
+FFMPEG_OPTION_MAP = {
+    CONF_RTSP_TRANSPORT: "rtsp_transport",
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: "use_wallclock_as_timestamps",
+}
 RTSP_TRANSPORTS = {
     "tcp": "TCP",
     "udp": "UDP",

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -29,7 +29,6 @@
           "authentication": "Authentication",
           "limit_refetch_to_url_change": "Limit refetch to url change",
           "password": "[%key:common::config_flow::data::password%]",
-          "use_wallclock_as_timestamps": "Rewrite timestamps",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "Frame Rate (Hz)",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -29,6 +29,7 @@
           "authentication": "Authentication",
           "limit_refetch_to_url_change": "Limit refetch to url change",
           "password": "[%key:common::config_flow::data::password%]",
+          "use_wallclock_as_timestamps": "Rewrite timestamps",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "Frame Rate (Hz)",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
@@ -55,6 +56,7 @@
           "authentication": "[%key:component::generic::config::step::user::data::authentication%]",
           "limit_refetch_to_url_change": "[%key:component::generic::config::step::user::data::limit_refetch_to_url_change%]",
           "password": "[%key:common::config_flow::data::password%]",
+          "use_wallclock_as_timestamps": "Rewrite timestamps",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "[%key:component::generic::config::step::user::data::framerate%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -55,7 +55,7 @@
           "authentication": "[%key:component::generic::config::step::user::data::authentication%]",
           "limit_refetch_to_url_change": "[%key:component::generic::config::step::user::data::limit_refetch_to_url_change%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "use_wallclock_as_timestamps": "Rewrite timestamps",
+          "use_wallclock_as_timestamps": "Advanced: Use wallclock as timestamps (usually not required)",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "[%key:component::generic::config::step::user::data::framerate%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -59,6 +59,9 @@
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "[%key:component::generic::config::step::user::data::framerate%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "use_wallclock_as_timestamps": "This option may correct segmenting or crashing issues arising from buggy timestamp implementations on some cameras"
         }
       },
       "content_type": {

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -55,7 +55,7 @@
           "authentication": "[%key:component::generic::config::step::user::data::authentication%]",
           "limit_refetch_to_url_change": "[%key:component::generic::config::step::user::data::limit_refetch_to_url_change%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "use_wallclock_as_timestamps": "Advanced: Use wallclock as timestamps (usually not required)",
+          "use_wallclock_as_timestamps": "Use wallclock as timestamps",
           "username": "[%key:common::config_flow::data::username%]",
           "framerate": "[%key:component::generic::config::step::user::data::framerate%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"

--- a/homeassistant/components/generic/translations/en.json
+++ b/homeassistant/components/generic/translations/en.json
@@ -32,14 +32,12 @@
             "user": {
                 "data": {
                     "authentication": "Authentication",
-                    "content_type": "Content Type",
                     "framerate": "Frame Rate (Hz)",
                     "limit_refetch_to_url_change": "Limit refetch to url change",
                     "password": "Password",
                     "rtsp_transport": "RTSP transport protocol",
                     "still_image_url": "Still Image URL (e.g. http://...)",
                     "stream_source": "Stream Source URL (e.g. rtsp://...)",
-                    "use_wallclock_as_timestamps": "Rewrite timestamps",
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
                 },
@@ -73,16 +71,18 @@
             "init": {
                 "data": {
                     "authentication": "Authentication",
-                    "content_type": "Content Type",
                     "framerate": "Frame Rate (Hz)",
                     "limit_refetch_to_url_change": "Limit refetch to url change",
                     "password": "Password",
                     "rtsp_transport": "RTSP transport protocol",
                     "still_image_url": "Still Image URL (e.g. http://...)",
                     "stream_source": "Stream Source URL (e.g. rtsp://...)",
-                    "use_wallclock_as_timestamps": "Rewrite timestamps",
+                    "use_wallclock_as_timestamps": "Use wallclock as timestamps",
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
+                },
+                "data_description": {
+                    "use_wallclock_as_timestamps": "This option may correct segmenting or crashing issues arising from buggy timestamp implementations on some cameras"
                 }
             }
         }

--- a/homeassistant/components/generic/translations/en.json
+++ b/homeassistant/components/generic/translations/en.json
@@ -39,6 +39,7 @@
                     "rtsp_transport": "RTSP transport protocol",
                     "still_image_url": "Still Image URL (e.g. http://...)",
                     "stream_source": "Stream Source URL (e.g. rtsp://...)",
+                    "use_wallclock_as_timestamps": "Rewrite timestamps",
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
                 },
@@ -79,6 +80,7 @@
                     "rtsp_transport": "RTSP transport protocol",
                     "still_image_url": "Still Image URL (e.g. http://...)",
                     "stream_source": "Stream Source URL (e.g. rtsp://...)",
+                    "use_wallclock_as_timestamps": "Rewrite timestamps",
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
                 }

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -76,6 +76,7 @@ async def test_form(hass, fakeimg_png, mock_av_open, user_flow):
         CONF_CONTENT_TYPE: "image/png",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
+        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()
@@ -109,6 +110,7 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
         CONF_CONTENT_TYPE: "image/png",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
+        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()
@@ -233,6 +235,7 @@ async def test_form_rtsp_mode(hass, fakeimg_png, mock_av_open, user_flow):
         CONF_CONTENT_TYPE: "image/png",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
+        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()
@@ -265,6 +268,7 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
         CONF_CONTENT_TYPE: "image/jpeg",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
+        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -41,11 +41,11 @@ TESTDATA = {
     CONF_PASSWORD: "bambam",
     CONF_FRAMERATE: 5,
     CONF_VERIFY_SSL: False,
-    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
 }
 
 TESTDATA_OPTIONS = {
     CONF_LIMIT_REFETCH_TO_URL_CHANGE: False,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     **TESTDATA,
 }
 
@@ -76,7 +76,6 @@ async def test_form(hass, fakeimg_png, mock_av_open, user_flow):
         CONF_CONTENT_TYPE: "image/png",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
-        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()
@@ -110,7 +109,6 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
         CONF_CONTENT_TYPE: "image/png",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
-        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()
@@ -235,7 +233,6 @@ async def test_form_rtsp_mode(hass, fakeimg_png, mock_av_open, user_flow):
         CONF_CONTENT_TYPE: "image/png",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
-        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()
@@ -268,7 +265,6 @@ async def test_form_only_stream(hass, mock_av_open, fakeimgbytes_jpg):
         CONF_CONTENT_TYPE: "image/jpeg",
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
-        CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
     }
 
     await hass.async_block_till_done()

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.components.generic.const import (
     CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DOMAIN,
 )
 from homeassistant.const import (
@@ -40,6 +41,7 @@ TESTDATA = {
     CONF_PASSWORD: "bambam",
     CONF_FRAMERATE: 5,
     CONF_VERIFY_SSL: False,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
 }
 
 TESTDATA_OPTIONS = {

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -672,7 +672,9 @@ async def test_use_wallclock_as_timestamps_option(hass, fakeimg_png, mock_av_ope
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-        result = await hass.config_entries.options.async_init(mock_entry.entry_id)
+        result = await hass.config_entries.options.async_init(
+            mock_entry.entry_id, context={"show_advanced_options": True}
+        )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "init"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows `generic` to rewrite camera timestamps using the `use_wallclock_as_timestamps ffmpeg` option. Use of this option helps correct various issues including sporadic crashes due to packet corruption and HLS segmenting issues with audio+video streams.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68312
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
