### PR TITLE
Add visual image preview during generic camera config flow

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -284,8 +284,8 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize Generic ConfigFlow."""
-        self.cached_user_input: dict[str, Any] = {}
-        self.cached_title = ""
+        self.user_input: dict[str, Any] = {}
+        self.title = ""
 
     @staticmethod
     def async_get_options_flow(
@@ -330,8 +330,8 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                         # The automatically generated still image that stream generates
                         # is always jpeg
                         user_input[CONF_CONTENT_TYPE] = "image/jpeg"
-                    self.cached_user_input = user_input
-                    self.cached_title = name
+                    self.user_input = user_input
+                    self.title = name
 
                     # Register a temporary view so that we can show a preview
                     register_preview(hass, self.flow_id, user_input)
@@ -362,11 +362,11 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         if not user_input.get(CONF_CONFIRMED_OK):
             return self.async_show_form(
                 step_id="user",
-                data_schema=build_schema(self.cached_user_input),
+                data_schema=build_schema(self.user_input),
                 errors={},
             )
         return self.async_create_entry(
-            title=self.cached_title, data={}, options=self.cached_user_input
+            title=self.title, data={}, options=self.user_input
         )
 
     async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -336,6 +336,8 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                     # temporary preview for user to check the image
                     self.context["preview_cam"] = user_input
                     return await self.async_step_user_confirm_still()
+        elif self.user_input:
+            user_input = self.user_input
         else:
             user_input = DEFAULT_DATA.copy()
         return self.async_show_form(
@@ -350,11 +352,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle user clicking confirm after still preview."""
         if user_input:
             if not user_input.get(CONF_CONFIRMED_OK):
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=build_schema(self.user_input),
-                    errors={},
-                )
+                return await self.async_step_user()
             return self.async_create_entry(
                 title=self.title, data={}, options=self.user_input
             )

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -272,14 +272,11 @@ async def async_test_stream(
 
 def register_preview(hass: HomeAssistant):
     """Set up previews for camera feeds during config flow."""
-    if not hass.data.get(DOMAIN):
-        hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
 
     if not hass.data[DOMAIN].get(PREVIEW):
         _LOGGER.debug("Registering camera image preview handler")
-        preview = CameraImagePreview(hass)
-
-        hass.http.register_view(preview)
+        hass.http.register_view(CameraImagePreview(hass))
         hass.data[DOMAIN][PREVIEW] = True
 
 

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -68,7 +68,6 @@ DEFAULT_DATA = {
 
 SUPPORTED_IMAGE_TYPES = {"png", "jpeg", "gif", "svg+xml", "webp"}
 IMAGE_PREVIEWS_ACTIVE = "previews"
-PREVIEW_EXPIRY_TIME = 5  # minutes
 
 
 def build_schema(

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -327,7 +327,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                     preview_id = f"{self.flow_id}_{self.preview_iterator}"
                     cam = GenericCamera(self.hass, user_input, preview_id, "preview")
                     self.temp_view = CameraImagePreView(self.hass, cam, preview_id)
-                    preview_url = f"/api/camera_preview_proxy/{preview_id}"
+                    preview_url = f"/api/generic/preview_flow/{preview_id}"
                     return self.async_show_form(
                         step_id="user_confirm_still",
                         data_schema=vol.Schema(
@@ -451,7 +451,7 @@ class GenericOptionsFlowHandler(OptionsFlow):
 class CameraImagePreView(CameraImageView):
     """Camera view to temporarily serve an image."""
 
-    name = "api:camera:imgepreview"
+    name = "api:generic:preview_flow_image"
     previews: dict[str, GenericCamera] = {}
     initialized = False
 
@@ -462,7 +462,7 @@ class CameraImagePreView(CameraImageView):
         self.preview_id = preview_id
         if not self.initialized:
             super().__init__(EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL))
-            self.url = "/api/camera_preview_proxy/{entity_id}"
+            self.url = "/api/generic/preview_flow_image/{entity_id}"
             hass.http.register_view(self)
 
         _LOGGER.debug("Adding temporary camera preview '%s'", preview_id)

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -334,9 +334,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.title = name
 
                     # temporary preview for user to check the image
-                    self.context["preview_cam"] = GenericCamera(
-                        self.hass, user_input, self.flow_id, "preview"
-                    )
+                    self.context["preview_cam"] = user_input
                     return await self.async_step_user_confirm_still()
         else:
             user_input = DEFAULT_DATA.copy()
@@ -476,7 +474,8 @@ class CameraImagePreview(HomeAssistantView):
             flow: FlowResult = self.hass.config_entries.flow.async_get(flow_id)
         except UnknownFlow as exc:
             raise web.HTTPNotFound() from exc
-        camera = flow["context"]["preview_cam"]
+        user_input = flow["context"]["preview_cam"]
+        camera = GenericCamera(self.hass, user_input, flow_id, "preview")
         if not camera.is_on:
             _LOGGER.debug("Camera is off")
             raise web.HTTPServiceUnavailable()

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -472,18 +472,11 @@ class CameraImagePreview(HomeAssistantView):
         _LOGGER.debug("processing GET request for flow_id=%s", flow_id)
         camera = self.hass.data[DOMAIN][PREVIEWS][flow_id]
 
-        if camera is None:
-            _LOGGER.warning("Not valid")
-            raise web.HTTPNotFound()
         if not camera.is_on:
             _LOGGER.debug("Camera is off")
             raise web.HTTPServiceUnavailable()
-        try:
-            image = await _async_get_image(
-                camera,
-                CAMERA_IMAGE_TIMEOUT,
-            )
-        except (ValueError) as ex:
-            raise web.HTTPInternalServerError() from ex
-        else:
-            return web.Response(body=image.content, content_type=image.content_type)
+        image = await _async_get_image(
+            camera,
+            CAMERA_IMAGE_TIMEOUT,
+        )
+        return web.Response(body=image.content, content_type=image.content_type)

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -203,7 +203,7 @@ def slug(
         url = template.async_render(parse_result=False)
         return slugify(yarl.URL(url).host)
     except (ValueError, TemplateError, TypeError) as err:
-        _LOGGER.error("Syntax error in '%s': %s", url, err)
+        _LOGGER.error("Syntax error in '%s': %s", template, err)
     return None
 
 

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -273,7 +273,7 @@ def register_preview(hass: HomeAssistant, flow_id: str, user_input: dict[str, An
     if not hass.data[DOMAIN].get(PREVIEWS):
         _LOGGER.debug("Registering camera image preview handler")
         hass.http.register_view(CameraImagePreview(hass))
-        hass.data[DOMAIN][PREVIEWS] = {}
+    hass.data[DOMAIN][PREVIEWS] = {}
     hass.data[DOMAIN][PREVIEWS][flow_id] = user_input
 
 

--- a/homeassistant/components/generic/const.py
+++ b/homeassistant/components/generic/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "generic"
 DEFAULT_NAME = "Generic Camera"
+CONF_CONFIRMED_OK = "confirmed_ok"
 CONF_CONTENT_TYPE = "content_type"
 CONF_LIMIT_REFETCH_TO_URL_CHANGE = "limit_refetch_to_url_change"
 CONF_STILL_IMAGE_URL = "still_image_url"

--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -3,6 +3,7 @@
   "name": "Generic Camera",
   "config_flow": true,
   "requirements": ["ha-av==10.0.0b5", "pillow==9.2.0"],
+  "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "codeowners": ["@davet2001"],
   "iot_class": "local_push"

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -40,8 +40,12 @@
           "content_type": "Content Type"
         }
       },
-      "confirm": {
-        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      "user_confirm_still": {
+        "title": "Preview",
+        "description": "![Camera Still Image Preview]({preview_url})",
+        "data": {
+          "confirmed_ok": "This image looks good."
+        }
       }
     }
   },

--- a/homeassistant/components/generic/translations/en.json
+++ b/homeassistant/components/generic/translations/en.json
@@ -23,9 +23,6 @@
             "unknown": "Unexpected error"
         },
         "step": {
-            "confirm": {
-                "description": "Do you want to start set up?"
-            },
             "content_type": {
                 "data": {
                     "content_type": "Content Type"
@@ -45,6 +42,13 @@
                     "verify_ssl": "Verify SSL certificate"
                 },
                 "description": "Enter the settings to connect to the camera."
+            },
+            "user_confirm_still": {
+                "data": {
+                    "confirmed_ok": "This image looks good."
+                },
+                "description": "![Camera Still Image Preview]({preview_url})",
+                "title": "Preview"
             }
         }
     },

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -7,7 +7,7 @@ from PIL import Image
 import pytest
 import respx
 
-from homeassistant import config_entries
+from homeassistant import config_entries, setup
 from homeassistant.components.generic.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -78,7 +78,7 @@ def mock_create_stream():
 @pytest.fixture
 async def user_flow(hass):
     """Initiate a user flow."""
-
+    await setup.async_setup_component(hass, "http", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -7,7 +7,7 @@ from PIL import Image
 import pytest
 import respx
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.generic.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -78,7 +78,6 @@ def mock_create_stream():
 @pytest.fixture
 async def user_flow(hass):
     """Initiate a user flow."""
-    await setup.async_setup_component(hass, "http", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -20,6 +20,7 @@ from homeassistant.components.generic.const import (
     CONF_STREAM_SOURCE,
     DOMAIN,
 )
+from homeassistant.components.stream.const import CONF_RTSP_TRANSPORT
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
@@ -209,6 +210,7 @@ async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png
             CONF_VERIFY_SSL: False,
             CONF_USERNAME: "barney",
             CONF_PASSWORD: "betty",
+            CONF_RTSP_TRANSPORT: "http",
         },
     )
     mock_entry.add_to_hass(hass)

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -146,8 +146,11 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
-async def test_form_reject_still_preview(hass, mock_create_stream, user_flow):
+async def test_form_reject_still_preview(
+    hass, fakeimgbytes_png, mock_create_stream, user_flow
+):
     """Test we go back to the config screen if the user rejects the still preview."""
+    respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
     with mock_create_stream:
         result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
@@ -155,10 +158,11 @@ async def test_form_reject_still_preview(hass, mock_create_stream, user_flow):
         )
     assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result1["step_id"] == "user_confirm_still"
-    result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"],
-        user_input={CONF_CONFIRMED_OK: False},
-    )
+    with mock_create_stream:
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: False},
+        )
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["step_id"] == "user"
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -158,11 +158,10 @@ async def test_form_reject_still_preview(
         )
     assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result1["step_id"] == "user_confirm_still"
