### PR TITLE
Add support for polled Smart Energy Metering sensors to ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -102,7 +102,7 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
             for attr, value in result.items():
                 self.async_send_signal(
                     f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
-                    self.cluster.attridx.get(attr, attr),
+                    self.cluster.find_attribute(attr).id,
                     attr,
                     value,
                 )

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -182,7 +182,7 @@ class Metering(ZigbeeChannel):
             for attr, value in result.items():
                 self.async_send_signal(
                     f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
-                    self.cluster.attridx.get(attr, attr),
+                    self.cluster.find_attribute(attr).id,
                     attr,
                     value,
                 )

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -7,7 +7,12 @@ from functools import partialmethod
 from zigpy.zcl.clusters import smartenergy
 
 from .. import registries, typing as zha_typing
-from ..const import REPORT_CONFIG_ASAP, REPORT_CONFIG_DEFAULT, REPORT_CONFIG_OP
+from ..const import (
+    REPORT_CONFIG_ASAP,
+    REPORT_CONFIG_DEFAULT,
+    REPORT_CONFIG_OP,
+    SIGNAL_ATTR_UPDATED,
+)
 from .base import ZigbeeChannel
 
 
@@ -162,6 +167,25 @@ class Metering(ZigbeeChannel):
             "summation_formatting", 0xF9
         )  # 1 digit to the right, 15 digits to the left
         self._summa_format = self.get_formatting(fmting)
+
+    async def async_force_update(self) -> None:
+        """Retrieve latest state."""
+        self.debug("async_force_update")
+
+        attrs = [
+            a["attr"]
+            for a in self.REPORT_CONFIG
+            if a["attr"] not in self.cluster.unsupported_attributes
+        ]
+        result = await self.get_attributes(attrs, from_cache=False, only_cache=False)
+        if result:
+            for attr, value in result.items():
+                self.async_send_signal(
+                    f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                    self.cluster.attridx.get(attr, attr),
+                    attr,
+                    value,
+                )
 
     @staticmethod
     def get_formatting(formatting: int) -> str:

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -469,7 +469,7 @@ class SmartEnergyMetering(Sensor):
 
 @MULTI_MATCH(
     channel_names=CHANNEL_SMARTENERGY_METERING,
-    models=["add-model-names-here"],
+    models={"TS011F"},
     stop_on_match_group=CHANNEL_SMARTENERGY_METERING,
 )
 class PolledSmartEnergyMetering(SmartEnergyMetering):

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -420,7 +420,10 @@ class Illuminance(Sensor):
         return round(pow(10, ((value - 1) / 10000)), 1)
 
 
-@MULTI_MATCH(channel_names=CHANNEL_SMARTENERGY_METERING)
+@MULTI_MATCH(
+    channel_names=CHANNEL_SMARTENERGY_METERING,
+    stop_on_match_group=CHANNEL_SMARTENERGY_METERING,
+)
 class SmartEnergyMetering(Sensor):
     """Metering sensor."""
 
@@ -462,6 +465,26 @@ class SmartEnergyMetering(Sensor):
         if (status := self._channel.status) is not None:
             attrs["status"] = str(status)[len(status.__class__.__name__) + 1 :]
         return attrs
