### PR TITLE
Speed up nightly database purges with lambda_stmt

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -14,14 +14,7 @@ from sqlalchemy.sql.expression import distinct
 from homeassistant.const import EVENT_STATE_CHANGED
 
 from .const import MAX_ROWS_TO_PURGE, SupportedDialect
-from .models import (
-    Events,
-    RecorderRuns,
-    StateAttributes,
-    States,
-    StatisticsRuns,
-    StatisticsShortTerm,
-)
+from .models import Events, RecorderRuns, StateAttributes, States, StatisticsRuns
 from .queries import (
     attributes_ids_exist_in_states,
     attributes_ids_exist_in_states_sqlite,
@@ -31,6 +24,7 @@ from .queries import (
     delete_states_attributes_rows,
     delete_states_rows,
     delete_statistics_runs_rows,
+    delete_statistics_short_term_rows,
     disconnect_states_rows,
     find_events_to_purge,
     find_short_term_statistics_to_purge,
@@ -368,10 +362,8 @@ def _purge_short_term_statistics(
     session: Session, short_term_statistics: list[int]
 ) -> None:
     """Delete by id."""
-    deleted_rows = (
-        session.query(StatisticsShortTerm)
-        .filter(StatisticsShortTerm.id.in_(short_term_statistics))
-        .delete(synchronize_session=False)
+    deleted_rows = session.execute(
+        delete_statistics_short_term_rows(short_term_statistics)
     )
     _LOGGER.debug("Deleted %s short term statistics", deleted_rows)
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -30,6 +30,7 @@ from .queries import (
     delete_event_data_rows,
     delete_states_attributes_rows,
     delete_states_rows,
+    delete_statistics_runs_rows,
     disconnect_states_rows,
     find_events_to_purge,
     find_short_term_statistics_to_purge,
@@ -359,11 +360,7 @@ def _purge_event_data_ids(
 
 def _purge_statistics_runs(session: Session, statistics_runs: list[int]) -> None:
     """Delete by run_id."""
-    deleted_rows = (
-        session.query(StatisticsRuns)
-        .filter(StatisticsRuns.run_id.in_(statistics_runs))
-        .delete(synchronize_session=False)
-    )
+    deleted_rows = session.execute(delete_statistics_runs_rows(statistics_runs))
     _LOGGER.debug("Deleted %s statistic runs", deleted_rows)
 
 

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -537,6 +537,17 @@ def delete_statistics_runs_rows(statistics_runs: list[int]) -> StatementLambdaEl
     )
 
 
+def delete_statistics_short_term_rows(
+    short_term_statistics: list[int],
+) -> StatementLambdaElement:
+    """Delete statistics_short_term rows."""
+    return lambda_stmt(
+        lambda: delete(StatisticsShortTerm, synchronize_session=False).where(
+            StatisticsShortTerm.id.in_(short_term_statistics)
+        )
+    )
+
+
 def find_events_to_purge(purge_before: datetime) -> StatementLambdaElement:
     """Find events to purge."""
     return lambda_stmt(

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -8,7 +8,14 @@ from sqlalchemy.sql.lambdas import StatementLambdaElement
 from sqlalchemy.sql.selectable import Select
 
 from .const import MAX_ROWS_TO_PURGE
-from .models import EventData, Events, StateAttributes, States, StatisticsShortTerm
+from .models import (
+    EventData,
+    Events,
+    StateAttributes,
+    States,
+    StatisticsRuns,
+    StatisticsShortTerm,
+)
 
 
 def find_shared_attributes_id(
@@ -517,6 +524,15 @@ def delete_states_attributes_rows(attributes_ids: set[int]) -> StatementLambdaEl
     return lambda_stmt(
         lambda: delete(StateAttributes, synchronize_session=False).where(
             StateAttributes.attributes_id.in_(attributes_ids)
+        )
+    )
+
+
+def delete_statistics_runs_rows(statistics_runs: list[int]) -> StatementLambdaElement:
+    """Delete statistics_runs rows."""
+    return lambda_stmt(
+        lambda: delete(StatisticsRuns, synchronize_session=False).where(
+            StatisticsRuns.run_id.in_(statistics_runs)
         )
     )
 

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -497,27 +497,28 @@ def data_ids_exist_in_events(
 def disconnect_states_rows(state_ids: Iterable[int]) -> StatementLambdaElement:
     """Disconnect states rows."""
     return lambda_stmt(
-        lambda: update(States, synchronize_session=False)
+        lambda: update(States)
         .where(States.old_state_id.in_(state_ids))
         .values(old_state_id=None)
+        .execution_options(synchronize_session=False)
     )
 
 
 def delete_states_rows(state_ids: Iterable[int]) -> StatementLambdaElement:
     """Delete states rows."""
     return lambda_stmt(
-        lambda: delete(States, synchronize_session=False).where(
-            States.state_id.in_(state_ids)
-        )
+        lambda: delete(States)
+        .where(States.state_id.in_(state_ids))
+        .execution_options(synchronize_session=False)
     )
 
 
 def delete_event_data_rows(data_ids: Iterable[int]) -> StatementLambdaElement:
     """Delete event_data rows."""
     return lambda_stmt(
-        lambda: delete(EventData, synchronize_session=False).where(
-            EventData.data_id.in_(data_ids)
-        )
+        lambda: delete(EventData)
+        .where(EventData.data_id.in_(data_ids))
+        .execution_options(synchronize_session=False)
     )
 
 
@@ -526,9 +527,9 @@ def delete_states_attributes_rows(
 ) -> StatementLambdaElement:
     """Delete states_attributes rows."""
     return lambda_stmt(
-        lambda: delete(StateAttributes, synchronize_session=False).where(
-            StateAttributes.attributes_id.in_(attributes_ids)
-        )
+        lambda: delete(StateAttributes)
+        .where(StateAttributes.attributes_id.in_(attributes_ids))
+        .execution_options(synchronize_session=False)
     )
 
 
@@ -537,9 +538,9 @@ def delete_statistics_runs_rows(
 ) -> StatementLambdaElement:
     """Delete statistics_runs rows."""
     return lambda_stmt(
-        lambda: delete(StatisticsRuns, synchronize_session=False).where(
-            StatisticsRuns.run_id.in_(statistics_runs)
-        )
+        lambda: delete(StatisticsRuns)
+        .where(StatisticsRuns.run_id.in_(statistics_runs))
+        .execution_options(synchronize_session=False)
     )
 
 
@@ -548,9 +549,9 @@ def delete_statistics_short_term_rows(
 ) -> StatementLambdaElement:
     """Delete statistics_short_term rows."""
     return lambda_stmt(
-        lambda: delete(StatisticsShortTerm, synchronize_session=False).where(
-            StatisticsShortTerm.id.in_(short_term_statistics)
-        )
+        lambda: delete(StatisticsShortTerm)
+        .where(StatisticsShortTerm.id.in_(short_term_statistics))
+        .execution_options(synchronize_session=False)
     )
 
 
@@ -559,9 +560,9 @@ def delete_event_rows(
 ) -> StatementLambdaElement:
     """Delete statistics_short_term rows."""
     return lambda_stmt(
-        lambda: delete(Events, synchronize_session=False).where(
-            Events.event_id.in_(event_ids)
-        )
+        lambda: delete(Events)
+        .where(Events.event_id.in_(event_ids))
+        .execution_options(synchronize_session=False)
     )
 
 
@@ -570,9 +571,10 @@ def delete_recorder_runs_rows(
 ) -> StatementLambdaElement:
     """Delete recorder_runs rows."""
     return lambda_stmt(
-        lambda: delete(RecorderRuns, synchronize_session=False)
+        lambda: delete(RecorderRuns)
         .filter(RecorderRuns.start < purge_before)
         .filter(RecorderRuns.run_id != current_run_id)
+        .execution_options(synchronize_session=False)
     )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up nightly database purges with lambda_stmt
https://docs.sqlalchemy.org/en/14/core/connections.html#quick-guidelines-for-lambdas

Closes #70409 Closes #70677 Closes #70309

The bulk of the python overhead is gone which makes the system much more responsive during the purge.  The purge process is now mostly sql work.  Before it was ~50/50 on my RPi3b
<img width="1333" alt="Screen Shot 2022-05-08 at 11 21 03" src="https://user-images.githubusercontent.com/663432/167305396-22b282cd-4b9c-40f4-bc9c-1d0216fd1d4a.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
