### PR TITLE
Fix process_datetime_to_timestamp and add test coverage

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -54,6 +54,10 @@ SCHEMA_VERSION = 28
 
 _LOGGER = logging.getLogger(__name__)
 
+# EPOCHORDINAL is not exposed as a constant
+# https://github.com/python/cpython/blob/3.10/Lib/zoneinfo/_zoneinfo.py#L12
+EPOCHORDINAL = datetime(1970, 1, 1).toordinal()
+
 DB_TIMEZONE = "+00:00"
 
 TABLE_EVENTS = "events"
@@ -619,10 +623,22 @@ def process_timestamp_to_utc_isoformat(ts: datetime | None) -> str | None:
 
 
 def process_datetime_to_timestamp(ts: datetime) -> float:
-    """Process a timestamp into a unix timestamp."""
-    if ts.tzinfo == dt_util.UTC:
-        return ts.timestamp()
-    return ts.replace(tzinfo=dt_util.UTC).timestamp()
+    """Process a datebase datetime to epoch.
+
+    Mirrors the behavior of process_timestamp_to_utc_isoformat
+    except it returns the epoch time.
+    """
+    if ts.tzinfo is None:
+        # Taken from
+        # https://github.com/python/cpython/blob/3.10/Lib/zoneinfo/_zoneinfo.py#L185
+        return (
+            (ts.toordinal() - EPOCHORDINAL) * 86400
+            + ts.hour * 3600
+            + ts.minute * 60
+            + ts.second
+            + (ts.microsecond / 1000000)
+        )
+    return ts.timestamp()
 
 
 class LazyState(State):

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timedelta
 from unittest.mock import PropertyMock
 
+from freezegun import freeze_time
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -14,6 +15,7 @@ from homeassistant.components.recorder.models import (
     RecorderRuns,
     StateAttributes,
     States,
+    process_datetime_to_timestamp,
     process_timestamp,
     process_timestamp_to_utc_isoformat,
 )
@@ -333,3 +335,73 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(caplog):
         "last_updated": "2020-06-12T03:04:01.000323+00:00",
         "state": "off",
     }
+
+
+@pytest.mark.parametrize(
+    "time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii", "UTC"]
+)
+def test_process_datetime_to_timestamp(time_zone, hass):
+    """Test we can handle processing database datatimes to timestamps."""
+    hass.config.set_time_zone(time_zone)
+    utc_now = dt_util.utcnow()
+    assert process_datetime_to_timestamp(utc_now) == utc_now.timestamp()
+    now = dt_util.now()
+    assert process_datetime_to_timestamp(now) == now.timestamp()
+
+
+@pytest.mark.parametrize(
+    "time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii", "UTC"]
+)
+def test_process_datetime_to_timestamp_freeze_time(time_zone, hass):
+    """Test we can handle processing database datatimes to timestamps.
+
+    This test freezes time to make sure everything matches.
+    """
+    hass.config.set_time_zone(time_zone)
+    utc_now = dt_util.utcnow()
+    with freeze_time(utc_now):
+        epoch = utc_now.timestamp()
+        assert process_datetime_to_timestamp(dt_util.utcnow()) == epoch
+        now = dt_util.now()
+        assert process_datetime_to_timestamp(now) == epoch
+
+
+@pytest.mark.parametrize(
+    "time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii", "UTC"]
+)
+async def test_process_datetime_to_timestamp_mirrors_utc_isoformat_behavior(
+    time_zone, hass
+):
+    """Test process_datetime_to_timestamp mirrors process_timestamp_to_utc_isoformat."""
+    hass.config.set_time_zone(time_zone)
+    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
+    datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
+    est = dt_util.get_time_zone("US/Eastern")
+    datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
+    est = dt_util.get_time_zone("US/Eastern")
+    datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
+    nst = dt_util.get_time_zone("Canada/Newfoundland")
+    datetime_nst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=nst)
+    hst = dt_util.get_time_zone("US/Hawaii")
+    datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
+
+    assert (
+        process_datetime_to_timestamp(datetime_with_tzinfo)
+        == dt_util.parse_datetime("2016-07-09T11:00:00+00:00").timestamp()
+    )
+    assert (
+        process_datetime_to_timestamp(datetime_without_tzinfo)
+        == dt_util.parse_datetime("2016-07-09T11:00:00+00:00").timestamp()
+    )
+    assert (
+        process_datetime_to_timestamp(datetime_est_timezone)
+        == dt_util.parse_datetime("2016-07-09T15:00:00+00:00").timestamp()
+    )
+    assert (
+        process_datetime_to_timestamp(datetime_nst_timezone)
+        == dt_util.parse_datetime("2016-07-09T13:30:00+00:00").timestamp()
+    )
+    assert (
+        process_datetime_to_timestamp(datetime_hst_timezone)
+        == dt_util.parse_datetime("2016-07-09T21:00:00+00:00").timestamp()
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


This function previously produced the wrong result when a non-UTC
timezone was set.  It was only correct for UTC and no timezone set on
the dt object.  Since all the database rows come back without a timezone
it went unnoticed before.

Speed up `process_datetime_to_timestamp` and add test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
