### PR TITLE
Always show the start and stop event in logbook

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -367,7 +367,7 @@ def humanify(
             yield data
 
         elif event_type in external_events:
-            domain, describe_event = external_events[row.event_type]
+            domain, describe_event = external_events[event_type]
             data = describe_event(event_cache.get(row))
             data["when"] = _row_time_fired_isoformat(row)
             data["domain"] = domain

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -114,6 +114,7 @@ ALL_EVENT_TYPES = [
 
 
 EVENT_COLUMNS = [
+    Events.event_id.label("event_id"),
     Events.event_type.label("event_type"),
     Events.event_data.label("event_data"),
     Events.time_fired.label("time_fired"),
@@ -123,6 +124,7 @@ EVENT_COLUMNS = [
 ]
 
 STATE_COLUMNS = [
+    States.state_id.label("state_id"),
     States.state.label("state"),
     States.entity_id.label("entity_id"),
     States.attributes.label("attributes"),
@@ -130,6 +132,7 @@ STATE_COLUMNS = [
 ]
 
 EMPTY_STATE_COLUMNS = [
+    literal(value=None, type_=sqlalchemy.Numeric).label("state_id"),
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
     literal(value=None, type_=sqlalchemy.Text).label("attributes"),
@@ -437,8 +440,9 @@ def _get_events(
         """Yield Events that are not filtered away."""
         for row in query.yield_per(1000):
             context_lookup.setdefault(row.context_id, row)
-            if row.event_type != EVENT_CALL_SERVICE and (
-                row.event_type == EVENT_STATE_CHANGED
+            event_type = row.event_type
+            if event_type != EVENT_CALL_SERVICE and (
+                event_type == EVENT_STATE_CHANGED
                 or _keep_row(hass, row, entities_filter)
             ):
                 yield row
@@ -508,6 +512,7 @@ def _get_events(
 
 def _generate_events_query_without_data(session: Session) -> Query:
     return session.query(
+        literal(value=None, type_=sqlalchemy.Numeric).label("event_id"),
         literal(value=EVENT_STATE_CHANGED, type_=sqlalchemy.String).label("event_type"),
         literal(value=None, type_=sqlalchemy.Text).label("event_data"),
         States.last_changed.label("time_fired"),
@@ -530,10 +535,7 @@ def _generate_legacy_events_context_id_query(
     legacy_context_id_query = session.query(
         *EVENT_COLUMNS,
         literal(value=None, type_=sqlalchemy.String).label("shared_data"),
-        States.state,
-        States.entity_id,
-        States.attributes,
-        StateAttributes.shared_attrs,
+        *STATE_COLUMNS,
     )
     legacy_context_id_query = _apply_event_time_filter(
         legacy_context_id_query, start_day, end_day
@@ -777,12 +779,15 @@ def _is_sensor_continuous(
 
 
 def _rows_match(row: Row, other_row: Row) -> bool:
-    """Check of rows match by using the same method as Events __hash__."""
-    return bool(
-        row.event_type == other_row.event_type
-        and row.context_id == other_row.context_id
-        and row.time_fired == other_row.time_fired
-    )
+    """Match on the database unique id."""
+    if (
+        (state_id := row.state_id) is not None
+        and state_id == other_row.state_id
+        or (event_id := row.event_id) is not None
+        and event_id == other_row.event_id
+    ):
+        return True
+    return False
 
 
 def _row_event_data_extract(row: Row, extractor: re.Pattern) -> str | None:

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Generator, Iterable
 from contextlib import suppress
 from datetime import datetime as dt, timedelta
 from http import HTTPStatus
-from itertools import groupby
 import json
 import re
 from typing import Any, cast
@@ -338,115 +337,76 @@ def humanify(
     """
     external_events = hass.data.get(DOMAIN, {})
     # Continuous sensors, will be excluded from the logbook
-    continuous_sensors = {}
+    continuous_sensors: dict[str, bool] = {}
 
-    # Group events in batches of GROUP_BY_MINUTES
-    for _, g_rows in groupby(
-        rows, lambda row: row.time_fired.minute // GROUP_BY_MINUTES  # type: ignore[no-any-return]
-    ):
+    # Process events
+    for row in rows:
+        event_type = row.event_type
+        if event_type == EVENT_STATE_CHANGED:
+            entity_id = row.entity_id
+            assert entity_id is not None
+            # Skip continuous sensors
+            if (
+                is_continuous := continuous_sensors.get(entity_id)
+            ) is None and split_entity_id(entity_id)[0] == SENSOR_DOMAIN:
+                is_continuous = _is_sensor_continuous(hass, entity_id)
+                continuous_sensors[entity_id] = is_continuous
+            if is_continuous:
+                continue
 
-        rows_batch = list(g_rows)
+            data = {
+                "when": _row_time_fired_isoformat(row),
+                "name": entity_name_cache.get(entity_id, row),
+                "state": row.state,
+                "entity_id": entity_id,
+            }
+            if icon := _row_attributes_extract(row, ICON_JSON_EXTRACT):
+                data["icon"] = icon
 
-        # Group HA start/stop events
-        # Maps minute of event to 1: stop, 2: stop + start
-        start_stop_events = {}
+            context_augmenter.augment(data, entity_id, row)
+            yield data
 
-        # Process events
-        for row in rows_batch:
-            if row.event_type == EVENT_STATE_CHANGED:
-                entity_id = row.entity_id
-                if (
-                    entity_id in continuous_sensors
-                    or split_entity_id(entity_id)[0] != SENSOR_DOMAIN
-                ):
-                    continue
-                assert entity_id is not None
-                continuous_sensors[entity_id] = _is_sensor_continuous(hass, entity_id)
+        elif event_type in external_events:
+            domain, describe_event = external_events[row.event_type]
+            data = describe_event(event_cache.get(row))
+            data["when"] = _row_time_fired_isoformat(row)
+            data["domain"] = domain
+            context_augmenter.augment(data, data.get(ATTR_ENTITY_ID), row)
+            yield data
 
-            elif row.event_type == EVENT_HOMEASSISTANT_STOP:
-                if row.time_fired.minute in start_stop_events:
-                    continue
+        elif event_type == EVENT_HOMEASSISTANT_START:
+            yield {
+                "when": _row_time_fired_isoformat(row),
+                "name": "Home Assistant",
+                "message": "started",
+                "domain": HA_DOMAIN,
+            }
+        elif event_type == EVENT_HOMEASSISTANT_STOP:
+            yield {
+                "when": _row_time_fired_isoformat(row),
+                "name": "Home Assistant",
+                "message": "stopped",
+                "domain": HA_DOMAIN,
+            }
 
-                start_stop_events[row.time_fired.minute] = 1
+        elif event_type == EVENT_LOGBOOK_ENTRY:
+            event = event_cache.get(row)
+            event_data = event.data
+            domain = event_data.get(ATTR_DOMAIN)
+            entity_id = event_data.get(ATTR_ENTITY_ID)
+            if domain is None and entity_id is not None:
+                with suppress(IndexError):
+                    domain = split_entity_id(str(entity_id))[0]
 
-            elif row.event_type == EVENT_HOMEASSISTANT_START:
-                if row.time_fired.minute not in start_stop_events:
-                    continue
-
-                start_stop_events[row.time_fired.minute] = 2
-
-        # Yield entries
-        for row in rows_batch:
-            if row.event_type == EVENT_STATE_CHANGED:
-                entity_id = row.entity_id
-                assert entity_id is not None
-
-                if continuous_sensors.get(entity_id):
-                    # Skip continuous sensors
-                    continue
-
-                data = {
-                    "when": _row_time_fired_isoformat(row),
-                    "name": entity_name_cache.get(entity_id, row),
-                    "state": row.state,
-                    "entity_id": entity_id,
-                }
-                if icon := _row_attributes_extract(row, ICON_JSON_EXTRACT):
-                    data["icon"] = icon
-
-                context_augmenter.augment(data, entity_id, row)
-                yield data
-
-            elif row.event_type in external_events:
-                domain, describe_event = external_events[row.event_type]
-                data = describe_event(event_cache.get(row))
-                data["when"] = _row_time_fired_isoformat(row)
-                data["domain"] = domain
-                context_augmenter.augment(data, data.get(ATTR_ENTITY_ID), row)
-                yield data
-
-            elif row.event_type == EVENT_HOMEASSISTANT_START:
-                if start_stop_events.get(row.time_fired.minute) == 2:
-                    continue
-
-                yield {
-                    "when": _row_time_fired_isoformat(row),
-                    "name": "Home Assistant",
-                    "message": "started",
-                    "domain": HA_DOMAIN,
-                }
-
-            elif row.event_type == EVENT_HOMEASSISTANT_STOP:
-                if start_stop_events.get(row.time_fired.minute) == 2:
-                    action = "restarted"
-                else:
-                    action = "stopped"
-
-                yield {
-                    "when": _row_time_fired_isoformat(row),
-                    "name": "Home Assistant",
-                    "message": action,
-                    "domain": HA_DOMAIN,
-                }
-
-            elif row.event_type == EVENT_LOGBOOK_ENTRY:
-                event = event_cache.get(row)
-                event_data = event.data
-                domain = event_data.get(ATTR_DOMAIN)
-                entity_id = event_data.get(ATTR_ENTITY_ID)
-                if domain is None and entity_id is not None:
-                    with suppress(IndexError):
-                        domain = split_entity_id(str(entity_id))[0]
-
-                data = {
-                    "when": _row_time_fired_isoformat(row),
-                    "name": event_data.get(ATTR_NAME),
-                    "message": event_data.get(ATTR_MESSAGE),
-                    "domain": domain,
-                    "entity_id": entity_id,
-                }
-                context_augmenter.augment(data, entity_id, row)
-                yield data
+            data = {
+                "when": _row_time_fired_isoformat(row),
+                "name": event_data.get(ATTR_NAME),
+                "message": event_data.get(ATTR_MESSAGE),
+                "domain": domain,
+                "entity_id": entity_id,
+            }
+            context_augmenter.augment(data, entity_id, row)
+            yield data
 
 
 def _get_events(

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -391,15 +391,10 @@ def humanify(
                     "state": row.state,
                     "entity_id": entity_id,
                 }
-
                 if icon := _row_attributes_extract(row, ICON_JSON_EXTRACT):
                     data["icon"] = icon
 
-                if row.context_user_id:
-                    data["context_user_id"] = row.context_user_id
-
                 context_augmenter.augment(data, entity_id, row)
-
                 yield data
 
             elif row.event_type in external_events:
@@ -407,9 +402,6 @@ def humanify(
                 data = describe_event(event_cache.get(row))
                 data["when"] = _row_time_fired_isoformat(row)
                 data["domain"] = domain
-                if row.context_user_id:
-                    data["context_user_id"] = row.context_user_id
-
                 entity_id = data.get(ATTR_ENTITY_ID)
                 context_augmenter.augment(data, entity_id, row)
                 yield data
@@ -417,6 +409,7 @@ def humanify(
             elif row.event_type == EVENT_HOMEASSISTANT_START:
                 if start_stop_events.get(row.time_fired.minute) == 2:
                     continue
+
                 yield {
                     "when": _row_time_fired_isoformat(row),
                     "name": "Home Assistant",
@@ -453,10 +446,6 @@ def humanify(
                     "domain": domain,
                     "entity_id": entity_id,
                 }
-
-                if row.context_user_id:
-                    data["context_user_id"] = row.context_user_id
-
                 context_augmenter.augment(data, entity_id, row)
                 yield data
 
@@ -746,6 +735,9 @@ class ContextAugmenter:
 
     def augment(self, data: dict[str, Any], entity_id: str | None, row: Row) -> None:
         """Augment data from the row and cache."""
+        if context_user_id := row.context_user_id:
+            data["context_user_id"] = context_user_id
+
         if not (context_row := self.context_lookup.get(row.context_id)):
             return
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -402,8 +402,7 @@ def humanify(
                 data = describe_event(event_cache.get(row))
                 data["when"] = _row_time_fired_isoformat(row)
                 data["domain"] = domain
-                entity_id = data.get(ATTR_ENTITY_ID)
-                context_augmenter.augment(data, entity_id, row)
+                context_augmenter.augment(data, data.get(ATTR_ENTITY_ID), row)
                 yield data
 
             elif row.event_type == EVENT_HOMEASSISTANT_START:

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -210,11 +210,8 @@ async def test_filter_sensor(hass_: ha.HomeAssistant, hass_client):
     _assert_entry(entries[2], name="ble", entity_id=entity_id4, state="10")
 
 
-def test_home_assistant_start_stop_grouped(hass_):
-    """Test if HA start and stop events are grouped.
-
-    Events that are occurring in the same minute.
-    """
+def test_home_assistant_start_stop_not_grouped(hass_):
+    """Test if HA start and stop events are no longer grouped."""
     entries = mock_humanify(
         hass_,
         (
@@ -223,10 +220,9 @@ def test_home_assistant_start_stop_grouped(hass_):
         ),
     )
 
-    assert len(entries) == 1
-    assert_entry(
-        entries[0], name="Home Assistant", message="restarted", domain=ha.DOMAIN
-    )
+    assert len(entries) == 2
+    assert_entry(entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN)
+    assert_entry(entries[1], name="Home Assistant", message="started", domain=ha.DOMAIN)
 
 
 def test_home_assistant_start(hass_):


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If the stop and start event were fired within the exact same minute we would previously show it as `restarted`  in the logbook.  When events crossed the minute boundary (i.e. we fired stop at 11:30:59 and start at 11:31:04) it would show separately as `stopped` and then `start`.  

This change eliminates the inconstancy by always showing them as `stopped` and `started` which allows us to simplify how we generate logbook rows.  We can now eliminate the grouping since #71331 was the other reason we had kept it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