-    with mock_create_stream:
-        result2 = await hass.config_entries.flow.async_configure(
-            result1["flow_id"],
-            user_input={CONF_CONFIRMED_OK: False},
-        )
+    result2 = await hass.config_entries.flow.async_configure(
+        result1["flow_id"],
+        user_input={CONF_CONFIRMED_OK: False},
+    )
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["step_id"] == "user"
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
         client = await hass_client()
         preview_id = result1["flow_id"] + "_1"
         # Check the preview image works.
-        resp = await client.get(f"/api/camera_preview_proxy/{preview_id}")
+        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
         assert resp.status == HTTPStatus.OK
         assert await resp.read() == fakeimgbytes_png
         result2 = await hass.config_entries.flow.async_configure(
@@ -100,7 +100,7 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
 
     await hass.async_block_till_done()
     # Check that the preview image is disabled after.
-    resp = await client.get(f"/api/camera_preview_proxy/{preview_id}")
+    resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
     assert resp.status == HTTPStatus.NOT_FOUND
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -181,7 +181,7 @@ async def test_form_still_preview_cam_off(
         preview_id = result1["flow_id"] + "_1"
         # Try to view the image, should be unavailable.
         client = await hass_client()
-        resp = await client.get(f"/api/camera_preview_proxy/{preview_id}")
+        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
     assert resp.status == HTTPStatus.SERVICE_UNAVAILABLE
 
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
         client = await hass_client()
         preview_id = result1["flow_id"]
         # Check the preview image works.
-        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
+        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}_1")
         assert resp.status == HTTPStatus.OK
         assert await resp.read() == fakeimgbytes_png
         result2 = await hass.config_entries.flow.async_configure(
@@ -182,7 +182,7 @@ async def test_form_still_preview_cam_off(
         preview_id = result1["flow_id"]
         # Try to view the image, should be unavailable.
         client = await hass_client()
-        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
+        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}_1")
     assert resp.status == HTTPStatus.SERVICE_UNAVAILABLE
 
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
         client = await hass_client()
         preview_id = result1["flow_id"]
         # Check the preview image works.
-        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}_1")
+        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}?t=1")
         assert resp.status == HTTPStatus.OK
         assert await resp.read() == fakeimgbytes_png
         result2 = await hass.config_entries.flow.async_configure(
@@ -182,7 +182,7 @@ async def test_form_still_preview_cam_off(
         preview_id = result1["flow_id"]
         # Try to view the image, should be unavailable.
         client = await hass_client()
-        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}_1")
+        resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}?t=1")
     assert resp.status == HTTPStatus.SERVICE_UNAVAILABLE
 
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -101,7 +101,8 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
     await hass.async_block_till_done()
     # Check that the preview image is disabled after.
     resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    # In reality it's not disabled & remains until next HA restart.
