### PR TITLE
Prevent history_stats from rejecting states when microseconds differ

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -96,7 +96,11 @@ class HistoryStats:
             new_data = False
             if event and event.data["new_state"] is not None:
                 new_state: State = event.data["new_state"]
-                if current_period_start <= new_state.last_changed <= current_period_end:
+                if (
+                    current_period_start_timestamp
+                    <= floored_timestamp(new_state.last_changed)
+                    <= current_period_end_timestamp
+                ):
                     self._history_current_period.append(new_state)
                     new_data = True
             if not new_data and current_period_end_timestamp < now_timestamp:

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1389,9 +1389,10 @@ async def test_measure_cet(hass, recorder_mock):
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 
-async def test_end_time_with_microseconds_zeroed(hass, recorder_mock):
+@pytest.mark.parametrize("time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii"])
+async def test_end_time_with_microseconds_zeroed(time_zone, hass, recorder_mock):
     """Test the history statistics sensor that has the end time microseconds zeroed out."""
-    hass.config.set_time_zone("Europe/Berlin")
+    hass.config.set_time_zone(time_zone)
     start_of_today = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
     start_time = start_of_today + timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -1459,6 +1460,7 @@ async def test_end_time_with_microseconds_zeroed(hass, recorder_mock):
         async_fire_time_changed(hass, time_600)
         await hass.async_block_till_done()
         assert hass.states.get("sensor.heatpump_compressor_today").state == "3.83"
+
     rolled_to_next_day = start_of_today + timedelta(days=1)
     assert rolled_to_next_day.hour == 0
     assert rolled_to_next_day.minute == 0
@@ -1469,3 +1471,33 @@ async def test_end_time_with_microseconds_zeroed(hass, recorder_mock):
         async_fire_time_changed(hass, rolled_to_next_day)
         await hass.async_block_till_done()
         assert hass.states.get("sensor.heatpump_compressor_today").state == "0.0"
+
+    rolled_to_next_day_plus_12 = start_of_today + timedelta(
+        days=1, hours=12, microseconds=0
+    )
+    with freeze_time(rolled_to_next_day_plus_12):
+        async_fire_time_changed(hass, rolled_to_next_day_plus_12)
+        await hass.async_block_till_done()
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "12.0"
+
+    rolled_to_next_day_plus_14 = start_of_today + timedelta(
+        days=1, hours=14, microseconds=0
+    )
+    with freeze_time(rolled_to_next_day_plus_14):
+        async_fire_time_changed(hass, rolled_to_next_day_plus_14)
+        await hass.async_block_till_done()
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "14.0"
+
+    rolled_to_next_day_plus_16_860000 = start_of_today + timedelta(
+        days=1, hours=16, microseconds=860000
+    )
+    with freeze_time(rolled_to_next_day_plus_16_860000):
+        hass.states.async_set("binary_sensor.heatpump_compressor_state", "off")
+        async_fire_time_changed(hass, rolled_to_next_day_plus_16_860000)
+        await hass.async_block_till_done()
+
+    rolled_to_next_day_plus_18 = start_of_today + timedelta(days=1, hours=18)
+    with freeze_time(rolled_to_next_day_plus_18):
+        async_fire_time_changed(hass, rolled_to_next_day_plus_18)
+        await hass.async_block_till_done()
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "16.0"


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- history_stats ignores microseconds but it was not doing
  it for state_changed events

Fixes #71593

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
