### PR TITLE
Streamline setup of deCONZ binary sensor platform

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -81,7 +81,7 @@ async def async_setup_entry(
 
     config_entry.async_on_unload(
         gateway.api.sensors.ancillary_control.subscribe(
-            async_add_sensor,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from pydeconz.interfaces.sensors import SensorResources
+from pydeconz.models.event import EventType
 from pydeconz.models.sensor.alarm import Alarm
 from pydeconz.models.sensor.carbon_monoxide import CarbonMonoxide
 from pydeconz.models.sensor.fire import Fire
@@ -188,46 +189,50 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_sensor(sensors: list[SensorResources] | None = None) -> None:
-        """Add binary sensor from deCONZ."""
-        entities: list[DeconzBinarySensor] = []
+    def async_add_sensor(_: EventType, sensor_id: str) -> None:
+        """Add sensor from deCONZ."""
+        if not gateway.option_allow_new_devices:
+            gateway.to_load_ignored_devices.add((async_add_sensor, sensor_id))
+            return
 
-        if sensors is None:
-            sensors = gateway.api.sensors.values()
+        sensor = gateway.api.sensors[sensor_id]
 
-        for sensor in sensors:
+        if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
+            return
 
-            if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
+        for description in (
+            ENTITY_DESCRIPTIONS.get(type(sensor), []) + BINARY_SENSOR_DESCRIPTIONS
+        ):
+            if (
+                not hasattr(sensor, description.key)
+                or description.value_fn(sensor) is None
+            ):
                 continue
 
-            known_entities = set(gateway.entities[DOMAIN])
-            for description in (
-                ENTITY_DESCRIPTIONS.get(type(sensor), []) + BINARY_SENSOR_DESCRIPTIONS
-            ):
+            async_add_entities([DeconzBinarySensor(sensor, gateway, description)])
 
-                if (
-                    not hasattr(sensor, description.key)
-                    or description.value_fn(sensor) is None
-                ):
-                    continue
+    config_entry.async_on_unload(
+        gateway.api.sensors.subscribe(
+            async_add_sensor,
+            EventType.ADDED,
+        )
+    )
+    for sensor_id in gateway.api.sensors:
+        async_add_sensor(EventType.ADDED, sensor_id)
 
-                new_sensor = DeconzBinarySensor(sensor, gateway, description)
-                if new_sensor.unique_id not in known_entities:
-                    entities.append(new_sensor)
-
-        if entities:
-            async_add_entities(entities)
+    @callback
+    def async_reload_clip_sensors() -> None:
+        """Load clip sensor sensors from deCONZ."""
+        for sensor_id, sensor in gateway.api.sensors.items():
+            if sensor.type.startswith("CLIP"):
+                async_add_sensor(EventType.ADDED, sensor_id)
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
             hass,
-            gateway.signal_new_sensor,
-            async_add_sensor,
+            gateway.signal_reload_clip_sensors,
+            async_reload_clip_sensors,
         )
-    )
-
-    async_add_sensor(
-        [gateway.api.sensors[key] for key in sorted(gateway.api.sensors, key=int)]
     )
 
 

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -191,10 +191,6 @@ async def async_setup_entry(
     @callback
     def async_add_sensor(_: EventType, sensor_id: str) -> None:
         """Add sensor from deCONZ."""
-        if not gateway.option_allow_new_devices:
-            gateway.to_load_ignored_devices.add((async_add_sensor, sensor_id))
-            return
-
         sensor = gateway.api.sensors[sensor_id]
 
         if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
@@ -213,7 +209,7 @@ async def async_setup_entry(
 
     config_entry.async_on_unload(
         gateway.api.sensors.subscribe(
-            async_add_sensor,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -97,28 +97,28 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_sensor(_: EventType, sensor_id: str) -> None:
-        """Add sensor from deCONZ."""
-        sensor = gateway.api.sensors.thermostat[sensor_id]
-        if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
+    def async_add_climate(_: EventType, climate_id: str) -> None:
+        """Add climate from deCONZ."""
+        climate = gateway.api.sensors.thermostat[climate_id]
+        if not gateway.option_allow_clip_sensor and climate.type.startswith("CLIP"):
             return
-        async_add_entities([DeconzThermostat(sensor, gateway)])
+        async_add_entities([DeconzThermostat(climate, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.sensors.thermostat.subscribe(
-            gateway.evaluate_add_device(async_add_sensor),
+            gateway.evaluate_add_device(async_add_climate),
             EventType.ADDED,
         )
     )
-    for sensor_id in gateway.api.sensors.thermostat:
-        async_add_sensor(EventType.ADDED, sensor_id)
+    for climate_id in gateway.api.sensors.thermostat:
+        async_add_climate(EventType.ADDED, climate_id)
 
     @callback
     def async_reload_clip_sensors() -> None:
         """Load clip sensors from deCONZ."""
-        for sensor_id, sensor in gateway.api.sensors.thermostat.items():
-            if sensor.type.startswith("CLIP"):
-                async_add_sensor(EventType.ADDED, sensor_id)
+        for climate_id, climate in gateway.api.sensors.thermostat.items():
+            if climate.type.startswith("CLIP"):
+                async_add_climate(EventType.ADDED, climate_id)
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -97,28 +97,28 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_climate(_: EventType, climate_id: str) -> None:
-        """Add climate from deCONZ."""
-        climate = gateway.api.sensors.thermostat[climate_id]
-        if not gateway.option_allow_clip_sensor and climate.type.startswith("CLIP"):
+    def async_add_sensor(_: EventType, sensor_id: str) -> None:
+        """Add sensor from deCONZ."""
+        sensor = gateway.api.sensors.thermostat[sensor_id]
+        if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
             return
-        async_add_entities([DeconzThermostat(climate, gateway)])
+        async_add_entities([DeconzThermostat(sensor, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.sensors.thermostat.subscribe(
-            async_add_climate,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )
-    for climate_id in gateway.api.sensors.thermostat:
-        async_add_climate(EventType.ADDED, climate_id)
+    for sensor_id in gateway.api.sensors.thermostat:
+        async_add_sensor(EventType.ADDED, sensor_id)
 
     @callback
     def async_reload_clip_sensors() -> None:
-        """Load clip climate sensors from deCONZ."""
-        for climate_id, climate in gateway.api.sensors.thermostat.items():
-            if climate.type.startswith("CLIP"):
-                async_add_climate(EventType.ADDED, climate_id)
+        """Load clip sensors from deCONZ."""
+        for sensor_id, sensor in gateway.api.sensors.thermostat.items():
+            if sensor.type.startswith("CLIP"):
+                async_add_sensor(EventType.ADDED, sensor_id)
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -38,19 +38,19 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_light(_: EventType, light_id: str) -> None:
-        """Add light from deCONZ."""
-        light = gateway.api.lights.covers[light_id]
-        async_add_entities([DeconzCover(light, gateway)])
+    def async_add_cover(_: EventType, cover_id: str) -> None:
+        """Add cover from deCONZ."""
+        cover = gateway.api.lights.covers[cover_id]
+        async_add_entities([DeconzCover(cover, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.covers.subscribe(
-            gateway.evaluate_add_device(async_add_light),
+            gateway.evaluate_add_device(async_add_cover),
             EventType.ADDED,
         )
     )
-    for light_id in gateway.api.lights.covers:
-        async_add_light(EventType.ADDED, light_id)
+    for cover_id in gateway.api.lights.covers:
+        async_add_cover(EventType.ADDED, cover_id)
 
 
 class DeconzCover(DeconzDevice, CoverEntity):

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -38,19 +38,19 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_cover(_: EventType, cover_id: str) -> None:
-        """Add cover from deCONZ."""
-        cover = gateway.api.lights.covers[cover_id]
-        async_add_entities([DeconzCover(cover, gateway)])
+    def async_add_light(_: EventType, light_id: str) -> None:
+        """Add light from deCONZ."""
+        light = gateway.api.lights.covers[light_id]
+        async_add_entities([DeconzCover(light, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.covers.subscribe(
-            async_add_cover,
+            gateway.evaluate_add_device(async_add_light),
             EventType.ADDED,
         )
     )
-    for cover_id in gateway.api.lights.covers:
-        async_add_cover(EventType.ADDED, cover_id)
+    for light_id in gateway.api.lights.covers:
+        async_add_light(EventType.ADDED, light_id)
 
 
 class DeconzCover(DeconzDevice, CoverEntity):

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -66,14 +66,14 @@ async def async_setup_events(gateway: DeconzGateway) -> None:
 
     gateway.config_entry.async_on_unload(
         gateway.api.sensors.ancillary_control.subscribe(
-            async_add_sensor,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )
 
     gateway.config_entry.async_on_unload(
         gateway.api.sensors.switch.subscribe(
-            async_add_sensor,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -43,19 +43,19 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_fan(_: EventType, fan_id: str) -> None:
-        """Add fan from deCONZ."""
-        fan = gateway.api.lights.fans[fan_id]
-        async_add_entities([DeconzFan(fan, gateway)])
+    def async_add_light(_: EventType, light_id: str) -> None:
+        """Add light from deCONZ."""
+        light = gateway.api.lights.fans[light_id]
+        async_add_entities([DeconzFan(light, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.fans.subscribe(
-            async_add_fan,
+            gateway.evaluate_add_device(async_add_light),
             EventType.ADDED,
         )
     )
-    for fan_id in gateway.api.lights.fans:
-        async_add_fan(EventType.ADDED, fan_id)
+    for light_id in gateway.api.lights.fans:
+        async_add_light(EventType.ADDED, light_id)
 
 
 class DeconzFan(DeconzDevice, FanEntity):

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -43,19 +43,19 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_light(_: EventType, light_id: str) -> None:
-        """Add light from deCONZ."""
-        light = gateway.api.lights.fans[light_id]
-        async_add_entities([DeconzFan(light, gateway)])
+    def async_add_fan(_: EventType, fan_id: str) -> None:
+        """Add fan from deCONZ."""
+        fan = gateway.api.lights.fans[fan_id]
+        async_add_entities([DeconzFan(fan, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.fans.subscribe(
-            gateway.evaluate_add_device(async_add_light),
+            gateway.evaluate_add_device(async_add_fan),
             EventType.ADDED,
         )
     )
-    for light_id in gateway.api.lights.fans:
-        async_add_light(EventType.ADDED, light_id)
+    for fan_id in gateway.api.lights.fans:
+        async_add_fan(EventType.ADDED, fan_id)
 
 
 class DeconzFan(DeconzDevice, FanEntity):

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -95,7 +95,7 @@ async def async_setup_entry(
 
     config_entry.async_on_unload(
         gateway.api.lights.lights.subscribe(
-            async_add_light,
+            gateway.evaluate_add_device(async_add_light),
             EventType.ADDED,
         )
     )

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -27,34 +27,34 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_lock_from_light(_: EventType, lock_id: str) -> None:
+    def async_add_light(_: EventType, light_id: str) -> None:
         """Add lock from deCONZ."""
-        lock = gateway.api.lights.locks[lock_id]
+        lock = gateway.api.lights.locks[light_id]
         async_add_entities([DeconzLock(lock, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.locks.subscribe(
-            async_add_lock_from_light,
+            gateway.evaluate_add_device(async_add_light),
             EventType.ADDED,
         )
     )
-    for lock_id in gateway.api.lights.locks:
-        async_add_lock_from_light(EventType.ADDED, lock_id)
+    for light_id in gateway.api.lights.locks:
+        async_add_light(EventType.ADDED, light_id)
 
     @callback
-    def async_add_lock_from_sensor(_: EventType, lock_id: str) -> None:
+    def async_add_sensor(_: EventType, sensor_id: str) -> None:
         """Add lock from deCONZ."""
-        lock = gateway.api.sensors.door_lock[lock_id]
+        lock = gateway.api.sensors.door_lock[sensor_id]
         async_add_entities([DeconzLock(lock, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.sensors.door_lock.subscribe(
-            async_add_lock_from_sensor,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )
-    for lock_id in gateway.api.sensors.door_lock:
-        async_add_lock_from_sensor(EventType.ADDED, lock_id)
+    for sensor_id in gateway.api.sensors.door_lock:
+        async_add_sensor(EventType.ADDED, sensor_id)
 
 
 class DeconzLock(DeconzDevice, LockEntity):

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -27,34 +27,34 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_light(_: EventType, light_id: str) -> None:
+    def async_add_lock_from_light(_: EventType, lock_id: str) -> None:
         """Add lock from deCONZ."""
-        lock = gateway.api.lights.locks[light_id]
+        lock = gateway.api.lights.locks[lock_id]
         async_add_entities([DeconzLock(lock, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.locks.subscribe(
-            gateway.evaluate_add_device(async_add_light),
+            gateway.evaluate_add_device(async_add_lock_from_light),
             EventType.ADDED,
         )
     )
-    for light_id in gateway.api.lights.locks:
-        async_add_light(EventType.ADDED, light_id)
+    for lock_id in gateway.api.lights.locks:
+        async_add_lock_from_light(EventType.ADDED, lock_id)
 
     @callback
-    def async_add_sensor(_: EventType, sensor_id: str) -> None:
+    def async_add_lock_from_sensor(_: EventType, lock_id: str) -> None:
         """Add lock from deCONZ."""
-        lock = gateway.api.sensors.door_lock[sensor_id]
+        lock = gateway.api.sensors.door_lock[lock_id]
         async_add_entities([DeconzLock(lock, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.sensors.door_lock.subscribe(
-            gateway.evaluate_add_device(async_add_sensor),
+            gateway.evaluate_add_device(async_add_lock_from_sensor),
             EventType.ADDED,
         )
     )
-    for sensor_id in gateway.api.sensors.door_lock:
-        async_add_sensor(EventType.ADDED, sensor_id)
+    for lock_id in gateway.api.sensors.door_lock:
+        async_add_lock_from_sensor(EventType.ADDED, lock_id)
 
 
 class DeconzLock(DeconzDevice, LockEntity):

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -77,7 +77,7 @@ async def async_setup_entry(
 
     config_entry.async_on_unload(
         gateway.api.sensors.presence.subscribe(
-            async_add_sensor,
+            gateway.evaluate_add_device(async_add_sensor),
             EventType.ADDED,
         )
     )

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -144,6 +144,7 @@ async def async_refresh_devices_service(gateway: DeconzGateway) -> None:
     """Refresh available devices from deCONZ."""
     gateway.ignore_state_updates = True
     await gateway.api.refresh_state()
+    gateway.load_ignored_devices()
     gateway.ignore_state_updates = False
 
     for resource_type in gateway.deconz_resource_type_to_signal_new_device:

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -30,19 +30,19 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_siren(_: EventType, siren_id: str) -> None:
+    def async_add_light(_: EventType, light_id: str) -> None:
         """Add siren from deCONZ."""
-        siren = gateway.api.lights.sirens[siren_id]
-        async_add_entities([DeconzSiren(siren, gateway)])
+        light = gateway.api.lights.sirens[light_id]
+        async_add_entities([DeconzSiren(light, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.sirens.subscribe(
-            async_add_siren,
+            gateway.evaluate_add_device(async_add_light),
             EventType.ADDED,
         )
     )
-    for siren_id in gateway.api.lights.sirens:
-        async_add_siren(EventType.ADDED, siren_id)
+    for light_id in gateway.api.lights.sirens:
+        async_add_light(EventType.ADDED, light_id)
 
 
 class DeconzSiren(DeconzDevice, SirenEntity):

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -30,19 +30,19 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_light(_: EventType, light_id: str) -> None:
+    def async_add_siren(_: EventType, siren_id: str) -> None:
         """Add siren from deCONZ."""
-        light = gateway.api.lights.sirens[light_id]
-        async_add_entities([DeconzSiren(light, gateway)])
+        siren = gateway.api.lights.sirens[siren_id]
+        async_add_entities([DeconzSiren(siren, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.sirens.subscribe(
-            gateway.evaluate_add_device(async_add_light),
+            gateway.evaluate_add_device(async_add_siren),
             EventType.ADDED,
         )
     )
-    for light_id in gateway.api.lights.sirens:
-        async_add_light(EventType.ADDED, light_id)
+    for siren_id in gateway.api.lights.sirens:
+        async_add_siren(EventType.ADDED, siren_id)
 
 
 class DeconzSiren(DeconzDevice, SirenEntity):

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -30,21 +30,21 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_light(_: EventType, light_id: str) -> None:
+    def async_add_switch(_: EventType, switch_id: str) -> None:
         """Add switch from deCONZ."""
-        light = gateway.api.lights.lights[light_id]
-        if light.type not in POWER_PLUGS:
+        switch = gateway.api.lights.lights[switch_id]
+        if switch.type not in POWER_PLUGS:
             return
-        async_add_entities([DeconzPowerPlug(light, gateway)])
+        async_add_entities([DeconzPowerPlug(switch, gateway)])
 
     config_entry.async_on_unload(
         gateway.api.lights.lights.subscribe(
-            gateway.evaluate_add_device(async_add_light),
+            gateway.evaluate_add_device(async_add_switch),
             EventType.ADDED,
         )
     )
-    for light_id in gateway.api.lights.lights:
-        async_add_light(EventType.ADDED, light_id)
+    for switch_id in gateway.api.lights.lights:
+        async_add_switch(EventType.ADDED, switch_id)
 
 
 class DeconzPowerPlug(DeconzDevice, SwitchEntity):

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_switch(_: EventType, light_id: str) -> None:
+    def async_add_light(_: EventType, light_id: str) -> None:
         """Add switch from deCONZ."""
         light = gateway.api.lights.lights[light_id]
         if light.type not in POWER_PLUGS:
@@ -39,12 +39,12 @@ async def async_setup_entry(
 
     config_entry.async_on_unload(
         gateway.api.lights.lights.subscribe(
-            async_add_switch,
+            gateway.evaluate_add_device(async_add_light),
             EventType.ADDED,
         )
     )
     for light_id in gateway.api.lights.lights:
-        async_add_switch(EventType.ADDED, light_id)
+        async_add_light(EventType.ADDED, light_id)
 
 
 class DeconzPowerPlug(DeconzDevice, SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added mechanism to manage ignoring devices and load them when using device_refresh service.
Changes except for **binary_sensor and gateway** are just boilerplate stuff adding the evaluate_add_device mechanism and some variable renames.

Utilise the improvements from refactoring pydeconz to stream line platform setup.

- https://github.com/home-assistant/core/pull/70589
- https://github.com/home-assistant/core/pull/70593
- https://github.com/home-assistant/core/pull/70700
- https://github.com/home-assistant/core/pull/70712
- https://github.com/home-assistant/core/pull/70822
- https://github.com/home-assistant/core/pull/71656
- https://github.com/home-assistant/core/pull/71658
- https://github.com/home-assistant/core/pull/71659
- https://github.com/home-assistant/core/pull/71660
- https://github.com/home-assistant/core/pull/71661
- https://github.com/home-assistant/core/pull/71707
- https://github.com/home-assistant/core/pull/71708
- https://github.com/home-assistant/core/pull/71820
- https://github.com/home-assistant/core/pull/71840
- https://github.com/home-assistant/core/pull/71905

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
