### PR TITLE
Use device ID as input for zwave_js WS device cmds

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -131,7 +131,7 @@ def register_node_in_dev_reg(
     dev_reg: device_registry.DeviceRegistry,
     client: ZwaveClient,
     node: ZwaveNode,
-    remove_device_func: Callable[[device_registry.DeviceEntry], None] | None = None,
+    remove_device_func: Callable[[device_registry.DeviceEntry], None],
 ) -> device_registry.DeviceEntry:
     """Register node in dev reg."""
     device_id = get_device_id(client, node)
@@ -141,8 +141,7 @@ def register_node_in_dev_reg(
     # Replace the device if it can be determined that this node is not the
     # same product as it was previously.
     if (
-        remove_device_func
-        and device_id_ext
+        device_id_ext
         and device
         and len(device.identifiers) == 2
         and device_id_ext not in device.identifiers

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -131,7 +131,7 @@ def register_node_in_dev_reg(
     dev_reg: device_registry.DeviceRegistry,
     client: ZwaveClient,
     node: ZwaveNode,
-    remove_device_func: Callable[[device_registry.DeviceEntry], None],
+    remove_device_func: Callable[[device_registry.DeviceEntry], None] | None = None,
 ) -> device_registry.DeviceEntry:
     """Register node in dev reg."""
     device_id = get_device_id(client, node)
@@ -141,7 +141,8 @@ def register_node_in_dev_reg(
     # Replace the device if it can be determined that this node is not the
     # same product as it was previously.
     if (
-        device_id_ext
+        remove_device_func
+        and device_id_ext
         and device
         and len(device.identifiers) == 2
         and device_id_ext not in device.identifiers

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -387,21 +387,6 @@ def copy_available_params(
     )
 
 
-@callback
-def async_is_device_config_entry_not_loaded(
-    hass: HomeAssistant, device_id: str
-) -> bool:
-    """Return whether device's config entries are not loaded."""
-    dev_reg = dr.async_get(hass)
-    if (device := dev_reg.async_get(device_id)) is None:
-        raise ValueError(f"Device {device_id} not found")
-    return any(
-        (entry := hass.config_entries.async_get_entry(entry_id))
-        and entry.state != ConfigEntryState.LOADED
-        for entry_id in device.config_entries
-    )
-
-
 def get_value_state_schema(
     value: ZwaveValue,
 ) -> vol.Schema | None:

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -397,7 +397,6 @@ def async_is_device_config_entry_not_loaded(
         raise ValueError(f"Device {device_id} not found")
     return any(
         (entry := hass.config_entries.async_get_entry(entry_id))
-        and entry.domain == DOMAIN
         and entry.state != ConfigEntryState.LOADED
         for entry_id in device.config_entries
     )


### PR DESCRIPTION
## Proposed change
As discussed in https://github.com/home-assistant/frontend/pull/12642 we can simplify the frontend logic by accepting device ID as input instead of config entry ID and node ID in places where the device is known already. 

Dependent on https://github.com/home-assistant/frontend/pull/12658

Primary changes:
- Removed ping_node WS API call because we will never use it now that we have the ping button entity
- Switched from node ID and config entry ID to device ID anywhere we are using the inputs to get a node from the driver
- Updated network_status WS API call to include node status instead just a list of node IDs. This removes a bunch of unnecessary calls to the node_status API


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/12658

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
