### PR TITLE
Decouple stream options from PyAV options

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -12,7 +12,7 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityFeature,
 )
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
+from homeassistant.components.stream.const import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_AUTHENTICATION,

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -12,7 +12,11 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityFeature,
 )
-from homeassistant.components.stream.const import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
+from homeassistant.components.stream.const import (
+    CONF_RTSP_TRANSPORT,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+    RTSP_TRANSPORTS,
+)
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_AUTHENTICATION,
@@ -37,7 +41,6 @@ from .const import (
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
-    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DEFAULT_NAME,
     GET_IMAGE_TIMEOUT,
 )
@@ -158,9 +161,7 @@ class GenericCamera(Camera):
             self.stream_options[CONF_RTSP_TRANSPORT] = device_info[CONF_RTSP_TRANSPORT]
         self._auth = generate_auth(device_info)
         if device_info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
-            self.stream_options[
-                FFMPEG_OPTION_MAP[CONF_USE_WALLCLOCK_AS_TIMESTAMPS]
-            ] = "1"
+            self.stream_options[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = True
 
         self._last_url = None
         self._last_image = None

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -12,7 +12,7 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityFeature,
 )
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_AUTHENTICATION,
@@ -61,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             cv.small_float, cv.positive_int
         ),
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANS_PROTOCOLS),
+        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS),
     }
 )
 

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -12,6 +12,7 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityFeature,
 )
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_AUTHENTICATION,
@@ -34,14 +35,11 @@ from .const import (
     CONF_CONTENT_TYPE,
     CONF_FRAMERATE,
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
-    CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
     CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DEFAULT_NAME,
-    FFMPEG_OPTION_MAP,
     GET_IMAGE_TIMEOUT,
-    RTSP_TRANSPORTS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             cv.small_float, cv.positive_int
         ),
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS.keys()),
+        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANS_PROTOCOLS),
     }
 )
 
@@ -157,9 +155,7 @@ class GenericCamera(Camera):
         self.content_type = device_info[CONF_CONTENT_TYPE]
         self.verify_ssl = device_info[CONF_VERIFY_SSL]
         if device_info.get(CONF_RTSP_TRANSPORT):
