### PR TITLE
Add additional context data to logbook events

### DIFF
--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -15,7 +15,7 @@ def async_describe_events(hass: HomeAssistant, async_describe_event):  # type: i
     def async_describe_logbook_event(event: LazyEventPartialState):  # type: ignore[no-untyped-def]
         """Describe a logbook event."""
         data = event.data
-        message = "has been triggered"
+        message = "triggered"
         if ATTR_SOURCE in data:
             message = f"{message} by {data[ATTR_SOURCE]}"
 

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -136,7 +136,7 @@ def async_describe_events(
 
         return {
             "name": f"{deconz_alarm_event.device.name}",
-            "message": f"fired event '{data}'.",
+            "message": f"fired event '{data}'",
         }
 
     @callback
@@ -158,26 +158,26 @@ def async_describe_events(
         if not data:
             return {
                 "name": f"{deconz_event.device.name}",
-                "message": "fired an unknown event.",
+                "message": "fired an unknown event",
             }
 
         # No device event match
         if not action:
             return {
                 "name": f"{deconz_event.device.name}",
-                "message": f"fired event '{data}'.",
+                "message": f"fired event '{data}'",
             }
 
         # Gesture event
         if not interface:
             return {
                 "name": f"{deconz_event.device.name}",
-                "message": f"fired event '{ACTIONS[action]}'.",
+                "message": f"fired event '{ACTIONS[action]}'",
             }
 
         return {
             "name": f"{deconz_event.device.name}",
-            "message": f"'{ACTIONS[action]}' event for '{INTERFACES[interface]}' was fired.",
+            "message": f"'{ACTIONS[action]}' event for '{INTERFACES[interface]}' was fired",
         }
 
     async_describe_event(

--- a/homeassistant/components/doorbird/logbook.py
+++ b/homeassistant/components/doorbird/logbook.py
@@ -17,7 +17,7 @@ def async_describe_events(hass, async_describe_event):
 
         return {
             "name": "Doorbird",
-            "message": f"Event {event.event_type} was fired.",
+            "message": f"Event {event.event_type} was fired",
             "entity_id": hass.data[DOMAIN][DOOR_STATION_EVENT_ENTITY_IDS].get(
                 doorbird_event, event.data.get(ATTR_ENTITY_ID)
             ),

--- a/homeassistant/components/homeassistant/logbook.py
+++ b/homeassistant/components/homeassistant/logbook.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.components.logbook import ATTR_MESSAGE
+from homeassistant.const import (
+    ATTR_ICON,
+    ATTR_NAME,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import Event, HomeAssistant, callback
 
 from . import DOMAIN
@@ -24,7 +30,11 @@ def async_describe_events(
     @callback
     def async_describe_hass_event(event: Event) -> dict[str, str]:
         """Describe homeassisant logbook event."""
-        return {"name": "Home Assistant", "message": EVENT_TO_NAME[event.event_type]}
+        return {
+            ATTR_NAME: "Home Assistant",
+            ATTR_MESSAGE: EVENT_TO_NAME[event.event_type],
+            ATTR_ICON: "mdi:home-assistant",
+        }
 
     async_describe_event(DOMAIN, EVENT_HOMEASSISTANT_STOP, async_describe_hass_event)
     async_describe_event(DOMAIN, EVENT_HOMEASSISTANT_START, async_describe_hass_event)

--- a/homeassistant/components/homeassistant/logbook.py
+++ b/homeassistant/components/homeassistant/logbook.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from homeassistant.components.logbook import ATTR_MESSAGE
-from homeassistant.const import (
-    ATTR_ICON,
-    ATTR_NAME,
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
+from homeassistant.components.logbook import (
+    LOGBOOK_ENTRY_ICON,
+    LOGBOOK_ENTRY_MESSAGE,
+    LOGBOOK_ENTRY_NAME,
 )
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 
 from . import DOMAIN
@@ -31,9 +30,9 @@ def async_describe_events(
     def async_describe_hass_event(event: Event) -> dict[str, str]:
         """Describe homeassisant logbook event."""
         return {
-            ATTR_NAME: "Home Assistant",
-            ATTR_MESSAGE: EVENT_TO_NAME[event.event_type],
-            ATTR_ICON: "mdi:home-assistant",
+            LOGBOOK_ENTRY_NAME: "Home Assistant",
+            LOGBOOK_ENTRY_MESSAGE: EVENT_TO_NAME[event.event_type],
+            LOGBOOK_ENTRY_ICON: "mdi:home-assistant",
         }
 
     async_describe_event(DOMAIN, EVENT_HOMEASSISTANT_STOP, async_describe_hass_event)

--- a/homeassistant/components/homeassistant/logbook.py
+++ b/homeassistant/components/homeassistant/logbook.py
@@ -1,0 +1,30 @@
+"""Describe homeassistant logbook events."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant, callback
+
+from . import DOMAIN
+
+EVENT_TO_NAME = {
+    EVENT_HOMEASSISTANT_STOP: "stopped",
+    EVENT_HOMEASSISTANT_START: "started",
+}
+
+
+@callback
+def async_describe_events(
+    hass: HomeAssistant,
+    async_describe_event: Callable[[str, str, Callable[[Event], dict[str, str]]], None],
+) -> None:
+    """Describe logbook events."""
+
+    @callback
+    def async_describe_hass_event(event: Event) -> dict[str, str]:
+        """Describe homeassisant logbook event."""
+        return {"name": "Home Assistant", "message": EVENT_TO_NAME[event.event_type]}
+
+    async_describe_event(DOMAIN, EVENT_HOMEASSISTANT_STOP, async_describe_hass_event)
+    async_describe_event(DOMAIN, EVENT_HOMEASSISTANT_START, async_describe_hass_event)

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -162,7 +162,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         message.hass = hass
         message = message.async_render(parse_result=False)
-        async_log_entry(hass, name, message, domain, entity_id)
+        async_log_entry(hass, name, message, domain, entity_id, service.context)
 
     frontend.async_register_built_in_panel(
         hass, "logbook", "logbook", "hass:format-list-bulleted-type"

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -596,8 +596,6 @@ class ContextAugmenter:
                 data["context_entity_id_name"] = self.entity_name_cache.get(
                     attr_entity_id, context_row
                 )
-            if ATTR_MESSAGE in described:
-                data["context_message"] = described[ATTR_MESSAGE]
             return
 
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -639,11 +639,14 @@ def _is_sensor_continuous(
 
 def _rows_match(row: Row, other_row: Row) -> bool:
     """Check of rows match by using the same method as Events __hash__."""
-    return bool(
-        row.event_type == other_row.event_type
-        and row.context_id == other_row.context_id
-        and row.time_fired == other_row.time_fired
-    )
+    if (
+        (state_id := row.state_id) is not None
+        and state_id == other_row.state_id
+        or (event_id := row.event_id) is not None
+        and event_id == other_row.event_id
+    ):
+        return True
+    return False
 
 
 def _row_event_data_extract(row: Row, extractor: re.Pattern) -> str | None:

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -591,10 +591,13 @@ class ContextAugmenter:
             described = describe_event(event)
             if name := described.get(ATTR_NAME):
                 data["context_name"] = name
-                if ATTR_MESSAGE in described:
-                    data["context_message"] = described[ATTR_MESSAGE]
-                if ATTR_ENTITY_ID in described:
-                    data["context_entity_id"] = described[ATTR_ENTITY_ID]
+            if attr_entity_id := described.get(ATTR_ENTITY_ID):
+                data["context_entity_id"] = attr_entity_id
+                data["context_entity_id_name"] = self.entity_name_cache.get(
+                    attr_entity_id, context_row
+                )
+            if ATTR_MESSAGE in described:
+                data["context_message"] = described[ATTR_MESSAGE]
             return
 
         if (

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -81,6 +81,7 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA}, extra=vol.ALLOW_EXTRA
 )
 
+ATTR_CONTEXT_USER_ID = "context_user_id"
 ATTR_CONTEXT_ENTITY_ID = f"context_{ATTR_ENTITY_ID}"
 ATTR_CONTEXT_ENTITY_ID_NAME = f"context_{ATTR_ENTITY_ID}_{ATTR_NAME}"
 ATTR_CONTEXT_EVENT_TYPE = "context_event_type"
@@ -527,7 +528,7 @@ class ContextAugmenter:
     def augment(self, data: dict[str, Any], entity_id: str | None, row: Row) -> None:
         """Augment data from the row and cache."""
         if context_user_id := row.context_user_id:
-            data["context_user_id"] = context_user_id
+            data[ATTR_CONTEXT_USER_ID] = context_user_id
 
         if not (context_row := self.context_lookup.get(row.context_id)):
             return

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -34,10 +34,8 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
-    ATTR_ICON,
     ATTR_NAME,
     ATTR_SERVICE,
-    ATTR_STATE,
     EVENT_CALL_SERVICE,
     EVENT_LOGBOOK_ENTRY,
     EVENT_STATE_CHANGED,
@@ -81,17 +79,22 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA}, extra=vol.ALLOW_EXTRA
 )
 
-ATTR_CONTEXT_USER_ID = "context_user_id"
-ATTR_CONTEXT_ENTITY_ID = f"context_{ATTR_ENTITY_ID}"
-ATTR_CONTEXT_ENTITY_ID_NAME = f"context_{ATTR_ENTITY_ID}_{ATTR_NAME}"
-ATTR_CONTEXT_EVENT_TYPE = "context_event_type"
-ATTR_CONTEXT_DOMAIN = f"context_{ATTR_DOMAIN}"
-ATTR_CONTEXT_SERVICE = f"context_{ATTR_SERVICE}"
-ATTR_CONTEXT_NAME = f"context_{ATTR_NAME}"
-ATTR_CONTEXT_MESSAGE = f"context_{ATTR_MESSAGE}"
+CONTEXT_USER_ID = "context_user_id"
+CONTEXT_ENTITY_ID = "context_entity_id"
+CONTEXT_ENTITY_ID_NAME = "context_entity_id_name"
+CONTEXT_EVENT_TYPE = "context_event_type"
+CONTEXT_DOMAIN = "context_domain"
+CONTEXT_SERVICE = "context_service"
+CONTEXT_NAME = "context_name"
+CONTEXT_MESSAGE = "context_message"
 
-ATTR_WHEN = "when"
-
+LOGBOOK_ENTRY_DOMAIN = "domain"
+LOGBOOK_ENTRY_ENTITY_ID = "entity_id"
+LOGBOOK_ENTRY_ICON = "icon"
+LOGBOOK_ENTRY_MESSAGE = "message"
+LOGBOOK_ENTRY_NAME = "name"
+LOGBOOK_ENTRY_STATE = "state"
+LOGBOOK_ENTRY_WHEN = "when"
 
 ALL_EVENT_TYPES_EXCEPT_STATE_CHANGED = {EVENT_LOGBOOK_ENTRY, EVENT_CALL_SERVICE}
 
@@ -135,12 +138,12 @@ def async_log_entry(
     context: Context | None = None,
 ) -> None:
     """Add an entry to the logbook."""
-    data = {ATTR_NAME: name, ATTR_MESSAGE: message}
+    data = {LOGBOOK_ENTRY_NAME: name, LOGBOOK_ENTRY_MESSAGE: message}
 
     if domain is not None:
-        data[ATTR_DOMAIN] = domain
+        data[LOGBOOK_ENTRY_DOMAIN] = domain
     if entity_id is not None:
-        data[ATTR_ENTITY_ID] = entity_id
+        data[LOGBOOK_ENTRY_ENTITY_ID] = entity_id
     hass.bus.async_fire(EVENT_LOGBOOK_ENTRY, data, context=context)
 
 
@@ -377,13 +380,13 @@ def _humanify(
                 continue
 
             data = {
-                ATTR_WHEN: format_time(row),
-                ATTR_NAME: entity_name_cache.get(entity_id, row),
-                ATTR_STATE: row.state,
-                ATTR_ENTITY_ID: entity_id,
+                LOGBOOK_ENTRY_WHEN: format_time(row),
+                LOGBOOK_ENTRY_NAME: entity_name_cache.get(entity_id, row),
+                LOGBOOK_ENTRY_STATE: row.state,
+                LOGBOOK_ENTRY_ENTITY_ID: entity_id,
             }
             if icon := _row_attributes_extract(row, ICON_JSON_EXTRACT):
-                data[ATTR_ICON] = icon
+                data[LOGBOOK_ENTRY_ICON] = icon
 
             context_augmenter.augment(data, entity_id, row)
             yield data
@@ -391,8 +394,8 @@ def _humanify(
         elif event_type in external_events:
             domain, describe_event = external_events[event_type]
             data = describe_event(event_cache.get(row))
-            data[ATTR_WHEN] = format_time(row)
-            data[ATTR_DOMAIN] = domain
+            data[LOGBOOK_ENTRY_WHEN] = format_time(row)
+            data[LOGBOOK_ENTRY_DOMAIN] = domain
             context_augmenter.augment(data, data.get(ATTR_ENTITY_ID), row)
             yield data
 
@@ -406,11 +409,11 @@ def _humanify(
                     domain = split_entity_id(str(entity_id))[0]
 
             data = {
-                ATTR_WHEN: format_time(row),
-                ATTR_NAME: event_data.get(ATTR_NAME),
-                ATTR_MESSAGE: event_data.get(ATTR_MESSAGE),
-                ATTR_DOMAIN: domain,
-                ATTR_ENTITY_ID: entity_id,
+                LOGBOOK_ENTRY_WHEN: format_time(row),
+                LOGBOOK_ENTRY_NAME: event_data.get(ATTR_NAME),
+                LOGBOOK_ENTRY_MESSAGE: event_data.get(ATTR_MESSAGE),
+                LOGBOOK_ENTRY_DOMAIN: domain,
+                LOGBOOK_ENTRY_ENTITY_ID: entity_id,
             }
             context_augmenter.augment(data, entity_id, row)
             yield data
@@ -528,7 +531,7 @@ class ContextAugmenter:
     def augment(self, data: dict[str, Any], entity_id: str | None, row: Row) -> None:
         """Augment data from the row and cache."""
         if context_user_id := row.context_user_id:
-            data[ATTR_CONTEXT_USER_ID] = context_user_id
+            data[CONTEXT_USER_ID] = context_user_id
 
         if not (context_row := self.context_lookup.get(row.context_id)):
             return
@@ -551,38 +554,38 @@ class ContextAugmenter:
 
         # State change
         if context_entity_id := context_row.entity_id:
-            data[ATTR_CONTEXT_ENTITY_ID] = context_entity_id
-            data[ATTR_CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
+            data[CONTEXT_ENTITY_ID] = context_entity_id
+            data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
                 context_entity_id, context_row
             )
-            data[ATTR_CONTEXT_EVENT_TYPE] = event_type
+            data[CONTEXT_EVENT_TYPE] = event_type
             return
 
         # Call service
         if event_type == EVENT_CALL_SERVICE:
             event = self.event_cache.get(context_row)
             event_data = event.data
-            data[ATTR_CONTEXT_DOMAIN] = event_data.get(ATTR_DOMAIN)
-            data[ATTR_CONTEXT_SERVICE] = event_data.get(ATTR_SERVICE)
-            data[ATTR_CONTEXT_EVENT_TYPE] = event_type
+            data[CONTEXT_DOMAIN] = event_data.get(ATTR_DOMAIN)
+            data[CONTEXT_SERVICE] = event_data.get(ATTR_SERVICE)
+            data[CONTEXT_EVENT_TYPE] = event_type
             return
 
         if event_type not in self.external_events:
             return
 
         domain, describe_event = self.external_events[event_type]
-        data[ATTR_CONTEXT_EVENT_TYPE] = event_type
-        data[ATTR_CONTEXT_DOMAIN] = domain
+        data[CONTEXT_EVENT_TYPE] = event_type
+        data[CONTEXT_DOMAIN] = domain
         event = self.event_cache.get(context_row)
         described = describe_event(event)
         if name := described.get(ATTR_NAME):
-            data[ATTR_CONTEXT_NAME] = name
+            data[CONTEXT_NAME] = name
         if message := described.get(ATTR_MESSAGE):
-            data[ATTR_CONTEXT_MESSAGE] = message
+            data[CONTEXT_MESSAGE] = message
         if not (attr_entity_id := described.get(ATTR_ENTITY_ID)):
             return
-        data[ATTR_CONTEXT_ENTITY_ID] = attr_entity_id
-        data[ATTR_CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
+        data[CONTEXT_ENTITY_ID] = attr_entity_id
+        data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
             attr_entity_id, context_row
         )
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -600,23 +600,6 @@ class ContextAugmenter:
                 data["context_message"] = described[ATTR_MESSAGE]
             return
 
-        if (
-            not entity_id
-            or (
-                attr_entity_id := _row_event_data_extract(
-                    context_row, ENTITY_ID_JSON_EXTRACT
-                )
-            )
-            is None
-            or attr_entity_id == entity_id
-        ):
-            return
-        data["context_entity_id"] = attr_entity_id
-        data["context_entity_id_name"] = self.entity_name_cache.get(
-            attr_entity_id, context_row
-        )
-        data["context_event_type"] = event_type
-
 
 def _is_sensor_continuous(
     hass: HomeAssistant,

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -583,20 +583,22 @@ class ContextAugmenter:
             data["context_event_type"] = event_type
             return
 
-        if event_type in self.external_events:
-            domain, describe_event = self.external_events[event_type]
-            data["context_event_type"] = event_type
-            data["context_domain"] = domain
-            event = self.event_cache.get(context_row)
-            described = describe_event(event)
-            if name := described.get(ATTR_NAME):
-                data["context_name"] = name
-            if attr_entity_id := described.get(ATTR_ENTITY_ID):
-                data["context_entity_id"] = attr_entity_id
-                data["context_entity_id_name"] = self.entity_name_cache.get(
-                    attr_entity_id, context_row
-                )
+        if event_type not in self.external_events:
             return
+
+        domain, describe_event = self.external_events[event_type]
+        data["context_event_type"] = event_type
+        data["context_domain"] = domain
+        event = self.event_cache.get(context_row)
+        described = describe_event(event)
+        if name := described.get(ATTR_NAME):
+            data["context_name"] = name
+        if not (attr_entity_id := described.get(ATTR_ENTITY_ID)):
+            return
+        data["context_entity_id"] = attr_entity_id
+        data["context_entity_id_name"] = self.entity_name_cache.get(
+            attr_entity_id, context_row
+        )
 
 
 def _is_sensor_continuous(

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -33,6 +33,7 @@ UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 
 
 EVENT_COLUMNS = (
+    Events.event_id.label("event_id"),
     Events.event_type.label("event_type"),
     Events.event_data.label("event_data"),
     Events.time_fired.label("time_fired"),
@@ -42,6 +43,7 @@ EVENT_COLUMNS = (
 )
 
 STATE_COLUMNS = (
+    States.state_id.label("state_id"),
     States.state.label("state"),
     States.entity_id.label("entity_id"),
     States.attributes.label("attributes"),
@@ -49,6 +51,7 @@ STATE_COLUMNS = (
 )
 
 EMPTY_STATE_COLUMNS = (
+    literal(value=None, type_=sqlalchemy.String).label("state_id"),
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
     literal(value=None, type_=sqlalchemy.Text).label("attributes"),
@@ -294,6 +297,7 @@ def _select_states(start_day: dt, end_day: dt) -> Select:
     old_state = aliased(States, name="old_state")
     return (
         select(
+            literal(value=None, type_=sqlalchemy.Text).label("event_id"),
             literal(value=EVENT_STATE_CHANGED, type_=sqlalchemy.String).label(
                 "event_type"
             ),

--- a/homeassistant/components/shelly/logbook.py
+++ b/homeassistant/components/shelly/logbook.py
@@ -49,7 +49,7 @@ def async_describe_events(
 
         return {
             "name": "Shelly",
-            "message": f"'{click_type}' click event for {input_name} Input was fired.",
+            "message": f"'{click_type}' click event for {input_name} Input was fired",
         }
 
     async_describe_event(DOMAIN, EVENT_SHELLY_CLICK, async_describe_shelly_click_event)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1243,12 +1243,12 @@ async def test_logbook_humanify_automation_triggered_event(hass):
 
     assert event1["name"] == "Hello Automation"
     assert event1["domain"] == "automation"
-    assert event1["message"] == "has been triggered"
+    assert event1["message"] == "triggered"
     assert event1["entity_id"] == "automation.hello"
 
     assert event2["name"] == "Bye Automation"
     assert event2["domain"] == "automation"
-    assert event2["message"] == "has been triggered by source of trigger"
+    assert event2["message"] == "triggered by source of trigger"
     assert event2["entity_id"] == "automation.bye"
 
 

--- a/tests/components/automation/test_logbook.py
+++ b/tests/components/automation/test_logbook.py
@@ -37,13 +37,13 @@ async def test_humanify_automation_trigger_event(hass):
     )
 
     assert event1["name"] == "Bla"
-    assert event1["message"] == "has been triggered by state change of input_boolean.yo"
+    assert event1["message"] == "triggered by state change of input_boolean.yo"
     assert event1["source"] == "state change of input_boolean.yo"
     assert event1["context_id"] == context.id
     assert event1["entity_id"] == "automation.bla"
 
     assert event2["name"] == "Bla"
-    assert event2["message"] == "has been triggered"
+    assert event2["message"] == "triggered"
     assert event2["source"] is None
     assert event2["context_id"] == context.id
     assert event2["entity_id"] == "automation.bla"

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -214,20 +214,20 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
 
     assert events[0]["name"] == "Switch 1"
     assert events[0]["domain"] == "deconz"
-    assert events[0]["message"] == "fired event '2000'."
+    assert events[0]["message"] == "fired event '2000'"
 
     assert events[1]["name"] == "Hue remote"
     assert events[1]["domain"] == "deconz"
-    assert events[1]["message"] == "'Long press' event for 'Dim up' was fired."
+    assert events[1]["message"] == "'Long press' event for 'Dim up' was fired"
 
     assert events[2]["name"] == "Xiaomi cube"
     assert events[2]["domain"] == "deconz"
-    assert events[2]["message"] == "fired event 'Shake'."
+    assert events[2]["message"] == "fired event 'Shake'"
 
     assert events[3]["name"] == "Xiaomi cube"
     assert events[3]["domain"] == "deconz"
-    assert events[3]["message"] == "fired event 'unsupported_gesture'."
+    assert events[3]["message"] == "fired event 'unsupported_gesture'"
 
     assert events[4]["name"] == "Faulty event"
     assert events[4]["domain"] == "deconz"
-    assert events[4]["message"] == "fired an unknown event."
+    assert events[4]["message"] == "fired an unknown event"

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -85,7 +85,7 @@ async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
 
     assert events[0]["name"] == "Keypad"
     assert events[0]["domain"] == "deconz"
-    assert events[0]["message"] == "fired event 'armed_away'."
+    assert events[0]["message"] == "fired event 'armed_away'"
 
 
 async def test_humanifying_deconz_event(hass, aioclient_mock):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1032,6 +1032,19 @@ async def test_logbook_context_id_automation_script_started_manually(
     )
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    script_2_context = ha.Context(
+        id="1234",
+        user_id="b400facee45711eaa9308bfd3d19e474",
+    )
+    hass.bus.async_fire(
+        EVENT_SCRIPT_STARTED,
+        {ATTR_NAME: "Mock script"},
+        context=script_2_context,
+    )
+    hass.states.async_set("switch.new", STATE_ON, context=script_2_context)
+    hass.states.async_set("switch.new", STATE_OFF, context=script_2_context)
+
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
@@ -1060,6 +1073,19 @@ async def test_logbook_context_id_automation_script_started_manually(
     assert json_dict[1]["context_id"] == "ac5bd62de45711eaaeb351041eec8dd9"
 
     assert json_dict[2]["domain"] == "homeassistant"
+
+    assert json_dict[3]["entity_id"] is None
+    assert json_dict[3]["name"] == "Mock script"
+    assert "context_entity_id" not in json_dict[1]
+    assert json_dict[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+    assert json_dict[3]["context_id"] == "1234"
+
+    assert json_dict[4]["entity_id"] == "switch.new"
+    assert json_dict[4]["state"] == "off"
+    assert "context_entity_id" not in json_dict[1]
+    assert json_dict[4]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+    assert json_dict[4]["context_event_type"] == "script_started"
+    assert json_dict[4]["context_domain"] == "script"
 
 
 async def test_logbook_entity_context_parent_id(hass, hass_client, recorder_mock):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the logbook component."""
 # pylint: disable=protected-access,invalid-name
+import asyncio
 import collections
 from datetime import datetime, timedelta
 from http import HTTPStatus
@@ -208,8 +209,10 @@ async def test_filter_sensor(hass_: ha.HomeAssistant, hass_client):
     _assert_entry(entries[2], name="ble", entity_id=entity_id4, state="10")
 
 
-def test_home_assistant_start_stop_not_grouped(hass_):
+async def test_home_assistant_start_stop_not_grouped(hass_):
     """Test if HA start and stop events are no longer grouped."""
+    await async_setup_component(hass_, "homeassistant", {})
+    await hass_.async_block_till_done()
     entries = mock_humanify(
         hass_,
         (
@@ -223,8 +226,10 @@ def test_home_assistant_start_stop_not_grouped(hass_):
     assert_entry(entries[1], name="Home Assistant", message="started", domain=ha.DOMAIN)
 
 
-def test_home_assistant_start(hass_):
+async def test_home_assistant_start(hass_):
     """Test if HA start is not filtered or converted into a restart."""
+    await async_setup_component(hass_, "homeassistant", {})
+    await hass_.async_block_till_done()
     entity_id = "switch.bla"
     pointA = dt_util.utcnow()
 
@@ -604,9 +609,12 @@ async def test_logbook_view_end_time_entity(hass, hass_client, recorder_mock):
 
 async def test_logbook_entity_filter_with_automations(hass, hass_client, recorder_mock):
     """Test the logbook view with end_time and entity with automations and scripts."""
-    await async_setup_component(hass, "logbook", {})
-    await async_setup_component(hass, "automation", {})
-    await async_setup_component(hass, "script", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
 
     await async_recorder_block_till_done(hass)
 
@@ -749,7 +757,12 @@ async def test_filter_continuous_sensor_values(
 
 async def test_exclude_new_entities(hass, hass_client, recorder_mock, set_utc):
     """Test if events are excluded on first update."""
-    await async_setup_component(hass, "logbook", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
     await async_recorder_block_till_done(hass)
 
     entity_id = "climate.bla"
@@ -781,7 +794,12 @@ async def test_exclude_new_entities(hass, hass_client, recorder_mock, set_utc):
 
 async def test_exclude_removed_entities(hass, hass_client, recorder_mock, set_utc):
     """Test if events are excluded on last update."""
-    await async_setup_component(hass, "logbook", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
     await async_recorder_block_till_done(hass)
 
     entity_id = "climate.bla"
@@ -820,7 +838,12 @@ async def test_exclude_removed_entities(hass, hass_client, recorder_mock, set_ut
 
 async def test_exclude_attribute_changes(hass, hass_client, recorder_mock, set_utc):
     """Test if events of attribute changes are filtered."""
-    await async_setup_component(hass, "logbook", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -855,9 +878,12 @@ async def test_exclude_attribute_changes(hass, hass_client, recorder_mock, set_u
 
 async def test_logbook_entity_context_id(hass, recorder_mock, hass_client):
     """Test the logbook view with end_time and entity with automations and scripts."""
-    await async_setup_component(hass, "logbook", {})
-    await async_setup_component(hass, "automation", {})
-    await async_setup_component(hass, "script", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
 
     await async_recorder_block_till_done(hass)
 
@@ -1004,9 +1030,12 @@ async def test_logbook_context_id_automation_script_started_manually(
     hass, recorder_mock, hass_client
 ):
     """Test the logbook populates context_ids for scripts and automations started manually."""
-    await async_setup_component(hass, "logbook", {})
-    await async_setup_component(hass, "automation", {})
-    await async_setup_component(hass, "script", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
 
     await async_recorder_block_till_done(hass)
 
@@ -1090,9 +1119,12 @@ async def test_logbook_context_id_automation_script_started_manually(
 
 async def test_logbook_entity_context_parent_id(hass, hass_client, recorder_mock):
     """Test the logbook view links events via context parent_id."""
-    await async_setup_component(hass, "logbook", {})
-    await async_setup_component(hass, "automation", {})
-    await async_setup_component(hass, "script", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
 
     await async_recorder_block_till_done(hass)
 
@@ -1266,7 +1298,13 @@ async def test_logbook_entity_context_parent_id(hass, hass_client, recorder_mock
 
 async def test_logbook_context_from_template(hass, hass_client, recorder_mock):
     """Test the logbook view with end_time and entity with automations and scripts."""
-    await async_setup_component(hass, "logbook", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
+
     assert await async_setup_component(
         hass,
         "switch",
@@ -1663,7 +1701,13 @@ async def test_logbook_invalid_entity(hass, hass_client, recorder_mock):
 
 async def test_icon_and_state(hass, hass_client, recorder_mock):
     """Test to ensure state and custom icons are returned."""
-    await async_setup_component(hass, "logbook", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
+
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1731,6 +1775,7 @@ async def test_exclude_events_domain(hass, hass_client, recorder_mock):
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
 
+    await async_setup_component(hass, "homeassistant", {})
     config = logbook.CONFIG_SCHEMA(
         {
             ha.DOMAIN: {},
@@ -1776,7 +1821,10 @@ async def test_exclude_events_domain_glob(hass, hass_client, recorder_mock):
             },
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1815,7 +1863,10 @@ async def test_include_events_entity(hass, hass_client, recorder_mock):
             },
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1847,7 +1898,10 @@ async def test_exclude_events_entity(hass, hass_client, recorder_mock):
             logbook.DOMAIN: {CONF_EXCLUDE: {CONF_ENTITIES: [entity_id]}},
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1880,7 +1934,10 @@ async def test_include_events_domain(hass, hass_client, recorder_mock):
             },
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1923,7 +1980,10 @@ async def test_include_events_domain_glob(hass, hass_client, recorder_mock):
             },
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1974,7 +2034,10 @@ async def test_include_exclude_events(hass, hass_client, recorder_mock):
             },
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2030,7 +2093,10 @@ async def test_include_exclude_events_with_glob_filters(
             },
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2073,7 +2139,10 @@ async def test_empty_config(hass, hass_client, recorder_mock):
             logbook.DOMAIN: {},
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await asyncio.gather(
+        async_setup_component(hass, "homeassistant", {}),
+        async_setup_component(hass, "logbook", config),
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2167,7 +2236,12 @@ def _assert_entry(
 async def test_get_events(hass, hass_ws_client, recorder_mock):
     """Test logbook get_events."""
     now = dt_util.utcnow()
-    await async_setup_component(hass, "logbook", {})
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/shelly/test_logbook.py
+++ b/tests/components/shelly/test_logbook.py
@@ -46,14 +46,14 @@ async def test_humanify_shelly_click_event_block_device(hass, coap_wrapper):
     assert event1["domain"] == DOMAIN
     assert (
         event1["message"]
-        == "'single' click event for Test name channel 1 Input was fired."
+        == "'single' click event for Test name channel 1 Input was fired"
     )
 
     assert event2["name"] == "Shelly"
     assert event2["domain"] == DOMAIN
     assert (
         event2["message"]
-        == "'long' click event for shellyswitch25-12345678 channel 2 Input was fired."
+        == "'long' click event for shellyswitch25-12345678 channel 2 Input was fired"
     )
 
 
@@ -91,12 +91,12 @@ async def test_humanify_shelly_click_event_rpc_device(hass, rpc_wrapper):
     assert event1["domain"] == DOMAIN
     assert (
         event1["message"]
-        == "'single_push' click event for test switch_0 Input was fired."
+        == "'single_push' click event for test switch_0 Input was fired"
     )
 
     assert event2["name"] == "Shelly"
     assert event2["domain"] == DOMAIN
     assert (
         event2["message"]
-        == "'btn_down' click event for shellypro4pm-12345678 channel 2 Input was fired."
+        == "'btn_down' click event for shellypro4pm-12345678 channel 2 Input was fired"
     )


### PR DESCRIPTION
frontend https://github.com/home-assistant/frontend/pull/12667

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional context data to logbook events by removing the guards that prevented context data from being added to anything that wasn't a state_changed event (`if not entity_id`).  Most of the special cases are gone so this is no longer needed. Additionally the `EVENT_HOMEASSISTANT_START` and `EVENT_HOMEASSISTANT_STOP` events no longer need to be special cases to they have been moved to an integration platform.

Drops the `has been` from trigger messages as it doesn't mesh well:

<img width="1147" alt="Screen Shot 2022-05-12 at 00 56 18" src="https://user-images.githubusercontent.com/663432/168001959-24f80282-f094-4765-8e81-7e23a2aad12d.png">

Before:
`Put Master Bed TV Lift Up` started from automation `Master Bed Harmony is Switch Off for 25 seconds` has been triggered by state of `Watching TV in Master Bedroom`

After:
`Put Master Bed TV Lift Up` started from automation `Master Bed Harmony is Switch Off for 25 seconds` triggered by state of `Watching TV in Master Bedroom`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
