### PR TITLE
Significantly improve logbook performance when selecting entities

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -477,9 +477,11 @@ def _get_events(
             entity_filter,
             context_id,
         )
-    _LOGGER.debug(
-        "Literal statement: %s", stmt.compile(compile_kwargs={"literal_binds": True})
-    )
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        _LOGGER.debug(
+            "Literal statement: %s",
+            stmt.compile(compile_kwargs={"literal_binds": True}),
+        )
     with session_scope(hass=hass) as session:
         return list(
             _humanify(

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -117,28 +117,34 @@ ALL_EVENT_TYPES = [
 ]
 
 
-EVENT_COLUMNS = [
+EVENT_COLUMNS = (
     Events.event_type.label("event_type"),
     Events.event_data.label("event_data"),
     Events.time_fired.label("time_fired"),
     Events.context_id.label("context_id"),
     Events.context_user_id.label("context_user_id"),
     Events.context_parent_id.label("context_parent_id"),
-]
+)
 
-STATE_COLUMNS = [
+STATE_COLUMNS = (
     States.state.label("state"),
     States.entity_id.label("entity_id"),
     States.attributes.label("attributes"),
     StateAttributes.shared_attrs.label("shared_attrs"),
-]
+)
 
-EMPTY_STATE_COLUMNS = [
+EMPTY_STATE_COLUMNS = (
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
     literal(value=None, type_=sqlalchemy.Text).label("attributes"),
     literal(value=None, type_=sqlalchemy.Text).label("shared_attrs"),
-]
+)
+
+EVENT_ROWS_NO_STATES = (
+    *EVENT_COLUMNS,
+    EventData.shared_data.label("shared_data"),
+    *EMPTY_STATE_COLUMNS,
+)
 
 SCRIPT_AUTOMATION_EVENTS = {EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED}
 
@@ -299,7 +305,6 @@ class LogbookView(HomeAssistantView):
 
         hass = request.app["hass"]
 
-        entity_matches_only = "entity_matches_only" in request.query
         context_id = request.query.get("context_id")
 
         if entity_ids and context_id:
@@ -317,7 +322,6 @@ class LogbookView(HomeAssistantView):
                     entity_ids,
                     self.filters,
                     self.entities_filter,
-                    entity_matches_only,
                     context_id,
                 )
             )
