### PR TITLE
Move manual configuration of MQTT fan and light to the integration key

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -189,7 +189,7 @@ MQTT_WILL_BIRTH_SCHEMA = vol.Schema(
 )
 
 PLATFORM_CONFIG_SCHEMA_BASE = vol.Schema(
-    {vol.Optional(component.value): vol.Coerce(list) for component in PLATFORMS}
+    {vol.Optional(component.value): cv.ensure_list for component in PLATFORMS}
 )
 
 CONFIG_SCHEMA_BASE = PLATFORM_CONFIG_SCHEMA_BASE.extend(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -189,7 +189,10 @@ MQTT_WILL_BIRTH_SCHEMA = vol.Schema(
 )
 
 PLATFORM_CONFIG_SCHEMA_BASE = vol.Schema(
-    {vol.Optional(component.value): cv.ensure_list for component in PLATFORMS}
+    {
+        vol.Optional(Platform.FAN.value): cv.ensure_list,
+        vol.Optional(Platform.LIGHT.value): cv.ensure_list,
+    }
 )
 
 CONFIG_SCHEMA_BASE = PLATFORM_CONFIG_SCHEMA_BASE.extend(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -261,7 +261,7 @@ SCHEMA_BASE = {
 MQTT_BASE_SCHEMA = vol.Schema(SCHEMA_BASE)
 
 # Will be removed when all platforms support a modern platform schema
-MQTT_BASE_PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
+MQTT_BASE_PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(SCHEMA_BASE)
 # Will be removed when all platforms support a modern platform schema
 MQTT_RO_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -258,10 +258,28 @@ SCHEMA_BASE = {
     vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
 }
 
-MQTT_BASE_PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(SCHEMA_BASE)
+MQTT_BASE_SCHEMA = vol.Schema(SCHEMA_BASE)
+
+# Will be removed when all platforms support a modern platform schema
+MQTT_BASE_PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
+# Will be removed when all platforms support a modern platform schema
+MQTT_RO_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_STATE_TOPIC): valid_subscribe_topic,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    }
+)
+# Will be removed when all platforms support a modern platform schema
+MQTT_RW_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
+        vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
+        vol.Optional(CONF_STATE_TOPIC): valid_subscribe_topic,
+    }
+)
 
 # Sensor type platforms subscribe to MQTT events
-MQTT_RO_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
+MQTT_RO_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
@@ -269,7 +287,7 @@ MQTT_RO_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
 )
 
 # Switch type platforms publish to MQTT and may subscribe
-MQTT_RW_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
+MQTT_RW_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -788,7 +788,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_entries_key = f"{component}.mqtt"
             if config_entries_key not in hass.data[CONFIG_ENTRY_IS_SETUP]:
                 hass.data[CONFIG_ENTRY_IS_SETUP].add(config_entries_key)
