### PR TITLE
Add amperage limit number to JuiceNet

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -574,6 +574,7 @@ omit =
     homeassistant/components/juicenet/const.py
     homeassistant/components/juicenet/device.py
     homeassistant/components/juicenet/entity.py
+    homeassistant/components/juicenet/number.py
     homeassistant/components/juicenet/sensor.py
     homeassistant/components/juicenet/switch.py
     homeassistant/components/kaiterra/*

--- a/homeassistant/components/juicenet/__init__.py
+++ b/homeassistant/components/juicenet/__init__.py
@@ -20,7 +20,7 @@ from .device import JuiceNetApi
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
 
 CONFIG_SCHEMA = vol.Schema(
     vol.All(

--- a/homeassistant/components/juicenet/entity.py
+++ b/homeassistant/components/juicenet/entity.py
@@ -1,7 +1,12 @@
 """Adapter to wrap the pyjuicenet api for home assistant."""
 
+from pyjuicenet import Charger
+
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .const import DOMAIN
 
@@ -9,16 +14,18 @@ from .const import DOMAIN
 class JuiceNetDevice(CoordinatorEntity):
     """Represent a base JuiceNet device."""
 
-    def __init__(self, device, sensor_type, coordinator):
+    def __init__(
+        self, device: Charger, key: str, coordinator: DataUpdateCoordinator
+    ) -> None:
         """Initialise the sensor."""
         super().__init__(coordinator)
         self.device = device
-        self.type = sensor_type
+        self.key = key
 
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return f"{self.device.id}-{self.type}"
+        return f"{self.device.id}-{self.key}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/juicenet/number.py
+++ b/homeassistant/components/juicenet/number.py
@@ -1,0 +1,93 @@
+"""Support for controlling juicenet/juicepoint/juicebox based EVSE numbers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pyjuicenet import Api, Charger
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.components.number.const import DEFAULT_MAX_VALUE
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, JUICENET_API, JUICENET_COORDINATOR
+from .entity import JuiceNetDevice
+
+
+@dataclass
+class JuiceNetNumberEntityDescription(NumberEntityDescription):
+    """An entity description for a JuiceNetNumber."""
+
+    setter_key: str | None = None
+    max_value_key: str | None = None
+
+
+NUMBER_TYPES: tuple[JuiceNetNumberEntityDescription, ...] = (
+    JuiceNetNumberEntityDescription(
+        name="Amperage Limit",
+        key="current_charging_amperage_limit",
+        min_value=6,
+        max_value_key="max_charging_amperage",
+        step=1,
+        setter_key="set_charging_amperage_limit",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the JuiceNet Numbers."""
+    juicenet_data = hass.data[DOMAIN][config_entry.entry_id]
+    api: Api = juicenet_data[JUICENET_API]
+    coordinator = juicenet_data[JUICENET_COORDINATOR]
+
+    entities = [
+        JuiceNetNumber(device, description, coordinator)
+        for device in api.devices
+        for description in NUMBER_TYPES
+    ]
+    async_add_entities(entities)
+
+
+class JuiceNetNumber(JuiceNetDevice, NumberEntity):
+    """Implementation of a JuiceNet number."""
+
+    entity_description: JuiceNetNumberEntityDescription
+
+    def __init__(
+        self,
+        device: Charger,
+        description: JuiceNetNumberEntityDescription,
+        coordinator: DataUpdateCoordinator,
+    ) -> None:
+        """Initialise the number."""
+        super().__init__(device, description.key, coordinator)
+        self.entity_description = description
+
+        self._attr_name = f"{self.device.name} {description.name}"
+
+    @property
+    def value(self) -> float | None:
+        """Return the value of the entity."""
+        return getattr(self.device, self.entity_description.key, None)
+
+    @property
+    def max_value(self) -> float:
+        """Return the maximum value."""
+        if self.entity_description.max_value_key is not None:
+            return getattr(self.device, self.entity_description.max_value_key)
+        if self.entity_description.max_value is not None:
+            return self.entity_description.max_value
+        return DEFAULT_MAX_VALUE
+
+    async def async_set_value(self, value: float) -> None:
+        """Update the current value."""
+        if self.entity_description.setter_key is not None:
+            await getattr(self.device, self.entity_description.setter_key)(value)
+        else:
+            raise NotImplementedError

--- a/homeassistant/components/juicenet/number.py
+++ b/homeassistant/components/juicenet/number.py
@@ -17,10 +17,18 @@ from .entity import JuiceNetDevice
 
 
 @dataclass
-class JuiceNetNumberEntityDescription(NumberEntityDescription):
+class JuiceNetNumberEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    setter_key: str
+
+
+@dataclass
+class JuiceNetNumberEntityDescription(
+    NumberEntityDescription, JuiceNetNumberEntityDescriptionMixin
+):
     """An entity description for a JuiceNetNumber."""
 
-    setter_key: str | None = None
     max_value_key: str | None = None
 
 
@@ -87,7 +95,4 @@ class JuiceNetNumber(JuiceNetDevice, NumberEntity):
 
     async def async_set_value(self, value: float) -> None:
         """Update the current value."""
-        if self.entity_description.setter_key is not None:
-            await getattr(self.device, self.entity_description.setter_key)(value)
-        else:
-            raise NotImplementedError
+        await getattr(self.device, self.entity_description.setter_key)(value)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a `number` entity which allows control of the max charge amperage to JuiceNet.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22717

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
