### PR TITLE
Remove ssh switch from unsupported devices for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -43,7 +43,7 @@ async def _set_highfps(obj: Camera, value: bool) -> None:
         await obj.set_video_mode(VideoMode.DEFAULT)
 
 
-ALL_DEVICES_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
+CAMERA_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ProtectSwitchEntityDescription(
         key="ssh",
         name="SSH Enabled",
@@ -53,9 +53,6 @@ ALL_DEVICES_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
         ufp_value="is_ssh_enabled",
         ufp_set_method="set_ssh",
     ),
-)
-
-CAMERA_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ProtectSwitchEntityDescription(
         key="status_light",
         name="Status Light On",
@@ -223,6 +220,15 @@ SENSE_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
 
 LIGHT_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ProtectSwitchEntityDescription(
+        key="ssh",
+        name="SSH Enabled",
+        icon="mdi:lock",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="is_ssh_enabled",
+        ufp_set_method="set_ssh",
+    ),
+    ProtectSwitchEntityDescription(
         key="status_light",
         name="Status Light On",
         icon="mdi:led-on",
@@ -243,6 +249,18 @@ DOORLOCK_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ),
 )
 
+VIEWER_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
+    ProtectSwitchEntityDescription(
+        key="ssh",
+        name="SSH Enabled",
+        icon="mdi:lock",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="is_ssh_enabled",
+        ufp_set_method="set_ssh",
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -254,11 +272,11 @@ async def async_setup_entry(
     entities: list[ProtectDeviceEntity] = async_all_device_entities(
         data,
         ProtectSwitch,
-        all_descs=ALL_DEVICES_SWITCHES,
         camera_descs=CAMERA_SWITCHES,
         light_descs=LIGHT_SWITCHES,
         sense_descs=SENSE_SWITCHES,
         lock_descs=DOORLOCK_SWITCHES,
+        viewer_descs=VIEWER_SWITCHES,
     )
     async_add_entities(entities)
 

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -10,7 +10,6 @@ from pyunifiprotect.data.types import RecordingMode, SmartDetectObjectType, Vide
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.switch import (
-    ALL_DEVICES_SWITCHES,
     CAMERA_SWITCHES,
     LIGHT_SWITCHES,
     ProtectSwitchEntityDescription,
@@ -29,7 +28,9 @@ from .conftest import (
 CAMERA_SWITCHES_BASIC = [
     d
     for d in CAMERA_SWITCHES
-    if d.name != "Detections: Face" and d.name != "Detections: Package"
+    if d.name != "Detections: Face"
+    and d.name != "Detections: Package"
+    and d.name != "SSH Enabled"
 ]
 CAMERA_SWITCHES_NO_EXTRA = [
     d for d in CAMERA_SWITCHES_BASIC if d.name not in ("High FPS", "Privacy Mode")
@@ -215,7 +216,7 @@ async def test_switch_setup_light(
 
     entity_registry = er.async_get(hass)
 
-    description = LIGHT_SWITCHES[0]
+    description = LIGHT_SWITCHES[1]
 
     unique_id, entity_id = ids_from_device_description(
         Platform.SWITCH, light, description
@@ -230,7 +231,7 @@ async def test_switch_setup_light(
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    description = ALL_DEVICES_SWITCHES[0]
+    description = LIGHT_SWITCHES[0]
 
     unique_id = f"{light.id}_{description.key}"
     entity_id = f"switch.test_light_{description.name.lower().replace(' ', '_')}"
@@ -271,7 +272,7 @@ async def test_switch_setup_camera_all(
         assert state.state == STATE_OFF
         assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    description = ALL_DEVICES_SWITCHES[0]
+    description = CAMERA_SWITCHES[0]
 
     description_entity_name = (
         description.name.lower().replace(":", "").replace(" ", "_")
@@ -301,7 +302,7 @@ async def test_switch_setup_camera_none(
 
     entity_registry = er.async_get(hass)
 
-    for description in CAMERA_SWITCHES:
+    for description in CAMERA_SWITCHES_BASIC:
         if description.ufp_required_field is not None:
             continue
 
@@ -318,7 +319,7 @@ async def test_switch_setup_camera_none(
         assert state.state == STATE_OFF
         assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    description = ALL_DEVICES_SWITCHES[0]
+    description = CAMERA_SWITCHES[0]
 
     description_entity_name = (
         description.name.lower().replace(":", "").replace(" ", "_")
@@ -342,7 +343,7 @@ async def test_switch_setup_camera_none(
 async def test_switch_light_status(hass: HomeAssistant, light: Light):
     """Tests status light switch for lights."""
 
-    description = LIGHT_SWITCHES[0]
+    description = LIGHT_SWITCHES[1]
 
     light.__fields__["set_status_light"] = Mock()
     light.set_status_light = AsyncMock()
@@ -367,7 +368,7 @@ async def test_switch_camera_ssh(
 ):
     """Tests SSH switch for cameras."""
 
-    description = ALL_DEVICES_SWITCHES[0]
+    description = CAMERA_SWITCHES[0]
 
     camera.__fields__["set_ssh"] = Mock()
     camera.set_ssh = AsyncMock()
@@ -418,7 +419,7 @@ async def test_switch_camera_simple(
 async def test_switch_camera_highfps(hass: HomeAssistant, camera: Camera):
     """Tests High FPS switch for cameras."""
 
-    description = CAMERA_SWITCHES[2]
+    description = CAMERA_SWITCHES[3]
 
     camera.__fields__["set_video_mode"] = Mock()
     camera.set_video_mode = AsyncMock()
@@ -441,7 +442,7 @@ async def test_switch_camera_highfps(hass: HomeAssistant, camera: Camera):
 async def test_switch_camera_privacy(hass: HomeAssistant, camera: Camera):
     """Tests Privacy Mode switch for cameras."""
 
-    description = CAMERA_SWITCHES[3]
+    description = CAMERA_SWITCHES[4]
 
     camera.__fields__["set_privacy"] = Mock()
     camera.set_privacy = AsyncMock()
@@ -468,7 +469,7 @@ async def test_switch_camera_privacy_already_on(
 ):
     """Tests Privacy Mode switch for cameras with privacy mode defaulted on."""
 
-    description = CAMERA_SWITCHES[3]
+    description = CAMERA_SWITCHES[4]
 
     camera_privacy.__fields__["set_privacy"] = Mock()
     camera_privacy.set_privacy = AsyncMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While all UniFi Protect devices have a `is_ssh_enabled` property and it can toggled on all devices, only Linux/BusyBox based devices (Camera, Viewport and Flood Light) actually support SSH. Bluetooth based (Smart Sensor and Doorlock) and ESP Home based devices (Smart Chime) do not actually support SSH and `is_ssh_enabled` does nothing for the device. 

This restricts the SSH Enabled switch to only the devices it will actually work on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