+    assert resp.status == HTTPStatus.OK
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
         assert result1["type"] == data_entry_flow.FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         client = await hass_client()
-        preview_id = result1["flow_id"] + "_1"
+        preview_id = result1["flow_id"]
         # Check the preview image works.
         resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
         assert resp.status == HTTPStatus.OK
@@ -101,7 +101,7 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
     await hass.async_block_till_done()
     # Check that the preview image is disabled after.
     resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")
-    assert resp.status == HTTPStatus.NOT_FOUND
+    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -178,7 +178,7 @@ async def test_form_still_preview_cam_off(
         )
         assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result1["step_id"] == "user_confirm_still"
-        preview_id = result1["flow_id"] + "_1"
+        preview_id = result1["flow_id"]
         # Try to view the image, should be unavailable.
         client = await hass_client()
         resp = await client.get(f"/api/generic/preview_flow_image/{preview_id}")

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -1,8 +1,9 @@
 """Test The generic (IP Camera) config flow."""
 
 import errno
+from http import HTTPStatus
 import os.path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import httpx
 import pytest
@@ -12,6 +13,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.camera import async_get_image
 from homeassistant.components.generic.config_flow import slug
 from homeassistant.components.generic.const import (
+    CONF_CONFIRMED_OK,
     CONF_CONTENT_TYPE,
     CONF_FRAMERATE,
     CONF_LIMIT_REFETCH_TO_URL_CHANGE,
@@ -58,16 +60,30 @@ TESTDATA_YAML = {
 
 
 @respx.mock
-async def test_form(hass, fakeimg_png, user_flow, mock_create_stream):
+async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_stream):
     """Test the form with a normal set of settings."""
 
+    respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
     with mock_create_stream as mock_setup, patch(
         "homeassistant.components.generic.async_setup_entry", return_value=True
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
+        result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
             TESTDATA,
         )
+        assert result1["type"] == data_entry_flow.FlowResultType.FORM
+        assert result1["step_id"] == "user_confirm_still"
+        client = await hass_client()
+        preview_id = result1["flow_id"] + "_1"
+        # Check the preview image works.
+        resp = await client.get(f"/api/camera_preview_proxy/{preview_id}")
+        assert resp.status == HTTPStatus.OK
+        assert await resp.read() == fakeimgbytes_png
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
+        )
+        await hass.async_block_till_done()
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
@@ -83,6 +99,9 @@ async def test_form(hass, fakeimg_png, user_flow, mock_create_stream):
     }
 
     await hass.async_block_till_done()
