### PR TITLE
Create ISY auxiliary sensors as sensor entities instead of attributes

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -41,6 +41,7 @@ from .const import (
     MANUFACTURER,
     PLATFORMS,
     PROGRAM_PLATFORMS,
+    SENSOR_AUX,
 )
 from .helpers import _categorize_nodes, _categorize_programs, _categorize_variables
 from .services import async_setup_services, async_unload_services
@@ -120,7 +121,7 @@ async def async_setup_entry(
     hass.data[DOMAIN][entry.entry_id] = {}
     hass_isy_data = hass.data[DOMAIN][entry.entry_id]
 
-    hass_isy_data[ISY994_NODES] = {}
+    hass_isy_data[ISY994_NODES] = {SENSOR_AUX: []}
     for platform in PLATFORMS:
         hass_isy_data[ISY994_NODES][platform] = []
 

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -191,6 +191,8 @@ UOM_INDEX = "25"
 UOM_ON_OFF = "2"
 UOM_PERCENTAGE = "51"
 
+SENSOR_AUX = "sensor_aux"
+
 # Do not use the Home Assistant consts for the states here - we're matching exact API
 # responses, not using them for Home Assistant states
 # Insteon Types: https://www.universal-devices.com/developers/wsdk/5.0.4/1_fam.xml

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -44,6 +44,7 @@ from .const import (
     NODE_FILTERS,
     PLATFORMS,
     PROGRAM_PLATFORMS,
+    SENSOR_AUX,
     SUBNODE_CLIMATE_COOL,
     SUBNODE_CLIMATE_HEAT,
     SUBNODE_EZIO2X4_SENSORS,
@@ -294,6 +295,10 @@ def _categorize_nodes(
         if hasattr(node, "protocol") and node.protocol == PROTO_GROUP:
             hass_isy_data[ISY994_NODES][ISY_GROUP_PLATFORM].append(node)
             continue
+
+        if getattr(node, "protocol", None) == PROTO_INSTEON:
+            for control in node.aux_properties:
+                hass_isy_data[ISY994_NODES][SENSOR_AUX].append((node, control))
 
         if sensor_identifier in path or sensor_identifier in node.name:
             # User has specified to treat this as a sensor. First we need to

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyisy.constants import ISY_VALUE_UNKNOWN
+from pyisy.constants import COMMAND_FRIENDLY_NAME, ISY_VALUE_UNKNOWN
+from pyisy.helpers import NodeProperty
+from pyisy.nodes import Node
 
-from homeassistant.components.sensor import DOMAIN as SENSOR, SensorEntity
+from homeassistant.components.sensor import (
+    DOMAIN as SENSOR,
+    SensorDeviceClass,
+    SensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
@@ -16,6 +22,7 @@ from .const import (
     DOMAIN as ISY994_DOMAIN,
     ISY994_NODES,
     ISY994_VARIABLES,
+    SENSOR_AUX,
     UOM_DOUBLE_TEMP,
     UOM_FRIENDLY_NAME,
     UOM_INDEX,
@@ -24,6 +31,20 @@ from .const import (
 )
 from .entity import ISYEntity, ISYNodeEntity
 from .helpers import convert_isy_value_to_hass, migrate_old_unique_ids
+
+# Disable general purpose and redundant sensors by default
+AUX_DISABLED_BY_DEFAULT = ["ERR", "GV", "CLIEMD", "CLIHCS", "DO", "OL", "RR", "ST"]
+
+ISY_CONTROL_TO_DEVICE_CLASS = {
+    "BARPRES": SensorDeviceClass.PRESSURE,
+    "BATLVL": SensorDeviceClass.BATTERY,
+    "CLIHUM": SensorDeviceClass.HUMIDITY,
+    "CLITEMP": SensorDeviceClass.TEMPERATURE,
+    "CO2LVL": SensorDeviceClass.CO2,
+    "CV": SensorDeviceClass.VOLTAGE,
+    "LUMIN": SensorDeviceClass.ILLUMINANCE,
+    "PF": SensorDeviceClass.POWER_FACTOR,
+}
 
 
 async def async_setup_entry(
@@ -37,6 +58,13 @@ async def async_setup_entry(
         _LOGGER.debug("Loading %s", node.name)
         entities.append(ISYSensorEntity(node))
 
+    for node, control in hass_isy_data[ISY994_NODES][SENSOR_AUX]:
+        _LOGGER.debug("Loading %s %s", node.name, node.aux_properties[control])
+        enabled_default = not any(
+            control.startswith(match) for match in AUX_DISABLED_BY_DEFAULT
+        )
+        entities.append(ISYAuxSensorEntity(node, control, enabled_default))
+
     for vname, vobj in hass_isy_data[ISY994_VARIABLES]:
         entities.append(ISYSensorVariableEntity(vname, vobj))
 
@@ -48,9 +76,19 @@ class ISYSensorEntity(ISYNodeEntity, SensorEntity):
     """Representation of an ISY994 sensor device."""
 
     @property
+    def target(self) -> Node | NodeProperty:
+        """Return target for the sensor."""
+        return self._node
+
+    @property
+    def target_value(self) -> Any:
+        """Return the target value."""
+        return self._node.status
+
+    @property
     def raw_unit_of_measurement(self) -> dict | str | None:
         """Get the raw unit of measurement for the ISY994 sensor device."""
-        uom = self._node.uom
+        uom = self.target.uom
 
         # Backwards compatibility for ISYv4 Firmware:
         if isinstance(uom, list):
@@ -69,7 +107,7 @@ class ISYSensorEntity(ISYNodeEntity, SensorEntity):
     @property
     def native_value(self) -> float | int | str | None:
         """Get the state of the ISY994 sensor device."""
-        if (value := self._node.status) == ISY_VALUE_UNKNOWN:
+        if (value := self.target_value) == ISY_VALUE_UNKNOWN:
             return None
 
         # Get the translated ISY Unit of Measurement
@@ -80,14 +118,14 @@ class ISYSensorEntity(ISYNodeEntity, SensorEntity):
             return uom.get(value, value)
 
         if uom in (UOM_INDEX, UOM_ON_OFF):
-            return cast(str, self._node.formatted)
+            return cast(str, self.target.formatted)
 
         # Check if this is an index type and get formatted value
-        if uom == UOM_INDEX and hasattr(self._node, "formatted"):
-            return cast(str, self._node.formatted)
+        if uom == UOM_INDEX and hasattr(self.target, "formatted"):
+            return cast(str, self.target.formatted)
 
         # Handle ISY precision and rounding
-        value = convert_isy_value_to_hass(value, uom, self._node.prec)
+        value = convert_isy_value_to_hass(value, uom, self.target.prec)
 
         # Convert temperatures to Home Assistant's unit
         if uom in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
@@ -109,6 +147,45 @@ class ISYSensorEntity(ISYNodeEntity, SensorEntity):
         if raw_units in (TEMP_FAHRENHEIT, TEMP_CELSIUS, UOM_DOUBLE_TEMP):
             return self.hass.config.units.temperature_unit
         return raw_units
+
+
+class ISYAuxSensorEntity(ISYSensorEntity):
+    """Representation of an ISY994 aux sensor device."""
+
+    def __init__(self, node: Node, control: str, enabled_default: bool) -> None:
+        """Initialize the ISY994 aux sensor."""
+        super().__init__(node)
+        self._control = control
+        self._attr_entity_registry_enabled_default = enabled_default
+
+    @property
+    def device_class(self) -> SensorDeviceClass | str | None:
+        """Return the device class for the sensor."""
+        return ISY_CONTROL_TO_DEVICE_CLASS.get(self._control, super().device_class)
+
+    @property
+    def target(self) -> Node | NodeProperty:
+        """Return target for the sensor."""
+        return cast(NodeProperty, self._node.aux_properties[self._control])
+
+    @property
+    def target_value(self) -> Any:
+        """Return the target value."""
+        return self.target.value
+
+    @property
+    def unique_id(self) -> str | None:
+        """Get the unique identifier of the device and aux sensor."""
+        if not hasattr(self._node, "address"):
+            return None
+        return f"{self._node.isy.configuration['uuid']}_{self._node.address}_{self._control}"
+
+    @property
+    def name(self) -> str:
+        """Get the name of the device and aux sensor."""
+        base_name = self._name or str(self._node.name)
+        name = COMMAND_FRIENDLY_NAME.get(self._control, self._control)
+        return f"{base_name} {name.replace('_', ' ').title()}"
 
 
 class ISYSensorVariableEntity(ISYEntity, SensorEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The auxiliary sensors for each insteon device are now
their own sensor entity instead of an attribute on
the parent entity which makes them easier to find and allows
attributes to be de-duplicated in the database.

<img width="685" alt="Screen Shot 2022-05-03 at 11 42 59" src="https://user-images.githubusercontent.com/663432/166500127-811e328d-b0ab-4b6c-8ae4-416125a413df.png">

General purpose, custom control, and redundant sensors are not enabled
by default.  If they are desired, they can be enabled in the UI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
