### PR TITLE
Avoid storing last_changed in the database if its the same as last_updated

### DIFF
--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -270,7 +270,9 @@ def _legacy_select_events_context_id(
             NOT_CONTEXT_ONLY,
         )
         .outerjoin(States, (Events.event_id == States.event_id))
-        .where(States.last_updated == States.last_changed)
+        .where(
+            (States.last_updated == States.last_changed) | States.last_changed.is_(None)
+        )
         .where(_not_continuous_entity_matcher())
         .outerjoin(
             StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
@@ -302,7 +304,7 @@ def _select_states(start_day: dt, end_day: dt) -> Select:
                 "event_type"
             ),
             literal(value=None, type_=sqlalchemy.Text).label("event_data"),
-            States.last_changed.label("time_fired"),
+            States.last_updated.label("time_fired"),
             States.context_id.label("context_id"),
             States.context_user_id.label("context_user_id"),
             States.context_parent_id.label("context_parent_id"),
@@ -314,7 +316,9 @@ def _select_states(start_day: dt, end_day: dt) -> Select:
         .outerjoin(old_state, (States.old_state_id == old_state.state_id))
         .where(_missing_state_matcher(old_state))
         .where(_not_continuous_entity_matcher())
-        .where(States.last_updated == States.last_changed)
+        .where(
+            (States.last_updated == States.last_changed) | States.last_changed.is_(None)
+        )
         .outerjoin(
             StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
         )

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -300,6 +300,9 @@ def get_significant_states_with_session(
     as well as all states from certain domains (for instance
     thermostat so that we get current temperature in our graphs).
     """
+    assert not (
+        minimal_response and not significant_changes_only
+    ), "significant_changes_only=False makes no sense when minimal_response=True"
     states = _query_significant_states_with_session(
         hass,
         session,
@@ -737,6 +740,11 @@ def _sorted_states_to_dict(
             ent_results.append(
                 {
                     attr_state: state,
+                    #
+                    # minimal_response only makes sense with last_updated == last_updated
+                    #
+                    # We use last_updated for for last_changed since its the same
+                    #
                     attr_last_changed: _process_timestamp(row.last_updated),
                 }
             )

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -300,9 +300,6 @@ def get_significant_states_with_session(
     as well as all states from certain domains (for instance
     thermostat so that we get current temperature in our graphs).
     """
-    assert not (
-        minimal_response and not significant_changes_only
-    ), "significant_changes_only=False makes no sense when minimal_response=True"
     states = _query_significant_states_with_session(
         hass,
         session,

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -250,7 +250,7 @@ class States(Base):  # type: ignore[misc,valid-type]
     event_id = Column(
         Integer, ForeignKey("events.event_id", ondelete="CASCADE"), index=True
     )
-    last_changed = Column(DATETIME_TYPE, default=dt_util.utcnow)
+    last_changed = Column(DATETIME_TYPE)
     last_updated = Column(DATETIME_TYPE, default=dt_util.utcnow, index=True)
     old_state_id = Column(Integer, ForeignKey("states.state_id"), index=True)
     attributes_id = Column(
@@ -291,12 +291,16 @@ class States(Base):  # type: ignore[misc,valid-type]
         # None state means the state was removed from the state machine
         if state is None:
             dbstate.state = ""
-            dbstate.last_changed = event.time_fired
             dbstate.last_updated = event.time_fired
+            dbstate.last_changed = None
+            return dbstate
+
+        dbstate.state = state.state
+        dbstate.last_updated = state.last_updated
+        if state.last_updated == state.last_changed:
+            dbstate.last_changed = None
         else:
-            dbstate.state = state.state
             dbstate.last_changed = state.last_changed
-            dbstate.last_updated = state.last_updated
 
         return dbstate
 
@@ -308,21 +312,27 @@ class States(Base):  # type: ignore[misc,valid-type]
             parent_id=self.context_parent_id,
         )
         try:
-            return State(
-                self.entity_id,
-                self.state,
-                # Join the state_attributes table on attributes_id to get the attributes
-                # for newer states
-                json.loads(self.attributes) if self.attributes else {},
-                process_timestamp(self.last_changed),
-                process_timestamp(self.last_updated),
-                context=context,
-                validate_entity_id=validate_entity_id,
-            )
+            attrs = json.loads(self.attributes) if self.attributes else {}
         except ValueError:
             # When json.loads fails
             _LOGGER.exception("Error converting row to state: %s", self)
             return None
+        if self.last_changed is None or self.last_changed == self.last_updated:
+            last_changed = last_updated = process_timestamp(self.last_updated)
+        else:
+            last_updated = process_timestamp(self.last_updated)
+            last_changed = process_timestamp(self.last_changed)
+        return State(
+            self.entity_id,
+            self.state,
+            # Join the state_attributes table on attributes_id to get the attributes
+            # for newer states
+            attrs,
+            last_changed,
+            last_updated,
+            context=context,
+            validate_entity_id=validate_entity_id,
+        )
 
 
 class StateAttributes(Base):  # type: ignore[misc,valid-type]
@@ -708,7 +718,10 @@ class LazyState(State):
     def last_changed(self) -> datetime:  # type: ignore[override]
         """Last changed datetime."""
         if self._last_changed is None:
-            self._last_changed = process_timestamp(self._row.last_changed)
+            if (last_changed := self._row.last_changed) is not None:
+                self._last_changed = process_timestamp(last_changed)
+            else:
+                self._last_changed = self.last_updated
         return self._last_changed
 
     @last_changed.setter
@@ -720,10 +733,7 @@ class LazyState(State):
     def last_updated(self) -> datetime:  # type: ignore[override]
         """Last updated datetime."""
         if self._last_updated is None:
-            if (last_updated := self._row.last_updated) is not None:
-                self._last_updated = process_timestamp(last_updated)
-            else:
-                self._last_updated = self.last_changed
+            self._last_updated = process_timestamp(self._row.last_updated)
         return self._last_updated
 
     @last_updated.setter
@@ -739,24 +749,24 @@ class LazyState(State):
         To be used for JSON serialization.
         """
         if self._last_changed is None and self._last_updated is None:
-            last_changed_isoformat = process_timestamp_to_utc_isoformat(
-                self._row.last_changed
+            last_updated_isoformat = process_timestamp_to_utc_isoformat(
+                self._row.last_updated
             )
             if (
-                self._row.last_updated is None
+                self._row.last_changed is None
                 or self._row.last_changed == self._row.last_updated
             ):
-                last_updated_isoformat = last_changed_isoformat
+                last_changed_isoformat = last_updated_isoformat
             else:
-                last_updated_isoformat = process_timestamp_to_utc_isoformat(
-                    self._row.last_updated
+                last_changed_isoformat = process_timestamp_to_utc_isoformat(
+                    self._row.last_changed
                 )
         else:
-            last_changed_isoformat = self.last_changed.isoformat()
+            last_updated_isoformat = self.last_updated.isoformat()
             if self.last_changed == self.last_updated:
-                last_updated_isoformat = last_changed_isoformat
+                last_changed_isoformat = last_updated_isoformat
             else:
-                last_updated_isoformat = self.last_updated.isoformat()
+                last_changed_isoformat = self.last_changed.isoformat()
         return {
             "entity_id": self.entity_id,
             "state": self.state,
@@ -801,13 +811,13 @@ def row_to_compressed_state(
     if start_time:
         last_changed = last_updated = start_time.timestamp()
     else:
-        row_changed_changed: datetime = row.last_changed
+        row_last_updated: datetime = row.last_updated
         if (
-            not (row_last_updated := row.last_updated)
+            not (row_changed_changed := row.last_changed)
             or row_last_updated == row_changed_changed
         ):
             last_changed = last_updated = process_datetime_to_timestamp(
-                row_changed_changed
+                row_last_updated
             )
         else:
             last_changed = process_datetime_to_timestamp(row_changed_changed)

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -1117,7 +1117,7 @@ async def test_history_during_period(hass, hass_ws_client, recorder_mock):
             "start_time": now.isoformat(),
             "entity_ids": ["sensor.test"],
             "include_start_time_state": True,
-            "significant_changes_only": True,
+            "significant_changes_only": False,
             "no_attributes": True,
             "minimal_response": True,
         }
@@ -1315,7 +1315,7 @@ async def test_history_during_period_significant_domain(
             "start_time": now.isoformat(),
             "entity_ids": ["climate.test"],
             "include_start_time_state": True,
-            "significant_changes_only": True,
+            "significant_changes_only": False,
             "no_attributes": True,
             "minimal_response": True,
         }

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -1117,7 +1117,7 @@ async def test_history_during_period(hass, hass_ws_client, recorder_mock):
             "start_time": now.isoformat(),
             "entity_ids": ["sensor.test"],
             "include_start_time_state": True,
-            "significant_changes_only": False,
+            "significant_changes_only": True,
             "no_attributes": True,
             "minimal_response": True,
         }
@@ -1315,7 +1315,7 @@ async def test_history_during_period_significant_domain(
             "start_time": now.isoformat(),
             "entity_ids": ["climate.test"],
             "include_start_time_state": True,
-            "significant_changes_only": False,
+            "significant_changes_only": True,
             "no_attributes": True,
             "minimal_response": True,
         }

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -22,12 +22,15 @@ from homeassistant.components.recorder.models import (
 )
 from homeassistant.components.recorder.util import session_scope
 import homeassistant.core as ha
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.json import JSONEncoder
 import homeassistant.util.dt as dt_util
 
 from tests.common import SetupRecorderInstanceT, mock_state_change_event
-from tests.components.recorder.common import wait_recording_done
+from tests.components.recorder.common import (
+    async_wait_recording_done,
+    wait_recording_done,
+)
 
 
 async def _async_get_states(
@@ -79,7 +82,7 @@ def _add_db_entries(
                     entity_id=entity_id,
                     state="on",
                     attributes='{"name":"the light"}',
-                    last_changed=point,
+                    last_changed=None,
                     last_updated=point,
                     event_id=1001 + idx,
                     attributes_id=1002 + idx,
@@ -785,3 +788,84 @@ async def test_get_states_query_during_migration_to_schema_25_multiple_entities(
         )
         assert hist[0].attributes == {"name": "the light"}
         assert hist[1].attributes == {"name": "the light"}
+
+
+async def test_get_full_significant_states_handles_empty_last_changed(
+    hass: ha.HomeAssistant,
+    async_setup_recorder_instance: SetupRecorderInstanceT,
+):
+    """Test getting states when last_changed is null."""
+    now = dt_util.utcnow()
+    hass.states.async_set("sensor.one", "on", {"attr": "original"})
+    state0 = hass.states.get("sensor.one")
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.one", "on", {"attr": "new"})
+    state1 = hass.states.get("sensor.one")
+
+    assert state0.last_changed == state1.last_changed
+    assert state0.last_updated != state1.last_updated
+    await async_wait_recording_done(hass)
+
+    def _get_entries():
+        with session_scope(hass=hass) as session:
+            return history.get_full_significant_states_with_session(
+                hass,
+                session,
+                now,
+                dt_util.utcnow(),
+                entity_ids=["sensor.one"],
+                significant_changes_only=False,
+            )
+
+    states = await recorder.get_instance(hass).async_add_executor_job(_get_entries)
+    sensor_one_states: list[State] = states["sensor.one"]
+    assert sensor_one_states[0] == state0
+    assert sensor_one_states[1] == state1
+    assert sensor_one_states[0].last_changed == sensor_one_states[1].last_changed
+    assert sensor_one_states[0].last_updated != sensor_one_states[1].last_updated
+
+    def _fetch_native_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            db_state_attributes = {
+                state_attributes.attributes_id: state_attributes
+                for state_attributes in session.query(StateAttributes)
+            }
+            for db_state in session.query(States):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes[
+                    db_state.attributes_id
+                ].to_native()
+                native_states.append(state)
+            return native_states
+
+    native_sensor_one_states = await recorder.get_instance(hass).async_add_executor_job(
+        _fetch_native_states
+    )
+    assert native_sensor_one_states[0] == state0
+    assert native_sensor_one_states[1] == state1
+    assert (
+        native_sensor_one_states[0].last_changed
+        == native_sensor_one_states[1].last_changed
+    )
+    assert (
+        native_sensor_one_states[0].last_updated
+        != native_sensor_one_states[1].last_updated
+    )
+
+    def _fetch_db_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            states = list(session.query(States))
+            session.expunge_all()
+            return states
+
+    db_sensor_one_states = await recorder.get_instance(hass).async_add_executor_job(
+        _fetch_db_states
+    )
+    assert db_sensor_one_states[0].last_changed is None
+    assert (
+        process_timestamp(db_sensor_one_states[1].last_changed) == state0.last_changed
+    )
+    assert db_sensor_one_states[0].last_updated is not None
+    assert db_sensor_one_states[1].last_updated is not None
+    assert db_sensor_one_states[0].last_updated != db_sensor_one_states[1].last_updated

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -795,6 +795,8 @@ async def test_get_full_significant_states_handles_empty_last_changed(
     async_setup_recorder_instance: SetupRecorderInstanceT,
 ):
     """Test getting states when last_changed is null."""
+    await async_setup_recorder_instance(hass, {})
+
     now = dt_util.utcnow()
     hass.states.async_set("sensor.one", "on", {"attr": "original"})
     state0 = hass.states.get("sensor.one")

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -79,7 +79,7 @@ def test_from_event_to_delete_state():
 
     assert db_state.entity_id == "sensor.temperature"
     assert db_state.state == ""
-    assert db_state.last_changed == event.time_fired
+    assert db_state.last_changed is None
     assert db_state.last_updated == event.time_fired
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Data PR https://github.com/home-assistant/data.home-assistant/pull/214

Since `last_updated` and `last_changed` are stored as strings in the database they take up
quite a bit of space.

In testing various production instances, ~75%-96% of `last_changed` was the same as `last_updated`
```
sqlite> select count(*) from states where last_updated == last_changed;
1353902
sqlite> select count(*) from states where last_updated != last_changed;
44720
```
```
sqlite> select count(*) from states where last_updated == last_changed;
1308420
sqlite> select count(*) from states where last_updated != last_changed;
351063
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/data.home-assistant/pull/214

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
