### PR TITLE
Avoid lowercasing entities after template ratelimit recovery

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -258,9 +258,6 @@ def _async_track_state_change_event(
     action: Callable[[Event], Any],
 ) -> CALLBACK_TYPE:
     """async_track_state_change_event without lowercasing."""
-    if not entity_ids:
-        return _remove_empty_listener
-
     entity_callbacks = hass.data.setdefault(TRACK_STATE_CHANGE_CALLBACKS, {})
 
     if TRACK_STATE_CHANGE_LISTENER not in hass.data:
@@ -441,9 +438,6 @@ def _async_track_state_added_domain(
     action: Callable[[Event], Any],
 ) -> CALLBACK_TYPE:
     """async_track_state_added_domain without lowercasing."""
-    if not domains:
-        return _remove_empty_listener
-
     domain_callbacks = hass.data.setdefault(TRACK_STATE_ADDED_DOMAIN_CALLBACKS, {})
 
     if TRACK_STATE_ADDED_DOMAIN_LISTENER not in hass.data:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -68,8 +68,8 @@ class TrackStates:
     """Class for keeping track of states being tracked.
 
     all_states: All states on the system are being tracked
-    entities: Entities to track
-    domains: Domains to track
+    entities: Lowercased entities to track
+    domains: Lowercased domains to track
     """
 
     all_states: bool
