### PR TITLE
Revert "Bump numpy to v1.22.3"

### DIFF
--- a/homeassistant/components/compensation/manifest.json
+++ b/homeassistant/components/compensation/manifest.json
@@ -2,7 +2,7 @@
   "domain": "compensation",
   "name": "Compensation",
   "documentation": "https://www.home-assistant.io/integrations/compensation",
-  "requirements": ["numpy==1.22.3"],
+  "requirements": ["numpy==1.21.6"],
   "codeowners": ["@Petro31"],
   "iot_class": "calculated"
 }

--- a/homeassistant/components/iqvia/manifest.json
+++ b/homeassistant/components/iqvia/manifest.json
@@ -3,7 +3,7 @@
   "name": "IQVIA",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iqvia",
-  "requirements": ["numpy==1.22.3", "pyiqvia==2022.04.0"],
+  "requirements": ["numpy==1.21.6", "pyiqvia==2022.04.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "loggers": ["pyiqvia"]

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -161,7 +161,7 @@ def calculate_trend(indices: list[float]) -> str:
     """Calculate the "moving average" of a set of indices."""
     index_range = np.arange(0, len(indices))
     index_array = np.array(indices)
-    linear_fit = np.polyfit(index_range, index_array, 1)
+    linear_fit = np.polyfit(index_range, index_array, 1)  # type: ignore[no-untyped-call]
     slope = round(linear_fit[0], 2)
 
     if slope > 0:

--- a/homeassistant/components/opencv/manifest.json
+++ b/homeassistant/components/opencv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "opencv",
   "name": "OpenCV",
   "documentation": "https://www.home-assistant.io/integrations/opencv",
-  "requirements": ["numpy==1.22.3", "opencv-python-headless==4.5.2.54"],
+  "requirements": ["numpy==1.21.6", "opencv-python-headless==4.5.2.54"],
   "codeowners": [],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/tensorflow/manifest.json
+++ b/homeassistant/components/tensorflow/manifest.json
@@ -6,7 +6,7 @@
     "tensorflow==2.5.0",
     "tf-models-official==2.5.0",
     "pycocotools==2.0.1",
-    "numpy==1.22.3",
+    "numpy==1.21.6",
     "pillow==9.1.0"
   ],
   "codeowners": [],

--- a/homeassistant/components/trend/manifest.json
+++ b/homeassistant/components/trend/manifest.json
@@ -2,7 +2,7 @@
   "domain": "trend",
   "name": "Trend",
   "documentation": "https://www.home-assistant.io/integrations/trend",
-  "requirements": ["numpy==1.22.3"],
+  "requirements": ["numpy==1.21.6"],
   "codeowners": [],
   "quality_scale": "internal",
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1114,7 +1114,7 @@ numato-gpio==0.10.0
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==1.22.3
+numpy==1.21.6
 
 # homeassistant.components.oasa_telematics
 oasatelematics==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -758,7 +758,7 @@ numato-gpio==0.10.0
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==1.22.3
+numpy==1.21.6
 
 # homeassistant.components.google
 oauth2client==4.1.3


### PR DESCRIPTION
Reverts home-assistant/core#71393

Fails for the same reason as 1.22.0. I guess may be an issue with GCC on the version we use for Alpine 3.14 because with Edge it seems to work.

Followup: https://github.com/home-assistant/core/pull/71408