### PR TITLE
Improve Airzone diagnostics

### DIFF
--- a/homeassistant/components/airzone/diagnostics.py
+++ b/homeassistant/components/airzone/diagnostics.py
@@ -3,16 +3,25 @@ from __future__ import annotations
 
 from typing import Any
 
-from aioairzone.const import AZD_MAC
+from aioairzone.const import API_MAC, AZD_MAC
 
 from homeassistant.components.diagnostics.util import async_redact_data
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import AirzoneUpdateCoordinator
 
-TO_REDACT = [
+TO_REDACT_API = [
+    API_MAC,
+]
+
+TO_REDACT_CONFIG = [
+    CONF_UNIQUE_ID,
+]
+
+TO_REDACT_COORD = [
     AZD_MAC,
 ]
 
@@ -24,6 +33,7 @@ async def async_get_config_entry_diagnostics(
     coordinator: AirzoneUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     return {
-        "info": async_redact_data(config_entry.data, TO_REDACT),
-        "data": async_redact_data(coordinator.data, TO_REDACT),
+        "api_data": async_redact_data(coordinator.airzone.raw_data(), TO_REDACT_API),
+        "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT_CONFIG),
+        "coord_data": async_redact_data(coordinator.data, TO_REDACT_COORD),
     }

--- a/tests/components/airzone/test_diagnostics.py
+++ b/tests/components/airzone/test_diagnostics.py
@@ -1,20 +1,30 @@
 """The diagnostics tests for the Airzone platform."""
 
+from unittest.mock import patch
+
 from aioairzone.const import (
+    API_DATA,
+    API_MAC,
+    API_SYSTEM_ID,
+    API_SYSTEMS,
+    API_WIFI_RSSI,
     AZD_ID,
     AZD_MASTER,
     AZD_SYSTEM,
     AZD_SYSTEMS,
     AZD_ZONES,
     AZD_ZONES_NUM,
+    RAW_HVAC,
+    RAW_WEBSERVER,
 )
 from aiohttp import ClientSession
 
 from homeassistant.components.airzone.const import DOMAIN
+from homeassistant.components.diagnostics.const import REDACTED
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
-from .util import CONFIG, async_init_integration
+from .util import CONFIG, HVAC_MOCK, HVAC_WEBSERVER_MOCK, async_init_integration
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
@@ -27,31 +37,55 @@ async def test_config_entry_diagnostics(
     assert hass.data[DOMAIN]
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.raw_data",
+        return_value={
+            RAW_HVAC: HVAC_MOCK,
+            RAW_WEBSERVER: HVAC_WEBSERVER_MOCK,
+        },
+    ):
+        diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
-    diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert (
+        diag["api_data"][RAW_HVAC][API_SYSTEMS][0][API_DATA][0].items()
+        >= {
+            API_SYSTEM_ID: HVAC_MOCK[API_SYSTEMS][0][API_DATA][0][API_SYSTEM_ID],
+        }.items()
+    )
 
-    assert diag["info"][CONF_HOST] == CONFIG[CONF_HOST]
-    assert diag["info"][CONF_PORT] == CONFIG[CONF_PORT]
+    assert (
+        diag["api_data"][RAW_WEBSERVER].items()
+        >= {
+            API_MAC: REDACTED,
+            API_WIFI_RSSI: HVAC_WEBSERVER_MOCK[API_WIFI_RSSI],
+        }.items()
+    )
 
-    assert diag["data"][AZD_SYSTEMS]["1"][AZD_ID] == 1
-    assert diag["data"][AZD_SYSTEMS]["1"][AZD_ZONES_NUM] == 5
+    assert (
+        diag["config_entry"].items()
+        >= {
+            "data": {
+                CONF_HOST: CONFIG[CONF_HOST],
+                CONF_PORT: CONFIG[CONF_PORT],
+            },
+            "domain": DOMAIN,
+            "unique_id": REDACTED,
+        }.items()
+    )
 
-    assert diag["data"][AZD_ZONES]["1:1"][AZD_ID] == 1
-    assert diag["data"][AZD_ZONES]["1:1"][AZD_MASTER] == 1
-    assert diag["data"][AZD_ZONES]["1:1"][AZD_SYSTEM] == 1
+    assert (
+        diag["coord_data"][AZD_SYSTEMS]["1"].items()
+        >= {
+            AZD_ID: 1,
+            AZD_ZONES_NUM: 5,
+        }.items()
+    )
 
-    assert diag["data"][AZD_ZONES]["1:2"][AZD_ID] == 2
-    assert diag["data"][AZD_ZONES]["1:2"][AZD_MASTER] == 0
-    assert diag["data"][AZD_ZONES]["1:2"][AZD_SYSTEM] == 1
-
-    assert diag["data"][AZD_ZONES]["1:3"][AZD_ID] == 3
-    assert diag["data"][AZD_ZONES]["1:3"][AZD_MASTER] == 0
-    assert diag["data"][AZD_ZONES]["1:3"][AZD_SYSTEM] == 1
-
-    assert diag["data"][AZD_ZONES]["1:4"][AZD_ID] == 4
-    assert diag["data"][AZD_ZONES]["1:4"][AZD_MASTER] == 0
-    assert diag["data"][AZD_ZONES]["1:4"][AZD_SYSTEM] == 1
-
-    assert diag["data"][AZD_ZONES]["1:5"][AZD_ID] == 5
-    assert diag["data"][AZD_ZONES]["1:5"][AZD_MASTER] == 0
-    assert diag["data"][AZD_ZONES]["1:5"][AZD_SYSTEM] == 1
+    assert (
+        diag["coord_data"][AZD_ZONES]["1:1"].items()
+        >= {
+            AZD_ID: 1,
+            AZD_MASTER: True,
+            AZD_SYSTEM: 1,
+        }.items()
+    )


### PR DESCRIPTION
## Proposed change
Improve Airzone diagnostics.
Adds full config_entry (vs only .data) and Airzone Local API raw data, which is useful to debug device differences due to the different Airzone variations and specific configurations.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