-                hass.async_add_job(
+                hass.async_create_task(
                     hass.config_entries.async_forward_entry_setup(entry, component)
                 )
 

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -28,6 +28,8 @@ CONF_CLIENT_CERT = "client_cert"
 CONF_TLS_INSECURE = "tls_insecure"
 CONF_TLS_VERSION = "tls_version"
 
+CONFIG_ENTRY_IS_SETUP = "mqtt_config_entry_is_setup"
+DATA_CONFIG_ENTRY_LOCK = "mqtt_config_entry_lock"
 DATA_MQTT_CONFIG = "mqtt_config"
 DATA_MQTT_RELOAD_NEEDED = "mqtt_reload_needed"
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -236,20 +236,16 @@ async def async_start(  # noqa: C901
                         # pylint: disable-next=import-outside-toplevel
                         from . import device_automation
 
-                        hass.async_add_job(
-                            device_automation.async_setup_entry(hass, config_entry)
-                        )
+                        await device_automation.async_setup_entry(hass, config_entry)
                     elif component == "tag":
                         # Local import to avoid circular dependencies
                         # pylint: disable-next=import-outside-toplevel
                         from . import tag
 
-                        hass.async_add_job(tag.async_setup_entry(hass, config_entry))
+                        await tag.async_setup_entry(hass, config_entry)
                     else:
-                        hass.async_add_job(
-                            hass.config_entries.async_forward_entry_setup(
-                                config_entry, component
-                            )
+                        await hass.config_entries.async_forward_entry_setup(
+                            config_entry, component
                         )
                     hass.data[CONFIG_ENTRY_IS_SETUP].add(config_entries_key)
 

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -1,6 +1,7 @@
 """Support for MQTT fans."""
 from __future__ import annotations
 
+import asyncio
 import functools
 import logging
 import math
@@ -225,10 +226,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up MQTT fan through configuration.yaml and dynamically through MQTT discovery."""
     # load and initialize platform config from configuration.yaml
-    for config in await async_get_platform_config_from_yaml(
-        hass, fan.DOMAIN, PLATFORM_SCHEMA_MODERN
-    ):
-        await _async_setup_entity(hass, async_add_entities, config, config_entry)
+    await asyncio.gather(
+        *(
+            _async_setup_entity(hass, async_add_entities, config, config_entry)
+            for config in await async_get_platform_config_from_yaml(
+                hass, fan.DOMAIN, PLATFORM_SCHEMA_MODERN
+            )
+        )
+    )
     # setup for discovery
     setup = functools.partial(
         _async_setup_entity, hass, async_add_entities, config_entry=config_entry

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -211,7 +211,7 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up MQTT fan through configuration.yaml (deprecated)."""
+    """Set up MQTT fans configured under the fan platform key (deprecated)."""
     # Deprecated in HA Core 2022.6
     await async_setup_platform_helper(
         hass, fan.DOMAIN, config, async_add_entities, _async_setup_entity

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
     CONF_OPTIMISTIC,
     CONF_PAYLOAD_OFF,
     CONF_PAYLOAD_ON,
-    CONF_PLATFORM,
     CONF_STATE,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -53,6 +52,7 @@ from .mixins import (
     async_get_platform_config_from_yaml,
     async_setup_entry_helper,
     async_setup_platform_helper,
+    validate_modern_schema,
 )
 
 CONF_PERCENTAGE_STATE_TOPIC = "percentage_state_topic"
@@ -179,7 +179,7 @@ PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
     valid_speed_range_configuration,
     valid_preset_mode_configuration,
-    cv.deprecated(CONF_PLATFORM),  # Deprecated in HA Core 2022.6
+    validate_modern_schema(fan.DOMAIN),
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -174,7 +174,7 @@ _PLATFORM_SCHEMA_BASE = mqtt.MQTT_RW_SCHEMA.extend(
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
-# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
+# Configuring MQTT Fans under the fan platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
     valid_speed_range_configuration,

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -52,7 +52,7 @@ from .mixins import (
     async_get_platform_config_from_yaml,
     async_setup_entry_helper,
     async_setup_platform_helper,
-    validate_modern_schema,
+    warn_for_legacy_schema,
 )
 
 CONF_PERCENTAGE_STATE_TOPIC = "percentage_state_topic"
@@ -179,7 +179,7 @@ PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
     valid_speed_range_configuration,
     valid_preset_mode_configuration,
-    validate_modern_schema(fan.DOMAIN),
+    warn_for_legacy_schema(fan.DOMAIN),
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -183,16 +183,6 @@ PLATFORM_SCHEMA = vol.All(
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(
-    # CONF_SPEED_COMMAND_TOPIC, CONF_SPEED_LIST, CONF_SPEED_STATE_TOPIC, CONF_SPEED_VALUE_TEMPLATE and
-    # Speeds SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH SPEED_OFF,
-    # are no longer supported, support was removed in release 2021.12
-    cv.removed(CONF_PAYLOAD_HIGH_SPEED),
-    cv.removed(CONF_PAYLOAD_LOW_SPEED),
-    cv.removed(CONF_PAYLOAD_MEDIUM_SPEED),
-    cv.removed(CONF_SPEED_COMMAND_TOPIC),
-    cv.removed(CONF_SPEED_LIST),
-    cv.removed(CONF_SPEED_STATE_TOPIC),
-    cv.removed(CONF_SPEED_VALUE_TEMPLATE),
     _PLATFORM_SCHEMA_BASE,
     valid_speed_range_configuration,
     valid_preset_mode_configuration,

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -49,6 +49,7 @@ from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
+    async_get_platform_config_from_yaml,
     async_setup_entry_helper,
     async_setup_platform_helper,
 )
@@ -201,7 +202,7 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up MQTT fan through configuration.yaml."""
+    """Set up MQTT fan through configuration.yaml (deprecated)."""
     await async_setup_platform_helper(
         hass, fan.DOMAIN, config, async_add_entities, _async_setup_entity
     )
@@ -212,7 +213,13 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up MQTT fan dynamically through MQTT discovery."""
+    """Set up MQTT fan through configuration.yaml and dynamically through MQTT discovery."""
+    # load and initialize platform config from configuration.yaml
+    for config in await async_get_platform_config_from_yaml(
+        hass, fan.DOMAIN, PLATFORM_SCHEMA
+    ):
+        await _async_setup_entity(hass, async_add_entities, config, config_entry)
+    # setup for discovery
     setup = functools.partial(
         _async_setup_entity, hass, async_add_entities, config_entry=config_entry
     )

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_OPTIMISTIC,
     CONF_PAYLOAD_OFF,
     CONF_PAYLOAD_ON,
+    CONF_PLATFORM,
     CONF_STATE,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -177,6 +178,7 @@ PLATFORM_SCHEMA = vol.All(
     _PLATFORM_SCHEMA_BASE,
     valid_speed_range_configuration,
     valid_preset_mode_configuration,
+    cv.deprecated(CONF_PLATFORM),  # Deprecated in HA Core 2022.6
 )
 
 DISCOVERY_SCHEMA = vol.All(
@@ -203,6 +205,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up MQTT fan through configuration.yaml (deprecated)."""
+    # Deprecated in HA Core 2022.6
     await async_setup_platform_helper(
         hass, fan.DOMAIN, config, async_add_entities, _async_setup_entity
     )

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -124,7 +124,7 @@ def valid_preset_mode_configuration(config):
     return config
 
 
-_PLATFORM_SCHEMA_BASE = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
+_PLATFORM_SCHEMA_BASE = mqtt.MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
@@ -174,11 +174,28 @@ _PLATFORM_SCHEMA_BASE = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
+# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA = vol.All(
-    _PLATFORM_SCHEMA_BASE,
+    cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
     valid_speed_range_configuration,
     valid_preset_mode_configuration,
     cv.deprecated(CONF_PLATFORM),  # Deprecated in HA Core 2022.6
+)
+
+PLATFORM_SCHEMA_MODERN = vol.All(
+    # CONF_SPEED_COMMAND_TOPIC, CONF_SPEED_LIST, CONF_SPEED_STATE_TOPIC, CONF_SPEED_VALUE_TEMPLATE and
+    # Speeds SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH SPEED_OFF,
+    # are no longer supported, support was removed in release 2021.12
+    cv.removed(CONF_PAYLOAD_HIGH_SPEED),
+    cv.removed(CONF_PAYLOAD_LOW_SPEED),
+    cv.removed(CONF_PAYLOAD_MEDIUM_SPEED),
+    cv.removed(CONF_SPEED_COMMAND_TOPIC),
+    cv.removed(CONF_SPEED_LIST),
+    cv.removed(CONF_SPEED_STATE_TOPIC),
+    cv.removed(CONF_SPEED_VALUE_TEMPLATE),
+    _PLATFORM_SCHEMA_BASE,
+    valid_speed_range_configuration,
+    valid_preset_mode_configuration,
 )
 
 DISCOVERY_SCHEMA = vol.All(
@@ -219,7 +236,7 @@ async def async_setup_entry(
     """Set up MQTT fan through configuration.yaml and dynamically through MQTT discovery."""
     # load and initialize platform config from configuration.yaml
     for config in await async_get_platform_config_from_yaml(
-        hass, fan.DOMAIN, PLATFORM_SCHEMA
+        hass, fan.DOMAIN, PLATFORM_SCHEMA_MODERN
     ):
         await _async_setup_entity(hass, async_add_entities, config, config_entry)
     # setup for discovery

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -74,7 +74,7 @@ DISCOVERY_SCHEMA = vol.All(
     validate_mqtt_light_discovery,
 )
 
-# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
+# Configuring MQTT Lights under the light platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema, extra=vol.ALLOW_EXTRA),
     validate_mqtt_light,

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 
 from homeassistant.components import light
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -17,6 +16,7 @@ from ..mixins import (
     async_get_platform_config_from_yaml,
     async_setup_entry_helper,
     async_setup_platform_helper,
+    validate_modern_schema,
 )
 from .schema import CONF_SCHEMA, MQTT_LIGHT_SCHEMA_SCHEMA
 from .schema_basic import (
@@ -78,7 +78,7 @@ DISCOVERY_SCHEMA = vol.All(
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema, extra=vol.ALLOW_EXTRA),
     validate_mqtt_light,
-    cv.deprecated(CONF_PLATFORM),
+    validate_modern_schema(light.DOMAIN),
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -105,7 +105,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up MQTT light through configuration.yaml and dynamically through MQTT discovery."""
+    """Set up MQTT lights configured under the light platform key (deprecated)."""
     # load and initialize platform config from configuration.yaml
     for config in await async_get_platform_config_from_yaml(
         hass, light.DOMAIN, PLATFORM_SCHEMA_MODERN

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -16,7 +16,7 @@ from ..mixins import (
     async_get_platform_config_from_yaml,
     async_setup_entry_helper,
     async_setup_platform_helper,
-    validate_modern_schema,
+    warn_for_legacy_schema,
 )
 from .schema import CONF_SCHEMA, MQTT_LIGHT_SCHEMA_SCHEMA
 from .schema_basic import (
@@ -78,7 +78,7 @@ DISCOVERY_SCHEMA = vol.All(
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema, extra=vol.ALLOW_EXTRA),
     validate_mqtt_light,
-    validate_modern_schema(light.DOMAIN),
+    warn_for_legacy_schema(light.DOMAIN),
 )
 
 PLATFORM_SCHEMA_MODERN = vol.All(

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -1,6 +1,7 @@
 """Support for MQTT lights."""
 from __future__ import annotations
 
+import asyncio
 import functools
 
 import voluptuous as vol
@@ -107,10 +108,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up MQTT lights configured under the light platform key (deprecated)."""
     # load and initialize platform config from configuration.yaml
-    for config in await async_get_platform_config_from_yaml(
-        hass, light.DOMAIN, PLATFORM_SCHEMA_MODERN
-    ):
-        await _async_setup_entity(hass, async_add_entities, config, config_entry)
+    await asyncio.gather(
+        *(
+            _async_setup_entity(hass, async_add_entities, config, config_entry)
+            for config in await async_get_platform_config_from_yaml(
+                hass, light.DOMAIN, PLATFORM_SCHEMA_MODERN
+            )
+        )
+    )
     # setup for discovery
     setup = functools.partial(
         _async_setup_entity, hass, async_add_entities, config_entry=config_entry

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -81,7 +81,10 @@ PLATFORM_SCHEMA = vol.All(
     cv.deprecated(CONF_PLATFORM),
 )
 
-PLATFORM_SCHEMA_MODERN = vol.All(MQTT_LIGHT_SCHEMA_SCHEMA, validate_mqtt_light_modern)
+PLATFORM_SCHEMA_MODERN = vol.All(
+    MQTT_LIGHT_SCHEMA_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA),
+    validate_mqtt_light_modern,
+)
 
 
 async def async_setup_platform(

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -7,7 +7,9 @@ import voluptuous as vol
 
 from homeassistant.components import light
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -57,6 +59,7 @@ def validate_mqtt_light(value):
 DISCOVERY_SCHEMA = vol.All(
     MQTT_LIGHT_SCHEMA_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA),
     validate_mqtt_light_discovery,
+    cv.deprecated(CONF_PLATFORM),  # Deprecated in HA Core 2022.6
 )
 
 
@@ -72,6 +75,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up MQTT light through configuration.yaml (deprecated)."""
+    # Deprecated in HA Core 2022.6
     await async_setup_platform_helper(
         hass, light.DOMAIN, config, async_add_entities, _async_setup_entity
     )

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -241,16 +241,7 @@ DISCOVERY_SCHEMA_BASIC = vol.All(
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
-PLATFORM_SCHEMA_MODERN_BASIC = vol.All(
-    # CONF_VALUE_TEMPLATE is no longer supported, support was removed in 2022.2
-    cv.removed(CONF_VALUE_TEMPLATE),
-    # CONF_WHITE_VALUE_* is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE_COMMAND_TOPIC),
-    cv.deprecated(CONF_WHITE_VALUE_SCALE),
-    cv.deprecated(CONF_WHITE_VALUE_STATE_TOPIC),
-    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
-    _PLATFORM_SCHEMA_BASE,
-)
+PLATFORM_SCHEMA_MODERN_BASIC = _PLATFORM_SCHEMA_BASE
 
 
 async def async_setup_entity_basic(

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -156,7 +156,7 @@ VALUE_TEMPLATE_KEYS = [
 ]
 
 _PLATFORM_SCHEMA_BASE = (
-    mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
+    mqtt.MQTT_RW_SCHEMA.extend(
         {
             vol.Optional(CONF_BRIGHTNESS_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_BRIGHTNESS_COMMAND_TOPIC): mqtt.valid_publish_topic,
@@ -220,13 +220,14 @@ _PLATFORM_SCHEMA_BASE = (
     .extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema)
 )
 
+# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_BASIC = vol.All(
     # CONF_WHITE_VALUE_* is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE_COMMAND_TOPIC),
     cv.deprecated(CONF_WHITE_VALUE_SCALE),
     cv.deprecated(CONF_WHITE_VALUE_STATE_TOPIC),
     cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
-    _PLATFORM_SCHEMA_BASE,
+    cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
 )
 
 DISCOVERY_SCHEMA_BASIC = vol.All(
@@ -238,6 +239,17 @@ DISCOVERY_SCHEMA_BASIC = vol.All(
     cv.deprecated(CONF_WHITE_VALUE_STATE_TOPIC),
     cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
+)
+
+PLATFORM_SCHEMA_MODERN_BASIC = vol.All(
+    # CONF_VALUE_TEMPLATE is no longer supported, support was removed in 2022.2
+    cv.removed(CONF_VALUE_TEMPLATE),
+    # CONF_WHITE_VALUE_* is deprecated, support will be removed in release 2022.9
+    cv.deprecated(CONF_WHITE_VALUE_COMMAND_TOPIC),
+    cv.deprecated(CONF_WHITE_VALUE_SCALE),
+    cv.deprecated(CONF_WHITE_VALUE_STATE_TOPIC),
+    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
+    _PLATFORM_SCHEMA_BASE,
 )
 
 

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -162,8 +162,6 @@ DISCOVERY_SCHEMA_JSON = vol.All(
 )
 
 PLATFORM_SCHEMA_MODERN_JSON = vol.All(
-    # CONF_WHITE_VALUE is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE),
     _PLATFORM_SCHEMA_BASE,
     valid_color_configuration,
 )

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -146,7 +146,7 @@ _PLATFORM_SCHEMA_BASE = (
     .extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema)
 )
 
-# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
+# Configuring MQTT Lights under the light platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_JSON = vol.All(
     # CONF_WHITE_VALUE is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE),

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -103,7 +103,7 @@ def valid_color_configuration(config):
 
 
 _PLATFORM_SCHEMA_BASE = (
-    mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
+    mqtt.MQTT_RW_SCHEMA.extend(
         {
             vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS): cv.boolean,
             vol.Optional(
@@ -146,10 +146,11 @@ _PLATFORM_SCHEMA_BASE = (
     .extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema)
 )
 
+# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_JSON = vol.All(
     # CONF_WHITE_VALUE is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE),
-    _PLATFORM_SCHEMA_BASE,
+    cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
     valid_color_configuration,
 )
 
@@ -157,6 +158,13 @@ DISCOVERY_SCHEMA_JSON = vol.All(
     # CONF_WHITE_VALUE is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
+    valid_color_configuration,
+)
+
+PLATFORM_SCHEMA_MODERN_JSON = vol.All(
+    # CONF_WHITE_VALUE is deprecated, support will be removed in release 2022.9
+    cv.deprecated(CONF_WHITE_VALUE),
+    _PLATFORM_SCHEMA_BASE,
     valid_color_configuration,
 )
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -90,7 +90,7 @@ _PLATFORM_SCHEMA_BASE = (
     .extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema)
 )
 
-# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
+# Configuring MQTT Lights under the light platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_TEMPLATE = vol.All(
     # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -103,11 +103,7 @@ DISCOVERY_SCHEMA_TEMPLATE = vol.All(
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
-PLATFORM_SCHEMA_MODERN_TEMPLATE = vol.All(
-    # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
-    _PLATFORM_SCHEMA_BASE,
-)
+PLATFORM_SCHEMA_MODERN_TEMPLATE = _PLATFORM_SCHEMA_BASE
 
 
 async def async_setup_entity_template(

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -67,7 +67,7 @@ CONF_RED_TEMPLATE = "red_template"
 CONF_WHITE_VALUE_TEMPLATE = "white_value_template"
 
 _PLATFORM_SCHEMA_BASE = (
-    mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
+    mqtt.MQTT_RW_SCHEMA.extend(
         {
             vol.Optional(CONF_BLUE_TEMPLATE): cv.template,
             vol.Optional(CONF_BRIGHTNESS_TEMPLATE): cv.template,
@@ -90,16 +90,23 @@ _PLATFORM_SCHEMA_BASE = (
     .extend(MQTT_LIGHT_SCHEMA_SCHEMA.schema)
 )
 
+# The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_TEMPLATE = vol.All(
     # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
-    _PLATFORM_SCHEMA_BASE,
+    cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
 )
 
 DISCOVERY_SCHEMA_TEMPLATE = vol.All(
     # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
     cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
+)
+
+PLATFORM_SCHEMA_MODERN_TEMPLATE = vol.All(
+    # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
+    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
+    _PLATFORM_SCHEMA_BASE,
 )
 
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -237,7 +237,8 @@ def warn_for_legacy_schema(domain: str) -> Callable:
             return config
 
         _LOGGER.warning(
-            "Manually configured MQTT item(s) found under platform key '%s'. Manually configured MQTT item configurations have been moved to the integration key, please move the configuration of MQTT %s to mqtt->%s",
+            "Manually configured MQTT %s(s) found under platform key '%s', "
+            "please move to the mqtt integration key, see https://www.home-assistant.io/integrations/%s.mqtt/",
             domain,
             domain,
             domain,

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -238,7 +238,8 @@ def warn_for_legacy_schema(domain: str) -> Callable:
 
         _LOGGER.warning(
             "Manually configured MQTT %s(s) found under platform key '%s', "
-            "please move to the mqtt integration key, see https://www.home-assistant.io/integrations/%s.mqtt/",
+            "please move to the mqtt integration key, see "
+            "https://www.home-assistant.io/integrations/%s.mqtt/",
             domain,
             domain,
             domain,

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -239,7 +239,7 @@ def warn_for_legacy_schema(domain: str) -> Callable:
         _LOGGER.warning(
             "Manually configured MQTT %s(s) found under platform key '%s', "
             "please move to the mqtt integration key, see "
-            "https://www.home-assistant.io/integrations/%s.mqtt/",
+            "https://www.home-assistant.io/integrations/%s.mqtt/#new_format",
             domain,
             domain,
             domain,

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -224,7 +224,7 @@ MQTT_ENTITY_COMMON_SCHEMA = MQTT_AVAILABILITY_SCHEMA.extend(
 )
 
 
-def validate_modern_schema(domain: str) -> Callable:
+def warn_for_legacy_schema(domain: str) -> Callable:
     """Warn once when a legacy platform schema is used."""
     warned = set()
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -224,6 +224,27 @@ MQTT_ENTITY_COMMON_SCHEMA = MQTT_AVAILABILITY_SCHEMA.extend(
 )
 
 
+def validate_modern_schema(domain: str) -> Callable:
+    """Warn once when a legacy platform schema is used."""
+    warned = set()
+
+    def validator(config: ConfigType) -> ConfigType:
+        """Return a validator."""
+        nonlocal warned
+
+        if domain in warned:
+            return config
+
+        _LOGGER.warning(
+            "Manual configured MQTT item found at platform key '%s'. Manual MQTT item configurations have been moved to the integration key",
+            domain,
+        )
+        warned.add(domain)
+        return config
+
+    return validator
+
+
 class SetupEntity(Protocol):
     """Protocol type for async_setup_entities."""
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -266,7 +266,7 @@ class SetupEntity(Protocol):
 async def async_get_platform_config_from_yaml(
     hass: HomeAssistant, domain: str, schema: vol.Schema
 ) -> list[ConfigType]:
-    """Return a list of validated configurations for the domain read from configuration.yaml."""
+    """Return a list of validated configurations for the domain."""
 
     def async_validate_config(
         hass: HomeAssistant,

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -236,7 +236,9 @@ def validate_modern_schema(domain: str) -> Callable:
             return config
 
         _LOGGER.warning(
-            "Manual configured MQTT item found at platform key '%s'. Manual MQTT item configurations have been moved to the integration key",
+            "Manually configured MQTT item(s) found under platform key '%s'. Manually configured MQTT item configurations have been moved to the integration key, please move the configuration of MQTT %s to mqtt->%s",
+            domain,
+            domain,
             domain,
         )
         warned.add(domain)

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -253,9 +253,7 @@ async def async_get_platform_config_from_yaml(
         return schema(config)
 
     config_yaml: ConfigType = hass.data.get(DATA_MQTT_CONFIG, {})
-    if not (integration_config := config_yaml.get(DOMAIN)) or not (
-        platform_configs := integration_config.get(domain)
-    ):
+    if not (platform_configs := config_yaml.get(domain)):
         return []
     errors = []
     try:

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -9,7 +9,6 @@ from typing import Any, Protocol, cast, final
 
 import voluptuous as vol
 
-from homeassistant.config import async_hass_config_yaml
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CONFIGURATION_URL,
@@ -66,6 +65,7 @@ from .const import (
     CONF_ENCODING,
     CONF_QOS,
     CONF_TOPIC,
+    DATA_MQTT_CONFIG,
     DATA_MQTT_RELOAD_NEEDED,
     DEFAULT_ENCODING,
     DEFAULT_PAYLOAD_AVAILABLE,
@@ -252,7 +252,7 @@ async def async_get_platform_config_from_yaml(
         config[CONF_PLATFORM] = DOMAIN
         return schema(config)
 
-    config_yaml = await async_hass_config_yaml(hass)
+    config_yaml: ConfigType = hass.data.get(DATA_MQTT_CONFIG, {})
     if not (integration_config := config_yaml.get(DOMAIN)) or not (
         platform_configs := integration_config.get(domain)
     ):

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
     CONF_ICON,
     CONF_MODEL,
     CONF_NAME,
-    CONF_PLATFORM,
     CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
 )
@@ -244,20 +243,12 @@ async def async_get_platform_config_from_yaml(
 ) -> list[ConfigType]:
     """Return a list of validated configurations for the platform read from configuration.yaml."""
 
-    def check_schema(config: dict, schema: vol.Schema) -> ConfigType:
-        """Update the platform for schema compatibility and check the schema."""
-        if CONF_PLATFORM in config:
-            error_string = f"Invalid keyword 'platform' found, please remove it from your configuration: {json.dumps(config)}"
-            raise ValueError(error_string)
-        config[CONF_PLATFORM] = DOMAIN
-        return schema(config)
-
     config_yaml: ConfigType = hass.data.get(DATA_MQTT_CONFIG, {})
     if not (platform_configs := config_yaml.get(domain)):
         return []
     errors = []
     try:
-        config = [check_schema(config, schema) for config in platform_configs]
+        config = [schema(config) for config in platform_configs]
     except (ValueError, vol.MultipleInvalid) as exc:
         errors.append(exc)
     if errors:

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -1693,21 +1693,41 @@ async def help_test_reloadable_late(hass, caplog, tmp_path, domain, config):
 
 
 async def help_test_setup_manual_entity_from_yaml(
-    hass, caplog, tmp_path, platform, config
+    hass,
+    caplog,
+    tmp_path,
+    platform,
+    config,
+    assert_entity_exists=True,
+    remove_platform=True,
 ):
-    """Test setup from yaml through configuration entry."""
-    yaml_config = copy.deepcopy(config)
-    yaml_config["name"] = "test"
+    """Test setup from yaml through configuration entry.
+
+    This helper has some optional parameters.
+    With the default settings a manual MQTT item will be setup with
+    the new config schema under the `mqtt->platform->[manual_config]` key.
+    A `platform` key will be removed from the config if the new schema is used
+    and `remove_platform` is set, this way we can share the PLATFORM_SCHEMA.
+    - `assert_entity_exists` adds a check to assert an entity with name platform.test exists.
+    - `remove_platform` mocks the forwarding og the entry setup to the platforms.
+    - `legacy_schema` uses the deprecated config schema to setup the manual MQTT item.
+    """
+    configs = []
+    if config:
+        yaml_config = copy.deepcopy(config)
+        if assert_entity_exists:
+            yaml_config["name"] = "test"
+        if remove_platform:
+            del yaml_config["platform"]
+        configs.append(yaml_config)
+    config_structure = {mqtt.DOMAIN: {platform: configs}}
     # Remove platform key from the config since this is not valid here
-    del yaml_config["platform"]
     new_yaml_config_file = tmp_path / "configuration.yaml"
-    new_yaml_config = yaml.dump({mqtt.DOMAIN: {platform: [yaml_config]}})
+    new_yaml_config = yaml.dump(config_structure)
     new_yaml_config_file.write_text(new_yaml_config)
     assert new_yaml_config_file.read_text() == new_yaml_config
 
-    await async_setup_component(
-        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {platform: [yaml_config]}}
-    )
+    await async_setup_component(hass, mqtt.DOMAIN, config_structure)
     # Mock config entry
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
@@ -1718,5 +1738,8 @@ async def help_test_setup_manual_entity_from_yaml(
         mock_client().connect = lambda *args: 0
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+    if not assert_entity_exists:
+        return
 
     assert hass.states.get(f"{platform}.test") is not None

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -1811,7 +1811,10 @@ async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
 async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
     """Test setup manual configured MQTT entity."""
     platform = fan.DOMAIN
-    config = DEFAULT_CONFIG[platform]
+    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config["name"] = "test"
+    del config["platform"]
     await help_test_setup_manual_entity_from_yaml(
         hass, caplog, tmp_path, platform, config
     )
+    assert hass.states.get(f"{platform}.test") is not None

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -55,6 +55,7 @@ from .test_common import (
     help_test_setting_attribute_via_mqtt_json_message,
     help_test_setting_attribute_with_template,
     help_test_setting_blocked_attribute_via_mqtt_json_message,
+    help_test_setup_manual_entity_from_yaml,
     help_test_unique_id,
     help_test_update_with_json_attrs_bad_JSON,
     help_test_update_with_json_attrs_not_dict,
@@ -1805,3 +1806,12 @@ async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     domain = fan.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
+
+
+async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
+    """Test setup manual configured MQTT entity."""
+    platform = fan.DOMAIN
+    config = DEFAULT_CONFIG[platform]
+    await help_test_setup_manual_entity_from_yaml(
+        hass, caplog, tmp_path, platform, config
+    )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1295,7 +1295,7 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog, tmp_path):
         remove_platform=False,
     )
     assert (
-        "voluptuous.error.MultipleInvalid: extra keys not allowed @ data['platform']"
+        "Invalid config for [light]: [platform] is an invalid option for [light]. Check: light->platform. (See ?, line ?)"
         in caplog.text
     )
 
@@ -1313,7 +1313,7 @@ async def test_setup_manual_mqtt_with_invalid_config(hass, caplog, tmp_path):
         remove_platform=False,
     )
     assert (
-        "voluptuous.error.MultipleInvalid: required key not provided @ data['command_topic']"
+        "Invalid config for [light]: required key not provided @ data['command_topic']. Got None. (See ?, line ?)"
         in caplog.text
     )
 
@@ -2483,7 +2483,7 @@ async def test_one_deprecation_warning_per_platform(hass, mqtt_mock, caplog):
     count = 0
     for record in caplog.records:
         if record.levelname == "WARNING" and (
-            f"Manual configured MQTT item found at platform key '{platform}'"
+            f"Manually configured MQTT item(s) found under platform key '{platform}'"
             in record.message
         ):
             count += 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2483,7 +2483,7 @@ async def test_one_deprecation_warning_per_platform(hass, mqtt_mock, caplog):
     count = 0
     for record in caplog.records:
         if record.levelname == "WARNING" and (
-            f"Manually configured MQTT item(s) found under platform key '{platform}'"
+            f"Manually configured MQTT {platform}(s) found under platform key '{platform}'"
             in record.message
         ):
             count += 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1313,7 +1313,8 @@ async def test_setup_manual_mqtt_with_invalid_config(hass, caplog, tmp_path):
         remove_platform=False,
     )
     assert (
-        "Invalid config for [light]: required key not provided @ data['command_topic']. Got None. (See ?, line ?)"
+        "Invalid config for [light]: required key not provided @ data['command_topic']."
+        " Got None. (See ?, line ?)"
         in caplog.text
     )
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1296,8 +1296,7 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog, tmp_path):
     )
     assert (
         "Invalid config for [light]: [platform] is an invalid option for [light]. "
-        "Check: light->platform. (See ?, line ?)"
-        in caplog.text
+        "Check: light->platform. (See ?, line ?)" in caplog.text
     )
 
 
@@ -1315,8 +1314,7 @@ async def test_setup_manual_mqtt_with_invalid_config(hass, caplog, tmp_path):
     )
     assert (
         "Invalid config for [light]: required key not provided @ data['command_topic']."
-        " Got None. (See ?, line ?)"
-        in caplog.text
+        " Got None. (See ?, line ?)" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1291,8 +1291,6 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog, tmp_path):
         tmp_path,
         "light",
         config,
-        assert_entity_exists=False,
-        remove_platform=False,
     )
     assert (
         "Invalid config for [light]: [platform] is an invalid option for [light]. "
@@ -1309,8 +1307,6 @@ async def test_setup_manual_mqtt_with_invalid_config(hass, caplog, tmp_path):
         tmp_path,
         "light",
         config,
-        assert_entity_exists=False,
-        remove_platform=False,
     )
     assert (
         "Invalid config for [light]: required key not provided @ data['command_topic']."
@@ -1327,8 +1323,6 @@ async def test_setup_manual_mqtt_empty_platform(hass, caplog, tmp_path):
         tmp_path,
         "light",
         config,
-        assert_entity_exists=False,
-        remove_platform=False,
     )
     assert "voluptuous.error.MultipleInvalid" not in caplog.text
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1295,7 +1295,8 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog, tmp_path):
         remove_platform=False,
     )
     assert (
-        "Invalid config for [light]: [platform] is an invalid option for [light]. Check: light->platform. (See ?, line ?)"
+        "Invalid config for [light]: [platform] is an invalid option for [light]. "
+        "Check: light->platform. (See ?, line ?)"
         in caplog.text
     )
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -30,6 +30,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
+from .test_common import help_test_setup_manual_entity_from_yaml
+
 from tests.common import (
     MockConfigEntry,
     async_fire_mqtt_message,
@@ -1277,6 +1279,57 @@ async def test_setup_override_configuration(hass, caplog, tmp_path):
             # Check if the password override worked
             assert calls_username_password_set[0][0] == "someuser"
             assert calls_username_password_set[0][1] == "somepassword"
+
+
+async def test_setup_manual_mqtt_with_platform_key(hass, caplog, tmp_path):
+    """Test set up a manual MQTT item with a platform key."""
+    config = {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
+    await help_test_setup_manual_entity_from_yaml(
+        hass,
+        caplog,
+        tmp_path,
+        "light",
+        config,
+        assert_entity_exists=False,
+        remove_platform=False,
+    )
+    assert (
+        "Invalid keyword 'platform' found, please remove it from your configuration"
+        in caplog.text
+    )
+
+
+async def test_setup_manual_mqtt_with_invalid_config(hass, caplog, tmp_path):
+    """Test set up a manual MQTT item with an invalid config."""
+    config = {"name": "test"}
+    await help_test_setup_manual_entity_from_yaml(
+        hass,
+        caplog,
+        tmp_path,
+        "light",
+        config,
+        assert_entity_exists=False,
+        remove_platform=False,
+    )
+    assert (
+        "voluptuous.error.MultipleInvalid: required key not provided @ data['command_topic']"
+        in caplog.text
+    )
+
+
+async def test_setup_manual_mqtt_empty_platform(hass, caplog, tmp_path):
+    """Test set up a manual MQTT platform without items."""
+    config = None
+    await help_test_setup_manual_entity_from_yaml(
+        hass,
+        caplog,
+        tmp_path,
+        "light",
+        config,
+        assert_entity_exists=False,
+        remove_platform=False,
+    )
+    assert "voluptuous.error.MultipleInvalid" not in caplog.text
 
 
 async def test_setup_mqtt_client_protocol(hass):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1294,7 +1294,7 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog, tmp_path):
         remove_platform=False,
     )
     assert (
-        "Invalid keyword 'platform' found, please remove it from your configuration"
+        "voluptuous.error.MultipleInvalid: extra keys not allowed @ data['platform']"
         in caplog.text
     )
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1628,7 +1628,8 @@ async def test_setup_entry_with_config_override(hass, device_reg, mqtt_client_mo
     # User sets up a config entry
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        assert await hass.config_entries.async_setup(entry.entry_id)
 
     # Discover a device to verify the entry was setup correctly
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -3680,7 +3680,10 @@ async def test_sending_mqtt_effect_command_with_template(hass, mqtt_mock):
 async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
-    config = DEFAULT_CONFIG[platform]
+    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config["name"] = "test"
+    del config["platform"]
     await help_test_setup_manual_entity_from_yaml(
         hass, caplog, tmp_path, platform, config
     )
+    assert hass.states.get(f"{platform}.test") is not None

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -347,7 +347,6 @@ async def test_legacy_controlling_state_via_topic(hass, mqtt_mock):
     """Test the controlling of the state via topic for legacy light (white_value)."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -237,6 +237,7 @@ from .test_common import (
     help_test_setting_attribute_via_mqtt_json_message,
     help_test_setting_attribute_with_template,
     help_test_setting_blocked_attribute_via_mqtt_json_message,
+    help_test_setup_manual_entity_from_yaml,
     help_test_unique_id,
     help_test_update_with_json_attrs_bad_JSON,
     help_test_update_with_json_attrs_not_dict,
@@ -3674,3 +3675,12 @@ async def test_sending_mqtt_effect_command_with_template(hass, mqtt_mock):
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes.get("effect") == "colorloop"
+
+
+async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
+    """Test setup manual configured MQTT entity."""
+    platform = light.DOMAIN
+    config = DEFAULT_CONFIG[platform]
+    await help_test_setup_manual_entity_from_yaml(
+        hass, caplog, tmp_path, platform, config
+    )

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -347,6 +347,7 @@ async def test_legacy_controlling_state_via_topic(hass, mqtt_mock):
     """Test the controlling of the state via topic for legacy light (white_value)."""
     config = {
         light.DOMAIN: {
+            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -2044,7 +2044,10 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
-    config = DEFAULT_CONFIG[platform]
+    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config["name"] = "test"
+    del config["platform"]
     await help_test_setup_manual_entity_from_yaml(
         hass, caplog, tmp_path, platform, config
     )
+    assert hass.states.get(f"{platform}.test") is not None

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -131,6 +131,7 @@ from .test_common import (
     help_test_setting_attribute_via_mqtt_json_message,
     help_test_setting_attribute_with_template,
     help_test_setting_blocked_attribute_via_mqtt_json_message,
+    help_test_setup_manual_entity_from_yaml,
     help_test_unique_id,
     help_test_update_with_json_attrs_bad_JSON,
     help_test_update_with_json_attrs_not_dict,
@@ -2037,4 +2038,13 @@ async def test_encoding_subscribable_topics(
         attribute_value,
         init_payload,
         skip_raw_test=True,
+    )
+
+
+async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
+    """Test setup manual configured MQTT entity."""
+    platform = light.DOMAIN
+    config = DEFAULT_CONFIG[platform]
+    await help_test_setup_manual_entity_from_yaml(
+        hass, caplog, tmp_path, platform, config
     )

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -1219,7 +1219,10 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
-    config = DEFAULT_CONFIG[platform]
+    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config["name"] = "test"
+    del config["platform"]
     await help_test_setup_manual_entity_from_yaml(
         hass, caplog, tmp_path, platform, config
     )
+    assert hass.states.get(f"{platform}.test") is not None

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -69,6 +69,7 @@ from .test_common import (
     help_test_setting_attribute_via_mqtt_json_message,
     help_test_setting_attribute_with_template,
     help_test_setting_blocked_attribute_via_mqtt_json_message,
+    help_test_setup_manual_entity_from_yaml,
     help_test_unique_id,
     help_test_update_with_json_attrs_bad_JSON,
     help_test_update_with_json_attrs_not_dict,
@@ -1212,4 +1213,13 @@ async def test_encoding_subscribable_topics(
         attribute,
         attribute_value,
         init_payload,
+    )
+
+
+async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
+    """Test setup manual configured MQTT entity."""
+    platform = light.DOMAIN
+    config = DEFAULT_CONFIG[platform]
+    await help_test_setup_manual_entity_from_yaml(
+        hass, caplog, tmp_path, platform, config
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -561,6 +561,7 @@ async def mqtt_mock(hass, mqtt_client_mock, mqtt_config, setup_components: list 
     )
 
     entry.add_to_hass(hass)
+    # Do not forward the entry setup to the components here
     with patch("homeassistant.components.mqtt.PLATFORMS", setup_components):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -547,7 +547,7 @@ def mqtt_client_mock(hass):
 
 
 @pytest.fixture
-async def mqtt_mock(hass, mqtt_client_mock, mqtt_config, setup_components: list = []):
+async def mqtt_mock(hass, mqtt_client_mock, mqtt_config):
     """Fixture to mock MQTT component."""
     if mqtt_config is None:
         mqtt_config = {mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_BIRTH_MESSAGE: {}}
@@ -562,7 +562,7 @@ async def mqtt_mock(hass, mqtt_client_mock, mqtt_config, setup_components: list 
 
     entry.add_to_hass(hass)
     # Do not forward the entry setup to the components here
-    with patch("homeassistant.components.mqtt.PLATFORMS", setup_components):
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -547,7 +547,7 @@ def mqtt_client_mock(hass):
 
 
 @pytest.fixture
-async def mqtt_mock(hass, mqtt_client_mock, mqtt_config):
+async def mqtt_mock(hass, mqtt_client_mock, mqtt_config, setup_components: list = []):
     """Fixture to mock MQTT component."""
     if mqtt_config is None:
         mqtt_config = {mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_BIRTH_MESSAGE: {}}
@@ -561,9 +561,9 @@ async def mqtt_mock(hass, mqtt_client_mock, mqtt_config):
     )
 
     entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.mqtt.PLATFORMS", setup_components):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     mqtt_component_mock = MagicMock(
         return_value=hass.data["mqtt"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Defining manually configured MQTT entities directly under the respective platform keys (e.g. `fan`, `light`) is deprecated and support will be removed in Home Assistant Core 2022.9.
Manually configured MQTT entities should now be defined under the `mqtt` key in `configuration.yaml` instead of under the platform key.

As an example, this is now deprecated:

```yaml
sensor:
  - platform: "mqtt"
    name: "My sensor"
    state_topic: "some-state-topic"
```

The configuration needs to updated to this format:

```yaml
mqtt:
  sensor:
   - name: "My sensor"
     state_topic: "some-state-topic"
```
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Setup MQTT yaml configured entities through config entry setup.
The PR will deprecate setting up MQTT entities using the following form:
```yaml
sensor:
  - platform: "mqtt"
    name: "My sensor"
    state_topic: "some-state-topic"
```
New manual configured MQTT entities need to be setup in the following form:
```yaml
mqtt:
  sensor:
   - name: "My sensor"
     state_topic: "some-state-topic"
```

The platform schema will stay the same, but the `platform` configuration item should not be configured.

The current PR (PoC) implements the platforms:
- `light`
- `fan`

A single test `test_setup_manual_entity_from_yaml` is added for each platform. A helper `help_test_setup_manual_entity_from_yaml` is added to make it easy to add a tests for the additional platform.

TODO (in follow-up PRs):
- Convert all tests to mainly test manual added MQTT items using the integration key.
- Implement the other platforms (will be done with different PR's).

The background for this PR is that the MQTT integration itself is setup via a config entry, with entities setup via discovery.
MQTT entities can also be setup through `configuration.yaml` though, and those entities are not aware of the MQTT config entry and thus are not removed if the MQTT config entry is disabled or removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22805

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
