### PR TITLE
Move recorder services to services.py

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -188,6 +188,7 @@ homeassistant.components.recorder.pool
 homeassistant.components.recorder.purge
 homeassistant.components.recorder.repack
 homeassistant.components.recorder.run_history
+homeassistant.components.recorder.services
 homeassistant.components.recorder.statistics
 homeassistant.components.recorder.system_health
 homeassistant.components.recorder.tasks

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.const import CONF_EXCLUDE, EVENT_STATE_CHANGED
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import (
     INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA,
@@ -17,15 +17,11 @@ from homeassistant.helpers.entityfilter import (
 from homeassistant.helpers.integration_platform import (
     async_process_integration_platforms,
 )
-from homeassistant.helpers.service import async_extract_entity_ids
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from . import history, statistics, websocket_api
 from .const import (
-    ATTR_APPLY_FILTER,
-    ATTR_KEEP_DAYS,
-    ATTR_REPACK,
     CONF_DB_INTEGRITY_CHECK,
     DATA_INSTANCE,
     DOMAIN,
@@ -33,38 +29,11 @@ from .const import (
     SQLITE_URL_PREFIX,
 )
 from .core import Recorder
+from .services import async_register_services
 from .tasks import AddRecorderPlatformTask
 
 _LOGGER = logging.getLogger(__name__)
 
-
-SERVICE_PURGE = "purge"
-SERVICE_PURGE_ENTITIES = "purge_entities"
-SERVICE_ENABLE = "enable"
-SERVICE_DISABLE = "disable"
-
-
-SERVICE_PURGE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_KEEP_DAYS): cv.positive_int,
-        vol.Optional(ATTR_REPACK, default=False): cv.boolean,
-        vol.Optional(ATTR_APPLY_FILTER, default=False): cv.boolean,
-    }
-)
-
-ATTR_DOMAINS = "domains"
-ATTR_ENTITY_GLOBS = "entity_globs"
-
-SERVICE_PURGE_ENTITIES_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_DOMAINS, default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(ATTR_ENTITY_GLOBS, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
-    }
-).extend(cv.ENTITY_SERVICE_FIELDS)
-SERVICE_ENABLE_SCHEMA = vol.Schema({})
-SERVICE_DISABLE_SCHEMA = vol.Schema({})
 
 DEFAULT_URL = "sqlite:///{hass_config_path}"
 DEFAULT_DB_FILE = "home-assistant_v2.db"
@@ -196,7 +165,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     instance.async_initialize()
     instance.async_register()
     instance.start()
-    _async_register_services(hass, instance)
+    async_register_services(hass, instance)
     history.async_setup(hass)
     statistics.async_setup(hass)
     websocket_api.async_setup(hass)
@@ -211,51 +180,3 @@ async def _process_recorder_platform(
     """Process a recorder platform."""
     instance: Recorder = hass.data[DATA_INSTANCE]
     instance.queue.put(AddRecorderPlatformTask(domain, platform))
-
-
-@callback
-def _async_register_services(hass: HomeAssistant, instance: Recorder) -> None:
-    """Register recorder services."""
-
-    async def async_handle_purge_service(service: ServiceCall) -> None:
-        """Handle calls to the purge service."""
-        instance.do_adhoc_purge(**service.data)
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_PURGE, async_handle_purge_service, schema=SERVICE_PURGE_SCHEMA
-    )
-
-    async def async_handle_purge_entities_service(service: ServiceCall) -> None:
-        """Handle calls to the purge entities service."""
-        entity_ids = await async_extract_entity_ids(hass, service)
-        domains = service.data.get(ATTR_DOMAINS, [])
-        entity_globs = service.data.get(ATTR_ENTITY_GLOBS, [])
-
-        instance.do_adhoc_purge_entities(entity_ids, domains, entity_globs)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_PURGE_ENTITIES,
-        async_handle_purge_entities_service,
-        schema=SERVICE_PURGE_ENTITIES_SCHEMA,
-    )
-
-    async def async_handle_enable_service(service: ServiceCall) -> None:
-        instance.set_enable(True)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ENABLE,
-        async_handle_enable_service,
-        schema=SERVICE_ENABLE_SCHEMA,
-    )
-
-    async def async_handle_disable_service(service: ServiceCall) -> None:
-        instance.set_enable(False)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_DISABLE,
-        async_handle_disable_service,
-        schema=SERVICE_DISABLE_SCHEMA,
-    )

