### PR TITLE
2022.5.2

### DIFF
--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -144,10 +144,11 @@ class CanaryCamera(CoordinatorEntity[CanaryDataUpdateCoordinator], Camera):
         if self._live_stream_session is None:
             return None
 
-        stream = CameraMjpeg(self._ffmpeg.binary)
-        await stream.open_camera(
-            self._live_stream_session.live_stream_url, extra_cmd=self._ffmpeg_arguments
+        live_stream_url = await self.hass.async_add_executor_job(
+            getattr, self._live_stream_session, "live_stream_url"
         )
+        stream = CameraMjpeg(self._ffmpeg.binary)
+        await stream.open_camera(live_stream_url, extra_cmd=self._ffmpeg_arguments)
 
         try:
             stream_reader = await stream.get_reader()

--- a/homeassistant/components/glances/manifest.json
+++ b/homeassistant/components/glances/manifest.json
@@ -3,7 +3,7 @@
   "name": "Glances",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/glances",
-  "requirements": ["glances_api==0.3.4"],
+  "requirements": ["glances_api==0.3.5"],
   "codeowners": ["@engrbm87"],
   "iot_class": "local_polling",
   "loggers": ["glances_api"]

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -308,6 +308,22 @@ class OnOffChannel(ZigbeeChannel):
         """Return cached value of on/off attribute."""
         return self.cluster.get("on_off")
 
+    async def turn_on(self) -> bool:
+        """Turn the on off cluster on."""
+        result = await self.on()
+        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            return False
+        self.cluster.update_attribute(self.ON_OFF, t.Bool.true)
+        return True
+
+    async def turn_off(self) -> bool:
+        """Turn the on off cluster off."""
+        result = await self.off()
+        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            return False
+        self.cluster.update_attribute(self.ON_OFF, t.Bool.false)
+        return True
+
     @callback
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -64,15 +64,15 @@ class Switch(ZhaEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        result = await self._on_off_channel.on()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        result = await self._on_off_channel.turn_on()
+        if not result:
             return
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        result = await self._on_off_channel.off()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        result = await self._on_off_channel.turn_off()
+        if not result:
             return
         self.async_write_ha_state()
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 5
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -73,11 +73,7 @@ class Selector:
 
     def serialize(self) -> Any:
         """Serialize Selector for voluptuous_serialize."""
-        return {"selector": {self.selector_type: self.serialize_config()}}
-
-    def serialize_config(self) -> Any:
-        """Serialize config."""
-        return self.config
+        return {"selector": {self.selector_type: self.config}}
 
 
 SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA = vol.Schema(
@@ -617,8 +613,8 @@ class NumberSelector(Selector):
                     vol.Coerce(float), vol.Range(min=1e-3)
                 ),
                 vol.Optional(CONF_UNIT_OF_MEASUREMENT): str,
-                vol.Optional(CONF_MODE, default=NumberSelectorMode.SLIDER): vol.Coerce(
-                    NumberSelectorMode
+                vol.Optional(CONF_MODE, default=NumberSelectorMode.SLIDER): vol.All(
+                    vol.Coerce(NumberSelectorMode), lambda val: val.value
                 ),
             }
         ),
@@ -628,13 +624,6 @@ class NumberSelector(Selector):
     def __init__(self, config: NumberSelectorConfig | None = None) -> None:
         """Instantiate a selector."""
         super().__init__(config)
-
-    def serialize_config(self) -> Any:
-        """Serialize the selector config."""
-        return {
-            **self.config,
-            "mode": self.config["mode"].value,
-        }
 
     def __call__(self, data: Any) -> float:
         """Validate the passed selection."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -723,7 +723,7 @@ gios==2.1.0
 gitterpy==0.1.7
 
 # homeassistant.components.glances
-glances_api==0.3.4
+glances_api==0.3.5
 
 # homeassistant.components.goalzero
 goalzero==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -514,7 +514,7 @@ getmac==0.8.2
 gios==2.1.0
 
 # homeassistant.components.glances
-glances_api==0.3.4
+glances_api==0.3.5
 
 # homeassistant.components.goalzero
 goalzero==0.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name         = homeassistant
-version      = 2022.5.1
+version      = 2022.5.2
 author       = The Home Assistant Authors
 author_email = hello@home-assistant.io
 license      = Apache-2.0

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1474,6 +1474,7 @@ async def test_blueprint_automation(hass, calls):
                     "input": {
                         "trigger_event": "blueprint_event",
                         "service_to_call": "test.automation",
+                        "a_number": 5,
                     },
                 }
             }
@@ -1499,6 +1500,7 @@ async def test_blueprint_automation_bad_config(hass, caplog):
                     "input": {
                         "trigger_event": "blueprint_event",
                         "service_to_call": {"dict": "not allowed"},
+                        "a_number": 5,
                     },
                 }
             }

--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -199,6 +199,7 @@ async def test_fetch_blueprint_from_github_url(hass, aioclient_mock, url):
     assert imported_blueprint.blueprint.inputs == {
         "service_to_call": None,
         "trigger_event": {"selector": {"text": {}}},
+        "a_number": {"selector": {"number": {"mode": "box", "step": 1.0}}},
     }
     assert imported_blueprint.suggested_filename == "balloob/motion_light"
     assert imported_blueprint.blueprint.metadata["source_url"] == url

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -33,6 +33,7 @@ async def test_list_blueprints(hass, hass_ws_client):
                 "input": {
                     "service_to_call": None,
                     "trigger_event": {"selector": {"text": {}}},
+                    "a_number": {"selector": {"number": {"mode": "box", "step": 1.0}}},
                 },
                 "name": "Call service based on event",
             },
@@ -95,6 +96,7 @@ async def test_import_blueprint(hass, aioclient_mock, hass_ws_client):
                 "input": {
                     "service_to_call": None,
                     "trigger_event": {"selector": {"text": {}}},
+                    "a_number": {"selector": {"number": {"mode": "box", "step": 1.0}}},
                 },
                 "name": "Call service based on event",
                 "source_url": "https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/motion_light.yaml",
@@ -129,7 +131,7 @@ async def test_save_blueprint(hass, aioclient_mock, hass_ws_client):
         assert msg["success"]
         assert write_mock.mock_calls
         assert write_mock.call_args[0] == (
-            "blueprint:\n  name: Call service based on event\n  domain: automation\n  input:\n    trigger_event:\n      selector:\n        text: {}\n    service_to_call:\n  source_url: https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/motion_light.yaml\ntrigger:\n  platform: event\n  event_type: !input 'trigger_event'\naction:\n  service: !input 'service_to_call'\n  entity_id: light.kitchen\n",
+            "blueprint:\n  name: Call service based on event\n  domain: automation\n  input:\n    trigger_event:\n      selector:\n        text: {}\n    service_to_call:\n    a_number:\n      selector:\n        number:\n          mode: box\n          step: 1.0\n  source_url: https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/motion_light.yaml\ntrigger:\n  platform: event\n  event_type: !input 'trigger_event'\naction:\n  service: !input 'service_to_call'\n  entity_id: light.kitchen\n",
         )
 
 

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -1539,6 +1539,7 @@ async def test_trace_blueprint_automation(
             "input": {
                 "trigger_event": "blueprint_event",
                 "service_to_call": "test.automation",
+                "a_number": 5,
             },
         },
     }

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1,4 +1,6 @@
 """Test selectors."""
+from enum import Enum
+
 import pytest
 import voluptuous as vol
 
@@ -52,6 +54,8 @@ def _test_selector(
     config = {selector_type: schema}
     selector.validate_selector(config)
     selector_instance = selector.selector(config)
+    # We do not allow enums in the config, as they cannot serialize
+    assert not any(isinstance(val, Enum) for val in selector_instance.config.values())
 
     # Use selector in schema and validate
     vol_schema = vol.Schema({"selection": selector_instance})

--- a/tests/testing_config/blueprints/automation/test_event_service.yaml
+++ b/tests/testing_config/blueprints/automation/test_event_service.yaml
@@ -6,6 +6,10 @@ blueprint:
       selector:
         text:
     service_to_call:
+    a_number:
+      selector:
+        number:
+          mode: "box"
 trigger:
   platform: event
   event_type: !input trigger_event


### PR DESCRIPTION
- Upgrade glances_api to 0.3.5 ([@difelice] - [#71243]) ([glances docs])
- Fix Canary camera stream blocking call ([@0bmay] - [#71369]) ([canary docs])
- Update Zigpy attribute cache for switch devices that do not report state ([@dmulcahey] - [#71417]) ([zha docs])
- Stringify enums in selectors ([@balloob] - [#71441]) ([blueprint docs])

[#71243]: https://github.com/home-assistant/core/pull/71243
[#71369]: https://github.com/home-assistant/core/pull/71369
[#71417]: https://github.com/home-assistant/core/pull/71417
[#71441]: https://github.com/home-assistant/core/pull/71441
[@0bmay]: https://github.com/0bmay
[@balloob]: https://github.com/balloob
[@difelice]: https://github.com/difelice
[@dmulcahey]: https://github.com/dmulcahey
[blueprint docs]: https://www.home-assistant.io/integrations/blueprint/
[canary docs]: https://www.home-assistant.io/integrations/canary/
[glances docs]: https://www.home-assistant.io/integrations/glances/
[zha docs]: https://www.home-assistant.io/integrations/zha/