### PR TITLE
Update pylint to 2.13.8

### DIFF
--- a/homeassistant/components/buienradar/util.py
+++ b/homeassistant/components/buienradar/util.py
@@ -115,7 +115,7 @@ class BrData:
             self.load_error_count += 1
             threshold_log(
                 self.load_error_count,
-                "Unable to retrieve json data from Buienradar" "(Msg: %s, status: %s,)",
+                "Unable to retrieve json data from Buienradar (Msg: %s, status: %s)",
                 content.get(MESSAGE),
                 content.get(STATUS_CODE),
             )
@@ -135,7 +135,7 @@ class BrData:
             # unable to get the data
             threshold_log(
                 self.rain_error_count,
-                "Unable to retrieve rain data from Buienradar" "(Msg: %s, status: %s)",
+                "Unable to retrieve rain data from Buienradar (Msg: %s, status: %s)",
                 raincontent.get(MESSAGE),
                 raincontent.get(STATUS_CODE),
             )

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -287,7 +287,7 @@ class ConfiguredDoorBird:
         self.device.change_favorite("http", f"Home Assistant ({event})", url)
         if not self.webhook_is_registered(url):
             _LOGGER.warning(
-                'Unable to set favorite URL "%s". ' 'Event "%s" will not fire',
+                'Unable to set favorite URL "%s". Event "%s" will not fire',
                 url,
                 event,
             )

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -159,7 +159,7 @@ def encrypt_message(secret, topic, message):
 
     if key is None:
         _LOGGER.warning(
-            "Unable to encrypt payload because no decryption key known " "for topic %s",
+            "Unable to encrypt payload because no decryption key known for topic %s",
             topic,
         )
         return None

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -235,7 +235,7 @@ def _attach_file(atch_name, content_id):
         attachment = MIMEImage(file_bytes)
     except TypeError:
         _LOGGER.warning(
-            "Attachment %s has an unknown MIME type. " "Falling back to file",
+            "Attachment %s has an unknown MIME type. Falling back to file",
             atch_name,
         )
         attachment = MIMEApplication(file_bytes, Name=atch_name)

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -242,7 +242,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         if state < 0 or state > 100:
             self._position = None
             _LOGGER.error(
-                "Cover position value must be" " between 0 and 100." " Value was: %.2f",
+                "Cover position value must be between 0 and 100. Value was: %.2f",
                 state,
             )
         else:

--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -139,7 +139,7 @@ class VasttrafikDepartureSensor(SensorEntity):
 
         if not self._departureboard:
             _LOGGER.debug(
-                "No departures from departure station %s " "to destination station %s",
+                "No departures from departure station %s to destination station %s",
                 self._departure["station_name"],
                 self._heading["station_name"] if self._heading else "ANY",
             )

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -540,7 +540,6 @@ class ZWaveServices:
 
     async def async_ping(self, service: ServiceCall) -> None:
         """Ping node(s)."""
-        # pylint: disable=no-self-use
         _LOGGER.warning(
             "This service is deprecated in favor of the ping button entity. Service "
             "calls will still work for now but the service will be removed in a "

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.2.1
 mock-open==1.4.0
 mypy==0.950
 pre-commit==2.17.0
-pylint==2.13.7
+pylint==2.13.8
 pipdeptree==2.2.1
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Proposed change
Small bugfix release.
Release notes: https://github.com/PyCQA/pylint/releases/tag/v2.13.8
Compare view: https://github.com/PyCQA/pylint/compare/v2.13.7...v2.13.8

Additionally, prepare for next minor release.
* Remove `pylint: disable=no-self-use` comment -> the error is already disabled globally
* Fix string concatenations inside function calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
