### PR TITLE
Add binary sensor for litter-robot status

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -11,6 +11,7 @@ from .const import DOMAIN
 from .hub import LitterRobotHub
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/litterrobot/binary_sensor.py
+++ b/homeassistant/components/litterrobot/binary_sensor.py
@@ -1,0 +1,50 @@
+"""Support for Litter-Robot binary sensors."""
+from pylitterbot.enums import LitterBoxStatus
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import LitterRobotEntity
+from .hub import LitterRobotHub
+
+
+class LitterRobotBinarySensor(LitterRobotEntity, BinarySensorEntity):
+    """Litter-Robot binary sensor."""
+
+
+class LitterRobotTimingModeSensor(LitterRobotBinarySensor):
+    """Litter-Robot timing mode sensor."""
+
+    @property
+    def is_on(self) -> bool:
+        """If the binary sensor is currently on or off."""
+        return self.robot.status == LitterBoxStatus.CAT_SENSOR_TIMING
+
+    @property
+    def icon(self) -> str:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:timer-outline" if self.is_on else "mdi:timer-off-outline"
+
+
+ROBOT_BINARY_SENSORS: list[tuple[type[LitterRobotBinarySensor], str]] = [
+    (LitterRobotTimingModeSensor, "Timing Mode"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Litter-Robot sensors using config entry."""
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+    for robot in hub.account.robots:
+        for (sensor_class, entity_type) in ROBOT_BINARY_SENSORS:
+            entities.append(sensor_class(robot=robot, entity_type=entity_type, hub=hub))
+
+    async_add_entities(entities)

--- a/tests/components/litterrobot/test_binary_sensor.py
+++ b/tests/components/litterrobot/test_binary_sensor.py
@@ -1,0 +1,32 @@
+"""Test the Litter-Robot binary sensor entity."""
+from unittest.mock import Mock
+
+from homeassistant.components.binary_sensor import DOMAIN as PLATFORM_DOMAIN
+from homeassistant.components.litterrobot.binary_sensor import (
+    LitterRobotTimingModeSensor,
+)
+
+from .conftest import create_mock_robot, setup_integration
+
+TIMING_MODE_ENTITY_ID = "binary_sensor.test_timing_mode"
+
+
+async def test_timing_mode_binary_sensor(hass, mock_account):
+    """Tests the waste drawer sensor entity was set up."""
+    await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
+
+    sensor = hass.states.get(TIMING_MODE_ENTITY_ID)
+    assert sensor
+    assert sensor.is_on is False
+    assert sensor.icon == "mdi:timer-off-outline"
+
+
+async def test_sleep_time_sensor_in_true_state(hass):
+    """Tests the sleep mode start time sensor where sleep mode is inactive."""
+    robot = create_mock_robot({"unitStatus": "CST"})
+    sensor = LitterRobotTimingModeSensor(robot, "Timing Mode", Mock())
+    sensor.hass = hass
+
+    assert sensor
+    assert sensor.is_on is True
+    assert sensor.icon == "mdi:timer-outline"

--- a/tests/components/litterrobot/test_binary_sensor.py
+++ b/tests/components/litterrobot/test_binary_sensor.py
@@ -17,8 +17,8 @@ async def test_timing_mode_binary_sensor(hass, mock_account):
 
     sensor = hass.states.get(TIMING_MODE_ENTITY_ID)
     assert sensor
-    assert sensor.is_on is False
-    assert sensor.icon == "mdi:timer-off-outline"
+    assert sensor.state == "off"
+    assert sensor.attributes["icon"] == "mdi:timer-off-outline"
 
 
 async def test_sleep_time_sensor_in_true_state(hass):
@@ -30,3 +30,14 @@ async def test_sleep_time_sensor_in_true_state(hass):
     assert sensor
     assert sensor.is_on is True
     assert sensor.icon == "mdi:timer-outline"
+
+
+async def test_sleep_time_sensor_in_false_state(hass):
+    """Tests the sleep mode start time sensor where sleep mode is inactive."""
+    robot = create_mock_robot({"unitStatus": "RDY"})
+    sensor = LitterRobotTimingModeSensor(robot, "Timing Mode", Mock())
+    sensor.hass = hass
+
+    assert sensor
+    assert sensor.is_on is False
+    assert sensor.icon == "mdi:timer-off-outline"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a binary sensor to the litter-robot integration to indicate whether a device is currently in "timing mode" (indicated physically by a "timing" LED on the front of the device). This means that it is counting down until operating what HA models as a vacuum start.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

I haven't been able to install requirements locally due to clashing dependency versions, I hope that I can check that it passes tests on CI at least.

- Link to documentation pull request: I will need to add one once this PR is agreed in principle

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
