### PR TITLE
Add buttons to Ring chime devices to play ding and motion chimes

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -32,6 +32,7 @@ DEFAULT_ENTITY_NAMESPACE = "ring"
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/ring/button.py
+++ b/homeassistant/components/ring/button.py
@@ -34,16 +34,17 @@ async def async_setup_entry(
 class BaseRingButton(RingEntityMixin, ButtonEntity):
     """Represents a Button for controlling an aspect of a ring device."""
 
-    def __init__(self, config_entry_id, device, device_type):
+    def __init__(self, config_entry_id, device, button_identifier, button_name):
         """Initialize the switch."""
         super().__init__(config_entry_id, device)
-        self._device_type = device_type
-        self._unique_id = f"{self._device.id}-{self._device_type}"
+        self._button_identifier = button_identifier
+        self._button_name = button_name
+        self._unique_id = f"{self._device.id}-{self._button_identifier}"
 
     @property
     def name(self):
         """Name of the device."""
-        return f"{self._device.name} {self._device_type}"
+        return f"{self._device.name} {self._button_name}"
 
     @property
     def unique_id(self):
@@ -56,7 +57,9 @@ class ChimeButton(BaseRingButton):
 
     def __init__(self, config_entry_id, device, kind):
         """Initialize the button for a device with a chime."""
-        super().__init__(config_entry_id, device, f"Play chime: {kind}")
+        super().__init__(
+            config_entry_id, device, f"play-chime-{kind}", f"Play chime: {kind}"
+        )
         self.kind = kind
 
     def press(self) -> None:

--- a/homeassistant/components/ring/button.py
+++ b/homeassistant/components/ring/button.py
@@ -49,6 +49,7 @@ class BaseRingButton(RingEntityMixin, ButtonEntity):
 
 class ChimeButton(BaseRingButton):
     """Creates a button to play the test chime of a Chime device."""
+
     _attr_icon = BELL_ICON
 
     def __init__(self, config_entry_id, device, kind):

--- a/homeassistant/components/ring/button.py
+++ b/homeassistant/components/ring/button.py
@@ -1,0 +1,70 @@
+"""This component provides HA button support for Ring Chimes."""
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN
+from .entity import RingEntityMixin
+
+_LOGGER = logging.getLogger(__name__)
+
+BELL_ICON = "mdi:bell-ring"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create the buttons for the Ring devices."""
+    devices = hass.data[DOMAIN][config_entry.entry_id]["devices"]
+    buttons = []
+
+    # add one button for each test chime type (ding, motion)
+    for device in devices["chimes"]:
+        buttons.append(ChimeButton(config_entry.entry_id, device, "ding"))
+        buttons.append(ChimeButton(config_entry.entry_id, device, "motion"))
+
+    async_add_entities(buttons)
+
+
+class BaseRingButton(RingEntityMixin, ButtonEntity):
+    """Represents a Button for controlling an aspect of a ring device."""
+
+    def __init__(self, config_entry_id, device, device_type):
+        """Initialize the switch."""
+        super().__init__(config_entry_id, device)
+        self._device_type = device_type
+        self._unique_id = f"{self._device.id}-{self._device_type}"
+
+    @property
+    def name(self):
+        """Name of the device."""
+        return f"{self._device.name} {self._device_type}"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+
+class ChimeButton(BaseRingButton):
+    """Creates a button to play the test chime of a Chime device."""
+
+    def __init__(self, config_entry_id, device, kind):
+        """Initialize the button for a device with a chime."""
+        super().__init__(config_entry_id, device, f"Play chime: {kind}")
+        self.kind = kind
+
+    def press(self) -> None:
+        """Send the test chime request."""
+        if not self._device.test_sound(kind=self.kind):
+            _LOGGER.error("Failed to ring chime sound on %s", self.name)
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return BELL_ICON

--- a/homeassistant/components/ring/button.py
+++ b/homeassistant/components/ring/button.py
@@ -39,21 +39,17 @@ class BaseRingButton(RingEntityMixin, ButtonEntity):
         super().__init__(config_entry_id, device)
         self._button_identifier = button_identifier
         self._button_name = button_name
-        self._unique_id = f"{self._device.id}-{self._button_identifier}"
+        self._attr_unique_id = f"{self._device.id}-{self._button_identifier}"
 
     @property
     def name(self):
         """Name of the device."""
         return f"{self._device.name} {self._button_name}"
 
-    @property
-    def unique_id(self):
-        """Return a unique ID."""
-        return self._unique_id
-
 
 class ChimeButton(BaseRingButton):
     """Creates a button to play the test chime of a Chime device."""
+    _attr_icon = BELL_ICON
 
     def __init__(self, config_entry_id, device, kind):
         """Initialize the button for a device with a chime."""
@@ -66,8 +62,3 @@ class ChimeButton(BaseRingButton):
         """Send the test chime request."""
         if not self._device.test_sound(kind=self.kind):
             _LOGGER.error("Failed to ring chime sound on %s", self.name)
-
-    @property
-    def icon(self):
-        """Return the icon."""
-        return BELL_ICON

--- a/tests/components/ring/test_button.py
+++ b/tests/components/ring/test_button.py
@@ -1,0 +1,55 @@
+"""The tests for the Ring button platform."""
+
+from homeassistant.const import Platform
+from homeassistant.helpers import entity_registry as er
+
+from .common import setup_platform
+
+
+async def test_entity_registry(hass, requests_mock):
+    """Tests that the devices are registered in the entity registry."""
+    await setup_platform(hass, Platform.BUTTON)
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get("button.downstairs_play_chime_ding")
+    assert entry.unique_id == "123456-play-chime-ding"
+
+    entry = entity_registry.async_get("button.downstairs_play_chime_motion")
+    assert entry.unique_id == "123456-play-chime-motion"
+
+
+async def test_play_chime_buttons_report_correctly(hass, requests_mock):
+    """Tests that the initial state of a device that should be on is correct."""
+    await setup_platform(hass, Platform.BUTTON)
+
+    state = hass.states.get("button.downstairs_play_chime_ding")
+    assert state.attributes.get("friendly_name") == "Downstairs Play chime: ding"
+    assert state.attributes.get("icon") == "mdi:bell-ring"
+
+    state = hass.states.get("button.downstairs_play_chime_motion")
+    assert state.attributes.get("friendly_name") == "Downstairs Play chime: motion"
+    assert state.attributes.get("icon") == "mdi:bell-ring"
+
+
+async def test_chime_can_be_played(hass, requests_mock):
+    """Tests the play chime request is sent correctly."""
+    await setup_platform(hass, Platform.BUTTON)
+
+    # Mocks the response for playing a test sound
+    requests_mock.post(
+        "https://api.ring.com/clients_api/chimes/123456/play_sound",
+        text="SUCCESS",
+    )
+    await hass.services.async_call(
+        "button",
+        "press",
+        {"entity_id": "button.downstairs_play_chime_ding"},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+
+    assert requests_mock.request_history[-1].url.startswith(
+        "https://api.ring.com/clients_api/chimes/123456/play_sound?"
+    )
+    assert "kind=ding" in requests_mock.request_history[-1].url


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Ring Chime products are great little noisemakers for notifications. There are some people (myself included) who may want to play these sounds outside of the context of a doorbell.

This adds two buttons per Chime device, one for playing each kind of chime notification (ding, motion). 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to the following feature request: https://community.home-assistant.io/t/ring-chime-integration-add-ring-chime-devices-as-switch-entities-to-allow-for-playing-ding-and-motion-sounds/374283

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass** **@grablair: (only ran tests associated with Ring)**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository. **@grablair: (going to this weekend!)**

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
