### PR TITLE
Allow mobile app to disable entities by default

### DIFF
--- a/homeassistant/components/mobile_app/binary_sensor.py
+++ b/homeassistant/components/mobile_app/binary_sensor.py
@@ -3,14 +3,13 @@ from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID, CONF_WEBHOOK_ID, STATE_ON
+from homeassistant.const import CONF_WEBHOOK_ID, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    ATTR_DEVICE_NAME,
     ATTR_SENSOR_ATTRIBUTES,
     ATTR_SENSOR_DEVICE_CLASS,
     ATTR_SENSOR_ENTITY_CATEGORY,
@@ -22,7 +21,7 @@ from .const import (
     ATTR_SENSOR_UNIQUE_ID,
     DOMAIN,
 )
-from .entity import MobileAppEntity, unique_id
+from .entity import MobileAppEntity
 
 
 async def async_setup_entry(
@@ -58,13 +57,6 @@ async def async_setup_entry(
     def handle_sensor_registration(data):
         if data[CONF_WEBHOOK_ID] != webhook_id:
             return
-
-        data[CONF_UNIQUE_ID] = unique_id(
-            data[CONF_WEBHOOK_ID], data[ATTR_SENSOR_UNIQUE_ID]
-        )
-        data[
-            CONF_NAME
-        ] = f"{config_entry.data[ATTR_DEVICE_NAME]} {data[ATTR_SENSOR_NAME]}"
 
         async_add_entities([MobileAppBinarySensor(data, config_entry)])
 

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -67,6 +67,7 @@ ERR_INVALID_FORMAT = "invalid_format"
 
 ATTR_SENSOR_ATTRIBUTES = "attributes"
 ATTR_SENSOR_DEVICE_CLASS = "device_class"
+ATTR_SENSOR_DEFAULT_DISABLED = "default_disabled"
 ATTR_SENSOR_ENTITY_CATEGORY = "entity_category"
 ATTR_SENSOR_ICON = "icon"
 ATTR_SENSOR_NAME = "name"

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -2,46 +2,35 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ICON,
-    CONF_NAME,
-    CONF_UNIQUE_ID,
-    CONF_WEBHOOK_ID,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import ATTR_ICON, CONF_NAME, CONF_UNIQUE_ID, STATE_UNAVAILABLE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     ATTR_SENSOR_ATTRIBUTES,
+    ATTR_SENSOR_DEFAULT_DISABLED,
     ATTR_SENSOR_DEVICE_CLASS,
     ATTR_SENSOR_ENTITY_CATEGORY,
     ATTR_SENSOR_ICON,
     ATTR_SENSOR_STATE,
-    ATTR_SENSOR_TYPE,
-    ATTR_SENSOR_UNIQUE_ID,
     SIGNAL_SENSOR_UPDATE,
 )
 from .helpers import device_info
 
 
-def unique_id(webhook_id, sensor_unique_id):
-    """Return a unique sensor ID."""
-    return f"{webhook_id}_{sensor_unique_id}"
-
-
 class MobileAppEntity(RestoreEntity):
     """Representation of an mobile app entity."""
+
+    _attr_should_poll = False
 
     def __init__(self, config: dict, entry: ConfigEntry) -> None:
         """Initialize the entity."""
         self._config = config
         self._entry = entry
         self._registration = entry.data
-        self._unique_id = config[CONF_UNIQUE_ID]
-        self._entity_type = config[ATTR_SENSOR_TYPE]
-        self._name = config[CONF_NAME]
+        self._attr_unique_id = config[CONF_UNIQUE_ID]
+        self._name = self._config[CONF_NAME]
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -68,14 +57,14 @@ class MobileAppEntity(RestoreEntity):
             self._config[ATTR_SENSOR_ICON] = last_state.attributes[ATTR_ICON]
 
     @property
-    def should_poll(self) -> bool:
-        """Declare that this entity pushes its state to HA."""
-        return False
-
-    @property
     def name(self):
         """Return the name of the mobile app sensor."""
         return self._name
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if entity should be enabled by default."""
+        return not self._config.get(ATTR_SENSOR_DEFAULT_DISABLED)
 
     @property
     def device_class(self):
@@ -98,11 +87,6 @@ class MobileAppEntity(RestoreEntity):
         return self._config.get(ATTR_SENSOR_ENTITY_CATEGORY)
 
     @property
-    def unique_id(self):
-        """Return the unique ID of this sensor."""
-        return self._unique_id
-
-    @property
     def device_info(self):
         """Return device registry information for this entity."""
         return device_info(self._registration)
@@ -113,10 +97,9 @@ class MobileAppEntity(RestoreEntity):
         return self._config.get(ATTR_SENSOR_STATE) != STATE_UNAVAILABLE
 
     @callback
-    def _handle_update(self, data):
+    def _handle_update(self, incoming_id, data):
         """Handle async event updates."""
-        incoming_id = unique_id(data[CONF_WEBHOOK_ID], data[ATTR_SENSOR_UNIQUE_ID])
-        if incoming_id != self._unique_id:
+        if incoming_id != self._attr_unique_id:
             return
 
         self._config = {**self._config, **data}

--- a/homeassistant/components/mobile_app/sensor.py
+++ b/homeassistant/components/mobile_app/sensor.py
@@ -5,12 +5,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_UNIQUE_ID,
-    CONF_WEBHOOK_ID,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import CONF_WEBHOOK_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -18,7 +13,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    ATTR_DEVICE_NAME,
     ATTR_SENSOR_ATTRIBUTES,
     ATTR_SENSOR_DEVICE_CLASS,
     ATTR_SENSOR_ENTITY_CATEGORY,
@@ -32,7 +26,7 @@ from .const import (
     ATTR_SENSOR_UOM,
     DOMAIN,
 )
-from .entity import MobileAppEntity, unique_id
+from .entity import MobileAppEntity
 
 
 async def async_setup_entry(
@@ -69,13 +63,6 @@ async def async_setup_entry(
     def handle_sensor_registration(data):
         if data[CONF_WEBHOOK_ID] != webhook_id:
             return
-
-        data[CONF_UNIQUE_ID] = unique_id(
-            data[CONF_WEBHOOK_ID], data[ATTR_SENSOR_UNIQUE_ID]
-        )
-        data[
-            CONF_NAME
-        ] = f"{config_entry.data[ATTR_DEVICE_NAME]} {data[ATTR_SENSOR_NAME]}"
 
         async_add_entities([MobileAppSensor(data, config_entry)])
 

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -34,6 +34,8 @@ from homeassistant.const import (
     ATTR_SERVICE,
     ATTR_SERVICE_DATA,
     ATTR_SUPPORTED_FEATURES,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
     CONF_WEBHOOK_ID,
 )
 from homeassistant.core import EventOrigin, HomeAssistant
@@ -62,6 +64,7 @@ from .const import (
     ATTR_NO_LEGACY_ENCRYPTION,
     ATTR_OS_VERSION,
     ATTR_SENSOR_ATTRIBUTES,
+    ATTR_SENSOR_DEFAULT_DISABLED,
     ATTR_SENSOR_DEVICE_CLASS,
     ATTR_SENSOR_ENTITY_CATEGORY,
     ATTR_SENSOR_ICON,
@@ -431,6 +434,11 @@ def _validate_state_class_sensor(value: dict):
     return value
 
 
+def _gen_unique_id(webhook_id, sensor_unique_id):
+    """Return a unique sensor ID."""
+    return f"{webhook_id}_{sensor_unique_id}"
+
+
 @WEBHOOK_COMMANDS.register("register_sensor")
 @validate_schema(
     vol.All(
@@ -449,6 +457,7 @@ def _validate_state_class_sensor(value: dict):
             vol.Optional(ATTR_SENSOR_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
             vol.Optional(ATTR_SENSOR_ICON, default="mdi:cellphone"): cv.icon,
             vol.Optional(ATTR_SENSOR_STATE_CLASS): vol.In(SENSOSR_STATE_CLASSES),
+            vol.Optional(ATTR_SENSOR_DEFAULT_DISABLED): bool,
         },
         _validate_state_class_sensor,
     )
@@ -459,7 +468,7 @@ async def webhook_register_sensor(hass, config_entry, data):
     unique_id = data[ATTR_SENSOR_UNIQUE_ID]
     device_name = config_entry.data[ATTR_DEVICE_NAME]
 
-    unique_store_key = f"{config_entry.data[CONF_WEBHOOK_ID]}_{unique_id}"
+    unique_store_key = _gen_unique_id(config_entry.data[CONF_WEBHOOK_ID], unique_id)
     entity_registry = er.async_get(hass)
     existing_sensor = entity_registry.async_get_entity_id(
         entity_type, DOMAIN, unique_store_key
@@ -493,8 +502,13 @@ async def webhook_register_sensor(hass, config_entry, data):
         if changes:
             entity_registry.async_update_entity(existing_sensor, **changes)
 
-        async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, data)
+        async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, unique_store_key, data)
     else:
+        data[CONF_UNIQUE_ID] = unique_store_key
+        data[
+            CONF_NAME
+        ] = f"{config_entry.data[ATTR_DEVICE_NAME]} {data[ATTR_SENSOR_NAME]}"
+
         register_signal = f"{DOMAIN}_{data[ATTR_SENSOR_TYPE]}_register"
         async_dispatcher_send(hass, register_signal, data)
 
@@ -543,7 +557,7 @@ async def webhook_update_sensor_states(hass, config_entry, data):
 
         unique_id = sensor[ATTR_SENSOR_UNIQUE_ID]
 
-        unique_store_key = f"{config_entry.data[CONF_WEBHOOK_ID]}_{unique_id}"
+        unique_store_key = _gen_unique_id(config_entry.data[CONF_WEBHOOK_ID], unique_id)
 
         entity_registry = er.async_get(hass)
         if not entity_registry.async_get_entity_id(
@@ -578,7 +592,12 @@ async def webhook_update_sensor_states(hass, config_entry, data):
             continue
 
         sensor[CONF_WEBHOOK_ID] = config_entry.data[CONF_WEBHOOK_ID]
-        async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, sensor)
+        async_dispatcher_send(
+            hass,
+            SIGNAL_SENSOR_UPDATE,
+            unique_store_key,
+            sensor,
+        )
 
         resp[unique_id] = {"success": True}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new optional `default_disabled` keyword to the `register_sensor` mobile app webhook. This allows the mobile app to indicate which sensors need to be disabled by default.

This is a step closer to keeping disabled entities in sync between mobile app / HA.

Also noticed some duplicate logic that I cleaned up.

CC @home-assistant/android @home-assistant/ios-developers 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