--- a/homeassistant/components/recorder/services.py
+++ b/homeassistant/components/recorder/services.py
@@ -1,0 +1,106 @@
+"""Support for recorder services."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.service import async_extract_entity_ids
+
+from .const import ATTR_APPLY_FILTER, ATTR_KEEP_DAYS, ATTR_REPACK, DOMAIN
+from .core import Recorder
+
+SERVICE_PURGE = "purge"
+SERVICE_PURGE_ENTITIES = "purge_entities"
+SERVICE_ENABLE = "enable"
+SERVICE_DISABLE = "disable"
+
+
+SERVICE_PURGE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_KEEP_DAYS): cv.positive_int,
+        vol.Optional(ATTR_REPACK, default=False): cv.boolean,
+        vol.Optional(ATTR_APPLY_FILTER, default=False): cv.boolean,
+    }
+)
+
+ATTR_DOMAINS = "domains"
+ATTR_ENTITY_GLOBS = "entity_globs"
+
+SERVICE_PURGE_ENTITIES_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_DOMAINS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_ENTITY_GLOBS, default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+    }
+).extend(cv.ENTITY_SERVICE_FIELDS)
+
+SERVICE_ENABLE_SCHEMA = vol.Schema({})
+SERVICE_DISABLE_SCHEMA = vol.Schema({})
+
+
+@callback
+def _async_register_purge_service(hass: HomeAssistant, instance: Recorder) -> None:
+    async def async_handle_purge_service(service: ServiceCall) -> None:
+        """Handle calls to the purge service."""
+        instance.do_adhoc_purge(**service.data)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_PURGE, async_handle_purge_service, schema=SERVICE_PURGE_SCHEMA
+    )
+
+
+@callback
+def _async_register_purge_entities_service(
+    hass: HomeAssistant, instance: Recorder
+) -> None:
+    async def async_handle_purge_entities_service(service: ServiceCall) -> None:
+        """Handle calls to the purge entities service."""
+        entity_ids = await async_extract_entity_ids(hass, service)
+        domains = service.data.get(ATTR_DOMAINS, [])
+        entity_globs = service.data.get(ATTR_ENTITY_GLOBS, [])
+
+        instance.do_adhoc_purge_entities(entity_ids, domains, entity_globs)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_PURGE_ENTITIES,
+        async_handle_purge_entities_service,
+        schema=SERVICE_PURGE_ENTITIES_SCHEMA,
+    )
+
+
+@callback
+def _async_register_enable_service(hass: HomeAssistant, instance: Recorder) -> None:
+    async def async_handle_enable_service(service: ServiceCall) -> None:
+        instance.set_enable(True)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ENABLE,
+        async_handle_enable_service,
+        schema=SERVICE_ENABLE_SCHEMA,
+    )
+
+
+@callback
+def _async_register_disable_service(hass: HomeAssistant, instance: Recorder) -> None:
+    async def async_handle_disable_service(service: ServiceCall) -> None:
+        instance.set_enable(False)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DISABLE,
+        async_handle_disable_service,
+        schema=SERVICE_DISABLE_SCHEMA,
+    )
+
+
+@callback
+def async_register_services(hass: HomeAssistant, instance: Recorder) -> None:
+    """Register recorder services."""
+    _async_register_purge_service(hass, instance)
+    _async_register_purge_entities_service(hass, instance)
+    _async_register_enable_service(hass, instance)
+    _async_register_disable_service(hass, instance)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1831,6 +1831,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.recorder.services]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.recorder.statistics]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -20,10 +20,6 @@ from homeassistant.components.recorder import (
     CONF_DB_URL,
     CONFIG_SCHEMA,
     DOMAIN,
-    SERVICE_DISABLE,
-    SERVICE_ENABLE,
-    SERVICE_PURGE,
-    SERVICE_PURGE_ENTITIES,
     SQLITE_URL_PREFIX,
     Recorder,
     get_instance,
@@ -37,6 +33,12 @@ from homeassistant.components.recorder.models import (
     States,
     StatisticsRuns,
     process_timestamp,
+)
+from homeassistant.components.recorder.services import (
+    SERVICE_DISABLE,
+    SERVICE_ENABLE,
+    SERVICE_PURGE,
+    SERVICE_PURGE_ENTITIES,
 )
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import (

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -19,6 +19,10 @@ from homeassistant.components.recorder.models import (
     StatisticsShortTerm,
 )
 from homeassistant.components.recorder.purge import purge_old_data
+from homeassistant.components.recorder.services import (
+    SERVICE_PURGE,
+    SERVICE_PURGE_ENTITIES,
+)
 from homeassistant.components.recorder.tasks import PurgeTask
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_ON
@@ -133,9 +137,7 @@ async def test_purge_old_states_encouters_database_corruption(
         "homeassistant.components.recorder.purge.purge_old_data",
         side_effect=sqlite3_exception,
     ):
-        await hass.services.async_call(
-            recorder.DOMAIN, recorder.SERVICE_PURGE, {"keep_days": 0}
-        )
+        await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, {"keep_days": 0})
         await hass.async_block_till_done()
         await async_wait_recording_done(hass)
 
@@ -169,9 +171,7 @@ async def test_purge_old_states_encounters_temporary_mysql_error(
     ), patch.object(
         instance.engine.dialect, "name", "mysql"
     ):
-        await hass.services.async_call(
-            recorder.DOMAIN, recorder.SERVICE_PURGE, {"keep_days": 0}
-        )
+        await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, {"keep_days": 0})
         await hass.async_block_till_done()
         await async_wait_recording_done(hass)
         await async_wait_recording_done(hass)
@@ -197,9 +197,7 @@ async def test_purge_old_states_encounters_operational_error(
         "homeassistant.components.recorder.purge._purge_old_recorder_runs",
         side_effect=exception,
     ):
-        await hass.services.async_call(
-            recorder.DOMAIN, recorder.SERVICE_PURGE, {"keep_days": 0}
-        )
+        await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, {"keep_days": 0})
         await hass.async_block_till_done()
         await async_wait_recording_done(hass)
         await async_wait_recording_done(hass)
@@ -452,9 +450,7 @@ async def test_purge_edge_case(
         events = session.query(Events).filter(Events.event_type == "EVENT_TEST_PURGE")
         assert events.count() == 1
 
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await hass.async_block_till_done()
 
     await async_recorder_block_till_done(hass)
@@ -722,9 +718,7 @@ async def test_purge_filtered_states(
         assert events_keep.count() == 1
 
     # Normal purge doesn't remove excluded entities
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await hass.async_block_till_done()
 
     await async_recorder_block_till_done(hass)
@@ -742,9 +736,7 @@ async def test_purge_filtered_states(
 
     # Test with 'apply_filter' = True
     service_data["apply_filter"] = True
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await hass.async_block_till_done()
 
     await async_recorder_block_till_done(hass)
@@ -780,9 +772,7 @@ async def test_purge_filtered_states(
         assert session.query(StateAttributes).count() == 11
 
     # Do it again to make sure nothing changes
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
@@ -794,9 +784,7 @@ async def test_purge_filtered_states(
         assert session.query(StateAttributes).count() == 11
 
     service_data = {"keep_days": 0}
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
@@ -844,9 +832,7 @@ async def test_purge_filtered_states_to_empty(
 
     # Test with 'apply_filter' = True
     service_data["apply_filter"] = True
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
@@ -858,9 +844,7 @@ async def test_purge_filtered_states_to_empty(
 
     # Do it again to make sure nothing changes
     # Why do we do this? Should we check the end result?
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
@@ -914,9 +898,7 @@ async def test_purge_without_state_attributes_filtered_states_to_empty(
 
     # Test with 'apply_filter' = True
     service_data["apply_filter"] = True
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
@@ -928,9 +910,7 @@ async def test_purge_without_state_attributes_filtered_states_to_empty(
 
     # Do it again to make sure nothing changes
     # Why do we do this? Should we check the end result?
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
@@ -985,9 +965,7 @@ async def test_purge_filtered_events(
         assert states.count() == 10
 
     # Normal purge doesn't remove excluded events
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await hass.async_block_till_done()
 
     await async_recorder_block_till_done(hass)
@@ -1005,9 +983,7 @@ async def test_purge_filtered_events(
 
     # Test with 'apply_filter' = True
     service_data["apply_filter"] = True
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await hass.async_block_till_done()
 
     await async_recorder_block_till_done(hass)
@@ -1105,9 +1081,7 @@ async def test_purge_filtered_events_state_changed(
         assert events_purge.count() == 60
         assert states.count() == 63
 
-    await hass.services.async_call(
-        recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
-    )
+    await hass.services.async_call(recorder.DOMAIN, SERVICE_PURGE, service_data)
     await hass.async_block_till_done()
 
     await async_recorder_block_till_done(hass)
@@ -1146,7 +1120,7 @@ async def test_purge_entities(
         }
 
         await hass.services.async_call(
-            recorder.DOMAIN, recorder.SERVICE_PURGE_ENTITIES, service_data
+            recorder.DOMAIN, SERVICE_PURGE_ENTITIES, service_data
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move recorder services to services.py

This is a code relocation only.  No functional changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
