### PR TITLE
Add ability to specify user(s) when sending DMs using the Twitter integration

### DIFF
--- a/homeassistant/components/twitter/notify.py
+++ b/homeassistant/components/twitter/notify.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_DATA,
+    ATTR_TARGET,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
@@ -63,7 +64,7 @@ class TwitterNotificationService(BaseNotificationService):
         username,
     ):
         """Initialize the service."""
-        self.user = username
+        self.default_user = username
         self.hass = hass
         self.api = TwitterAPI(
             consumer_key, consumer_secret, access_token_key, access_token_secret
@@ -72,6 +73,7 @@ class TwitterNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Tweet a message, optionally with media."""
         data = kwargs.get(ATTR_DATA)
+        target = kwargs.get(ATTR_TARGET)
 
         media = None
         if data:
@@ -79,6 +81,11 @@ class TwitterNotificationService(BaseNotificationService):
             if not self.hass.config.is_allowed_path(media):
                 _LOGGER.warning("'%s' is not a whitelisted directory", media)
                 return
+
+        if target:
+            self.user = target
+        else:
+            self.user = self.default_user
 
         callback = partial(self.send_message_callback, message)
 

--- a/homeassistant/components/twitter/notify.py
+++ b/homeassistant/components/twitter/notify.py
@@ -83,18 +83,16 @@ class TwitterNotificationService(BaseNotificationService):
                 return
 
         if target:
-            self.user = target
+            callback = partial(self.send_message_callback, message, target)
         else:
-            self.user = self.default_user
-
-        callback = partial(self.send_message_callback, message)
+            callback = partial(self.send_message_callback, message, self.default_user)
 
         self.upload_media_then_callback(callback, media)
 
-    def send_message_callback(self, message, media_id=None):
+    def send_message_callback(self, message, user, media_id=None):
         """Tweet a message, optionally with media."""
-        if self.user:
-            user_resp = self.api.request("users/lookup", {"screen_name": self.user})
+        if user:
+            user_resp = self.api.request("users/lookup", {"screen_name": user})
             user_id = user_resp.json()[0]["id"]
             if user_resp.status_code != HTTPStatus.OK:
                 self.log_error_resp(user_resp)

--- a/homeassistant/components/twitter/notify.py
+++ b/homeassistant/components/twitter/notify.py
@@ -73,7 +73,7 @@ class TwitterNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Tweet a message, optionally with media."""
         data = kwargs.get(ATTR_DATA)
-        target = kwargs.get(ATTR_TARGET)
+        targets = kwargs.get(ATTR_TARGET)
 
         media = None
         if data:
@@ -81,13 +81,14 @@ class TwitterNotificationService(BaseNotificationService):
             if not self.hass.config.is_allowed_path(media):
                 _LOGGER.warning("'%s' is not a whitelisted directory", media)
                 return
-
-        if target:
-            callback = partial(self.send_message_callback, message, target)
+        
+        if targets:
+            for target in targets:
+                callback = partial(self.send_message_callback, message, target)
+                self.upload_media_then_callback(callback, media)
         else:
             callback = partial(self.send_message_callback, message, self.default_user)
-
-        self.upload_media_then_callback(callback, media)
+            self.upload_media_then_callback(callback, media)
 
     def send_message_callback(self, message, user, media_id=None):
         """Tweet a message, optionally with media."""


### PR DESCRIPTION
## Proposed change
When sending a DM using the Twitter integration, it is now possible to specify user(s) as the target object. 
If there is no user provided, the default user specified in the yaml configuration will be used and the service will behave as before.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
