### PR TITLE
Parallelize zwave_js service calls

### DIFF
--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Generator
 import logging
-from typing import Any, cast
+from typing import Any
 
 import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass, CommandStatus
-from zwave_js_server.exceptions import FailedCommand, SetValueFailed
+from zwave_js_server.exceptions import SetValueFailed
 from zwave_js_server.model.endpoint import Endpoint
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import get_value_id
@@ -38,6 +39,12 @@ from .helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+SET_VALUE_FAILED_EXC = SetValueFailed(
+    "Unable to set value, refer to "
+    "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "
+    "possible reasons"
+)
+
 
 def parameter_name_does_not_need_bitmask(
     val: dict[str, int | str | list[str]]
@@ -62,6 +69,33 @@ def broadcast_command(val: dict[str, Any]) -> dict[str, Any]:
         "Either `broadcast` must be set to True or multiple devices/entities must be "
         "specified"
     )
+
+
+def get_valid_responses_from_results(
+    zwave_objects: set[ZwaveNode | Endpoint], results: tuple[Any, ...]
+) -> Generator[tuple[ZwaveNode | Endpoint, Any], None, None]:
+    """Return valid responses from a list of results."""
+    for zwave_object, result in zip(zwave_objects, results):
+        if not isinstance(result, Exception):
+            yield zwave_object, result
+
+
+def raise_exceptions_from_results(
+    zwave_objects: set[ZwaveNode | Endpoint] | tuple[ZwaveNode | str, ...],
+    results: tuple[Any, ...],
+) -> None:
+    """Raise list of exceptions from a list of results."""
+    if errors := [
+        tup for tup in zip(zwave_objects, results) if isinstance(tup[1], Exception)
+    ]:
+        lines = (
+            f"{len(errors)} error(s):",
+            *(
+                f"{zwave_object} - {error.__class__.__name__}: {error.args[0]}"
+                for zwave_object, error in errors
+            ),
+        )
+        raise HomeAssistantError("\n".join(lines))
 
 
 class ZWaveServices:
@@ -371,14 +405,21 @@ class ZWaveServices:
         property_key = service.data.get(const.ATTR_CONFIG_PARAMETER_BITMASK)
         new_value = service.data[const.ATTR_CONFIG_VALUE]
 
-        for node in nodes:
-            zwave_value, cmd_status = await async_set_config_parameter(
-                node,
-                new_value,
-                property_or_property_name,
-                property_key=property_key,
-            )
-
+        results = await asyncio.gather(
+            *(
+                async_set_config_parameter(
+                    node,
+                    new_value,
+                    property_or_property_name,
+                    property_key=property_key,
+                )
+                for node in nodes
+            ),
+            return_exceptions=True,
+        )
+        for node, result in get_valid_responses_from_results(nodes, results):
+            zwave_value = result[0]
+            cmd_status = result[1]
             if cmd_status == CommandStatus.ACCEPTED:
                 msg = "Set configuration parameter %s on Node %s with value %s"
             else:
@@ -386,8 +427,8 @@ class ZWaveServices:
                     "Added command to queue to set configuration parameter %s on Node "
                     "%s with value %s. Parameter will be set when the device wakes up"
                 )
-
             _LOGGER.info(msg, zwave_value, node, new_value)
