### PR TITLE
Add currently playing track's context to Spotify's state attributes

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -242,6 +242,16 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         return self._playlist["name"]
 
     @property
+    def media_context_id(self):
+        """The url of the context (e.g. album, playlist) of the currently playing track"""
+        if (
+            not self._currently_playing
+            or self._currently_playing.get("context") is None
+        ):
+            return None
+        return self._currently_playing["context"]["uri"]
+
+    @property
     def source(self) -> str | None:
         """Return the current playback device."""
         if not self._currently_playing:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -243,7 +243,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
 
     @property
     def media_context_id(self):
-        """The url of the context (e.g. album, playlist) of the currently playing track"""
+        """Return the url of the context (e.g. album, playlist) of the currently playing track."""
         if (
             not self._currently_playing
             or self._currently_playing.get("context") is None


### PR DESCRIPTION
## Proposed change
Allows identification of the spotify URI of the context of
the current track.  For example, if the song is playing
as part of a playlist, this returns a `spotify:playlist:xxx`
URI.  If it's playing as part of an album, it will return
a `spotify:album:xxx` URI.

This is helpful to enable transferring the context to a new
media player on a location change.  For example, if I'm playing
Spotify in my car and I'd like to transfer to my Sonos system
when I arrive home, I can grab the context and then call
`media_player.play_media` with that context.

To some extent, this is a workaround due to the poor spotify &
sonos integration, as Sonos speakers are not available as spotify
sources and thus it's not possible to select a new source for
the currently playing track.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I couldn't find any requests for this information but I know I could use it!

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