-            self.stream_options[FFMPEG_OPTION_MAP[CONF_RTSP_TRANSPORT]] = device_info[
-                CONF_RTSP_TRANSPORT
-            ]
+            self.stream_options[CONF_RTSP_TRANSPORT] = device_info[CONF_RTSP_TRANSPORT]
         self._auth = generate_auth(device_info)
         if device_info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
             self.stream_options[

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -16,8 +16,12 @@ from httpx import HTTPStatusError, RequestError, TimeoutException
 import voluptuous as vol
 import yarl
 
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
-from homeassistant.components.stream.const import SOURCE_TIMEOUT
+from homeassistant.components.stream.const import (
+    CONF_RTSP_TRANSPORT,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+    RTSP_TRANSPORTS,
+    SOURCE_TIMEOUT,
+)
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import (
     CONF_AUTHENTICATION,
@@ -41,7 +45,6 @@ from .const import (
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
-    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DEFAULT_NAME,
     DOMAIN,
     GET_IMAGE_TIMEOUT,
@@ -198,7 +201,7 @@ async def async_test_stream(hass, info) -> dict[str, str]:
         # For RTSP streams, prefer TCP. This code is duplicated from
         # homeassistant.components.stream.__init__.py:create_stream()
         # It may be possible & better to call create_stream() directly.
-        stream_options: dict[str, str] = {}
+        stream_options: dict[str, bool | str] = {}
         if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
             stream_options = {
                 "rtsp_flags": "prefer_tcp",

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -16,6 +16,7 @@ from httpx import HTTPStatusError, RequestError, TimeoutException
 import voluptuous as vol
 import yarl
 
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
 from homeassistant.components.stream.const import SOURCE_TIMEOUT
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import (
@@ -38,15 +39,12 @@ from .const import (
     CONF_CONTENT_TYPE,
     CONF_FRAMERATE,
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
-    CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
     CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DEFAULT_NAME,
     DOMAIN,
-    FFMPEG_OPTION_MAP,
     GET_IMAGE_TIMEOUT,
-    RTSP_TRANSPORTS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,7 +78,7 @@ def build_schema(
         vol.Optional(
             CONF_RTSP_TRANSPORT,
             description={"suggested_value": user_input.get(CONF_RTSP_TRANSPORT)},
-        ): vol.In(RTSP_TRANSPORTS),
+        ): vol.In(RTSP_TRANS_PROTOCOLS),
         vol.Optional(
             CONF_AUTHENTICATION,
             description={"suggested_value": user_input.get(CONF_AUTHENTICATION)},
@@ -207,9 +205,9 @@ async def async_test_stream(hass, info) -> dict[str, str]:
                 "stimeout": "5000000",
             }
         if rtsp_transport := info.get(CONF_RTSP_TRANSPORT):
-            stream_options[FFMPEG_OPTION_MAP[CONF_RTSP_TRANSPORT]] = rtsp_transport
+            stream_options[CONF_RTSP_TRANSPORT] = rtsp_transport
         if info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
-            stream_options[FFMPEG_OPTION_MAP[CONF_USE_WALLCLOCK_AS_TIMESTAMPS]] = "1"
+            stream_options[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = True
         _LOGGER.debug("Attempting to open stream %s", stream_source)
         container = await hass.async_add_executor_job(
             partial(

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -202,7 +202,7 @@ async def async_test_stream(hass, info) -> dict[str, str]:
         if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
             stream_options = {
                 "rtsp_flags": "prefer_tcp",
-                "timeout": "5000000",
+                "stimeout": "5000000",
             }
         if rtsp_transport := info.get(CONF_RTSP_TRANSPORT):
             stream_options[CONF_RTSP_TRANSPORT] = rtsp_transport

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -202,7 +202,7 @@ async def async_test_stream(hass, info) -> dict[str, str]:
         if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
             stream_options = {
                 "rtsp_flags": "prefer_tcp",
-                "stimeout": "5000000",
+                "timeout": "5000000",
             }
         if rtsp_transport := info.get(CONF_RTSP_TRANSPORT):
             stream_options[CONF_RTSP_TRANSPORT] = rtsp_transport

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -16,7 +16,7 @@ from httpx import HTTPStatusError, RequestError, TimeoutException
 import voluptuous as vol
 import yarl
 
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
 from homeassistant.components.stream.const import SOURCE_TIMEOUT
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import (
@@ -78,7 +78,7 @@ def build_schema(
         vol.Optional(
             CONF_RTSP_TRANSPORT,
             description={"suggested_value": user_input.get(CONF_RTSP_TRANSPORT)},
-        ): vol.In(RTSP_TRANS_PROTOCOLS),
+        ): vol.In(RTSP_TRANSPORTS),
         vol.Optional(
             CONF_AUTHENTICATION,
             description={"suggested_value": user_input.get(CONF_AUTHENTICATION)},

--- a/homeassistant/components/generic/const.py
+++ b/homeassistant/components/generic/const.py
@@ -7,18 +7,6 @@ CONF_LIMIT_REFETCH_TO_URL_CHANGE = "limit_refetch_to_url_change"
 CONF_STILL_IMAGE_URL = "still_image_url"
 CONF_STREAM_SOURCE = "stream_source"
 CONF_FRAMERATE = "framerate"
-CONF_RTSP_TRANSPORT = "rtsp_transport"
-CONF_USE_WALLCLOCK_AS_TIMESTAMPS = "use_wallclock_as_timestamps"
-FFMPEG_OPTION_MAP = {
-    CONF_RTSP_TRANSPORT: "rtsp_transport",
-    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: "use_wallclock_as_timestamps",
-}
-RTSP_TRANSPORTS = {
-    "tcp": "TCP",
-    "udp": "UDP",
-    "udp_multicast": "UDP Multicast",
-    "http": "HTTP",
-}
 GET_IMAGE_TIMEOUT = 10
 
 DEFAULT_USERNAME = None

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -2,7 +2,7 @@
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
 
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
+from homeassistant.components.stream.const import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -2,6 +2,7 @@
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
 
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
@@ -12,13 +13,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import (
-    CONF_RTSP_TRANSPORT,
-    CONF_SNAPSHOT_AUTH,
-    DEFAULT_ARGUMENTS,
-    DOMAIN,
-    RTSP_TRANS_PROTOCOLS,
-)
+from .const import CONF_SNAPSHOT_AUTH, DEFAULT_ARGUMENTS, DOMAIN
 from .device import ONVIFDevice
 
 

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -2,7 +2,7 @@
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
 
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
@@ -94,7 +94,7 @@ async def async_populate_options(hass, entry):
     """Populate default options for device."""
     options = {
         CONF_EXTRA_ARGUMENTS: DEFAULT_ARGUMENTS,
-        CONF_RTSP_TRANSPORT: RTSP_TRANS_PROTOCOLS[0],
+        CONF_RTSP_TRANSPORT: next(iter(RTSP_TRANSPORTS)),
     }
 
     hass.config_entries.async_update_entry(entry, options=options)

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -9,6 +9,7 @@ from yarl import URL
 from homeassistant.components import ffmpeg
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS, get_ffmpeg_manager
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import HTTP_BASIC_AUTHENTICATION
 from homeassistant.core import HomeAssistant
@@ -27,7 +28,6 @@ from .const import (
     ATTR_SPEED,
     ATTR_TILT,
     ATTR_ZOOM,
-    CONF_RTSP_TRANSPORT,
     CONF_SNAPSHOT_AUTH,
     CONTINUOUS_MOVE,
     DIR_DOWN,

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -9,7 +9,7 @@ from yarl import URL
 from homeassistant.components import ffmpeg
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS, get_ffmpeg_manager
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT
+from homeassistant.components.stream.const import CONF_RTSP_TRANSPORT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import HTTP_BASIC_AUTHENTICATION
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -13,7 +13,7 @@ from zeep.exceptions import Fault
 
 from homeassistant import config_entries
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANSPORTS
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -287,9 +287,9 @@ class OnvifOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_RTSP_TRANSPORT,
                         default=self.config_entry.options.get(
-                            CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS[0]
+                            CONF_RTSP_TRANSPORT, next(iter(RTSP_TRANSPORTS))
                         ),
-                    ): vol.In(RTSP_TRANS_PROTOCOLS),
+                    ): vol.In(RTSP_TRANSPORTS),
                 }
             ),
         )

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -13,6 +13,7 @@ from zeep.exceptions import Fault
 
 from homeassistant import config_entries
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT, RTSP_TRANS_PROTOCOLS
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -22,15 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
-from .const import (
-    CONF_DEVICE_ID,
-    CONF_RTSP_TRANSPORT,
-    DEFAULT_ARGUMENTS,
-    DEFAULT_PORT,
-    DOMAIN,
-    LOGGER,
-    RTSP_TRANS_PROTOCOLS,
-)
+from .const import CONF_DEVICE_ID, DEFAULT_ARGUMENTS, DEFAULT_PORT, DOMAIN, LOGGER
 from .device import get_device
 
 CONF_MANUAL_INPUT = "Manually configure ONVIF device"

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -9,10 +9,7 @@ DEFAULT_PORT = 80
 DEFAULT_ARGUMENTS = "-pred 1"
 
 CONF_DEVICE_ID = "deviceid"
-CONF_RTSP_TRANSPORT = "rtsp_transport"
 CONF_SNAPSHOT_AUTH = "snapshot_auth"
-
-RTSP_TRANS_PROTOCOLS = ["tcp", "udp", "udp_multicast", "http"]
 
 ATTR_PAN = "pan"
 ATTR_TILT = "tilt"

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -93,7 +93,7 @@ def create_stream(
     if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
         stream_options = {
             "rtsp_flags": "prefer_tcp",
-            "timeout": "5000000",
+            "stimeout": "5000000",
             **stream_options,
         }
 

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_PART_DURATION,
     CONF_RTSP_TRANSPORT,
     CONF_SEGMENT_DURATION,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DOMAIN,
     HLS_PROVIDER,
     MAX_SEGMENTS,
@@ -489,5 +490,7 @@ def convert_stream_options(stream_options: dict[str, Any]) -> dict[str, str]:
 
     if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
         pyav_options["rtsp_transport"] = rtsp_transport
+    if stream_options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
+        pyav_options["use_wallclock_as_timestamps"] = "1"
 
     return pyav_options

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -23,7 +23,7 @@ import secrets
 import threading
 import time
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import voluptuous as vol
 
@@ -39,12 +39,14 @@ from .const import (
     ATTR_STREAMS,
     CONF_LL_HLS,
     CONF_PART_DURATION,
+    CONF_RTSP_TRANSPORT,
     CONF_SEGMENT_DURATION,
     DOMAIN,
     HLS_PROVIDER,
     MAX_SEGMENTS,
     OUTPUT_IDLE_TIMEOUT,
     RECORDER_PROVIDER,
+    RTSP_TRANS_PROTOCOLS,
     SEGMENT_DURATION_ADJUSTER,
     STREAM_RESTART_INCREMENT,
     STREAM_RESTART_RESET_TIME,
@@ -72,28 +74,32 @@ def redact_credentials(data: str) -> str:
 def create_stream(
     hass: HomeAssistant,
     stream_source: str,
-    options: dict[str, str],
+    options: dict[str, Any],
     stream_label: str | None = None,
 ) -> Stream:
     """Create a stream with the specified identfier based on the source url.
 
     The stream_source is typically an rtsp url (though any url accepted by ffmpeg is fine) and
-    options are passed into pyav / ffmpeg as options.
+    options are converted and passed into pyav / ffmpeg as options.
 
     The stream_label is a string used as an additional message in logging.
     """
     if DOMAIN not in hass.config.components:
         raise HomeAssistantError("Stream integration is not set up.")
 
+    # Convert extra stream options into PyAV options
+    stream_options = convert_stream_options(options)
     # For RTSP streams, prefer TCP
     if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
-        options = {
+        stream_options = {
             "rtsp_flags": "prefer_tcp",
-            "stimeout": "5000000",
-            **options,
+            "timeout": "5000000",
+            **stream_options,
         }
 
-    stream = Stream(hass, stream_source, options=options, stream_label=stream_label)
+    stream = Stream(
+        hass, stream_source, options=stream_options, stream_label=stream_label
+    )
     hass.data[DOMAIN][ATTR_STREAMS].append(stream)
     return stream
 
@@ -464,3 +470,25 @@ class Stream:
 def _should_retry() -> bool:
     """Return true if worker failures should be retried, for disabling during tests."""
     return True
+
+
+STREAM_OPTIONS_SCHEMA: Final = vol.Schema(
+    {
+        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANS_PROTOCOLS),
+    }
+)
+
+
+def convert_stream_options(stream_options: dict[str, Any]) -> dict[str, str]:
+    """Convert options from stream options into PyAV options."""
+    pyav_options: dict[str, str] = {}
+    try:
+        STREAM_OPTIONS_SCHEMA(stream_options)
+    except vol.Invalid as exc:
+        _LOGGER.error("Invalid stream options: %s", exc)
+        return pyav_options
+
+    if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
+        pyav_options["rtsp_transport"] = rtsp_transport
+
+    return pyav_options

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -476,6 +476,7 @@ def _should_retry() -> bool:
 STREAM_OPTIONS_SCHEMA: Final = vol.Schema(
     {
         vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS),
+        vol.Optional(CONF_USE_WALLCLOCK_AS_TIMESTAMPS): bool,
     }
 )
 

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -46,7 +46,7 @@ from .const import (
     MAX_SEGMENTS,
     OUTPUT_IDLE_TIMEOUT,
     RECORDER_PROVIDER,
-    RTSP_TRANS_PROTOCOLS,
+    RTSP_TRANSPORTS,
     SEGMENT_DURATION_ADJUSTER,
     STREAM_RESTART_INCREMENT,
     STREAM_RESTART_RESET_TIME,
@@ -474,7 +474,7 @@ def _should_retry() -> bool:
 
 STREAM_OPTIONS_SCHEMA: Final = vol.Schema(
     {
-        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANS_PROTOCOLS),
+        vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS),
     }
 )
 

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -88,17 +88,17 @@ def create_stream(
         raise HomeAssistantError("Stream integration is not set up.")
 
     # Convert extra stream options into PyAV options
-    stream_options = convert_stream_options(options)
+    pyav_options = convert_stream_options(options)
     # For RTSP streams, prefer TCP
     if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
-        stream_options = {
+        pyav_options = {
             "rtsp_flags": "prefer_tcp",
             "stimeout": "5000000",
-            **stream_options,
+            **pyav_options,
         }
 
     stream = Stream(
-        hass, stream_source, options=stream_options, stream_label=stream_label
+        hass, stream_source, options=pyav_options, stream_label=stream_label
     )
     hass.data[DOMAIN][ATTR_STREAMS].append(stream)
     return stream

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -80,7 +80,7 @@ def create_stream(
     """Create a stream with the specified identfier based on the source url.
 
     The stream_source is typically an rtsp url (though any url accepted by ffmpeg is fine) and
-    options are converted and passed into pyav / ffmpeg as options.
+    options (see STREAM_OPTIONS_SCHEMA) are converted and passed into pyav / ffmpeg.
 
     The stream_label is a string used as an additional message in logging.
     """

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -485,8 +485,7 @@ def convert_stream_options(stream_options: dict[str, Any]) -> dict[str, str]:
     try:
         STREAM_OPTIONS_SCHEMA(stream_options)
     except vol.Invalid as exc:
-        _LOGGER.error("Invalid stream options: %s", exc)
-        return pyav_options
+        raise HomeAssistantError("Invalid stream options") from exc
 
     if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
         pyav_options["rtsp_transport"] = rtsp_transport

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -42,3 +42,7 @@ STREAM_RESTART_RESET_TIME = 300  # Reset wait_timeout after this many seconds
 CONF_LL_HLS = "ll_hls"
 CONF_PART_DURATION = "part_duration"
 CONF_SEGMENT_DURATION = "segment_duration"
+
+CONF_PREFER_TCP = "prefer_tcp"
+CONF_RTSP_TRANSPORT = "rtsp_transport"
+RTSP_TRANS_PROTOCOLS = ["tcp", "udp", "udp_multicast", "http"]

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -45,4 +45,9 @@ CONF_SEGMENT_DURATION = "segment_duration"
 
 CONF_PREFER_TCP = "prefer_tcp"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
-RTSP_TRANS_PROTOCOLS = ["tcp", "udp", "udp_multicast", "http"]
+RTSP_TRANSPORTS = {
+    "tcp": "TCP",
+    "udp": "UDP",
+    "udp_multicast": "UDP Multicast",
+    "http": "HTTP",
+}

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -45,6 +45,7 @@ CONF_SEGMENT_DURATION = "segment_duration"
 
 CONF_PREFER_TCP = "prefer_tcp"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
+# The first dict entry below may be used as the default when populating options
 RTSP_TRANSPORTS = {
     "tcp": "TCP",
     "udp": "UDP",

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -52,3 +52,4 @@ RTSP_TRANSPORTS = {
     "udp_multicast": "UDP Multicast",
     "http": "HTTP",
 }
+CONF_USE_WALLCLOCK_AS_TIMESTAMPS = "use_wallclock_as_timestamps"

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -452,6 +452,10 @@ def stream_worker(
 ) -> None:
     """Handle consuming streams."""
 
+    if av.library_versions["libavformat"][0] >= 59:
+        # the stimeout option was renamed to timeout as of ffmpeg 5.0
+        options["timeout"] = options["stimeout"]
+        del options["stimeout"]
     try:
         container = av.open(source, options=options, timeout=SOURCE_TIMEOUT)
     except av.AVError as err:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -452,7 +452,7 @@ def stream_worker(
 ) -> None:
     """Handle consuming streams."""
 
-    if av.library_versions["libavformat"][0] >= 59:
+    if av.library_versions["libavformat"][0] >= 59 and "stimeout" in options:
         # the stimeout option was renamed to timeout as of ffmpeg 5.0
         options["timeout"] = options["stimeout"]
         del options["stimeout"]

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -17,10 +17,12 @@ from homeassistant.components.generic.const import (
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
-    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DOMAIN,
 )
-from homeassistant.components.stream import CONF_RTSP_TRANSPORT
+from homeassistant.components.stream.const import (
+    CONF_RTSP_TRANSPORT,
+    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+)
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_NAME,

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -15,12 +15,12 @@ from homeassistant.components.generic.const import (
     CONF_CONTENT_TYPE,
     CONF_FRAMERATE,
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
-    CONF_RTSP_TRANSPORT,
     CONF_STILL_IMAGE_URL,
     CONF_STREAM_SOURCE,
     CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
     DOMAIN,
 )
+from homeassistant.components.stream import CONF_RTSP_TRANSPORT
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_NAME,

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -323,12 +323,12 @@ async def test_option_flow(hass):
         result["flow_id"],
         user_input={
             config_flow.CONF_EXTRA_ARGUMENTS: "",
-            config_flow.CONF_RTSP_TRANSPORT: config_flow.RTSP_TRANS_PROTOCOLS[1],
+            config_flow.CONF_RTSP_TRANSPORT: list(config_flow.RTSP_TRANSPORTS)[1],
         },
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"] == {
         config_flow.CONF_EXTRA_ARGUMENTS: "",
-        config_flow.CONF_RTSP_TRANSPORT: config_flow.RTSP_TRANS_PROTOCOLS[1],
+        config_flow.CONF_RTSP_TRANSPORT: list(config_flow.RTSP_TRANSPORTS)[1],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`create_stream()` takes an options dict and passes it straight through to PyAV, which passes it straight into the ffmpeg libraries. This PR adds an intermediate layer through the new `STREAM_OPTIONS_SCHEMA` and `convert_stream_options()` function to decouple the options used internally in stream from the options used in ffmpeg. This allows us to 1) restrict the options used to a subset we have tested while also sanitizing them if necessary, 2) change the syntax of the stream options, and potentially 3) group some PyAV options together in a single stream option.
This PR doesn't break anything in core, as the appropriate changes have been made to generic and ONVIF, but this may break some custom components which implement `Camera`  and use the `stream_options` member to pass in custom PyAV options.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently `create_stream()` takes an options dict which (after having two options added) passes through to the `Stream` constructor, which in turn passes the options through the stream worker, eventually ending up in the PyAV av.open() function. These options ~don't seem to be used in the HA code base~ are used in ONVIF and generic, so those uses were changed here, but it's possible that some custom components also use them.
This PR removes passing the options through directly, decoupling the camera/stream interface from the PyAV API. (Note that currently only one option is supported, and that option is still effectively passed through as is.) If desired, specific options can be defined and checked against in create_stream and then added to the options dict. For example, #71245 can add a boolean option `{"rewrite_timestamps" : True}` instead of having to know about the PyAV option `{"use_wallclock_as_timestamps": "1"}`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
