### PR TITLE
Only test for EncryptedBridge in Samsung J/H models

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -30,7 +30,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.typing import ConfigType
 
-from .bridge import SamsungTVBridge, async_get_device_info, mac_from_device_info
+from .bridge import (
+    SamsungTVBridge,
+    async_get_device_info,
+    mac_from_device_info,
+    model_requires_encryption,
+)
 from .const import (
     CONF_ON_ACTION,
     CONF_SESSION_ID,
@@ -214,11 +219,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def _model_requires_encryption(model: str | None) -> bool:
-    """H and J models need pairing with PIN."""
-    return model is not None and len(model) > 4 and model[4] in ("H", "J")
-
-
 async def _async_create_bridge_with_updated_data(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> SamsungTVBridge:
@@ -279,7 +279,7 @@ async def _async_create_bridge_with_updated_data(
                 LOGGER.info("Updated model to %s for %s", model, host)
                 updated_data[CONF_MODEL] = model
 
-    if _model_requires_encryption(model) and method != METHOD_ENCRYPTED_WEBSOCKET:
+    if model_requires_encryption(model) and method != METHOD_ENCRYPTED_WEBSOCKET:
         LOGGER.info(
             "Detected model %s for %s. Some televisions from H and J series use "
             "an encrypted protocol but you are using %s which may not be supported",

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -22,7 +22,7 @@ from samsungtvws.remote import ChannelEmitCommand
 from homeassistant.components.samsungtv.const import WEBSOCKET_SSL_PORT
 import homeassistant.util.dt as dt_util
 
-from .const import SAMPLE_DEVICE_INFO_WIFI
+from .const import SAMPLE_DEVICE_INFO_UE48JU6400, SAMPLE_DEVICE_INFO_WIFI
 
 
 @pytest.fixture(autouse=True)
@@ -177,7 +177,7 @@ def rest_api_fixture_non_ssl_only() -> Mock:
             """Mock rest_device_info to fail for ssl and work for non-ssl."""
             if self.port == WEBSOCKET_SSL_PORT:
                 raise ResponseError
-            return SAMPLE_DEVICE_INFO_WIFI
+            return SAMPLE_DEVICE_INFO_UE48JU6400
 
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -340,16 +340,16 @@ async def test_user_encrypted_websocket(
         )
 
     assert result4["type"] == "create_entry"
-    assert result4["title"] == "Living Room (82GXARRS)"
+    assert result4["title"] == "TV-UE48JU6470 (UE48JU6400)"
     assert result4["data"][CONF_HOST] == "fake_host"
-    assert result4["data"][CONF_NAME] == "Living Room"
+    assert result4["data"][CONF_NAME] == "TV-UE48JU6470"
     assert result4["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result4["data"][CONF_MANUFACTURER] == "Samsung"
-    assert result4["data"][CONF_MODEL] == "82GXARRS"
+    assert result4["data"][CONF_MODEL] == "UE48JU6400"
     assert result4["data"][CONF_SSDP_RENDERING_CONTROL_LOCATION] is None
     assert result4["data"][CONF_TOKEN] == "037739871315caef138547b03e348b72"
     assert result4["data"][CONF_SESSION_ID] == "1"
-    assert result4["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
+    assert result4["result"].unique_id == "223da676-497a-4e06-9507-5e27ec4f0fb3"
 
 
 @pytest.mark.usefixtures("rest_api_failing")
@@ -714,19 +714,19 @@ async def test_ssdp_encrypted_websocket_success_populates_mac_address_and_ssdp_l
         )
 
     assert result4["type"] == "create_entry"
-    assert result4["title"] == "Living Room (82GXARRS)"
+    assert result4["title"] == "TV-UE48JU6470 (UE48JU6400)"
     assert result4["data"][CONF_HOST] == "fake_host"
-    assert result4["data"][CONF_NAME] == "Living Room"
+    assert result4["data"][CONF_NAME] == "TV-UE48JU6470"
     assert result4["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result4["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
-    assert result4["data"][CONF_MODEL] == "82GXARRS"
+    assert result4["data"][CONF_MODEL] == "UE48JU6400"
     assert (
         result4["data"][CONF_SSDP_RENDERING_CONTROL_LOCATION]
         == "https://fake_host:12345/test"
     )
     assert result4["data"][CONF_TOKEN] == "037739871315caef138547b03e348b72"
     assert result4["data"][CONF_SESSION_ID] == "1"
-    assert result4["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
+    assert result4["result"].unique_id == "223da676-497a-4e06-9507-5e27ec4f0fb3"
 
 
 @pytest.mark.usefixtures("rest_api_non_ssl_only")
@@ -1036,13 +1036,13 @@ async def test_dhcp_wireless(hass: HomeAssistant) -> None:
         result["flow_id"], user_input="whatever"
     )
     assert result["type"] == "create_entry"
-    assert result["title"] == "Living Room (82GXARRS)"
+    assert result["title"] == "TV-UE48JU6470 (UE48JU6400)"
     assert result["data"][CONF_HOST] == "fake_host"
-    assert result["data"][CONF_NAME] == "Living Room"
+    assert result["data"][CONF_NAME] == "TV-UE48JU6470"
     assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result["data"][CONF_MANUFACTURER] == "Samsung"
-    assert result["data"][CONF_MODEL] == "82GXARRS"
-    assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
+    assert result["data"][CONF_MODEL] == "UE48JU6400"
+    assert result["result"].unique_id == "223da676-497a-4e06-9507-5e27ec4f0fb3"
 
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only test for EncryptedBridge in Samsung J/H models

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #70708
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