+
+
+@MULTI_MATCH(
+    channel_names=CHANNEL_SMARTENERGY_METERING,
+    models=["add-model-names-here"],
+    stop_on_match_group=CHANNEL_SMARTENERGY_METERING,
+)
+class PolledSmartEnergyMetering(SmartEnergyMetering):
+    """Polled metering sensor."""
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll the entity for current state."""
+        return True
+
+    async def async_update(self) -> None:
+        """Retrieve latest state."""
+        if not self.available:
+            return
+        await self._channel.async_force_update()
 
 
 @MULTI_MATCH(channel_names=CHANNEL_SMARTENERGY_METERING)

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -29,6 +29,7 @@ from .entity import ZhaEntity, ZhaGroupEntity
 
 if TYPE_CHECKING:
     from .core.channels.base import ZigbeeChannel
+    from .core.channels.general import OnOffChannel
     from .core.device import ZHADevice
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.SWITCH)
@@ -62,10 +63,16 @@ async def async_setup_entry(
 class Switch(ZhaEntity, SwitchEntity):
     """ZHA switch."""
 
-    def __init__(self, unique_id, zha_device, channels, **kwargs):
+    def __init__(
+        self,
+        unique_id: str,
+        zha_device: ZHADevice,
+        channels: list[ZigbeeChannel],
+        **kwargs: Any,
+    ) -> None:
         """Initialize the ZHA switch."""
         super().__init__(unique_id, zha_device, channels, **kwargs)
-        self._on_off_channel = self.cluster_channels.get(CHANNEL_ON_OFF)
+        self._on_off_channel: OnOffChannel = self.cluster_channels.get(CHANNEL_ON_OFF)
 
     @property
     def is_on(self) -> bool:
@@ -74,14 +81,14 @@ class Switch(ZhaEntity, SwitchEntity):
             return False
         return self._on_off_channel.on_off
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         result = await self._on_off_channel.turn_on()
         if not result:
             return
         self.async_write_ha_state()
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         result = await self._on_off_channel.turn_off()
         if not result:
@@ -112,7 +119,12 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
     """Representation of a switch group."""
 
     def __init__(
-        self, entity_ids: list[str], unique_id: str, group_id: int, zha_device, **kwargs
+        self,
+        entity_ids: list[str],
+        unique_id: str,
+        group_id: int,
+        zha_device: ZHADevice,
+        **kwargs: Any,
     ) -> None:
         """Initialize a switch group."""
         super().__init__(entity_ids, unique_id, group_id, zha_device, **kwargs)
@@ -126,7 +138,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
         """Return if the switch is on based on the statemachine."""
         return bool(self._state)
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         result = await self._on_off_channel.on()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -134,7 +146,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
         self._state = True
         self.async_write_ha_state()
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         result = await self._on_off_channel.off()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -165,7 +177,7 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
         unique_id: str,
         zha_device: ZHADevice,
         channels: list[ZigbeeChannel],
-        **kwargs,
+        **kwargs: Any,
     ) -> ZhaEntity | None:
         """Entity Factory.
 
@@ -190,7 +202,7 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
         unique_id: str,
         zha_device: ZHADevice,
         channels: list[ZigbeeChannel],
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Init this number configuration entity."""
         self._channel: ZigbeeChannel = channels[0]
@@ -215,7 +227,7 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
         invert = bool(self._channel.cluster.get(self._zcl_inverter_attribute))
         return (not val) if invert else val
 
-    async def async_turn_on_off(self, state) -> None:
+    async def async_turn_on_off(self, state: bool) -> None:
         """Turn the entity on or off."""
         try:
             invert = bool(self._channel.cluster.get(self._zcl_inverter_attribute))
@@ -230,11 +242,11 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
         ):
             self.async_write_ha_state()
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.async_turn_on_off(True)
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.async_turn_on_off(False)
 
@@ -263,8 +275,8 @@ class OnOffWindowDetectionFunctionConfigurationEntity(
 ):
     """Representation of a ZHA window detection configuration entity."""
 
-    _zcl_attribute = "window_detection_function"
-    _zcl_inverter_attribute = "window_detection_function_inverter"
+    _zcl_attribute: str = "window_detection_function"
+    _zcl_inverter_attribute: str = "window_detection_function_inverter"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.motion.ac02"})
@@ -273,4 +285,4 @@ class P1MotionTriggerIndicatorSwitch(
 ):
     """Representation of a ZHA motion triggering configuration entity."""
 
-    _zcl_attribute = "trigger_indicator"
+    _zcl_attribute: str = "trigger_indicator"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Several manufacturers do not follow the specs and the Smart Energy Metering based sensors need to be polled in order to get updated data. This PR adds a framework to address that.

Fixes: #67232

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #67232
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
