### PR TITLE
Mobile app to notify when sensor is disabled

### DIFF
--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -67,7 +67,7 @@ ERR_INVALID_FORMAT = "invalid_format"
 
 ATTR_SENSOR_ATTRIBUTES = "attributes"
 ATTR_SENSOR_DEVICE_CLASS = "device_class"
-ATTR_SENSOR_DEFAULT_DISABLED = "default_disabled"
+ATTR_SENSOR_DISABLED = "disabled"
 ATTR_SENSOR_ENTITY_CATEGORY = "entity_category"
 ATTR_SENSOR_ICON = "icon"
 ATTR_SENSOR_NAME = "name"

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -9,8 +9,8 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     ATTR_SENSOR_ATTRIBUTES,
-    ATTR_SENSOR_DEFAULT_DISABLED,
     ATTR_SENSOR_DEVICE_CLASS,
+    ATTR_SENSOR_DISABLED,
     ATTR_SENSOR_ENTITY_CATEGORY,
     ATTR_SENSOR_ICON,
     ATTR_SENSOR_STATE,
@@ -64,7 +64,7 @@ class MobileAppEntity(RestoreEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if entity should be enabled by default."""
-        return not self._config.get(ATTR_SENSOR_DEFAULT_DISABLED)
+        return not self._config.get(ATTR_SENSOR_DISABLED)
 
     @property
     def device_class(self):

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -64,8 +64,8 @@ from .const import (
     ATTR_NO_LEGACY_ENCRYPTION,
     ATTR_OS_VERSION,
     ATTR_SENSOR_ATTRIBUTES,
-    ATTR_SENSOR_DEFAULT_DISABLED,
     ATTR_SENSOR_DEVICE_CLASS,
+    ATTR_SENSOR_DISABLED,
     ATTR_SENSOR_ENTITY_CATEGORY,
     ATTR_SENSOR_ICON,
     ATTR_SENSOR_NAME,
@@ -462,7 +462,7 @@ def _extract_sensor_unique_id(webhook_id, unique_id):
             vol.Optional(ATTR_SENSOR_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
             vol.Optional(ATTR_SENSOR_ICON, default="mdi:cellphone"): cv.icon,
             vol.Optional(ATTR_SENSOR_STATE_CLASS): vol.In(SENSOSR_STATE_CLASSES),
-            vol.Optional(ATTR_SENSOR_DEFAULT_DISABLED): bool,
+            vol.Optional(ATTR_SENSOR_DISABLED): bool,
         },
         _validate_state_class_sensor,
     )
@@ -494,6 +494,15 @@ async def webhook_register_sensor(hass, config_entry, data):
             new_name := f"{device_name} {data[ATTR_SENSOR_NAME]}"
         ) != entry.original_name:
             changes["original_name"] = new_name
+
+        if (
+            should_be_disabled := data.get(ATTR_SENSOR_DISABLED)
+        ) is None or should_be_disabled == entry.disabled:
+            pass
+        elif should_be_disabled:
+            changes["disabled_by"] = er.RegistryEntryDisabler.INTEGRATION
+        else:
+            changes["disabled_by"] = None
 
         for ent_reg_key, data_key in (
             ("device_class", ATTR_SENSOR_DEVICE_CLASS),

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -373,3 +373,70 @@ async def test_default_disabling_entity(hass, create_registrations, webhook_clie
         er.async_get(hass).async_get("sensor.test_1_battery_state").disabled_by
         == er.RegistryEntryDisabler.INTEGRATION
     )
+
+
+async def test_updating_disabled_sensor(hass, create_registrations, webhook_client):
+    """Test that sensors return error if disabled in instance."""
+    webhook_id = create_registrations[1]["webhook_id"]
+    webhook_url = f"/api/webhook/{webhook_id}"
+
+    reg_resp = await webhook_client.post(
+        webhook_url,
+        json={
+            "type": "register_sensor",
+            "data": {
+                "name": "Battery State",
+                "state": None,
+                "type": "sensor",
+                "unique_id": "battery_state",
+            },
+        },
+    )
+
+    assert reg_resp.status == HTTPStatus.CREATED
+
+    update_resp = await webhook_client.post(
+        webhook_url,
+        json={
+            "type": "update_sensor_states",
+            "data": [
+                {
+                    "icon": "mdi:battery-unknown",
+                    "state": 123,
+                    "type": "sensor",
+                    "unique_id": "battery_state",
+                },
+            ],
+        },
+    )
+
+    assert update_resp.status == HTTPStatus.OK
+
+    json = await update_resp.json()
+    assert json["battery_state"]["success"] is True
+    assert "is_disabled" not in json["battery_state"]
+
+    er.async_get(hass).async_update_entity(
+        "sensor.test_1_battery_state", disabled_by=er.RegistryEntryDisabler.USER
+    )
+
+    update_resp = await webhook_client.post(
+        webhook_url,
+        json={
+            "type": "update_sensor_states",
+            "data": [
+                {
+                    "icon": "mdi:battery-unknown",
+                    "state": 123,
+                    "type": "sensor",
+                    "unique_id": "battery_state",
+                },
+            ],
+        },
+    )
+
+    assert update_resp.status == HTTPStatus.OK
+
+    json = await update_resp.json()
+    assert json["battery_state"]["success"] is True
+    assert json["battery_state"]["is_disabled"] is True

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -355,7 +355,7 @@ async def test_default_disabling_entity(hass, create_registrations, webhook_clie
                 "name": "Battery State",
                 "type": "sensor",
                 "unique_id": "battery_state",
-                "default_disabled": True,
+                "disabled": True,
             },
         },
     )

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -268,7 +268,7 @@ async def test_webhook_handle_get_config(hass, create_registrations, webhook_cli
             "name": "Battery Charging",
             "type": "sensor",
             "unique_id": "battery-charging-id",
-            "default_disabled": True,
+            "disabled": True,
         },
     ):
         reg_resp = await webhook_client.post(
@@ -927,6 +927,7 @@ async def test_reregister_sensor(hass, create_registrations, webhook_client):
     assert entry.unit_of_measurement is None
     assert entry.entity_category is None
     assert entry.original_icon == "mdi:cellphone"
+    assert entry.disabled_by is None
 
     reg_resp = await webhook_client.post(
         webhook_url,
@@ -942,6 +943,7 @@ async def test_reregister_sensor(hass, create_registrations, webhook_client):
                 "entity_category": "diagnostic",
                 "icon": "mdi:new-icon",
                 "unit_of_measurement": "%",
+                "disabled": True,
             },
         },
     )
@@ -953,3 +955,21 @@ async def test_reregister_sensor(hass, create_registrations, webhook_client):
     assert entry.unit_of_measurement == "%"
     assert entry.entity_category == "diagnostic"
     assert entry.original_icon == "mdi:new-icon"
+    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+
+    reg_resp = await webhook_client.post(
+        webhook_url,
+        json={
+            "type": "register_sensor",
+            "data": {
+                "name": "New Name",
+                "type": "sensor",
+                "unique_id": "abcd",
+                "disabled": False,
+            },
+        },
+    )
+
+    assert reg_resp.status == HTTPStatus.CREATED
+    entry = ent_reg.async_get("sensor.test_1_battery_state")
+    assert entry.disabled_by is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will add a new `is_disabled` field set to `True` to the success response for a sensor that is disabled. This allows the app to update the settings and stop reporting the sensor.

I initially had made it an error but realized that it would be backwards incompatible.

CC @home-assistant/android @home-assistant/ios-developers 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
