### PR TITLE
Do not fire numeric_state trigger on unknown values

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -352,13 +352,16 @@ class BayesianBinarySensor(BinarySensorEntity):
         entity = entity_observation["entity_id"]
 
         try:
-            return condition.async_numeric_state(
-                self.hass,
-                entity,
-                entity_observation.get("below"),
-                entity_observation.get("above"),
-                None,
-                entity_observation,
+            return (
+                condition.async_numeric_state(
+                    self.hass,
+                    entity,
+                    entity_observation.get("below"),
+                    entity_observation.get("above"),
+                    None,
+                    entity_observation,
+                )
+                is True
             )
         except ConditionError:
             return False

--- a/homeassistant/components/cover/device_condition.py
+++ b/homeassistant/components/cover/device_condition.py
@@ -151,8 +151,11 @@ def async_condition_from_config(
         hass: HomeAssistant, variables: TemplateVarsType = None
     ) -> bool:
         """Return whether the criteria are met."""
-        return condition.async_numeric_state(
-            hass, config[ATTR_ENTITY_ID], max_pos, min_pos, attribute=position_attr
+        return (
+            condition.async_numeric_state(
+                hass, config[ATTR_ENTITY_ID], max_pos, min_pos, attribute=position_attr
+            )
+            is True
         )
 
     return check_numeric_state

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -289,7 +289,7 @@ def numeric_state(
     above: float | str | None = None,
     value_template: Template | None = None,
     variables: TemplateVarsType = None,
-) -> bool:
+) -> bool | None:
     """Test a numeric state condition."""
     return run_callback_threadsafe(
         hass.loop,
@@ -311,8 +311,11 @@ def async_numeric_state(  # noqa: C901
     value_template: Template | None = None,
     variables: TemplateVarsType = None,
     attribute: str | None = None,
-) -> bool:
-    """Test a numeric state condition."""
+) -> bool | None:
+    """Test a numeric state condition.
+
+    Returns None if a value is unknown and raises ConditionError if it is invalid.
+    """
     if entity is None:
         raise ConditionErrorMessage("numeric_state", "no entity specified")
 
@@ -329,7 +332,7 @@ def async_numeric_state(  # noqa: C901
             False,
             message=f"attribute '{attribute}' of entity {entity_id} does not exist",
         )
-        return False
+        return None
 
     value: Any = None
     if value_template is None:
@@ -353,7 +356,7 @@ def async_numeric_state(  # noqa: C901
             False,
             message=f"value '{value}' is non-numeric and treated as False",
         )
-        return False
+        return None
 
     try:
         fvalue = float(value)
@@ -373,7 +376,7 @@ def async_numeric_state(  # noqa: C901
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                return False
+                return None
             try:
                 if fvalue >= float(below_entity.state):
                     condition_trace_set_result(
@@ -401,7 +404,7 @@ def async_numeric_state(  # noqa: C901
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                return False
+                return None
             try:
                 if fvalue <= float(above_entity.state):
                     condition_trace_set_result(

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1454,6 +1454,23 @@ async def test_numeric_state_known_non_matching(hass):
     )
 
 
+async def test_numeric_state_return_for_unknown(hass):
+    """Test numeric_state return for unknown values."""
+    # False for false
+    hass.states.async_set("sensor.temperature", 0)
+    assert (
+        condition.async_numeric_state(hass, entity="sensor.temperature", above=1)
+        is False
+    )
+
+    # None for unknown
+    hass.states.async_set("sensor.temperature", "unknown")
+    assert (
+        condition.async_numeric_state(hass, entity="sensor.temperature", above=0)
+        is None
+    )
+
+
 async def test_numeric_state_raises(hass):
     """Test that numeric_state raises ConditionError on errors."""
     # Unknown entities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `numeric_state` trigger will no longer fire when a value changes from unknown/unavailable, even if the `above`/`below` matches. It will now only fire when the from and to states are both valid numbers (and a threshold is crossed, of course).


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This implements home-assistant/architecture#668.

The `numeric_state` condition is extended to return `None` for situations where a value is missing and only return `True`/`False` when a comparison has actually taken place. The `numeric_state` trigger is modified to use the new return value to ignore transitions from unknown values.

I have modified the two other callers of the condition to check for `True` explicitly even though this is not absolutely required since `None` is still falsy.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/architecture#668
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
