### PR TITLE
Avoid matching entity_id/domain attributes in logbook when there is no entities_filter

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -427,6 +427,8 @@ def _humanify(
         elif event_type == EVENT_LOGBOOK_ENTRY:
             event = event_cache.get(row)
             event_data = event.data
+            if not event_data:
+                continue
             domain = event_data.get(ATTR_DOMAIN)
             entity_id = event_data.get(ATTR_ENTITY_ID)
             if domain is None and entity_id is not None:
@@ -474,6 +476,22 @@ def _get_events(
 
     def yield_rows(query: Query) -> Generator[Row, None, None]:
         """Yield Events that are not filtered away."""
+
+        def _keep_row(row: Row, event_type: str) -> bool:
+            """Check if the entity_filter rejects a row."""
+            assert entities_filter is not None
+            if entity_id := _row_event_data_extract(row, ENTITY_ID_JSON_EXTRACT):
+                return entities_filter(entity_id)
+
+            if event_type in external_events:
+                # If the entity_id isn't described, use the domain that describes
+                # the event for filtering.
+                domain: str | None = external_events[event_type][0]
+            else:
+                domain = _row_event_data_extract(row, DOMAIN_JSON_EXTRACT)
+
+            return domain is not None and entities_filter(f"{domain}._")
+
         # end_day - start_day intentionally checks .days and not .total_seconds()
         # since we don't want to switch over to buffered if they go
         # over one day by a few hours since the UI makes it so easy to do that.
@@ -490,16 +508,17 @@ def _get_events(
             # so we don't switch over until we request > 1 day+ of data.
             #
             rows = query.yield_per(1024)
+
         for row in rows:
             context_lookup.setdefault(row.context_id, row)
-            if row.context_only:
-                continue
-            event_type = row.event_type
-            if event_type != EVENT_CALL_SERVICE and (
-                event_type == EVENT_STATE_CHANGED
-                or _keep_row(hass, event_type, row, entities_filter)
-            ):
-                yield row
+            if not row.context_only:
+                event_type = row.event_type
+                if event_type != EVENT_CALL_SERVICE and (
+                    entities_filter is None
+                    or event_type == EVENT_STATE_CHANGED
+                    or _keep_row(row, event_type)
+                ):
+                    yield row
 
     if entity_ids is not None:
         entities_filter = generate_filter([], entity_ids, [], [])
@@ -524,27 +543,6 @@ def _get_events(
                 format_time,
             )
         )
-
-
-def _keep_row(
-    hass: HomeAssistant,
-    event_type: str,
-    row: Row,
-    entities_filter: EntityFilter | Callable[[str], bool] | None = None,
-) -> bool:
-    if entity_id := _row_event_data_extract(row, ENTITY_ID_JSON_EXTRACT):
-        return entities_filter is None or entities_filter(entity_id)
-
-    if event_type in hass.data[DOMAIN]:
-        # If the entity_id isn't described, use the domain that describes
-        # the event for filtering.
-        domain = hass.data[DOMAIN][event_type][0]
-    else:
-        domain = _row_event_data_extract(row, DOMAIN_JSON_EXTRACT)
-
-    return domain is not None and (
-        entities_filter is None or entities_filter(f"{domain}._")
-    )
 
 
 class ContextAugmenter:

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -426,8 +426,7 @@ def _humanify(
 
         elif event_type == EVENT_LOGBOOK_ENTRY:
             event = event_cache.get(row)
-            event_data = event.data
-            if not event_data:
+            if not (event_data := event.data):
                 continue
             domain = event_data.get(ATTR_DOMAIN)
             entity_id = event_data.get(ATTR_ENTITY_ID)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1761,13 +1761,21 @@ async def test_fire_logbook_entries(hass, hass_client, recorder_mock):
             logbook.EVENT_LOGBOOK_ENTRY,
             {},
         )
+    hass.bus.async_fire(
+        logbook.EVENT_LOGBOOK_ENTRY,
+        {
+            logbook.ATTR_NAME: "Alarm",
+            logbook.ATTR_MESSAGE: "is triggered",
+            logbook.ATTR_DOMAIN: "switch",
+        },
+    )
     await async_wait_recording_done(hass)
 
     client = await hass_client()
     response_json = await _async_fetch_logbook(client)
 
     # The empty events should be skipped
-    assert len(response_json) == 10
+    assert len(response_json) == 11
 
 
 async def test_exclude_events_domain(hass, hass_client, recorder_mock):
@@ -1986,6 +1994,15 @@ async def test_include_events_domain_glob(hass, hass_client, recorder_mock):
     )
     await async_recorder_block_till_done(hass)
 
+    # Should get excluded by domain
+    hass.bus.async_fire(
+        logbook.EVENT_LOGBOOK_ENTRY,
+        {
+            logbook.ATTR_NAME: "Alarm",
+            logbook.ATTR_MESSAGE: "is triggered",
+            logbook.ATTR_DOMAIN: "switch",
+        },
+    )
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     hass.bus.async_fire(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The `_keep_rows` function has been reduced so much with all
  the refactoring that it is no longer necessary to call unless we
  have a yaml configured entity filter since all it was
  doing was extracting the `entity_id` or `domain` and than
  not rejecting them if there was no filter

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
