### PR TITLE
Remove YAML configuration from filesize

### DIFF
--- a/homeassistant/components/filesize/__init__.py
+++ b/homeassistant/components/filesize/__init__.py
@@ -1,7 +1,6 @@
 """The filesize component."""
 from __future__ import annotations
 
-import logging
 import pathlib
 
 from homeassistant.config_entries import ConfigEntry
@@ -10,8 +9,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import PLATFORMS
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/filesize/config_flow.py
+++ b/homeassistant/components/filesize/config_flow.py
@@ -67,10 +67,6 @@ class FilesizeConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
-    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
-        """Handle import from configuration.yaml."""
-        return await self.async_step_user(user_input)
-
 
 class NotValidError(Exception):
     """Path is not valid error."""

--- a/homeassistant/components/filesize/const.py
+++ b/homeassistant/components/filesize/const.py
@@ -4,5 +4,3 @@ from homeassistant.const import Platform
 
 DOMAIN = "filesize"
 PLATFORMS = [Platform.SENSOR]
-
-CONF_FILE_PATHS = "file_paths"

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -6,23 +6,18 @@ import logging
 import os
 import pathlib
 
-import voluptuous as vol
-
 from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_FILE_PATH, DATA_BYTES, DATA_MEGABYTES
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -30,7 +25,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_FILE_PATHS, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,34 +58,6 @@ SENSOR_TYPES = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
-
-PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
-    {vol.Required(CONF_FILE_PATHS): vol.All(cv.ensure_list, [cv.isfile])}
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the file size sensor."""
-    _LOGGER.warning(
-        # Filesize config flow added in 2022.4 and should be removed in 2022.6
-        "Configuration of the Filesize sensor platform in YAML is deprecated and "
-        "will be removed in Home Assistant 2022.6; Your existing configuration "
-        "has been imported into the UI automatically and can be safely removed "
-        "from your configuration.yaml file"
-    )
-    for path in config[CONF_FILE_PATHS]:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data={CONF_FILE_PATH: path},
-            )
-        )
 
 
 async def async_setup_entry(

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -1,10 +1,8 @@
 """Tests for the Filesize config flow."""
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant.components.filesize.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_FILE_PATH
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -40,37 +38,20 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     assert result2.get("data") == {CONF_FILE_PATH: TEST_FILE}
 
 
-@pytest.mark.parametrize("source", [SOURCE_USER, SOURCE_IMPORT])
 async def test_unique_path(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    source: str,
 ) -> None:
     """Test we abort if already setup."""
     hass.config.allowlist_external_dirs = {TEST_DIR}
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": source}, data={CONF_FILE_PATH: TEST_FILE}
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_FILE_PATH: TEST_FILE}
     )
 
     assert result.get("type") == RESULT_TYPE_ABORT
     assert result.get("reason") == "already_configured"
-
-
-async def test_import_flow(hass: HomeAssistant) -> None:
-    """Test the import configuration flow."""
-    create_file(TEST_FILE)
-    hass.config.allowlist_external_dirs = {TEST_DIR}
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_FILE_PATH: TEST_FILE},
-    )
-
-    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
-    assert result.get("title") == TEST_FILE_NAME
-    assert result.get("data") == {CONF_FILE_PATH: TEST_FILE}
 
 
 async def test_flow_fails_on_validation(hass: HomeAssistant) -> None:

--- a/tests/components/filesize/test_init.py
+++ b/tests/components/filesize/test_init.py
@@ -1,21 +1,10 @@
 """Tests for the Filesize integration."""
-from unittest.mock import AsyncMock
-
-from homeassistant.components.filesize.const import CONF_FILE_PATHS, DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.filesize.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_FILE_PATH
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
-from . import (
-    TEST_DIR,
-    TEST_FILE,
-    TEST_FILE2,
-    TEST_FILE_NAME,
-    TEST_FILE_NAME2,
-    create_file,
-)
+from . import create_file
 
 from tests.common import MockConfigEntry
 
@@ -75,36 +64,3 @@ async def test_not_valid_path_to_file(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_import_config(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test Filesize being set up from config via import."""
-    create_file(TEST_FILE)
-    create_file(TEST_FILE2)
-    hass.config.allowlist_external_dirs = {TEST_DIR}
-    assert await async_setup_component(
-        hass,
-        SENSOR_DOMAIN,
-        {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
-                CONF_FILE_PATHS: [TEST_FILE, TEST_FILE2],
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(config_entries) == 2
-
-    entry = config_entries[0]
-    assert entry.title == TEST_FILE_NAME
-    assert entry.unique_id == TEST_FILE
-    assert entry.data == {CONF_FILE_PATH: TEST_FILE}
-    entry2 = config_entries[1]
-    assert entry2.title == TEST_FILE_NAME2
-    assert entry2.unique_id == TEST_FILE2
-    assert entry2.data == {CONF_FILE_PATH: TEST_FILE2}

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -1,11 +1,9 @@
 """The tests for the filesize sensor."""
 import os
 
-from homeassistant.components.filesize.const import DOMAIN
 from homeassistant.const import CONF_FILE_PATH, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
-from homeassistant.setup import async_setup_component
 
 from . import TEST_FILE, TEST_FILE_NAME, create_file
 
@@ -71,23 +69,3 @@ async def test_state_unavailable(
 
     state = hass.states.get("sensor.file_txt_size")
     assert state.state == STATE_UNAVAILABLE
-
-
-async def test_import_query(hass: HomeAssistant, tmpdir: str) -> None:
-    """Test import from yaml."""
-    testfile = f"{tmpdir}/file.txt"
-    create_file(testfile)
-    hass.config.allowlist_external_dirs = {tmpdir}
-    config = {
-        "sensor": {
-            "platform": "filesize",
-            "file_paths": [testfile],
-        }
-    }
-
-    assert await async_setup_component(hass, "sensor", config)
-    await hass.async_block_till_done()
-
-    assert hass.config_entries.async_entries(DOMAIN)
-    data = hass.config_entries.async_entries(DOMAIN)[0].data
-    assert data[CONF_FILE_PATH] == testfile


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration for the filesize integration has been removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
