### PR TITLE
Remove unused calls fixture from template tests

### DIFF
--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -2,8 +2,6 @@
 import datetime as dt
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant import setup
 from homeassistant.components.button.const import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.template.button import DEFAULT_NAME
@@ -16,19 +14,13 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity_registry import async_get
 
-from tests.common import assert_setup_component, async_mock_service
+from tests.common import assert_setup_component
 
 _TEST_BUTTON = "button.template_button"
 _TEST_OPTIONS_BUTTON = "button.test"
 
 
-@pytest.fixture
-def calls(hass):
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
-
-async def test_missing_optional_config(hass, calls):
+async def test_missing_optional_config(hass):
     """Test: missing optional template is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -50,7 +42,7 @@ async def test_missing_optional_config(hass, calls):
     _verify(hass, STATE_UNKNOWN)
 
 
-async def test_missing_required_keys(hass, calls):
+async def test_missing_required_keys(hass):
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
@@ -128,7 +120,7 @@ async def test_all_optional_config(hass, calls):
     assert er.async_get_entity_id("button", "template", "test-test")
 
 
-async def test_name_template(hass, calls):
+async def test_name_template(hass):
     """Test: name template."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -158,7 +150,7 @@ async def test_name_template(hass, calls):
     )
 
 
-async def test_unique_id(hass, calls):
+async def test_unique_id(hass):
     """Test: unique id is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -396,7 +396,7 @@ async def test_on_off(hass):
         _verify(hass, state, 0, None, None, None)
 
 
-async def test_set_invalid_direction_from_initial_stage(hass, calls):
+async def test_set_invalid_direction_from_initial_stage(hass):
     """Test set invalid direction when fan is in initial state."""
     await _register_components(hass)
 

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -1,5 +1,4 @@
 """The tests for the Template number platform."""
-import pytest
 
 from homeassistant import setup
 from homeassistant.components.input_number import (
@@ -19,11 +18,7 @@ from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import Context
 from homeassistant.helpers.entity_registry import async_get
 
-from tests.common import (
-    assert_setup_component,
-    async_capture_events,
-    async_mock_service,
-)
+from tests.common import assert_setup_component, async_capture_events
 
 _TEST_NUMBER = "number.template_number"
 # Represent for number's value
@@ -47,13 +42,7 @@ _VALUE_INPUT_NUMBER_CONFIG = {
 }
 
 
-@pytest.fixture
-def calls(hass):
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
-
-async def test_missing_optional_config(hass, calls):
+async def test_missing_optional_config(hass):
     """Test: missing optional template is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -77,7 +66,7 @@ async def test_missing_optional_config(hass, calls):
     _verify(hass, 4, 1, 0.0, 100.0)
 
 
-async def test_missing_required_keys(hass, calls):
+async def test_missing_required_keys(hass):
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
@@ -112,7 +101,7 @@ async def test_missing_required_keys(hass, calls):
     assert hass.states.async_all("number") == []
 
 
-async def test_all_optional_config(hass, calls):
+async def test_all_optional_config(hass):
     """Test: including all optional templates is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -138,7 +127,7 @@ async def test_all_optional_config(hass, calls):
     _verify(hass, 4, 1, 3, 5)
 
 
-async def test_templates_with_entities(hass, calls):
+async def test_templates_with_entities(hass):
     """Test templates with values from other entities."""
     with assert_setup_component(4, "input_number"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -1,6 +1,4 @@
 """The tests for the Template select platform."""
-import pytest
-
 from homeassistant import setup
 from homeassistant.components.input_select import (
     ATTR_OPTION as INPUT_SELECT_ATTR_OPTION,
@@ -19,24 +17,14 @@ from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import Context
 from homeassistant.helpers.entity_registry import async_get
 
-from tests.common import (
-    assert_setup_component,
-    async_capture_events,
-    async_mock_service,
-)
+from tests.common import assert_setup_component, async_capture_events
 
 _TEST_SELECT = "select.template_select"
 # Represent for select's current_option
 _OPTION_INPUT_SELECT = "input_select.option"
 
 
-@pytest.fixture
-def calls(hass):
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
-
-async def test_missing_optional_config(hass, calls):
+async def test_missing_optional_config(hass):
     """Test: missing optional template is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -60,7 +48,7 @@ async def test_missing_optional_config(hass, calls):
     _verify(hass, "a", ["a", "b"])
 
 
-async def test_multiple_configs(hass, calls):
+async def test_multiple_configs(hass):
     """Test: multiple select entities get created."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -92,7 +80,7 @@ async def test_multiple_configs(hass, calls):
     _verify(hass, "a", ["a", "b"], f"{_TEST_SELECT}_2")
 
 
-async def test_missing_required_keys(hass, calls):
+async def test_missing_required_keys(hass):
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
@@ -143,7 +131,7 @@ async def test_missing_required_keys(hass, calls):
     assert hass.states.async_all("select") == []
 
 
-async def test_templates_with_entities(hass, calls):
+async def test_templates_with_entities(hass):
     """Test templates with values from other entities."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(
@@ -290,7 +278,7 @@ def _verify(hass, expected_current_option, expected_options, entity_name=_TEST_S
     assert attributes.get(SELECT_ATTR_OPTIONS) == expected_options
 
 
-async def test_template_icon_with_entities(hass, calls):
+async def test_template_icon_with_entities(hass):
     """Test templates with values from other entities."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove unused calls fixture from template tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