@@ -420,7 +424,6 @@ def _get_events(
     entity_ids: list[str] | None = None,
     filters: Filters | None = None,
     entities_filter: EntityFilter | Callable[[str], bool] | None = None,
-    entity_matches_only: bool = False,
     context_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Get events for a period of time."""
@@ -494,6 +497,28 @@ def _get_events(
         )
 
 
+def _generate_entities_context_ids_sub_query(
+    start_day: dt,
+    end_day: dt,
+    event_types: list[str],
+    entity_ids: list[str],
+) -> Select:
+    """Generate a subquery to find context ids for entities."""
+    return (
+        select(Events.context_id)
+        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
+        .where(Events.event_type.in_(event_types))
+        .where(_apply_event_entity_id_matchers(entity_ids))
+        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+        .union_all(
+            select(States.context_id)
+            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
+            .where(States.entity_id.in_(entity_ids))
+        )
+        .subquery()
+    )
+
+
 def _generate_logbook_entities_query(
     start_day: dt,
     end_day: dt,
@@ -501,6 +526,7 @@ def _generate_logbook_entities_query(
     entity_ids: list[str],
 ) -> StatementLambdaElement:
     sorted_entities = ",".join(sorted(entity_ids))
+    sorted_event_types = ",".join(sorted(event_types))
 
     stmt = lambda_stmt(
         lambda: _generate_events_query_without_states()
@@ -517,35 +543,20 @@ def _generate_logbook_entities_query(
             _generate_states_query()
             .filter((States.last_updated > start_day) & (States.last_updated < end_day))
             .where(States.entity_id.in_(entity_ids)),
-            select(
-                *EVENT_COLUMNS,
-                EventData.shared_data.label("shared_data"),
-                *EMPTY_STATE_COLUMNS,
-                literal("1").label("context_only"),
-            )
+            select(*EVENT_ROWS_NO_STATES, literal("1").label("context_only"))
             .where(
                 Events.context_id.in_(
-                    select(Events.context_id)
-                    .where(
-                        (Events.time_fired > start_day) & (Events.time_fired < end_day)
+                    _generate_entities_context_ids_sub_query(
+                        start_day,
+                        end_day,
+                        event_types,
+                        entity_ids,
                     )
-                    .where(Events.event_type.in_(event_types))
-                    .where(_apply_event_entity_id_matchers(entity_ids))
-                    .outerjoin(EventData, (Events.data_id == EventData.data_id))
-                    .union_all(
-                        select(States.context_id)
-                        .filter(
-                            (States.last_updated > start_day)
-                            & (States.last_updated < end_day)
-                        )
-                        .where(States.entity_id.in_(entity_ids))
-                    )
-                    .subquery(),
                 )
             )
             .outerjoin(EventData, (Events.data_id == EventData.data_id)),
         ),
-        track_on=(sorted_entities, start_day, end_day, ",".join(sorted(event_types))),
+        track_on=(sorted_entities, start_day, end_day, sorted_event_types),
     )
     stmt += lambda s: s.order_by(Events.time_fired)
     return stmt
@@ -632,9 +643,7 @@ def _generate_legacy_events_context_id_query() -> Select:
 
 def _generate_events_query_without_states() -> Select:
     return select(
-        *EVENT_COLUMNS,
-        EventData.shared_data.label("shared_data"),
-        *EMPTY_STATE_COLUMNS,
+        *EVENT_ROWS_NO_STATES,
         literal(None).label("context_only"),
     )
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -500,7 +500,7 @@ def _generate_logbook_entities_query(
     event_types: list[str],
     entity_ids: list[str],
 ) -> StatementLambdaElement:
-    entities_cache_key = (",".join(sorted(entity_ids)),)
+    sorted_entities = ",".join(sorted(entity_ids))
 
     stmt = lambda_stmt(
         lambda: _generate_events_query_without_states()
@@ -510,7 +510,7 @@ def _generate_logbook_entities_query(
     )
     stmt = stmt.add_criteria(
         lambda s: s.where(_apply_event_entity_id_matchers(entity_ids)),
-        track_on=entities_cache_key,
+        track_on=(sorted_entities,),
     )
     stmt = stmt.add_criteria(
         lambda s: s.union_all(
@@ -545,7 +545,7 @@ def _generate_logbook_entities_query(
             )
             .outerjoin(EventData, (Events.data_id == EventData.data_id)),
         ),
-        track_on=entities_cache_key,
+        track_on=(sorted_entities, start_day, end_day, ",".join(sorted(event_types))),
     )
     stmt += lambda s: s.order_by(Events.time_fired)
     return stmt

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -63,7 +63,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util
 
-from .queries import generate_statement_for_request
+from .queries import statement_for_request
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -407,7 +407,7 @@ def _get_events(
     if entity_ids is not None:
         entities_filter = generate_filter([], entity_ids, [], [])
 
-    stmt = generate_statement_for_request(
+    stmt = statement_for_request(
         start_day, end_day, event_types, entity_ids, filters, context_id
     )
     if _LOGGER.isEnabledFor(logging.DEBUG):

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -1,7 +1,7 @@
 """Event parser and human readable log generator."""
 from __future__ import annotations
 
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator
 from contextlib import suppress
 from datetime import datetime as dt, timedelta
 from http import HTTPStatus
@@ -11,14 +11,8 @@ import re
 from typing import Any, cast
 
 from aiohttp import web
-import sqlalchemy
-from sqlalchemy import lambda_stmt, select
 from sqlalchemy.engine.row import Row
-from sqlalchemy.orm import aliased
 from sqlalchemy.orm.query import Query
-from sqlalchemy.sql.expression import literal
-from sqlalchemy.sql.lambdas import StatementLambdaElement
-from sqlalchemy.sql.selectable import Select
 import voluptuous as vol
 
 from homeassistant.components import frontend
@@ -28,15 +22,8 @@ from homeassistant.components.history import (
     sqlalchemy_filter_from_include_exclude_conf,
 )
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.proximity import DOMAIN as PROXIMITY_DOMAIN
 from homeassistant.components.recorder import get_instance
-from homeassistant.components.recorder.models import (
-    EventData,
-    Events,
-    StateAttributes,
-    States,
-    process_timestamp_to_utc_isoformat,
-)
+from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.sensor import ATTR_STATE_CLASS, DOMAIN as SENSOR_DOMAIN
@@ -76,74 +63,31 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util
 
+from .queries import generate_statement_for_request
+
 _LOGGER = logging.getLogger(__name__)
 
 
-ENTITY_ID_JSON_TEMPLATE = '%"entity_id":"{}"%'
 FRIENDLY_NAME_JSON_EXTRACT = re.compile('"friendly_name": ?"([^"]+)"')
 ENTITY_ID_JSON_EXTRACT = re.compile('"entity_id": ?"([^"]+)"')
 DOMAIN_JSON_EXTRACT = re.compile('"domain": ?"([^"]+)"')
 ICON_JSON_EXTRACT = re.compile('"icon": ?"([^"]+)"')
 ATTR_MESSAGE = "message"
 
-CONTINUOUS_DOMAINS = {PROXIMITY_DOMAIN, SENSOR_DOMAIN}
-CONTINUOUS_ENTITY_ID_LIKE = [f"{domain}.%" for domain in CONTINUOUS_DOMAINS]
-
 DOMAIN = "logbook"
 
-EMPTY_JSON_OBJECT = "{}"
-UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
-UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 HA_DOMAIN_ENTITY_ID = f"{HA_DOMAIN}._"
 
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA}, extra=vol.ALLOW_EXTRA
 )
 
-HOMEASSISTANT_EVENTS = [
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
-]
+HOMEASSISTANT_EVENTS = {EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP}
 
-ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED = [
+ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED = (
     EVENT_LOGBOOK_ENTRY,
     EVENT_CALL_SERVICE,
     *HOMEASSISTANT_EVENTS,
-]
-
-ALL_EVENT_TYPES = [
-    EVENT_STATE_CHANGED,
-    *ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED,
-]
-
-
-EVENT_COLUMNS = (
-    Events.event_type.label("event_type"),
-    Events.event_data.label("event_data"),
-    Events.time_fired.label("time_fired"),
-    Events.context_id.label("context_id"),
-    Events.context_user_id.label("context_user_id"),
-    Events.context_parent_id.label("context_parent_id"),
-)
-
-STATE_COLUMNS = (
-    States.state.label("state"),
-    States.entity_id.label("entity_id"),
-    States.attributes.label("attributes"),
-    StateAttributes.shared_attrs.label("shared_attrs"),
-)
-
-EMPTY_STATE_COLUMNS = (
-    literal(value=None, type_=sqlalchemy.String).label("state"),
-    literal(value=None, type_=sqlalchemy.String).label("entity_id"),
-    literal(value=None, type_=sqlalchemy.Text).label("attributes"),
-    literal(value=None, type_=sqlalchemy.Text).label("shared_attrs"),
-)
-
-EVENT_ROWS_NO_STATES = (
-    *EVENT_COLUMNS,
-    EventData.shared_data.label("shared_data"),
-    *EMPTY_STATE_COLUMNS,
 )
 
 SCRIPT_AUTOMATION_EVENTS = {EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED}
@@ -435,10 +379,13 @@ def _get_events(
     event_data_cache: dict[str, dict[str, Any]] = {}
     context_lookup: dict[str | None, Row | None] = {None: None}
     event_cache = EventCache(event_data_cache)
-    external_events = hass.data.get(DOMAIN, {})
+    external_events: dict[
+        str, tuple[str, Callable[[LazyEventPartialState], dict[str, Any]]]
+    ] = hass.data.get(DOMAIN, {})
     context_augmenter = ContextAugmenter(
         context_lookup, entity_name_cache, external_events, event_cache
     )
+    event_types = (*ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED, *external_events)
 
     def yield_rows(query: Query) -> Generator[Row, None, None]:
         """Yield Events that are not filtered away."""
@@ -460,31 +407,15 @@ def _get_events(
     if entity_ids is not None:
         entities_filter = generate_filter([], entity_ids, [], [])
 
-    event_types = [
-        *ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED,
-        *hass.data.get(DOMAIN, {}),
-    ]
-    if entity_ids:
-        stmt = _generate_logbook_entities_query(
-            start_day,
-            end_day,
-            event_types,
-            entity_ids,
-        )
-    else:
-        entity_filter = filters.entity_filter() if filters else None  # type: ignore[no-untyped-call]
-        stmt = _generate_logbook_query(
-            start_day,
-            end_day,
-            event_types,
-            entity_filter,
-            context_id,
-        )
+    stmt = generate_statement_for_request(
+        start_day, end_day, event_types, entity_ids, filters, context_id
+    )
     if _LOGGER.isEnabledFor(logging.DEBUG):
         _LOGGER.debug(
             "Literal statement: %s",
             stmt.compile(compile_kwargs={"literal_binds": True}),
         )
+
     with session_scope(hass=hass) as session:
         return list(
             _humanify(
@@ -495,239 +426,6 @@ def _get_events(
                 context_augmenter,
             )
         )
-
-
-def _generate_entities_context_ids_sub_query(
-    start_day: dt,
-    end_day: dt,
-    event_types: list[str],
-    entity_ids: list[str],
-) -> Select:
-    """Generate a subquery to find context ids for entities."""
-    return (
-        select(Events.context_id)
-        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
-        .where(Events.event_type.in_(event_types))
-        .where(_apply_event_entity_id_matchers(entity_ids))
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
-        .union_all(
-            select(States.context_id)
-            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
-            .where(States.entity_id.in_(entity_ids))
-        )
-        .subquery()
-    )
-
-
-def _generate_logbook_entities_query(
-    start_day: dt,
-    end_day: dt,
-    event_types: list[str],
-    entity_ids: list[str],
-) -> StatementLambdaElement:
-    sorted_entities = ",".join(sorted(entity_ids))
-    sorted_event_types = ",".join(sorted(event_types))
-
-    stmt = lambda_stmt(
-        lambda: _generate_events_query_without_states()
-        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
-        .where(Events.event_type.in_(event_types))
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
-    )
-    stmt = stmt.add_criteria(
-        lambda s: s.where(_apply_event_entity_id_matchers(entity_ids)),
-        track_on=(sorted_entities,),
-    )
-    stmt = stmt.add_criteria(
-        lambda s: s.union_all(
-            _generate_states_query()
-            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
-            .where(States.entity_id.in_(entity_ids)),
-            select(*EVENT_ROWS_NO_STATES, literal("1").label("context_only"))
-            .where(
-                Events.context_id.in_(
-                    _generate_entities_context_ids_sub_query(
-                        start_day,
-                        end_day,
-                        event_types,
-                        entity_ids,
-                    )
-                )
-            )
-            .outerjoin(EventData, (Events.data_id == EventData.data_id)),
-        ),
-        track_on=(sorted_entities, start_day, end_day, sorted_event_types),
-    )
-    stmt += lambda s: s.order_by(Events.time_fired)
-    return stmt
-
-
-def _generate_logbook_query(
-    start_day: dt,
-    end_day: dt,
-    event_types: list[str],
-    entity_filter: Any | None = None,
-    context_id: str | None = None,
-) -> StatementLambdaElement:
-    """Generate a logbook query lambda_stmt."""
-    stmt = lambda_stmt(
-        lambda: _generate_events_query_without_states()
-        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
-        .where(Events.event_type.in_(event_types))
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
-    )
-    if context_id is not None:
-        # Once all the old `state_changed` events
-        # are gone from the database remove the
-        # union_all(_generate_legacy_events_context_id_query()....)
-        stmt += lambda s: s.where(Events.context_id == context_id).union_all(
-            _generate_legacy_events_context_id_query()
-            .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
-            .where(Events.context_id == context_id),
-            _generate_states_query()
-            .where((States.last_updated > start_day) & (States.last_updated < end_day))
-            .outerjoin(Events, (States.event_id == Events.event_id))
-            .where(States.context_id == context_id),
-        )
-    elif entity_filter is not None:
-        stmt += lambda s: s.union_all(
-            _generate_states_query()
-            .where((States.last_updated > start_day) & (States.last_updated < end_day))
-            .where(entity_filter)
-        )
-    else:
-        stmt += lambda s: s.union_all(
-            _generate_states_query().where(
-                (States.last_updated > start_day) & (States.last_updated < end_day)
-            )
-        )
-    stmt += lambda s: s.order_by(Events.time_fired)
-    return stmt
-
-
-def _generate_events_query_without_data() -> Select:
-    return select(
-        literal(value=EVENT_STATE_CHANGED, type_=sqlalchemy.String).label("event_type"),
-        literal(value=None, type_=sqlalchemy.Text).label("event_data"),
-        States.last_changed.label("time_fired"),
-        States.context_id.label("context_id"),
-        States.context_user_id.label("context_user_id"),
-        States.context_parent_id.label("context_parent_id"),
-        literal(value=None, type_=sqlalchemy.Text).label("shared_data"),
-        *STATE_COLUMNS,
-        literal(None).label("context_only"),
-    )
-
-
-def _generate_legacy_events_context_id_query() -> Select:
-    """Generate a legacy events context id query that also joins states."""
-    # This can be removed once we no longer have event_ids in the states table
-    return (
-        select(
-            *EVENT_COLUMNS,
-            literal(value=None, type_=sqlalchemy.String).label("shared_data"),
-            States.state,
-            States.entity_id,
-            States.attributes,
-            StateAttributes.shared_attrs,
-            literal(None).label("context_only"),
-        )
-        .outerjoin(States, (Events.event_id == States.event_id))
-        .where(States.last_updated == States.last_changed)
-        .where(_not_continuous_entity_matcher())
-        .outerjoin(
-            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
-        )
-    )
-
-
-def _generate_events_query_without_states() -> Select:
-    return select(
-        *EVENT_ROWS_NO_STATES,
-        literal(None).label("context_only"),
-    )
-
-
-def _generate_states_query() -> Select:
-    old_state = aliased(States, name="old_state")
-    return (
-        _generate_events_query_without_data()
-        .outerjoin(old_state, (States.old_state_id == old_state.state_id))
-        .where(_missing_state_matcher(old_state))
-        .where(_not_continuous_entity_matcher())
-        .where(States.last_updated == States.last_changed)
-        .outerjoin(
-            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
-        )
-    )
-
-
-def _missing_state_matcher(old_state: States) -> sqlalchemy.and_:
-    # The below removes state change events that do not have
-    # and old_state or the old_state is missing (newly added entities)
-    # or the new_state is missing (removed entities)
-    return sqlalchemy.and_(
-        old_state.state_id.isnot(None),
-        (States.state != old_state.state),
-        States.state.isnot(None),
-    )
-
-
-def _not_continuous_entity_matcher() -> sqlalchemy.or_:
-    """Match non continuous entities."""
-    return sqlalchemy.or_(
-        _not_continuous_domain_matcher(),
-        sqlalchemy.and_(
-            _continuous_domain_matcher, _not_uom_attributes_matcher()
-        ).self_group(),
-    )
-
-
-def _not_continuous_domain_matcher() -> sqlalchemy.and_:
-    """Match not continuous domains."""
-    return sqlalchemy.and_(
-        *[
-            ~States.entity_id.like(entity_domain)
-            for entity_domain in CONTINUOUS_ENTITY_ID_LIKE
-        ],
-    ).self_group()
-
-
-def _continuous_domain_matcher() -> sqlalchemy.or_:
-    """Match continuous domains."""
-    return sqlalchemy.or_(
-        *[
-            States.entity_id.like(entity_domain)
-            for entity_domain in CONTINUOUS_ENTITY_ID_LIKE
-        ],
-    ).self_group()
-
-
-def _not_uom_attributes_matcher() -> Any:
-    """Prefilter ATTR_UNIT_OF_MEASUREMENT as its much faster in sql."""
-    return ~StateAttributes.shared_attrs.like(
-        UNIT_OF_MEASUREMENT_JSON_LIKE
-    ) | ~States.attributes.like(UNIT_OF_MEASUREMENT_JSON_LIKE)
-
-
-def _apply_event_entity_id_matchers(entity_ids: Iterable[str]) -> sqlalchemy.or_:
-    """Create matchers for the entity_id in the event_data."""
-    ors = []
-    for entity_id in entity_ids:
-        like = ENTITY_ID_JSON_TEMPLATE.format(entity_id)
-        ors.append(Events.event_data.like(like))
-        ors.append(EventData.shared_data.like(like))
-    return sqlalchemy.or_(*ors)
-
-
-def _apply_not_event_entity_id_matchers(entity_ids: Iterable[str]) -> sqlalchemy.not_:
-    """Create matchers for the entity_id in the event_data."""
-    ors = []
-    for entity_id in entity_ids:
-        like = ENTITY_ID_JSON_TEMPLATE.format(entity_id)
-        ors.append(Events.event_data.like(like))
-        ors.append(EventData.shared_data.like(like))
-    return sqlalchemy.not_(sqlalchemy.or_(*ors))
 
 
 def _keep_row(

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from datetime import datetime as dt, timedelta
 from http import HTTPStatus
 import json
+import logging
 import re
 from typing import Any, cast
 
@@ -74,6 +75,9 @@ from homeassistant.helpers.integration_platform import (
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
 
 ENTITY_ID_JSON_TEMPLATE = '%"entity_id":"{}"%'
 FRIENDLY_NAME_JSON_EXTRACT = re.compile('"friendly_name": ?"([^"]+)"')
@@ -473,6 +477,9 @@ def _get_events(
             entity_filter,
             context_id,
         )
+    _LOGGER.debug(
+        "Literal statement: %s", stmt.compile(compile_kwargs={"literal_binds": True})
+    )
     with session_scope(hass=hass) as session:
         return list(
             _humanify(
@@ -492,6 +499,7 @@ def _generate_logbook_entities_query(
     entity_ids: list[str],
 ) -> StatementLambdaElement:
     entities_cache_key = (",".join(sorted(entity_ids)),)
+
     stmt = lambda_stmt(
         lambda: _generate_events_query_without_states()
         .where((Events.time_fired > start_day) & (Events.time_fired < end_day))

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -81,7 +81,7 @@ def statement_for_request(
     # limited by the context_id and the yaml configured filter
     if not entity_ids:
         entity_filter = filters.entity_filter() if filters else None  # type: ignore[no-untyped-call]
-        return _all_query(start_day, end_day, event_types, entity_filter, context_id)
+        return _all_stmt(start_day, end_day, event_types, entity_filter, context_id)
 
     # Multiple entities: logbook sends everything for the timeframe for the entities
     #
@@ -89,12 +89,12 @@ def statement_for_request(
     # like matching which means part of the query has to be built each
     # time when the entity_ids are not in the cache
     if len(entity_ids) > 1:
-        return _entities_query(start_day, end_day, event_types, entity_ids)
+        return _entities_stmt(start_day, end_day, event_types, entity_ids)
 
     # Single entity: logbook sends everything for the timeframe for the entity
     entity_id = entity_ids[0]
     entity_like = ENTITY_ID_JSON_TEMPLATE.format(entity_id)
-    return _single_entity_query(start_day, end_day, event_types, entity_id, entity_like)
+    return _single_entity_stmt(start_day, end_day, event_types, entity_id, entity_like)
 
 
 def _select_events_context_id_subquery(
@@ -141,7 +141,7 @@ def _select_events_context_only() -> Select:
     )
 
 
-def _entities_query(
+def _entities_stmt(
     start_day: dt,
     end_day: dt,
     event_types: tuple[str, ...],
@@ -198,7 +198,7 @@ def _select_entity_context_ids_sub_query(
     )
 
 
-def _single_entity_query(
+def _single_entity_stmt(
     start_day: dt,
     end_day: dt,
     event_types: tuple[str, ...],
@@ -227,7 +227,7 @@ def _single_entity_query(
     return stmt
 
 
-def _all_query(
+def _all_stmt(
     start_day: dt,
     end_day: dt,
     event_types: tuple[str, ...],

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -301,6 +301,7 @@ def _generate_events_query_without_states(
 
 
 def _generate_states_query(start_day: dt, end_day: dt) -> Select:
+    """Generate a states query that formats the states table as event rows."""
     old_state = aliased(States, name="old_state")
     return (
         select(

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -71,13 +71,24 @@ def generate_statement_for_request(
     context_id: str | None = None,
 ) -> StatementLambdaElement:
     """Generate the logbook statement for a logbook request."""
+
+    # No entities: logbook sends everything for the timeframe
+    # limited by the context_id and the yaml configured filter
     if not entity_ids:
         entity_filter = filters.entity_filter() if filters else None  # type: ignore[no-untyped-call]
         return _generate_all_query(
             start_day, end_day, event_types, entity_filter, context_id
         )
+
+    # Multiple entities: logbook sends everything for the timeframe for the entities
+    #
+    # This is the least efficient query because we use
+    # like matching which means part of the query has to be built each
+    # time when the entity_ids are not in the cache
     if len(entity_ids) > 1:
         return _generate_entities_query(start_day, end_day, event_types, entity_ids)
+
+    # Single entity: logbook sends everything for the timeframe for the entity
     entity_id = entity_ids[0]
     entity_like = ENTITY_ID_JSON_TEMPLATE.format(entity_id)
     return _generate_single_entity_query(

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -1,0 +1,372 @@
+"""Queries for logbook."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime as dt
+from typing import Any
+
+import sqlalchemy
+from sqlalchemy import lambda_stmt, select
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql.expression import literal
+from sqlalchemy.sql.lambdas import StatementLambdaElement
+from sqlalchemy.sql.selectable import Select
+
+from homeassistant.components.history import Filters
+from homeassistant.components.proximity import DOMAIN as PROXIMITY_DOMAIN
+from homeassistant.components.recorder.models import (
+    EventData,
+    Events,
+    StateAttributes,
+    States,
+)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import EVENT_STATE_CHANGED
+
+ENTITY_ID_JSON_TEMPLATE = '%"entity_id":"{}"%'
+
+CONTINUOUS_DOMAINS = {PROXIMITY_DOMAIN, SENSOR_DOMAIN}
+CONTINUOUS_ENTITY_ID_LIKE = [f"{domain}.%" for domain in CONTINUOUS_DOMAINS]
+
+UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
+UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
+
+
+EVENT_COLUMNS = (
+    Events.event_type.label("event_type"),
+    Events.event_data.label("event_data"),
+    Events.time_fired.label("time_fired"),
+    Events.context_id.label("context_id"),
+    Events.context_user_id.label("context_user_id"),
+    Events.context_parent_id.label("context_parent_id"),
+)
+
+STATE_COLUMNS = (
+    States.state.label("state"),
+    States.entity_id.label("entity_id"),
+    States.attributes.label("attributes"),
+    StateAttributes.shared_attrs.label("shared_attrs"),
+)
+
+EMPTY_STATE_COLUMNS = (
+    literal(value=None, type_=sqlalchemy.String).label("state"),
+    literal(value=None, type_=sqlalchemy.String).label("entity_id"),
+    literal(value=None, type_=sqlalchemy.Text).label("attributes"),
+    literal(value=None, type_=sqlalchemy.Text).label("shared_attrs"),
+)
+
+EVENT_ROWS_NO_STATES = (
+    *EVENT_COLUMNS,
+    EventData.shared_data.label("shared_data"),
+    *EMPTY_STATE_COLUMNS,
+)
+
+
+def generate_statement_for_request(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+    entity_ids: list[str] | None = None,
+    filters: Filters | None = None,
+    context_id: str | None = None,
+) -> StatementLambdaElement:
+    """Generate the logbook statement for a logbook request."""
+    if not entity_ids:
+        entity_filter = filters.entity_filter() if filters else None  # type: ignore[no-untyped-call]
+        return _generate_all_query(
+            start_day, end_day, event_types, entity_filter, context_id
+        )
+    if len(entity_ids) > 1:
+        return _generate_entities_query(start_day, end_day, event_types, entity_ids)
+    entity_id = entity_ids[0]
+    entity_like = ENTITY_ID_JSON_TEMPLATE.format(entity_id)
+    return _generate_single_entity_query(
+        start_day, end_day, event_types, entity_id, entity_like
+    )
+
+
+def _select_events_context_id_subquery(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+) -> Select:
+    """Generate the select for a context_id subquery."""
+    return (
+        select(Events.context_id)
+        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
+        .where(Events.event_type.in_(event_types))
+        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+    )
+
+
+def _generate_entities_context_ids_sub_query(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+    entity_ids: list[str],
+) -> Select:
+    """Generate a subquery to find context ids for multiple entities."""
+    return (
+        _select_events_context_id_subquery(start_day, end_day, event_types)
+        .where(_apply_event_entity_id_matchers(entity_ids))
+        .union_all(
+            select(States.context_id)
+            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
+            .where(States.entity_id.in_(entity_ids))
+        )
+        .subquery()
+    )
+
+
+def _generate_events_query_for_context_only() -> Select:
+    """Generate an events query that mark them as for context_only.
+
+    By marking them as context_only we know they are only for
+    linking context ids and we can avoid processing them.
+    """
+    return select(*EVENT_ROWS_NO_STATES, literal("1").label("context_only")).outerjoin(
+        EventData, (Events.data_id == EventData.data_id)
+    )
+
+
+def _generate_entities_query(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+    entity_ids: list[str],
+) -> StatementLambdaElement:
+    """Generate a logbook query for multiple entities."""
+    stmt = lambda_stmt(
+        lambda: _generate_events_query_without_states(start_day, end_day, event_types)
+    )
+    stmt = stmt.add_criteria(
+        lambda s: s.where(_apply_event_entity_id_matchers(entity_ids)).union_all(
+            _generate_states_query(start_day, end_day).where(
+                States.entity_id.in_(entity_ids)
+            ),
+            _generate_events_query_for_context_only().where(
+                Events.context_id.in_(
+                    _generate_entities_context_ids_sub_query(
+                        start_day,
+                        end_day,
+                        event_types,
+                        entity_ids,
+                    )
+                )
+            ),
+        ),
+        # Since _apply_event_entity_id_matchers generates multiple
+        # like statements we need to use the entity_ids in the
+        # the cache key since the sql can change based on the
+        # likes.
+        track_on=(str(entity_ids),),
+    )
+    stmt += lambda s: s.order_by(Events.time_fired)
+    return stmt
+
+
+def _generate_entity_context_ids_sub_query(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+    entity_id: str,
+    entity_id_like: str,
+) -> Select:
+    """Generate a subquery to find context ids for a single entity."""
+    return (
+        _select_events_context_id_subquery(start_day, end_day, event_types)
+        .where(
+            Events.event_data.like(entity_id_like)
+            | EventData.shared_data.like(entity_id_like)
+        )
+        .union_all(
+            select(States.context_id)
+            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
+            .where(States.entity_id == entity_id)
+        )
+        .subquery()
+    )
+
+
+def _generate_single_entity_query(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+    entity_id: str,
+    entity_id_like: str,
+) -> StatementLambdaElement:
+    """Generate a logbook query for a single entity."""
+    stmt = lambda_stmt(
+        lambda: _generate_events_query_without_states(start_day, end_day, event_types)
+        .where(
+            Events.event_data.like(entity_id_like)
+            | EventData.shared_data.like(entity_id_like)
+        )
+        .union_all(
+            _generate_states_query(start_day, end_day).where(
+                States.entity_id == entity_id
+            ),
+            _generate_events_query_for_context_only().where(
+                Events.context_id.in_(
+                    _generate_entity_context_ids_sub_query(
+                        start_day, end_day, event_types, entity_id, entity_id_like
+                    )
+                )
+            ),
+        )
+        .order_by(Events.time_fired)
+    )
+    return stmt
+
+
+def _generate_all_query(
+    start_day: dt,
+    end_day: dt,
+    event_types: tuple[str, ...],
+    entity_filter: Any | None = None,
+    context_id: str | None = None,
+) -> StatementLambdaElement:
+    """Generate a logbook query for all entities."""
+    stmt = lambda_stmt(
+        lambda: _generate_events_query_without_states(start_day, end_day, event_types)
+    )
+    if context_id is not None:
+        # Once all the old `state_changed` events
+        # are gone from the database remove the
+        # _generate_legacy_events_context_id_query()
+        stmt += lambda s: s.where(Events.context_id == context_id).union_all(
+            _generate_states_query(start_day, end_day).where(
+                States.context_id == context_id
+            ),
+            _generate_legacy_events_context_id_query(start_day, end_day, context_id),
+        )
+    elif entity_filter is not None:
+        stmt += lambda s: s.union_all(
+            _generate_states_query(start_day, end_day).where(entity_filter)
+        )
+    else:
+        stmt += lambda s: s.union_all(_generate_states_query(start_day, end_day))
+    stmt += lambda s: s.order_by(Events.time_fired)
+    return stmt
+
+
+def _generate_legacy_events_context_id_query(
+    start_day: dt, end_day: dt, context_id: str
+) -> Select:
+    """Generate a legacy events context id query that also joins states."""
+    # This can be removed once we no longer have event_ids in the states table
+    return (
+        select(
+            *EVENT_COLUMNS,
+            literal(value=None, type_=sqlalchemy.String).label("shared_data"),
+            *STATE_COLUMNS,
+            literal(None).label("context_only"),
+        )
+        .outerjoin(States, (Events.event_id == States.event_id))
+        .where(States.last_updated == States.last_changed)
+        .where(_not_continuous_entity_matcher())
+        .outerjoin(
+            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
+        )
+        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
+        .where(Events.context_id == context_id)
+    )
+
+
+def _generate_events_query_without_states(
+    start_day: dt, end_day: dt, event_types: tuple[str, ...]
+) -> Select:
+    return (
+        select(
+            *EVENT_ROWS_NO_STATES,
+            literal(None).label("context_only"),
+        )
+        .where((Events.time_fired > start_day) & (Events.time_fired < end_day))
+        .where(Events.event_type.in_(event_types))
+        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+    )
+
+
+def _generate_states_query(start_day: dt, end_day: dt) -> Select:
+    old_state = aliased(States, name="old_state")
+    return (
+        select(
+            literal(value=EVENT_STATE_CHANGED, type_=sqlalchemy.String).label(
+                "event_type"
+            ),
+            literal(value=None, type_=sqlalchemy.Text).label("event_data"),
+            States.last_changed.label("time_fired"),
+            States.context_id.label("context_id"),
+            States.context_user_id.label("context_user_id"),
+            States.context_parent_id.label("context_parent_id"),
+            literal(value=None, type_=sqlalchemy.Text).label("shared_data"),
+            *STATE_COLUMNS,
+            literal(None).label("context_only"),
+        )
+        .filter((States.last_updated > start_day) & (States.last_updated < end_day))
+        .outerjoin(old_state, (States.old_state_id == old_state.state_id))
+        .where(_missing_state_matcher(old_state))
+        .where(_not_continuous_entity_matcher())
+        .where(States.last_updated == States.last_changed)
+        .outerjoin(
+            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
+        )
+    )
+
+
+def _missing_state_matcher(old_state: States) -> sqlalchemy.and_:
+    # The below removes state change events that do not have
+    # and old_state or the old_state is missing (newly added entities)
+    # or the new_state is missing (removed entities)
+    return sqlalchemy.and_(
+        old_state.state_id.isnot(None),
+        (States.state != old_state.state),
+        States.state.isnot(None),
+    )
+
+
+def _not_continuous_entity_matcher() -> sqlalchemy.or_:
+    """Match non continuous entities."""
+    return sqlalchemy.or_(
+        _not_continuous_domain_matcher(),
+        sqlalchemy.and_(
+            _continuous_domain_matcher, _not_uom_attributes_matcher()
+        ).self_group(),
+    )
+
+
+def _not_continuous_domain_matcher() -> sqlalchemy.and_:
+    """Match not continuous domains."""
+    return sqlalchemy.and_(
+        *[
+            ~States.entity_id.like(entity_domain)
+            for entity_domain in CONTINUOUS_ENTITY_ID_LIKE
+        ],
+    ).self_group()
+
+
+def _continuous_domain_matcher() -> sqlalchemy.or_:
+    """Match continuous domains."""
+    return sqlalchemy.or_(
+        *[
+            States.entity_id.like(entity_domain)
+            for entity_domain in CONTINUOUS_ENTITY_ID_LIKE
+        ],
+    ).self_group()
+
+
+def _not_uom_attributes_matcher() -> Any:
+    """Prefilter ATTR_UNIT_OF_MEASUREMENT as its much faster in sql."""
+    return ~StateAttributes.shared_attrs.like(
+        UNIT_OF_MEASUREMENT_JSON_LIKE
+    ) | ~States.attributes.like(UNIT_OF_MEASUREMENT_JSON_LIKE)
+
+
+def _apply_event_entity_id_matchers(entity_ids: Iterable[str]) -> sqlalchemy.or_:
+    """Create matchers for the entity_id in the event_data."""
+    ors = []
+    for entity_id in entity_ids:
+        like = ENTITY_ID_JSON_TEMPLATE.format(entity_id)
+        ors.append(Events.event_data.like(like))
+        ors.append(EventData.shared_data.like(like))
+    return sqlalchemy.or_(*ors)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1480,7 +1480,7 @@ async def test_custom_log_entry_discoverable_via_entity_matches_only(
     assert json_dict[0]["entity_id"] == "switch.test_switch"
 
 
-async def test_logbook_entity_matches_only_multiple(hass, hass_client, recorder_mock):
+async def test_logbook_entity_matches_only_multiple_x(hass, hass_client, recorder_mock):
     """Test the logbook view with a multiple entities and entity_matches_only."""
     await async_setup_component(hass, "logbook", {})
     assert await async_setup_component(

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1321,8 +1321,8 @@ async def test_logbook_context_from_template(hass, hass_client, recorder_mock):
     assert json_dict[5]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
-async def test_logbook_entity_matches_only(hass, hass_client, recorder_mock):
-    """Test the logbook view with a single entity and entity_matches_only."""
+async def test_logbook_(hass, hass_client, recorder_mock):
+    """Test the logbook view with a single entity and ."""
     await async_setup_component(hass, "logbook", {})
     assert await async_setup_component(
         hass,
@@ -1377,7 +1377,7 @@ async def test_logbook_entity_matches_only(hass, hass_client, recorder_mock):
     # Test today entries with filter by end_time
     end_time = start + timedelta(hours=24)
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=switch.test_state&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=switch.test_state"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1390,10 +1390,8 @@ async def test_logbook_entity_matches_only(hass, hass_client, recorder_mock):
     assert json_dict[1]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
-async def test_logbook_entity_matches_only_multiple_calls(
-    hass, hass_client, recorder_mock
-):
-    """Test the logbook view with a single entity and entity_matches_only called multiple times."""
+async def test_logbook_many_entities_multiple_calls(hass, hass_client, recorder_mock):
+    """Test the logbook view with a many entities called multiple times."""
     await async_setup_component(hass, "logbook", {})
     await async_setup_component(hass, "automation", {})
 
@@ -1421,7 +1419,7 @@ async def test_logbook_entity_matches_only_multiple_calls(
     for automation_id in range(5):
         # Test today entries with filter by end_time
         response = await client.get(
-            f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=automation.mock_{automation_id}_automation&entity_matches_only"
+            f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=automation.mock_{automation_id}_automation"
         )
         assert response.status == HTTPStatus.OK
         json_dict = await response.json()
@@ -1432,7 +1430,7 @@ async def test_logbook_entity_matches_only_multiple_calls(
         )
 
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=automation.mock_0_automation,automation.mock_1_automation,automation.mock_2_automation&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=automation.mock_0_automation,automation.mock_1_automation,automation.mock_2_automation"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1443,7 +1441,7 @@ async def test_logbook_entity_matches_only_multiple_calls(
     assert json_dict[2]["entity_id"] == "automation.mock_2_automation"
 
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=automation.mock_4_automation,automation.mock_2_automation,automation.mock_0_automation,automation.mock_1_automation&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=automation.mock_4_automation,automation.mock_2_automation,automation.mock_0_automation,automation.mock_1_automation"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1455,17 +1453,15 @@ async def test_logbook_entity_matches_only_multiple_calls(
     assert json_dict[3]["entity_id"] == "automation.mock_4_automation"
 
     response = await client.get(
-        f"/api/logbook/{end_time.isoformat()}?end_time={end_time}&entity=automation.mock_4_automation,automation.mock_2_automation,automation.mock_0_automation,automation.mock_1_automation&entity_matches_only"
+        f"/api/logbook/{end_time.isoformat()}?end_time={end_time}&entity=automation.mock_4_automation,automation.mock_2_automation,automation.mock_0_automation,automation.mock_1_automation"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
     assert len(json_dict) == 0
 
 
-async def test_custom_log_entry_discoverable_via_entity_matches_only(
-    hass, hass_client, recorder_mock
-):
-    """Test if a custom log entry is later discoverable via entity_matches_only."""
+async def test_custom_log_entry_discoverable_via_(hass, hass_client, recorder_mock):
+    """Test if a custom log entry is later discoverable via ."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
 
@@ -1487,7 +1483,7 @@ async def test_custom_log_entry_discoverable_via_entity_matches_only(
     # Test today entries with filter by end_time
     end_time = start + timedelta(hours=24)
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time.isoformat()}&entity=switch.test_switch&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time.isoformat()}&entity=switch.test_switch"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1499,8 +1495,8 @@ async def test_custom_log_entry_discoverable_via_entity_matches_only(
     assert json_dict[0]["entity_id"] == "switch.test_switch"
 
 
-async def test_logbook_entity_matches_only_multiple(hass, hass_client, recorder_mock):
-    """Test the logbook view with a multiple entities and entity_matches_only."""
+async def test_logbook_multiple_entities(hass, hass_client, recorder_mock):
+    """Test the logbook view with a multiple entities."""
     await async_setup_component(hass, "logbook", {})
     assert await async_setup_component(
         hass,
@@ -1565,7 +1561,7 @@ async def test_logbook_entity_matches_only_multiple(hass, hass_client, recorder_
     # Test today entries with filter by end_time
     end_time = start + timedelta(hours=24)
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=switch.test_state,light.test_state&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=switch.test_state,light.test_state"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1585,7 +1581,7 @@ async def test_logbook_entity_matches_only_multiple(hass, hass_client, recorder_
     # Test today entries with filter by end_time
     end_time = start + timedelta(hours=24)
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=binary_sensor.test_state,light.test_state&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=binary_sensor.test_state,light.test_state"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1605,7 +1601,7 @@ async def test_logbook_entity_matches_only_multiple(hass, hass_client, recorder_
     # Test today entries with filter by end_time
     end_time = start + timedelta(hours=24)
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=light.test_state,binary_sensor.test_state&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=light.test_state,binary_sensor.test_state"
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
@@ -1636,7 +1632,7 @@ async def test_logbook_invalid_entity(hass, hass_client, recorder_mock):
     # Test today entries with filter by end_time
     end_time = start + timedelta(hours=24)
     response = await client.get(
-        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=invalid&entity_matches_only"
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=invalid"
     )
     assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
 


### PR DESCRIPTION
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change only affects developers using the logbook api.

The `entity_matches_only` parameter to the logbook api has been been removed as it is no longer necessary.    It was originally added for the logbook card to avoid performance problem that this PR has now solved.  cc @zsarnett 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces a new faster query for selecting context ids for specific entities.   The makes the logbook card extremely responsive.

Demo of reloading 3 logbook cards
![logbook_card](https://user-images.githubusercontent.com/663432/167717939-1a498639-f1e4-4542-9b70-0fc7edab5ed8.gif)

The previous implementation had to process ALL events inside the time window.  The new implementation uses a more efficient database query which is able to narrow the rows returned to only ones that have the context id.  In production testing this reduced the api call time from ~800ms to ~50ms on a database that generates 100MiB/day.  With larger databases the improvement will be at least two orders of magnitude.

All the logbook queries have been separated into `queries.py`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io