### PR TITLE
Motion blinds restore angle

### DIFF
--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -162,6 +162,7 @@ async def async_setup_entry(
 
 class MotionPositionDevice(CoordinatorEntity, CoverEntity):
     """Representation of a Motion Blind Device."""
+    _restore_tilt = False
 
     def __init__(self, coordinator, blind, device_class, sw_version):
         """Initialize the blind."""
@@ -285,9 +286,13 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
+        angle = kwargs.get(ATTR_TILT_POSITION)
         async with self._api_lock:
             await self.hass.async_add_executor_job(
-                self._blind.Set_position, 100 - position
+                self._blind.Set_position,
+                100 - position,
+                angle=angle,
+                restore_angle=self._restore_tilt,
             )
         await self.async_request_position_till_stop()
 
@@ -308,6 +313,7 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
 
 class MotionTiltDevice(MotionPositionDevice):
     """Representation of a Motion Blind Device."""
+    _restore_tilt = True
 
     @property
     def current_cover_tilt_position(self):

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -163,6 +163,7 @@ async def async_setup_entry(
 
 class MotionPositionDevice(CoordinatorEntity, CoverEntity):
     """Representation of a Motion Blind Device."""
+
     _restore_tilt = False
 
     def __init__(self, coordinator, blind, device_class, sw_version):
@@ -319,6 +320,7 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
 
 class MotionTiltDevice(MotionPositionDevice):
     """Representation of a Motion Blind Device."""
+
     _restore_tilt = True
 
     @property

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -3,7 +3,7 @@
   "name": "Motion Blinds",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/motion_blinds",
-  "requirements": ["motionblinds==0.6.5"],
+  "requirements": ["motionblinds==0.6.7"],
   "dependencies": ["network"],
   "dhcp": [
     { "registered_devices": true },

--- a/homeassistant/components/motion_blinds/services.yaml
+++ b/homeassistant/components/motion_blinds/services.yaml
@@ -14,15 +14,17 @@ set_absolute_position:
       required: true
       selector:
         number:
-          min: 1
+          min: 0
           max: 100
+          unit_of_measurement: "%"
     tilt_position:
       name: Tilt position
       description: Tilt position to move to.
       selector:
         number:
-          min: 1
+          min: 0
           max: 100
+          unit_of_measurement: "%"
     width:
       name: Width
       description: Specify the width that is covered, only for TDBU Combined entities.
@@ -30,3 +32,4 @@ set_absolute_position:
         number:
           min: 1
           max: 100
+          unit_of_measurement: "%"

--- a/homeassistant/components/motion_blinds/services.yaml
+++ b/homeassistant/components/motion_blinds/services.yaml
@@ -16,6 +16,13 @@ set_absolute_position:
         number:
           min: 1
           max: 100
+    tilt_position:
+      name: Tilt position
+      description: Tilt position to move to.
+      selector:
+        number:
+          min: 1
+          max: 100
     width:
       name: Width
       description: Specify the width that is covered, only for TDBU Combined entities.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1032,7 +1032,7 @@ mitemp_bt==0.0.5
 moehlenhoff-alpha2==1.1.2
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.5
+motionblinds==0.6.7
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -706,7 +706,7 @@ minio==5.0.10
 moehlenhoff-alpha2==1.1.2
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.5
+motionblinds==0.6.7
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.12


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When moving a Tilt capable motion blind, the tilt will be set back to its original value before the move such that moving the blind does not influence the tilt.
The `motion_blinds.set_absolute_position` service got a extra optinal attribute for specifying the tilt position to move to.
If the normal `cover.set_position` is issued and emidiatly after a `cover.set_tilt` is issued, the blind will stop moving and start adjusting the tilt before it reaches the intended position.
With the `motion_blinds.set_absolute_position` both a new position and a new tilt can be specified and the blind will move to the new position and then adjust its tilt.

Bump motionblinds to 0.6.7:
https://github.com/starkillerOG/motion-blinds/compare/0.6.5...0.6.7

    Add optional angle control to 'Set_position'
    Add optional restore angle to 'Set_position'
    Fix false positives for Check_gateway_multicast

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22732

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