+        raise_exceptions_from_results(nodes, results)
 
     async def async_bulk_set_partial_config_parameters(
         self, service: ServiceCall
@@ -397,22 +438,30 @@ class ZWaveServices:
         property_ = service.data[const.ATTR_CONFIG_PARAMETER]
         new_value = service.data[const.ATTR_CONFIG_VALUE]
 
-        for node in nodes:
-            cmd_status = await async_bulk_set_partial_config_parameters(
-                node,
-                property_,
-                new_value,
-            )
+        results = await asyncio.gather(
+            *(
+                async_bulk_set_partial_config_parameters(
+                    node,
+                    property_,
+                    new_value,
+                )
+                for node in nodes
+            ),
+            return_exceptions=True,
+        )
 
+        for node, cmd_status in get_valid_responses_from_results(nodes, results):
             if cmd_status == CommandStatus.ACCEPTED:
                 msg = "Bulk set partials for configuration parameter %s on Node %s"
             else:
                 msg = (
-                    "Added command to queue to bulk set partials for configuration "
-                    "parameter %s on Node %s"
+                    "Queued command to bulk set partials for configuration parameter "
+                    "%s on Node %s"
                 )
 
             _LOGGER.info(msg, property_, node)
+
+        raise_exceptions_from_results(nodes, results)
 
     async def async_poll_value(self, service: ServiceCall) -> None:
         """Poll value on a node."""
@@ -436,6 +485,7 @@ class ZWaveServices:
         wait_for_result = service.data.get(const.ATTR_WAIT_FOR_RESULT)
         options = service.data.get(const.ATTR_OPTIONS)
 
+        coros = []
         for node in nodes:
             value_id = get_value_id(
                 node,
@@ -455,19 +505,30 @@ class ZWaveServices:
                 new_value_ = str(new_value)
             else:
                 new_value_ = new_value
-            success = await node.async_set_value(
-                value_id,
-                new_value_,
-                options=options,
-                wait_for_result=wait_for_result,
+            coros.append(
+                node.async_set_value(
+                    value_id,
+                    new_value_,
+                    options=options,
+                    wait_for_result=wait_for_result,
+                )
             )
 
-            if success is False:
-                raise HomeAssistantError(
-                    "Unable to set value, refer to "
-                    "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue "
-                    "for possible reasons"
-                ) from SetValueFailed
+        results = await asyncio.gather(*coros, return_exceptions=True)
+        # multiple set_values my fail so we will track the entire list
+        set_value_failed_nodes_list = []
+        for node, success in get_valid_responses_from_results(nodes, results):
+            if success:
+                continue
+            # If we failed to set a value, add node to SetValueFailed exception list
+            set_value_failed_nodes_list.append(node)
+
+        # Add the SetValueFailed exception to the results and the nodes to the node
+        # list. No-op if there are no SetValueFailed exceptions
+        raise_exceptions_from_results(
+            (*nodes, *set_value_failed_nodes_list),
+            (*results, *([SET_VALUE_FAILED_EXC] * len(set_value_failed_nodes_list))),
+        )
 
     async def async_multicast_set_value(self, service: ServiceCall) -> None:
         """Set a value via multicast to multiple nodes."""
@@ -556,24 +617,29 @@ class ZWaveServices:
 
         async def _async_invoke_cc_api(endpoints: set[Endpoint]) -> None:
             """Invoke the CC API on a node endpoint."""
-            errors: list[str] = []
-            for endpoint in endpoints:
+            results = await asyncio.gather(
+                *(
+                    endpoint.async_invoke_cc_api(
+                        command_class, method_name, *parameters
+                    )
+                    for endpoint in endpoints
+                ),
+                return_exceptions=True,
+            )
+            for endpoint, result in get_valid_responses_from_results(
+                endpoints, results
+            ):
                 _LOGGER.info(
-                    "Invoking %s CC API method %s on endpoint %s",
+                    (
+                        "Invoked %s CC API method %s on endpoint %s with the following "
+                        "result: %s"
+                    ),
                     command_class.name,
                     method_name,
                     endpoint,
+                    result,
                 )
-                try:
-                    await endpoint.async_invoke_cc_api(
-                        command_class, method_name, *parameters
-                    )
-                except FailedCommand as err:
-                    errors.append(cast(str, err.args[0]))
-            if errors:
-                raise HomeAssistantError(
-                    "\n".join([f"{len(errors)} error(s):", *errors])
-                )
+            raise_exceptions_from_results(endpoints, results)
 
         # If an endpoint is provided, we assume the user wants to call the CC API on
         # that endpoint for all target nodes

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -518,10 +518,9 @@ class ZWaveServices:
         # multiple set_values my fail so we will track the entire list
         set_value_failed_nodes_list = []
         for node, success in get_valid_responses_from_results(nodes, results):
-            if success:
-                continue
-            # If we failed to set a value, add node to SetValueFailed exception list
-            set_value_failed_nodes_list.append(node)
+            if success is False:
+                # If we failed to set a value, add node to SetValueFailed exception list
+                set_value_failed_nodes_list.append(node)
 
         # Add the SetValueFailed exception to the results and the nodes to the node
         # list. No-op if there are no SetValueFailed exceptions

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -518,6 +518,71 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
         )
 
 
+async def test_set_config_parameter_gather(
+    hass,
+    client,
+    multisensor_6,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+):
+    """Test the set_config_parameter service gather functionality."""
+    # Test setting config parameter by property and validate that the first node which
+    # which triggers an error doesn't prevent the second one to be called.
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_CONFIG_PARAMETER,
+            {
+                ATTR_ENTITY_ID: [
+                    AIR_TEMPERATURE_SENSOR,
+                    CLIMATE_RADIO_THERMOSTAT_ENTITY,
+                ],
+                ATTR_CONFIG_PARAMETER: 1,
+                ATTR_CONFIG_VALUE: 1,
+            },
+            blocking=True,
+        )
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 26
+    assert args["valueId"] == {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 1,
+        "propertyName": "Temperature Reporting Threshold",
+        "ccVersion": 1,
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "description": "Reporting threshold for changes in the ambient temperature",
+            "label": "Temperature Reporting Threshold",
+            "default": 2,
+            "min": 0,
+            "max": 4,
+            "states": {
+                "0": "Disabled",
+                "1": "0.5\u00b0 F",
+                "2": "1.0\u00b0 F",
+                "3": "1.5\u00b0 F",
+                "4": "2.0\u00b0 F",
+            },
+            "valueSize": 1,
+            "format": 0,
+            "allowManualEntry": False,
+            "isFromConfig": True,
+        },
+        "value": 1,
+    }
+    assert args["value"] == 1
+
+    client.async_send_command.reset_mock()
+
+
 async def test_bulk_set_config_parameters(hass, client, multisensor_6, integration):
     """Test the bulk_set_partial_config_parameters service."""
     dev_reg = async_get_dev_reg(hass)
