### PR TITLE
Fix sqlalchemy warning about logbook query being converted from subquery

### DIFF
--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -185,18 +185,13 @@ def _select_entity_context_ids_sub_query(
     """Generate a subquery to find context ids for a single entity."""
     return select(
         union_all(
-            _select_events_context_id_subquery(start_day, end_day, event_types)
-            .where(
+            _select_events_context_id_subquery(start_day, end_day, event_types).where(
                 Events.event_data.like(entity_id_like)
                 | EventData.shared_data.like(entity_id_like)
-            )
-            .union_all(
-                select(States.context_id)
-                .filter(
-                    (States.last_updated > start_day) & (States.last_updated < end_day)
-                )
-                .where(States.entity_id == entity_id)
-            )
+            ),
+            select(States.context_id)
+            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
+            .where(States.entity_id == entity_id),
         ).c.context_id
     )
 

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -6,7 +6,7 @@ from datetime import datetime as dt
 from typing import Any
 
 import sqlalchemy
-from sqlalchemy import lambda_stmt, select
+from sqlalchemy import lambda_stmt, select, union_all
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import literal
 from sqlalchemy.sql.lambdas import StatementLambdaElement
@@ -118,15 +118,15 @@ def _select_entities_context_ids_sub_query(
     entity_ids: list[str],
 ) -> Select:
     """Generate a subquery to find context ids for multiple entities."""
-    return (
-        _select_events_context_id_subquery(start_day, end_day, event_types)
-        .where(_apply_event_entity_id_matchers(entity_ids))
-        .union_all(
+    return select(
+        union_all(
+            _select_events_context_id_subquery(start_day, end_day, event_types).where(
+                _apply_event_entity_id_matchers(entity_ids)
+            ),
             select(States.context_id)
             .filter((States.last_updated > start_day) & (States.last_updated < end_day))
-            .where(States.entity_id.in_(entity_ids))
-        )
-        .subquery()
+            .where(States.entity_id.in_(entity_ids)),
+        ).c.context_id
     )
 
 
@@ -183,18 +183,21 @@ def _select_entity_context_ids_sub_query(
     entity_id_like: str,
 ) -> Select:
     """Generate a subquery to find context ids for a single entity."""
-    return (
-        _select_events_context_id_subquery(start_day, end_day, event_types)
-        .where(
-            Events.event_data.like(entity_id_like)
-            | EventData.shared_data.like(entity_id_like)
-        )
-        .union_all(
-            select(States.context_id)
-            .filter((States.last_updated > start_day) & (States.last_updated < end_day))
-            .where(States.entity_id == entity_id)
-        )
-        .subquery()
+    return select(
+        union_all(
+            _select_events_context_id_subquery(start_day, end_day, event_types)
+            .where(
+                Events.event_data.like(entity_id_like)
+                | EventData.shared_data.like(entity_id_like)
+            )
+            .union_all(
+                select(States.context_id)
+                .filter(
+                    (States.last_updated > start_day) & (States.last_updated < end_day)
+                )
+                .where(States.entity_id == entity_id)
+            )
+        ).c.context_id
     )
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes `SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly Events.context_id.in_(`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