@@ -248,6 +248,18 @@ def async_track_state_change_event(
     """
     if not (entity_ids := _async_string_to_lower_list(entity_ids)):
         return _remove_empty_listener
+    return _async_track_state_change_event(hass, entity_ids, action)
+
+
+@bind_hass
+def _async_track_state_change_event(
+    hass: HomeAssistant,
+    entity_ids: str | Iterable[str],
+    action: Callable[[Event], Any],
+) -> CALLBACK_TYPE:
+    """async_track_state_change_event without lowercasing."""
+    if not entity_ids:
+        return _remove_empty_listener
 
     entity_callbacks = hass.data.setdefault(TRACK_STATE_CHANGE_CALLBACKS, {})
 
@@ -418,6 +430,18 @@ def async_track_state_added_domain(
 ) -> CALLBACK_TYPE:
     """Track state change events when an entity is added to domains."""
     if not (domains := _async_string_to_lower_list(domains)):
+        return _remove_empty_listener
+    return _async_track_state_added_domain(hass, domains, action)
+
+
+@bind_hass
+def _async_track_state_added_domain(
+    hass: HomeAssistant,
+    domains: str | Iterable[str],
+    action: Callable[[Event], Any],
+) -> CALLBACK_TYPE:
+    """async_track_state_added_domain without lowercasing."""
+    if not domains:
         return _remove_empty_listener
 
     domain_callbacks = hass.data.setdefault(TRACK_STATE_ADDED_DOMAIN_CALLBACKS, {})
@@ -626,7 +650,7 @@ class _TrackStateChangeFiltered:
         if not entities:
             return
 
-        self._listeners[_ENTITIES_LISTENER] = async_track_state_change_event(
+        self._listeners[_ENTITIES_LISTENER] = _async_track_state_change_event(
             self.hass, entities, self._action
         )
 
@@ -643,7 +667,7 @@ class _TrackStateChangeFiltered:
         if not domains:
             return
 
-        self._listeners[_DOMAINS_LISTENER] = async_track_state_added_domain(
+        self._listeners[_DOMAINS_LISTENER] = _async_track_state_added_domain(
             self.hass, domains, self._state_added
         )
 
@@ -1217,7 +1241,7 @@ def async_track_same_state(
     else:
         async_remove_state_for_cancel = async_track_state_change_event(
             hass,
-            [entity_ids] if isinstance(entity_ids, str) else entity_ids,
+            entity_ids,
             state_for_cancel_listener,
         )
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1983,6 +1983,69 @@ async def test_track_template_result_and_conditional(hass):
     assert specific_runs[2] == "on"
 
 
+async def test_track_template_result_and_conditional_upper_case(hass):
+    """Test tracking template with an and conditional with an upper case template."""
+    specific_runs = []
+    hass.states.async_set("light.a", "off")
+    hass.states.async_set("light.b", "off")
+    template_str = '{% if states.light.A.state == "on" and states.light.B.state == "on" %}on{% else %}off{% endif %}'
+
+    template = Template(template_str, hass)
+
+    def specific_run_callback(event, updates):
+        specific_runs.append(updates.pop().result)
+
+    info = async_track_template_result(
+        hass, [TrackTemplate(template, None)], specific_run_callback
+    )
+    await hass.async_block_till_done()
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": {"light.a"},
+        "time": False,
+    }
+
+    hass.states.async_set("light.b", "on")
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 0
+
+    hass.states.async_set("light.a", "on")
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+    assert specific_runs[0] == "on"
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": {"light.a", "light.b"},
+        "time": False,
+    }
+
+    hass.states.async_set("light.b", "off")
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 2
+    assert specific_runs[1] == "off"
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": {"light.a", "light.b"},
+        "time": False,
+    }
+
+    hass.states.async_set("light.a", "off")
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 2
+
+    hass.states.async_set("light.b", "on")
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 2
+
+    hass.states.async_set("light.a", "on")
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 3
+    assert specific_runs[2] == "on"
+
+
 async def test_track_template_result_iterator(hass):
     """Test tracking template."""
     iterator_runs = []
@@ -2187,7 +2250,7 @@ async def test_track_template_rate_limit(hass):
     assert refresh_runs == [0]
     info.async_refresh()
     assert refresh_runs == [0, 1]
-    hass.states.async_set("sensor.two", "any")
+    hass.states.async_set("sensor.TWO", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [0, 1]
     next_time = dt_util.utcnow() + timedelta(seconds=0.125)
@@ -2200,7 +2263,7 @@ async def test_track_template_rate_limit(hass):
     hass.states.async_set("sensor.three", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [0, 1, 2]
-    hass.states.async_set("sensor.four", "any")
+    hass.states.async_set("sensor.fOuR", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [0, 1, 2]
     next_time = dt_util.utcnow() + timedelta(seconds=0.125 * 2)
@@ -2385,7 +2448,7 @@ async def test_track_template_rate_limit_super_3(hass):
     await hass.async_block_till_done()
 
     assert refresh_runs == []
-    hass.states.async_set("sensor.one", "any")
+    hass.states.async_set("sensor.ONE", "any")
     await hass.async_block_till_done()
     assert refresh_runs == []
     info.async_refresh()
@@ -2408,7 +2471,7 @@ async def test_track_template_rate_limit_super_3(hass):
     hass.states.async_set("sensor.four", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [1, 2]
-    hass.states.async_set("sensor.five", "any")
+    hass.states.async_set("sensor.FIVE", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [1, 2]
     next_time = dt_util.utcnow() + timedelta(seconds=0.125 * 2)
@@ -2453,7 +2516,7 @@ async def test_track_template_rate_limit_suppress_listener(hass):
     await hass.async_block_till_done()
 
     assert refresh_runs == [0]
-    hass.states.async_set("sensor.one", "any")
+    hass.states.async_set("sensor.oNe", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [0]
     info.async_refresh()
@@ -2482,7 +2545,7 @@ async def test_track_template_rate_limit_suppress_listener(hass):
         "time": False,
     }
     assert refresh_runs == [0, 1, 2]
-    hass.states.async_set("sensor.three", "any")
+    hass.states.async_set("sensor.Three", "any")
     await hass.async_block_till_done()
     assert refresh_runs == [0, 1, 2]
     hass.states.async_set("sensor.four", "any")
@@ -2509,7 +2572,7 @@ async def test_track_template_rate_limit_suppress_listener(hass):
         "time": False,
     }
     assert refresh_runs == [0, 1, 2, 4]
-    hass.states.async_set("sensor.five", "any")
+    hass.states.async_set("sensor.Five", "any")
     await hass.async_block_till_done()
     # Rate limit hit and the all listener is shut off
     assert info.listeners == {


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- For templates that get ratelimited, we would lowercase the entities
  that were returned from the template tracking.  If they are enumerating
  an entire domain, this can be large list that is potentially getting
  done every second for multiple templates.


Test yaml
```yaml
sensor:
  - platform: template
    sensors:
      all_sensors:
        entity_id: sensor.time
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        value_template: "{{states.sensor|rejectattr('state', 'in', ['unavailable','unknown','none'])|map(attribute='state')|list|join(', ')|count}}"
      unavailable_entities:
        entity_id: sensor.time
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        icon_template: >
          {% if states('sensor.unavailable_entities')|int == 0 %}
            mdi:check-circle
          {% else %}
            mdi:alert-circle
          {% endif %}
        value_template: >
          {% if states('sensor.uptime_in_uren')|float > 0.05|float %}
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq', states.group.entity_blacklist)
              |list|length}}
           {% else %}
            0
          {% endif %}
        attribute_templates:
          entities: >
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq' , states.group.entity_blacklist)
              |map(attribute='entity_id')|list|join(', ')}}
      unavailable_entities2:
        entity_id: sensor.time
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        icon_template: >
          {% if states('sensor.unavailable_entities')|int == 0 %}
            mdi:check-circle
          {% else %}
            mdi:alert-circle
          {% endif %}
        value_template: >
          {% if states('sensor.uptime_in_uren')|float > 0.05|float %}
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq', states.group.entity_blacklist)
              |list|length}}
           {% else %}
            0
          {% endif %}
        attribute_templates:
          entities: >
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq' , states.group.entity_blacklist)
              |map(attribute='entity_id')|list|join(', ')}}
      unavailable_entities3:
        entity_id: sensor.time
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        icon_template: >
          {% if states('sensor.unavailable_entities')|int == 0 %}
            mdi:check-circle
          {% else %}
            mdi:alert-circle
          {% endif %}
        value_template: >
          {% if states('sensor.uptime_in_uren')|float > 0.05|float %}
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq', states.group.entity_blacklist)
              |list|length}}
           {% else %}
            0
          {% endif %}
        attribute_templates:
          entities: >
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq' , states.group.entity_blacklist)
              |map(attribute='entity_id')|list|join(', ')}}
      unavailable_entities4:
        entity_id: sensor.time
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        icon_template: >
          {% if states('sensor.unavailable_entities')|int == 0 %}
            mdi:check-circle
          {% else %}
            mdi:alert-circle
          {% endif %}
        value_template: >
          {% if states('sensor.uptime_in_uren')|float > 0.05|float %}
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq', states.group.entity_blacklist)
              |list|length}}
           {% else %}
            0
          {% endif %}
        attribute_templates:
          entities: >
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq' , states.group.entity_blacklist)
              |map(attribute='entity_id')|list|join(', ')}}
      unavailable_entities5:
        entity_id: sensor.time
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        icon_template: >
          {% if states('sensor.unavailable_entities')|int == 0 %}
            mdi:check-circle
          {% else %}
            mdi:alert-circle
          {% endif %}
        value_template: >
          {% if states('sensor.uptime_in_uren')|float > 0.05|float %}
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq', states.group.entity_blacklist)
              |list|length}}
           {% else %}
            0
          {% endif %}
        attribute_templates:
          entities: >
            {{states.sensor|selectattr('state', 'in', ['unavailable','unknown','none'])
              |reject('in', expand('group.entity_blacklist'))
              |reject('eq' , states.group.entity_blacklist)
              |map(attribute='entity_id')|list|join(', ')}}

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