+    # Check that the preview image is disabled after.
+    resp = await client.get(f"/api/camera_preview_proxy/{preview_id}")
+    assert resp.status == HTTPStatus.NOT_FOUND
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -99,11 +118,17 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
     with patch("homeassistant.components.generic.async_setup_entry", return_value=True):
-        result2 = await hass.config_entries.flow.async_configure(
+        result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
             data,
         )
         await hass.async_block_till_done()
+        assert result1["type"] == data_entry_flow.FlowResultType.FORM
+        assert result1["step_id"] == "user_confirm_still"
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
+        )
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
@@ -121,14 +146,60 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
+async def test_form_reject_still_preview(hass, mock_create_stream, user_flow):
+    """Test we go back to the config screen if the user rejects the still preview."""
+    with mock_create_stream:
+        result1 = await hass.config_entries.flow.async_configure(
+            user_flow["flow_id"],
+            TESTDATA,
+        )
+    assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result1["step_id"] == "user_confirm_still"
+    result2 = await hass.config_entries.flow.async_configure(
+        result1["flow_id"],
+        user_input={CONF_CONFIRMED_OK: False},
+    )
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["step_id"] == "user"
+
+
+@respx.mock
+async def test_form_still_preview_cam_off(
+    hass, fakeimg_png, mock_create_stream, user_flow, hass_client
+):
+    """Test camera errors are triggered during preview."""
+    with patch(
+        "homeassistant.components.generic.camera.GenericCamera.is_on",
+        new_callable=PropertyMock(return_value=False),
+    ), mock_create_stream:
+        result1 = await hass.config_entries.flow.async_configure(
+            user_flow["flow_id"],
+            TESTDATA,
+        )
+        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["step_id"] == "user_confirm_still"
+        preview_id = result1["flow_id"] + "_1"
+        # Try to view the image, should be unavailable.
+        client = await hass_client()
+        resp = await client.get(f"/api/camera_preview_proxy/{preview_id}")
+    assert resp.status == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+@respx.mock
 async def test_form_only_stillimage_gif(hass, fakeimg_gif, user_flow):
     """Test we complete ok if the user wants a gif."""
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
     with patch("homeassistant.components.generic.async_setup_entry", return_value=True):
