### PR TITLE
Improve eight sleep code quality and fix bug

### DIFF
--- a/homeassistant/components/eight_sleep/__init__.py
+++ b/homeassistant/components/eight_sleep/__init__.py
@@ -156,14 +156,12 @@ class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
         eight: EightSleep,
         user_id: str | None,
         sensor: str,
-        units: str | None = None,
     ) -> None:
         """Initialize the data object."""
         super().__init__(coordinator)
         self._eight = eight
         self._user_id = user_id
         self._sensor = sensor
-        self._units = units
         self._user_obj: EightUser | None = None
         if self._user_id:
             self._user_obj = self._eight.users[user_id]

--- a/homeassistant/components/eight_sleep/binary_sensor.py
+++ b/homeassistant/components/eight_sleep/binary_sensor.py
@@ -45,6 +45,8 @@ async def async_setup_platform(
 class EightHeatSensor(EightSleepBaseEntity, BinarySensorEntity):
     """Representation of a Eight Sleep heat-based sensor."""
 
+    _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -54,7 +56,6 @@ class EightHeatSensor(EightSleepBaseEntity, BinarySensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, eight, user_id, sensor)
-        self._attr_device_class = BinarySensorDeviceClass.OCCUPANCY
         assert self._user_obj
         _LOGGER.debug(
             "Presence Sensor: %s, Side: %s, User: %s",

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -68,24 +68,19 @@ async def async_setup_platform(
     heat_coordinator: DataUpdateCoordinator = hass.data[DOMAIN][DATA_HEAT]
     user_coordinator: DataUpdateCoordinator = hass.data[DOMAIN][DATA_USER]
 
-    if hass.config.units.is_metric:
-        units = "si"
-    else:
-        units = "us"
-
     all_sensors: list[SensorEntity] = []
 
     for obj in eight.users.values():
         for sensor in EIGHT_USER_SENSORS:
             all_sensors.append(
-                EightUserSensor(user_coordinator, eight, obj.userid, sensor, units)
+                EightUserSensor(user_coordinator, eight, obj.userid, sensor)
             )
         for sensor in EIGHT_HEAT_SENSORS:
             all_sensors.append(
                 EightHeatSensor(heat_coordinator, eight, obj.userid, sensor)
             )
     for sensor in EIGHT_ROOM_SENSORS:
-        all_sensors.append(EightRoomSensor(user_coordinator, eight, sensor, units))
+        all_sensors.append(EightRoomSensor(user_coordinator, eight, sensor))
 
     async_add_entities(all_sensors)
 
@@ -156,10 +151,9 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         eight: EightSleep,
         user_id: str,
         sensor: str,
-        units: str,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, eight, user_id, sensor, units)
+        super().__init__(coordinator, eight, user_id, sensor)
         assert self._user_obj
 
         if self._sensor == "bed_temperature":
@@ -269,18 +263,11 @@ class EightRoomSensor(EightSleepBaseEntity, SensorEntity):
         coordinator: DataUpdateCoordinator,
         eight: EightSleep,
         sensor: str,
-        units: str,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, eight, None, sensor, units)
+        super().__init__(coordinator, eight, None, sensor)
 
     @property
     def native_value(self) -> int | float | None:
         """Return the state of the sensor."""
-        temp = self._eight.room_temperature()
-        try:
-            if self._units == "si":
-                return round(temp, 2)
-            return round((temp * 1.8) + 32, 2)
-        except TypeError:
-            return None
+        return self._eight.room_temperature()

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -93,6 +93,8 @@ async def async_setup_platform(
 class EightHeatSensor(EightSleepBaseEntity, SensorEntity):
     """Representation of an eight sleep heat-based sensor."""
 
+    _attr_native_unit_of_measurement = PERCENTAGE
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -102,7 +104,6 @@ class EightHeatSensor(EightSleepBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, eight, user_id, sensor)
-        self._attr_native_unit_of_measurement = PERCENTAGE
         assert self._user_obj
 
         _LOGGER.debug(
@@ -259,6 +260,10 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
 class EightRoomSensor(EightSleepBaseEntity, SensorEntity):
     """Representation of an eight sleep room sensor."""
 
+    _attr_icon = "mdi:thermometer"
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = TEMP_CELSIUS
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -268,10 +273,6 @@ class EightRoomSensor(EightSleepBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, eight, None, sensor, units)
-
-        self._attr_icon = "mdi:thermometer"
-        self._attr_device_class = SensorDeviceClass.TEMPERATURE
-        self._attr_native_unit_of_measurement = TEMP_CELSIUS
 
     @property
     def native_value(self) -> int | float | None:


### PR DESCRIPTION
## Proposed change
The main changes were:
- Temperature sensors now have a temperature device class and have a static unit of measurement so that HA can do the necessary conversion
- The `_get_rounded_value` accepted a key as a parameter but the actual key name in the code was hard-coded. This fixes that (was inadvertently introduced in https://github.com/home-assistant/core/pull/58508)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
