### PR TITLE
Reduce overhead to enforce template rate limits that match a whole domain

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -554,7 +554,7 @@ class _TrackStateChangeFiltered:
             self._setup_all_listener()
             return
 
-        self._setup_domains_listener(track_states.domains)
+        self._setup_entity_added_domain_listener(track_states.domains)
         self._setup_entities_listener(track_states.domains, track_states.entities)
 
     @property
@@ -570,6 +570,8 @@ class _TrackStateChangeFiltered:
     @callback
     def async_update_listeners(self, new_track_states: TrackStates) -> None:
         """Update the listeners based on the new TrackStates."""
+        if new_track_states == self._last_track_states:
+            return
         last_track_states = self._last_track_states
         self._last_track_states = new_track_states
 
@@ -591,7 +593,7 @@ class _TrackStateChangeFiltered:
         if had_all_listener or domains_changed:
             domains_changed = True
             self._cancel_listener(_DOMAINS_LISTENER)
-            self._setup_domains_listener(new_track_states.domains)
+            self._setup_entity_added_domain_listener(new_track_states.domains)
 
         if (
             had_all_listener
@@ -631,7 +633,8 @@ class _TrackStateChangeFiltered:
         )
 
     @callback
-    def _state_added(self, event: Event) -> None:
+    def _state_added_domain(self, event: Event) -> None:
+        """Call when a state is added to a domain."""
         self._cancel_listener(_ENTITIES_LISTENER)
         self._setup_entities_listener(
             self._last_track_states.domains, self._last_track_states.entities
@@ -639,12 +642,13 @@ class _TrackStateChangeFiltered:
         self.hass.async_run_hass_job(self._action_as_hassjob, event)
 
     @callback
-    def _setup_domains_listener(self, domains: set[str]) -> None:
+    def _setup_entity_added_domain_listener(self, domains: set[str]) -> None:
+        """Listen for a new state to to appear in a domain."""
         if not domains:
             return
 
         self._listeners[_DOMAINS_LISTENER] = async_track_state_added_domain(
-            self.hass, domains, self._state_added
+            self.hass, domains, self._state_added_domain
         )
 
     @callback
@@ -1060,7 +1064,7 @@ class _TrackTemplateResultInfo:
             self._track_state_changes.async_update_listeners(
                 _render_infos_to_track_states(
                     [
-                        _suppress_domain_all_in_render_info(info)
+                        _suppress_all_in_render_info(info)
                         if self._rate_limit.async_has_timer(template)
                         else info
                         for template, info in self._info.items()
@@ -1623,11 +1627,11 @@ def _rate_limit_for_event(
     return rate_limit
 
 
-def _suppress_domain_all_in_render_info(render_info: RenderInfo) -> RenderInfo:
-    """Remove the domains and all_states from render info during a ratelimit."""
+def _suppress_all_in_render_info(render_info: RenderInfo) -> RenderInfo:
+    """Remove all_states from render info during a ratelimit."""
+    if not render_info.all_states and not render_info.all_states_lifecycle:
+        return render_info
     rate_limited_render_info = copy.copy(render_info)
     rate_limited_render_info.all_states = False
     rate_limited_render_info.all_states_lifecycle = False
-    rate_limited_render_info.domains = set()
-    rate_limited_render_info.domains_lifecycle = set()
     return rate_limited_render_info


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I noticed this when reviewing some of the `py-spy`s from the
users who provided them during the recent cycle of database
improvements.

- Removing the domain listener was more expensive than allowing
  it to reject since its quite rare that a new state is added
  to the state machine after startup. More time was spent tearing
  down and setting back up the listeners when the ratelimit expired
  for this case. We now keep the listener and allow it to reject
  in the rare event it is actually called.

  This change does not affect how rate limits for `all` states listeners
  are handled as its still quite important to tear down the listener
  for `all` states when hitting the rate limit as the cost of setting
  it back up again is far less than the cost to reject all the callbacks
  when the ratelimit is in effect. Its also much cheaper to set back
  up again since it is only one listener.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
