### PR TITLE
Only lookup unknown Google Cast models once

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -58,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cast from a config entry."""
     await home_assistant_cast.async_setup_ha_cast(hass, entry)
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN] = {"cast_platform": {}, "unknown_models": {}}
     await async_process_integration_platforms(hass, DOMAIN, _register_cast_platform)
     return True
 
@@ -107,7 +107,7 @@ async def _register_cast_platform(
         or not hasattr(platform, "async_play_media")
     ):
         raise HomeAssistantError(f"Invalid cast platform {platform}")
-    hass.data[DOMAIN][integration_domain] = platform
+    hass.data[DOMAIN]["cast_platform"][integration_domain] = platform
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/homeassistant/components/cast/discovery.py
+++ b/homeassistant/components/cast/discovery.py
@@ -34,7 +34,7 @@ def discover_chromecast(
         _LOGGER.error("Discovered chromecast without uuid %s", info)
         return
 
-    info = info.fill_out_missing_chromecast_info()
+    info = info.fill_out_missing_chromecast_info(hass)
     _LOGGER.debug("Discovered new or updated chromecast %s", info)
 
     dispatcher_send(hass, SIGNAL_CAST_DISCOVERED, info)

--- a/homeassistant/components/cast/helpers.py
+++ b/homeassistant/components/cast/helpers.py
@@ -15,7 +15,10 @@ from pychromecast import dial
 from pychromecast.const import CAST_TYPE_GROUP
 from pychromecast.models import CastInfo
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,18 +50,50 @@ class ChromecastInfo:
         """Return the UUID."""
         return self.cast_info.uuid
 
-    def fill_out_missing_chromecast_info(self) -> ChromecastInfo:
+    def fill_out_missing_chromecast_info(self, hass: HomeAssistant) -> ChromecastInfo:
         """Return a new ChromecastInfo object with missing attributes filled in.
 
         Uses blocking HTTP / HTTPS.
         """
         cast_info = self.cast_info
         if self.cast_info.cast_type is None or self.cast_info.manufacturer is None:
-            # Manufacturer and cast type is not available in mDNS data, get it over http
-            cast_info = dial.get_cast_type(
-                cast_info,
-                zconf=ChromeCastZeroconf.get_zeroconf(),
-            )
+            unknown_models = hass.data[DOMAIN]["unknown_models"]
+            if self.cast_info.model_name not in unknown_models:
+                # Manufacturer and cast type is not available in mDNS data, get it over http
+                cast_info = dial.get_cast_type(
+                    cast_info,
+                    zconf=ChromeCastZeroconf.get_zeroconf(),
+                )
+                unknown_models[self.cast_info.model_name] = (
+                    cast_info.cast_type,
+                    cast_info.manufacturer,
+                )
+
+                report_issue = (
+                    "create a bug report at "
+                    "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
+                    "+label%3A%22integration%3A+cast%22"
+                )
+
+                _LOGGER.info(
+                    "Fetched cast details for unknown model '%s' manufacturer: '%s', type: '%s'. Please %s",
+                    cast_info.model_name,
+                    cast_info.manufacturer,
+                    cast_info.cast_type,
+                    report_issue,
+                )
+            else:
+                cast_type, manufacturer = unknown_models[self.cast_info.model_name]
+                cast_info = CastInfo(
+                    cast_info.services,
+                    cast_info.uuid,
+                    cast_info.model_name,
+                    cast_info.friendly_name,
+                    cast_info.host,
+                    cast_info.port,
+                    cast_type,
+                    manufacturer,
+                )
 
         if not self.is_audio_group or self.is_dynamic_group is not None:
             # We have all information, no need to check HTTP API.

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==12.0.0"],
+  "requirements": ["pychromecast==12.1.0"],
   "after_dependencies": [
     "cloud",
     "http",

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -535,7 +535,7 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
         """Generate root node."""
         children = []
         # Add media browsers
-        for platform in self.hass.data[CAST_DOMAIN].values():
+        for platform in self.hass.data[CAST_DOMAIN]["cast_platform"].values():
             children.extend(
                 await platform.async_get_media_browser_root_object(
                     self.hass, self._chromecast.cast_type
@@ -587,7 +587,7 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
         if media_content_id is None:
             return await self._async_root_payload(content_filter)
 
-        for platform in self.hass.data[CAST_DOMAIN].values():
+        for platform in self.hass.data[CAST_DOMAIN]["cast_platform"].values():
             browse_media = await platform.async_browse_media(
                 self.hass,
                 media_content_type,
@@ -646,7 +646,7 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
             return
 
         # Try the cast platforms
-        for platform in self.hass.data[CAST_DOMAIN].values():
+        for platform in self.hass.data[CAST_DOMAIN]["cast_platform"].values():
             result = await platform.async_play_media(
                 self.hass, self.entity_id, self._chromecast, media_type, media_id
             )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ pycfdns==1.2.2
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==12.0.0
+pychromecast==12.1.0
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -941,7 +941,7 @@ pybotvac==0.0.23
 pycfdns==1.2.2
 
 # homeassistant.components.cast
-pychromecast==12.0.0
+pychromecast==12.1.0
 
 # homeassistant.components.climacell
 pyclimacell==0.18.2

--- a/tests/components/cast/conftest.py
+++ b/tests/components/cast/conftest.py
@@ -15,6 +15,13 @@ def get_multizone_status_mock():
 
 
 @pytest.fixture()
+def get_cast_type_mock():
+    """Mock pychromecast dial."""
+    mock = MagicMock(spec_set=pychromecast.dial.get_cast_type)
+    return mock
+
+
+@pytest.fixture()
 def castbrowser_mock():
     """Mock pychromecast CastBrowser."""
     return MagicMock(spec=pychromecast.discovery.CastBrowser)
@@ -43,6 +50,7 @@ def cast_mock(
     mz_mock,
     quick_play_mock,
     castbrowser_mock,
+    get_cast_type_mock,
     get_chromecast_mock,
     get_multizone_status_mock,
 ):
@@ -52,6 +60,9 @@ def cast_mock(
     with patch(
         "homeassistant.components.cast.discovery.pychromecast.discovery.CastBrowser",
         castbrowser_mock,
+    ), patch(
+        "homeassistant.components.cast.helpers.dial.get_cast_type",
+        get_cast_type_mock,
     ), patch(
         "homeassistant.components.cast.helpers.dial.get_multizone_status",
         get_multizone_status_mock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only lookup unknown Google Cast models via http once:
- Fixes a problem where some TVs stutter when accessed via http
- Prevents log spamming for devices which don't implement the http API
- Suggest users to file an issue to add unknown models to pychromecast

Depends on a pychromecast release with https://github.com/home-assistant-libs/pychromecast/pull/620

Release notes https://github.com/home-assistant-libs/pychromecast/releases/tag/12.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
