### PR TITLE
Fix Insteon issue with dimmer default on level

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -49,7 +49,8 @@ async def async_get_device_config(hass, config_entry):
         with suppress(AttributeError):
             await devices[address].async_status()
 
-    load_aldb = devices.modem.aldb.read_write_mode == ReadWriteMode.UNKNOWN
+    read_status = devices.modem.aldb.read_write_mode == ReadWriteMode.UNKNOWN
+    load_aldb = 2 if read_status else 1
     await devices.async_load(id_devices=1, load_modem_aldb=load_aldb)
     for addr in devices:
         device = devices[addr]

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -49,8 +49,7 @@ async def async_get_device_config(hass, config_entry):
         with suppress(AttributeError):
             await devices[address].async_status()
 
-    read_status = devices.modem.aldb.read_write_mode == ReadWriteMode.UNKNOWN
-    load_aldb = 2 if read_status else 1
+    load_aldb = 2 if devices.modem.aldb.read_write_mode == ReadWriteMode.UNKNOWN else 1
     await devices.async_load(id_devices=1, load_modem_aldb=load_aldb)
     for addr in devices:
         device = devices[addr]

--- a/homeassistant/components/insteon/insteon_entity.py
+++ b/homeassistant/components/insteon/insteon_entity.py
@@ -3,7 +3,6 @@ import functools
 import logging
 
 from pyinsteon import devices
-from pyinsteon.config import get_usable_value
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -154,10 +153,9 @@ class InsteonEntity(Entity):
 
     def get_device_property(self, name: str):
         """Get a single Insteon device property value (raw)."""
-        value = None
         if (prop := self._insteon_device.properties.get(name)) is not None:
-            value = get_usable_value(prop)
-        return value
+            return prop.value
+        return None
 
     def _get_label(self):
         """Get the device label for grouped devices."""

--- a/homeassistant/components/insteon/insteon_entity.py
+++ b/homeassistant/components/insteon/insteon_entity.py
@@ -3,6 +3,7 @@ import functools
 import logging
 
 from pyinsteon import devices
+from pyinsteon.config import get_usable_value
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -155,7 +156,7 @@ class InsteonEntity(Entity):
         """Get a single Insteon device property value (raw)."""
         value = None
         if (prop := self._insteon_device.properties.get(name)) is not None:
-            value = prop.value if prop.new_value is None else prop.new_value
+            value = get_usable_value(prop)
         return value
 
     def _get_label(self):

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -56,15 +56,16 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn light on."""
-        brightness = 0xFF
         if ATTR_BRIGHTNESS in kwargs:
             brightness = int(kwargs[ATTR_BRIGHTNESS])
         elif self._insteon_device_group.group == 1:
             brightness = self.get_device_property(ON_LEVEL)
-
-        await self._insteon_device.async_on(
-            on_level=brightness, group=self._insteon_device_group.group
-        )
+        if brightness:
+            await self._insteon_device.async_on(
+                on_level=brightness, group=self._insteon_device_group.group
+            )
+        else:
+            await self._insteon_device.async_on(group=self._insteon_device_group.group)
 
     async def async_turn_off(self, **kwargs):
         """Turn light off."""

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -60,7 +60,7 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
             brightness = int(kwargs[ATTR_BRIGHTNESS])
         else:
             brightness = self.get_device_property(ON_LEVEL)
-        if brightness is not None:
+        if brightness:
             await self._insteon_device.async_on(
                 on_level=brightness, group=self._insteon_device_group.group
             )

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -56,16 +56,15 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn light on."""
+        brightness = 0xFF
         if ATTR_BRIGHTNESS in kwargs:
             brightness = int(kwargs[ATTR_BRIGHTNESS])
-        else:
+        elif self._insteon_device_group.group == 1:
             brightness = self.get_device_property(ON_LEVEL)
-        if brightness:
-            await self._insteon_device.async_on(
-                on_level=brightness, group=self._insteon_device_group.group
-            )
-        else:
-            await self._insteon_device.async_on(group=self._insteon_device_group.group)
+
+        await self._insteon_device.async_on(
+            on_level=brightness, group=self._insteon_device_group.group
+        )
 
     async def async_turn_off(self, **kwargs):
         """Turn light off."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes an issue where the default on level is not read from the device property and results in the "on" command turning the device to a brightness of zero by mistake. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
