### PR TITLE
Remove YAML configuration from Discord

### DIFF
--- a/homeassistant/components/discord/__init__.py
+++ b/homeassistant/components/discord/__init__.py
@@ -2,31 +2,15 @@
 from aiohttp.client_exceptions import ClientConnectorError
 import nextcord
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_API_TOKEN, CONF_PLATFORM, Platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import discovery
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
 PLATFORMS = [Platform.NOTIFY]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Discord component."""
-    # Iterate all entries for notify to only get Discord
-    if Platform.NOTIFY in config:
-        for entry in config[Platform.NOTIFY]:
-            if entry[CONF_PLATFORM] == DOMAIN:
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
-                    )
-                )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/discord/config_flow.py
+++ b/homeassistant/components/discord/config_flow.py
@@ -8,7 +8,7 @@ import nextcord
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_API_TOKEN, CONF_NAME, CONF_TOKEN
+from homeassistant.const import CONF_API_TOKEN, CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN, URL_PLACEHOLDER
@@ -79,20 +79,6 @@ class DiscordFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders=URL_PLACEHOLDER,
             errors=errors,
         )
-
-    async def async_step_import(self, import_config: dict[str, str]) -> FlowResult:
-        """Import a config entry from configuration.yaml."""
-        _LOGGER.warning(
-            "Configuration of the Discord integration in YAML is deprecated and "
-            "will be removed in Home Assistant 2022.6; Your existing configuration "
-            "has been imported into the UI automatically and can be safely removed "
-            "from your configuration.yaml file"
-        )
-        for entry in self._async_current_entries():
-            if entry.data[CONF_API_TOKEN] == import_config[CONF_TOKEN]:
-                return self.async_abort(reason="already_configured")
-        import_config[CONF_API_TOKEN] = import_config.pop(CONF_TOKEN)
-        return await self.async_step_user(import_config)
 
 
 async def _async_try_connect(token: str) -> tuple[str | None, nextcord.AppInfo | None]:

--- a/homeassistant/components/discord/config_flow.py
+++ b/homeassistant/components/discord/config_flow.py
@@ -69,7 +69,7 @@ class DiscordFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=info.name,
-                    data=user_input | {CONF_NAME: user_input.get(CONF_NAME, info.name)},
+                    data=user_input | {CONF_NAME: info.name},
                 )
 
         user_input = user_input or {}

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -7,17 +7,14 @@ from typing import Any, cast
 
 import nextcord
 from nextcord.abc import Messageable
-import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
-    PLATFORM_SCHEMA,
     BaseNotificationService,
 )
-from homeassistant.const import CONF_API_TOKEN, CONF_TOKEN
+from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,9 +29,6 @@ ATTR_EMBED_TITLE = "title"
 ATTR_EMBED_THUMBNAIL = "thumbnail"
 ATTR_EMBED_URL = "url"
 ATTR_IMAGES = "images"
-
-# Deprecated in Home Assistant 2022.4
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_TOKEN): cv.string})
 
 
 async def async_get_service(

--- a/tests/components/discord/__init__.py
+++ b/tests/components/discord/__init__.py
@@ -6,7 +6,7 @@ import nextcord
 
 from homeassistant.components.discord.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_TOKEN, CONF_NAME, CONF_TOKEN
+from homeassistant.const import CONF_API_TOKEN, CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -20,10 +20,6 @@ CONF_DATA = {
     CONF_API_TOKEN: TOKEN,
     CONF_NAME: NAME,
 }
-
-CONF_IMPORT_DATA_NO_NAME = {CONF_TOKEN: TOKEN}
-
-CONF_IMPORT_DATA = CONF_IMPORT_DATA_NO_NAME | {CONF_NAME: NAME}
 
 
 def create_entry(hass: HomeAssistant) -> ConfigEntry:

--- a/tests/components/discord/test_config_flow.py
+++ b/tests/components/discord/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test Discord config flow."""
 import nextcord
-from pytest import LogCaptureFixture
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.discord.const import DOMAIN
@@ -9,8 +8,6 @@ from homeassistant.core import HomeAssistant
 
 from . import (
     CONF_DATA,
-    CONF_IMPORT_DATA,
-    CONF_IMPORT_DATA_NO_NAME,
     CONF_INPUT,
     NAME,
     create_entry,
@@ -119,49 +116,6 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"] == CONF_DATA
-
-
-async def test_flow_import(hass: HomeAssistant, caplog: LogCaptureFixture) -> None:
-    """Test an import flow."""
-    with mocked_discord_info(), patch_discord_login():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=CONF_IMPORT_DATA.copy(),
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
-    assert result["data"] == CONF_DATA
-    assert "Discord integration in YAML" in caplog.text
-
-
-async def test_flow_import_no_name(hass: HomeAssistant) -> None:
-    """Test import flow with no name in config."""
-    with mocked_discord_info(), patch_discord_login():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=CONF_IMPORT_DATA_NO_NAME,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
-    assert result["data"] == CONF_DATA
-
-
-async def test_flow_import_already_configured(hass: HomeAssistant) -> None:
-    """Test an import flow already configured."""
-    create_entry(hass)
-    with mocked_discord_info(), patch_discord_login():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=CONF_IMPORT_DATA,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
 
 
 async def test_flow_reauth(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration for the Discord integration has been removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
