### PR TITLE
Add tilt support to Tasmota covers

### DIFF
--- a/homeassistant/components/tasmota/cover.py
+++ b/homeassistant/components/tasmota/cover.py
@@ -9,6 +9,7 @@ from hatasmota.models import DiscoveryHashType
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
+    ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     CoverEntity,
     CoverEntityFeature,
@@ -55,22 +56,31 @@ class TasmotaCover(
 ):
     """Representation of a Tasmota cover."""
 
-    _attr_supported_features = (
-        CoverEntityFeature.OPEN
-        | CoverEntityFeature.CLOSE
-        | CoverEntityFeature.STOP
-        | CoverEntityFeature.SET_POSITION
-    )
     _tasmota_entity: tasmota_shutter.TasmotaShutter
 
     def __init__(self, **kwds: Any) -> None:
         """Initialize the Tasmota cover."""
         self._direction: int | None = None
         self._position: int | None = None
+        self._tilt_position: int | None = None
 
         super().__init__(
             **kwds,
         )
+
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.SET_POSITION
+        )
+        if self._tasmota_entity.supports_tilt:
+            self._attr_supported_features |= (
+                CoverEntityFeature.OPEN_TILT
+                | CoverEntityFeature.CLOSE_TILT
+                | CoverEntityFeature.STOP_TILT
+                | CoverEntityFeature.SET_TILT_POSITION
+            )
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""
@@ -82,6 +92,7 @@ class TasmotaCover(
         """Handle state updates."""
         self._direction = kwargs["direction"]
         self._position = kwargs["position"]
+        self._tilt_position = kwargs["tilt"]
         self.async_write_ha_state()
 
     @property
@@ -91,6 +102,14 @@ class TasmotaCover(
         None is unknown, 0 is closed, 100 is fully open.
         """
         return self._position
+
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Return current tilt position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return self._tilt_position
 
     @property
     def is_opening(self) -> bool:
@@ -124,4 +143,21 @@ class TasmotaCover(
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
+        await self._tasmota_entity.stop()
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        await self._tasmota_entity.open_tilt()
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close cover tilt."""
+        await self._tasmota_entity.close_tilt()
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the cover tilt to a specific position."""
+        tilt = kwargs[ATTR_TILT_POSITION]
+        await self._tasmota_entity.set_tilt_position(tilt)
+
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the cover tilt."""
         await self._tasmota_entity.stop()

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.4.1"],
+  "requirements": ["hatasmota==0.5.0"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -795,7 +795,7 @@ hass-nabucasa==0.54.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.4.1
+hatasmota==0.5.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -565,7 +565,7 @@ hangups==0.4.18
 hass-nabucasa==0.54.0
 
 # homeassistant.components.tasmota
-hatasmota==0.4.1
+hatasmota==0.5.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -30,6 +30,19 @@ from .test_common import (
 
 from tests.common import async_fire_mqtt_message
 
+COVER_SUPPORT = (
+    cover.SUPPORT_OPEN
+    | cover.SUPPORT_CLOSE
+    | cover.SUPPORT_STOP
+    | cover.SUPPORT_SET_POSITION
+)
+TILT_SUPPORT = (
+    cover.SUPPORT_OPEN_TILT
+    | cover.SUPPORT_CLOSE_TILT
+    | cover.SUPPORT_STOP_TILT
+    | cover.SUPPORT_SET_TILT_POSITION
+)
+
 
 async def test_missing_relay(hass, mqtt_mock, setup_tasmota):
     """Test no cover is discovered if relays are missing."""
@@ -64,11 +77,46 @@ async def test_multiple_covers(
     assert len(hass.states.async_all("cover")) == num_covers
 
 
+async def test_tilt_support(hass, mqtt_mock, setup_tasmota):
+    """Test tilt support detection."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["rl"] = [3, 3, 3, 3, 3, 3, 3, 3]
+    config["sht"] = [
+        [0, 0, 0],  # Default settings, no tilt
+        [-90, 90, 24],  # Tilt configured
+        [-90, 90, 0],  # Duration 0, no tilt
+        [-90, -90, 24],  # min+max same, no tilt
+    ]
+    mac = config["mac"]
+
+    async_fire_mqtt_message(
+        hass,
+        f"{DEFAULT_PREFIX}/{mac}/config",
+        json.dumps(config),
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("cover")) == 4
+
+    state = hass.states.get("cover.tasmota_cover_1")
+    assert state.attributes["supported_features"] == COVER_SUPPORT
+
+    state = hass.states.get("cover.tasmota_cover_2")
+    assert state.attributes["supported_features"] == COVER_SUPPORT | TILT_SUPPORT
+
+    state = hass.states.get("cover.tasmota_cover_3")
+    assert state.attributes["supported_features"] == COVER_SUPPORT
+
+    state = hass.states.get("cover.tasmota_cover_4")
+    assert state.attributes["supported_features"] == COVER_SUPPORT
+
+
 async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 3
     config["rl"][1] = 3
+    config["sht"] = [[-90, 90, 24]]
     mac = config["mac"]
 
     async_fire_mqtt_message(
@@ -86,40 +134,39 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == STATE_UNKNOWN
-    assert (
-        state.attributes["supported_features"]
-        == cover.SUPPORT_OPEN
-        | cover.SUPPORT_CLOSE
-        | cover.SUPPORT_STOP
-        | cover.SUPPORT_SET_POSITION
-    )
+    assert state.attributes["supported_features"] == COVER_SUPPORT | TILT_SUPPORT
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     # Periodic updates
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/tele/SENSOR",
-        '{"Shutter1":{"Position":54,"Direction":-1}}',
+        '{"Shutter1":{"Position":54,"Direction":-1,"Tilt":-90}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "closing"
     assert state.attributes["current_position"] == 54
+    assert state.attributes["current_tilt_position"] == 0
 
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/tele/SENSOR",
-        '{"Shutter1":{"Position":100,"Direction":1}}',
+        '{"Shutter1":{"Position":100,"Direction":1,"Tilt":90}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "opening"
     assert state.attributes["current_position"] == 100
+    assert state.attributes["current_tilt_position"] == 100
 
     async_fire_mqtt_message(
-        hass, "tasmota_49A3BC/tele/SENSOR", '{"Shutter1":{"Position":0,"Direction":0}}'
+        hass,
+        "tasmota_49A3BC/tele/SENSOR",
+        '{"Shutter1":{"Position":0,"Direction":0,"Tilt":0}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "closed"
     assert state.attributes["current_position"] == 0
+    assert state.attributes["current_tilt_position"] == 50
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/tele/SENSOR", '{"Shutter1":{"Position":1,"Direction":0}}'
@@ -141,29 +188,32 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/stat/STATUS10",
-        '{"StatusSNS":{"Shutter1":{"Position":54,"Direction":-1}}}',
+        '{"StatusSNS":{"Shutter1":{"Position":54,"Direction":-1,"Tilt":-90}}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "closing"
     assert state.attributes["current_position"] == 54
+    assert state.attributes["current_tilt_position"] == 0
 
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/stat/STATUS10",
-        '{"StatusSNS":{"Shutter1":{"Position":100,"Direction":1}}}',
+        '{"StatusSNS":{"Shutter1":{"Position":100,"Direction":1,"Tilt":90}}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "opening"
     assert state.attributes["current_position"] == 100
+    assert state.attributes["current_tilt_position"] == 100
 
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/stat/STATUS10",
-        '{"StatusSNS":{"Shutter1":{"Position":0,"Direction":0}}}',
+        '{"StatusSNS":{"Shutter1":{"Position":0,"Direction":0,"Tilt":0}}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "closed"
     assert state.attributes["current_position"] == 0
+    assert state.attributes["current_tilt_position"] == 50
 
     async_fire_mqtt_message(
         hass,
@@ -187,27 +237,32 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/stat/RESULT",
-        '{"Shutter1":{"Position":54,"Direction":-1}}',
+        '{"Shutter1":{"Position":54,"Direction":-1,"Tilt":-90}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "closing"
     assert state.attributes["current_position"] == 54
+    assert state.attributes["current_tilt_position"] == 0
 
     async_fire_mqtt_message(
         hass,
         "tasmota_49A3BC/stat/RESULT",
-        '{"Shutter1":{"Position":100,"Direction":1}}',
+        '{"Shutter1":{"Position":100,"Direction":1,"Tilt":90}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "opening"
     assert state.attributes["current_position"] == 100
+    assert state.attributes["current_tilt_position"] == 100
 
     async_fire_mqtt_message(
-        hass, "tasmota_49A3BC/stat/RESULT", '{"Shutter1":{"Position":0,"Direction":0}}'
+        hass,
+        "tasmota_49A3BC/stat/RESULT",
+        '{"Shutter1":{"Position":0,"Direction":0,"Tilt":0}}',
     )
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == "closed"
     assert state.attributes["current_position"] == 0
+    assert state.attributes["current_tilt_position"] == 50
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Shutter1":{"Position":1,"Direction":0}}'
@@ -249,14 +304,7 @@ async def test_controlling_state_via_mqtt_inverted(hass, mqtt_mock, setup_tasmot
     await hass.async_block_till_done()
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == STATE_UNKNOWN
-    assert (
-        state.attributes["supported_features"]
-        == cover.SUPPORT_OPEN
-        | cover.SUPPORT_CLOSE
-        | cover.SUPPORT_STOP
-        | cover.SUPPORT_SET_POSITION
-    )
-    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+    assert state.attributes["supported_features"] == COVER_SUPPORT
 
     # Periodic updates
     async_fire_mqtt_message(
@@ -405,6 +453,7 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     config["dn"] = "Test"
     config["rl"][0] = 3
     config["rl"][1] = 3
+    config["sht"] = [[-90, 90, 24]]
     mac = config["mac"]
 
     async_fire_mqtt_message(
@@ -458,6 +507,45 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     await call_service(hass, "cover.test_cover_1", "set_cover_position", position=99)
     mqtt_mock.async_publish.assert_called_once_with(
         "tasmota_49A3BC/cmnd/ShutterPosition1", "99", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Close the cover tilt and verify MQTT message is sent
+    await call_service(hass, "cover.test_cover_1", "close_cover_tilt")
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/ShutterTilt1", "CLOSE", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Open the cover tilt and verify MQTT message is sent
+    await call_service(hass, "cover.test_cover_1", "open_cover_tilt")
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/ShutterTilt1", "OPEN", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Stop the cover tilt and verify MQTT message is sent
+    await call_service(hass, "cover.test_cover_1", "stop_cover_tilt")
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/ShutterStop1", "", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Set tilt position and verify MQTT message is sent
+    await call_service(
+        hass, "cover.test_cover_1", "set_cover_tilt_position", tilt_position=0
+    )
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/ShutterTilt1", "-90", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Set tilt position and verify MQTT message is sent
+    await call_service(
+        hass, "cover.test_cover_1", "set_cover_tilt_position", tilt_position=100
+    )
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/ShutterTilt1", "90", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tilt support to Tasmota shutters
Note: This also needs https://github.com/arendst/Tasmota/pull/15612 which is included in Tasmota v 12.0.0, and daily dev builds starting from 2022-05-14

Bump hatasmota from 0.4.1 to 0.5.0

Changes:

- 0.5.0 (https://github.com/emontnemery/hatasmota/releases/tag/0.5.0)
   - https://github.com/emontnemery/hatasmota/pull/153

Git compare: https://github.com/emontnemery/hatasmota/compare/0.4.1..0.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/71452
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