-        result2 = await hass.config_entries.flow.async_configure(
+        result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
             data,
+        )
+        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["step_id"] == "user_confirm_still"
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
         )
         await hass.async_block_till_done()
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -143,11 +214,17 @@ async def test_form_only_svg_whitespace(hass, fakeimgbytes_svg, user_flow):
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
     with patch("homeassistant.components.generic.async_setup_entry", return_value=True):
-        result2 = await hass.config_entries.flow.async_configure(
+        result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
             data,
         )
-        await hass.async_block_till_done()
+        assert result1["type"] == data_entry_flow.FlowResultType.FORM
+        assert result1["step_id"] == "user_confirm_still"
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
+        )
+    await hass.async_block_till_done()
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
@@ -170,9 +247,15 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
     with patch("homeassistant.components.generic.async_setup_entry", return_value=True):
-        result2 = await hass.config_entries.flow.async_configure(
+        result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
             data,
+        )
+        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["step_id"] == "user_confirm_still"
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
         )
         await hass.async_block_till_done()
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -186,31 +269,31 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
         (
             "http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png",
             "http://localhost:8123/static/icons/favicon-apple-180x180.png",
-            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            "user_confirm_still",
             None,
         ),
         (
             "{% if 1 %}https://bla{% else %}https://yo{% endif %}",
             "https://bla/",
-            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            "user_confirm_still",
             None,
         ),
         (
             "http://{{example.org",
             "http://example.org",
-            data_entry_flow.FlowResultType.FORM,
+            "user",
             {"still_image_url": "template_error"},
         ),
         (
             "invalid1://invalid:4\\1",
             "invalid1://invalid:4%5c1",
-            data_entry_flow.FlowResultType.FORM,
+            "user",
             {"still_image_url": "malformed_url"},
         ),
         (
             "relative/urls/are/not/allowed.jpg",
             "relative/urls/are/not/allowed.jpg",
-            data_entry_flow.FlowResultType.FORM,
+            "user",
             {"still_image_url": "relative_url"},
         ),
     ],
@@ -229,7 +312,7 @@ async def test_still_template(
             data,
         )
         await hass.async_block_till_done()
-    assert result2["type"] == expected_result
+    assert result2["step_id"] == expected_result
     assert result2.get("errors") == expected_errors
 
 
@@ -242,10 +325,15 @@ async def test_form_rtsp_mode(hass, fakeimg_png, user_flow, mock_create_stream):
     with mock_create_stream as mock_setup, patch(
         "homeassistant.components.generic.async_setup_entry", return_value=True
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"], data
         )
-    assert "errors" not in result2, f"errors={result2['errors']}"
+        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["step_id"] == "user_confirm_still"
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
+        )
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
@@ -265,21 +353,23 @@ async def test_form_rtsp_mode(hass, fakeimg_png, user_flow, mock_create_stream):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_form_only_stream(hass, fakeimgbytes_jpg, mock_create_stream):
+async def test_form_only_stream(hass, fakeimgbytes_jpg, user_flow, mock_create_stream):
     """Test we complete ok if the user wants stream only."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
     data = TESTDATA.copy()
     data.pop(CONF_STILL_IMAGE_URL)
     data[CONF_STREAM_SOURCE] = "rtsp://user:pass@127.0.0.1/testurl/2"
     with mock_create_stream as mock_setup:
-        result3 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result1 = await hass.config_entries.flow.async_configure(
+            user_flow["flow_id"],
             data,
         )
+        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["step_id"] == "user_confirm_still"
+        result3 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={CONF_CONFIRMED_OK: True},
+        )
         await hass.async_block_till_done()
-
     assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "127_0_0_1"
     assert result3["options"] == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a preview of the camera image during UI setup of a generic camera.

Reasons for this:
- Provide friendly user confirmation that the connection is working
- Catch more problems during configuration to avoid the user having to delete/re-add to fix things.

![Peek 2022-05-02 22-47_hen](https://user-images.githubusercontent.com/17680170/166571408-571d4a1b-eeed-4d20-b187-3a80d71c5ace.gif)

I would value someone looking at how I've generated the preview.  ~It feels like a bit of a cheeky way of doing it, but it works.~ I've implemented the feedback suggestions from initial reviews (thank you!).

Limitations:
- The preview is a single frame - does not change.
- No preview for streams yet - possibly will be in a future PR.

Todo:
 - [ ] ~~Add the same functionality to the options flow~~(will do this in a follow up PR)
 - [x] Is there a proper way to unregister views? 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
