### PR TITLE
Fix history using pre v25 queries during v26 migration

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -1013,6 +1013,8 @@ class Recorder(threading.Thread):
                 )
                 self._shutdown()
                 return
+        else:
+            self.schema_version = SCHEMA_VERSION
 
         _LOGGER.debug("Recorder processing the queue")
         self.hass.add_job(self._async_recorder_ready)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -79,6 +79,7 @@ from .const import (
 )
 from .executor import DBInterruptibleThreadPoolExecutor
 from .models import (
+    SCHEMA_VERSION,
     Base,
     Events,
     StateAttributes,
@@ -634,6 +635,7 @@ class Recorder(threading.Thread):
         self.entity_filter = entity_filter
         self.exclude_t = exclude_t
 
+        self.schema_version = 0
         self._commits_without_expire = 0
         self._old_states: dict[str, States] = {}
         self._state_attributes_ids: LRU = LRU(STATE_ATTRIBUTES_ID_CACHE_SIZE)
@@ -973,6 +975,8 @@ class Recorder(threading.Thread):
             self.hass.add_job(self.async_connection_failed)
             return
 
+        self.schema_version = current_version
+
         schema_is_current = migration.schema_is_current(current_version)
         if schema_is_current:
             self._setup_run()
@@ -1009,6 +1013,7 @@ class Recorder(threading.Thread):
                 self._shutdown()
                 return
 
+        self.schema_version = SCHEMA_VERSION
         _LOGGER.debug("Recorder processing the queue")
         self.hass.add_job(self._async_recorder_ready)
         self._run_event_loop()

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -1013,8 +1013,6 @@ class Recorder(threading.Thread):
                 )
                 self._shutdown()
                 return
-        else:
-            self.schema_version = SCHEMA_VERSION
 
         _LOGGER.debug("Recorder processing the queue")
         self.hass.add_job(self._async_recorder_ready)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -998,6 +998,7 @@ class Recorder(threading.Thread):
         # with startup which is also cpu intensive
         if not schema_is_current:
             if self._migrate_schema_and_setup_run(current_version):
+                self.schema_version = SCHEMA_VERSION
                 if not self._event_listener:
                     # If the schema migration takes so long that the end
                     # queue watcher safety kicks in because MAX_QUEUE_BACKLOG
@@ -1013,7 +1014,6 @@ class Recorder(threading.Thread):
                 self._shutdown()
                 return
 
-        self.schema_version = SCHEMA_VERSION
         _LOGGER.debug("Recorder processing the queue")
         self.hass.add_job(self._async_recorder_ready)
         self._run_event_loop()

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -116,7 +116,7 @@ def query_and_join_attributes(
     # If we in the process of migrating schema we do
     # not want to join the state_attributes table as we
     # do not know if it will be there yet
-    if recorder.get_instance(hass).migration_in_progress:
+    if recorder.get_instance(hass).schema_version < 25:
         return QUERY_STATES_PRE_SCHEMA_25, False
     # Finally if no migration is in progress and no_attributes
     # was not requested, we query both attributes columns and
@@ -146,7 +146,7 @@ def bake_query_and_join_attributes(
     # If we in the process of migrating schema we do
     # not want to join the state_attributes table as we
     # do not know if it will be there yet
-    if recorder.get_instance(hass).migration_in_progress:
+    if recorder.get_instance(hass).schema_version < 25:
         if include_last_updated:
             return (
                 bakery(lambda session: session.query(*QUERY_STATES_PRE_SCHEMA_25)),

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -628,7 +628,7 @@ async def test_state_changes_during_period_query_during_migration_to_schema_25(
         conn.execute(text("drop table state_attributes;"))
         conn.commit()
 
-    with patch.object(instance, "migration_in_progress", True):
+    with patch.object(instance, "schema_version", 24):
         no_attributes = True
         hist = history.state_changes_during_period(
             hass, start, end, entity_id, no_attributes, include_start_time_state=False
@@ -674,7 +674,7 @@ async def test_get_states_query_during_migration_to_schema_25(
         conn.execute(text("drop table state_attributes;"))
         conn.commit()
 
-    with patch.object(instance, "migration_in_progress", True):
+    with patch.object(instance, "schema_version", 24):
         no_attributes = True
         hist = await _async_get_states(
             hass, end, [entity_id], no_attributes=no_attributes
@@ -723,7 +723,7 @@ async def test_get_states_query_during_migration_to_schema_25_multiple_entities(
         conn.execute(text("drop table state_attributes;"))
         conn.commit()
 
-    with patch.object(instance, "migration_in_progress", True):
+    with patch.object(instance, "schema_version", 24):
         no_attributes = True
         hist = await _async_get_states(
             hass, end, entity_ids, no_attributes=no_attributes

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -439,7 +439,7 @@ def _state_empty_context(hass, entity_id):
     return state
 
 
-def test_setup_without_migraton(hass_recorder):
+def test_setup_without_migration(hass_recorder):
     """Verify the schema version without a migration."""
     hass = hass_recorder()
     assert recorder.get_instance(hass).schema_version == SCHEMA_VERSION

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -31,6 +31,7 @@ from homeassistant.components.recorder import (
 )
 from homeassistant.components.recorder.const import DATA_INSTANCE
 from homeassistant.components.recorder.models import (
+    SCHEMA_VERSION,
     Events,
     RecorderRuns,
     StateAttributes,
@@ -436,6 +437,12 @@ def _state_empty_context(hass, entity_id):
     state = hass.states.get(entity_id)
     state.context = Context(id=None)
     return state
+
+
+def test_setup_without_migraton(hass_recorder):
+    """Verify the schema version without a migration."""
+    hass = hass_recorder()
+    assert recorder.get_instance(hass).schema_version == SCHEMA_VERSION
 
 
 # pylint: disable=redefined-outer-name,invalid-name

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -22,7 +22,11 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import persistent_notification as pn, recorder
 from homeassistant.components.recorder import migration, models
 from homeassistant.components.recorder.const import DATA_INSTANCE
-from homeassistant.components.recorder.models import RecorderRuns, States
+from homeassistant.components.recorder.models import (
+    SCHEMA_VERSION,
+    RecorderRuns,
+    States,
+)
 from homeassistant.components.recorder.util import session_scope
 import homeassistant.util.dt as dt_util
 
@@ -79,6 +83,7 @@ async def test_migration_in_progress(hass):
         await async_wait_recording_done(hass)
 
     assert recorder.util.async_migration_in_progress(hass) is False
+    assert recorder.get_instance(hass).schema_version == SCHEMA_VERSION
 
 
 async def test_database_migration_failed(hass):


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The check was for any migration in progress and
we need to check the specific schema version
since we have another one in this version otherwise
sensors that populate from the database will get empty
data if they win the race to setup before the migration
is completed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