@@ -724,6 +789,45 @@ async def test_bulk_set_config_parameters(hass, client, multisensor_6, integrati
     assert args["value"] == 241
 
     client.async_send_command.reset_mock()
+
+
+async def test_bulk_set_config_parameters_gather(
+    hass,
+    client,
+    multisensor_6,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+):
+    """Test the bulk_set_partial_config_parameters service gather functionality."""
+    # Test setting config parameter by property and validate that the first node which
+    # which triggers an error doesn't prevent the second one to be called.
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
+            {
+                ATTR_ENTITY_ID: [
+                    CLIMATE_RADIO_THERMOSTAT_ENTITY,
+                    AIR_TEMPERATURE_SENSOR,
+                ],
+                ATTR_CONFIG_PARAMETER: 102,
+                ATTR_CONFIG_VALUE: 241,
+            },
+            blocking=True,
+        )
+
+    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClass": 112,
+        "property": 102,
+    }
+    assert args["value"] == 241
+
+    client.async_send_command_no_wait.reset_mock()
 
 
 async def test_refresh_value(
@@ -1124,6 +1228,66 @@ async def test_set_value_options(hass, client, aeon_smart_switch_6, integration)
     assert args["options"] == {"transitionDuration": 1}
 
     client.async_send_command.reset_mock()
+
+
+async def test_set_value_gather(
+    hass,
+    client,
+    multisensor_6,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+):
+    """Test the set_value service gather functionality."""
+    # Test setting config parameter by property and validate that the first node which
+    # which triggers an error doesn't prevent the second one to be called.
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: [
+                    CLIMATE_RADIO_THERMOSTAT_ENTITY,
+                    AIR_TEMPERATURE_SENSOR,
+                ],
+                ATTR_COMMAND_CLASS: 112,
+                ATTR_PROPERTY: 102,
+                ATTR_PROPERTY_KEY: 1,
+                ATTR_VALUE: 1,
+            },
+            blocking=True,
+        )
+
+    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClassName": "Configuration",
+        "commandClass": 112,
+        "endpoint": 0,
+        "property": 102,
+        "propertyKey": 1,
+        "propertyName": "Group 2: Send battery reports",
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "valueSize": 4,
+            "min": 0,
+            "max": 1,
+            "default": 1,
+            "format": 0,
+            "allowManualEntry": True,
+            "label": "Group 2: Send battery reports",
+            "description": "Include battery information in periodic reports to Group 2",
+            "isFromConfig": True,
+        },
+        "value": 0,
+    }
+    assert args["value"] == 1
+
+    client.async_send_command_no_wait.reset_mock()
 
 
 async def test_multicast_set_value(
@@ -1728,7 +1892,8 @@ async def test_invoke_cc_api(
     client.async_send_command.reset_mock()
     client.async_send_command_no_wait.reset_mock()
 
-    # Test failed invoke_cc_api call on one node
+    # Test failed invoke_cc_api call on one node. We return the error on
+    # the first node int he call to make sure that gather works as expected
     client.async_send_command.return_value = {"response": True}
     client.async_send_command_no_wait.side_effect = FailedZWaveCommand(
         "test", 12, "test"
@@ -1740,8 +1905,8 @@ async def test_invoke_cc_api(
             SERVICE_INVOKE_CC_API,
             {
                 ATTR_DEVICE_ID: [
-                    device_radio_thermostat.id,
                     device_danfoss.id,
+                    device_radio_thermostat.id,
                 ],
                 ATTR_COMMAND_CLASS: 132,
                 ATTR_ENDPOINT: 0,

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -799,7 +799,7 @@ async def test_bulk_set_config_parameters_gather(
     integration,
 ):
     """Test the bulk_set_partial_config_parameters service gather functionality."""
-    # Test setting config parameter by property and validate that the first node
+    # Test bulk setting config parameter by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -1238,7 +1238,7 @@ async def test_set_value_gather(
     integration,
 ):
     """Test the set_value service gather functionality."""
-    # Test setting config parameter by property and validate that the first node
+    # Test setting value by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -526,7 +526,7 @@ async def test_set_config_parameter_gather(
     integration,
 ):
     """Test the set_config_parameter service gather functionality."""
-    # Test setting config parameter by property and validate that the first node which
+    # Test setting config parameter by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -799,7 +799,7 @@ async def test_bulk_set_config_parameters_gather(
     integration,
 ):
     """Test the bulk_set_partial_config_parameters service gather functionality."""
-    # Test setting config parameter by property and validate that the first node which
+    # Test setting config parameter by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -1238,7 +1238,7 @@ async def test_set_value_gather(
     integration,
 ):
     """Test the set_value service gather functionality."""
-    # Test setting config parameter by property and validate that the first node which
+    # Test setting config parameter by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -1893,7 +1893,7 @@ async def test_invoke_cc_api(
     client.async_send_command_no_wait.reset_mock()
 
     # Test failed invoke_cc_api call on one node. We return the error on
-    # the first node int he call to make sure that gather works as expected
+    # the first node in the call to make sure that gather works as expected
     client.async_send_command.return_value = {"response": True}
     client.async_send_command_no_wait.side_effect = FailedZWaveCommand(
         "test", 12, "test"


### PR DESCRIPTION
## Proposed change
It was discovered recently that because we wait for responses from the driver in most cases, and service calls issue commands serially, it can take a lot longer to iterate through the calls than it should and can also cause unintended behavior (e.g. setting a value on multiple nodes because you want them to act on it at the same time).

With this change, we issue all the commands and then await the results. Finally we will let users know about the successful calls in cases where we already do, and if there were any exceptions, we would combine them into one large one.

@MartinHjelmare before I add tests, what do you think about this approach?

CC @kpine 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
