### PR TITLE
Escape % and _ in history/logbook entity_globs, and use ? as _

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -43,8 +43,13 @@ DOMAIN = "history"
 CONF_ORDER = "use_include_order"
 
 GLOB_TO_SQL_CHARS = {
-    42: "%",  # *
-    46: "_",  # .
+    ord("*"): "%",
+    # TODO: remove - matches domain separator & inconsistent with recorder globs
+    ord("."): "_",
+    ord("?"): "_",
+    ord("%"): "\\%",
+    ord("_"): "\\_",
+    ord("\\"): "\\\\",
 }
 
 CONFIG_SCHEMA = vol.Schema(
@@ -392,7 +397,9 @@ class Filters:
 
 def _glob_to_like(glob_str):
     """Translate glob to sql."""
-    return history_models.States.entity_id.like(glob_str.translate(GLOB_TO_SQL_CHARS))
+    return history_models.States.entity_id.like(
+        glob_str.translate(GLOB_TO_SQL_CHARS), escape="\\"
+    )
 
 
 def _entities_may_have_state_changes_after(

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -714,7 +714,7 @@ async def test_fetch_period_api_with_entity_glob_exclude(
         {
             "history": {
                 "exclude": {
-                    "entity_globs": ["light.k*"],
+                    "entity_globs": ["light.k*", "binary_sensor.*_?"],
                     "domains": "switch",
                     "entities": "media_player.test",
                 },
@@ -726,6 +726,9 @@ async def test_fetch_period_api_with_entity_glob_exclude(
     hass.states.async_set("light.match", "on")
     hass.states.async_set("switch.match", "on")
     hass.states.async_set("media_player.test", "on")
+    hass.states.async_set("binary_sensor.sensor_l", "on")
+    hass.states.async_set("binary_sensor.sensor_r", "on")
+    hass.states.async_set("binary_sensor.sensor", "on")
 
     await async_wait_recording_done(hass)
 
@@ -735,9 +738,10 @@ async def test_fetch_period_api_with_entity_glob_exclude(
     )
     assert response.status == HTTPStatus.OK
     response_json = await response.json()
-    assert len(response_json) == 2
-    assert response_json[0][0]["entity_id"] == "light.cow"
-    assert response_json[1][0]["entity_id"] == "light.match"
+    assert len(response_json) == 3
+    assert response_json[0][0]["entity_id"] == "binary_sensor.sensor"
+    assert response_json[1][0]["entity_id"] == "light.cow"
+    assert response_json[2][0]["entity_id"] == "light.match"
 
 
 async def test_fetch_period_api_with_entity_glob_include_and_exclude(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are two ways to convert entity globs to filters, and they are inconsistent:
1. `homeassistant.helpers.entityfilter.convert_include_exclude_filter` uses the UNIX glob syntax with `*`, `?`, `[abc]`, and `[!abc]`;
2. `homeassistant.components.history.Filters` constructs LIKE statements which only have `%` and `_`, but it also converts `*` and `.` to the former two.

As a result, there is some weirdness around `.` and `?` which probably went unnoticed because not a lot of people need that. A more noticeable problem is that `_` in history/logbook globs matches any character, so e.g. the `sensor.weather_*` example from the docs will also match `sensor.weathers` and it will not be visible in the UI - probably not expected.

This PR escapes `%` and `_` when constructing LIKE statements, and also replaces `?` with `_` so that it has the UNIX meaning. Using `.` in that meaning is deprecated (and was a bad idea in the first place, considering it's the domain separator).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: home-assistant/home-assistant.io#22694

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
