### PR TITLE
Use recorder db_url to determine default database for sql

### DIFF
--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -17,17 +17,17 @@ def remove_configured_db_url_if_not_needed(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
     """Remove db url from config if it matches recorder database."""
-    if entry.options[CONF_DB_URL] == get_instance(hass).db_url:
-        new_options = {**entry.options, **{CONF_DB_URL: None}}
-        hass.config_entries.async_update_entry(
-            entry,
-            options=new_options,
-        )
+    new_options = {**entry.options, **{CONF_DB_URL: None}}
+    hass.config_entries.async_update_entry(
+        entry,
+        options=new_options,
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SQL from a config entry."""
-    remove_configured_db_url_if_not_needed(hass, entry)
+    if entry.options[CONF_DB_URL] == get_instance(hass).db_url:
+        remove_configured_db_url_if_not_needed(hass, entry)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
 

--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -1,6 +1,7 @@
 """The sql component."""
 from __future__ import annotations
 
+from homeassistant.components.recorder import CONF_DB_URL, get_instance
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -12,8 +13,22 @@ async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+def remove_configured_db_url_if_not_needed(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Remove db url from config if it matches recorder database."""
+    if entry.options[CONF_DB_URL] == get_instance(hass).db_url:
+        new_options = {**entry.options, **{CONF_DB_URL: None}}
+        hass.config_entries.async_update_entry(
+            entry,
+            options=new_options,
+        )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SQL from a config entry."""
+    remove_configured_db_url_if_not_needed(hass, entry)
+
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -95,7 +95,7 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
 
-            db_url = user_input.get(CONF_DB_URL, None)
+            db_url = user_input.get(CONF_DB_URL)
             query = user_input[CONF_QUERY]
             column = user_input[CONF_COLUMN_NAME]
             uom = user_input.get(CONF_UNIT_OF_MEASUREMENT)
@@ -148,7 +148,7 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            db_url = user_input.get(CONF_DB_URL, None)
+            db_url = user_input.get(CONF_DB_URL)
             query = user_input[CONF_QUERY]
             column = user_input[CONF_COLUMN_NAME]
 

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import CONF_COLUMN_NAME, CONF_QUERIES, CONF_QUERY, DB_URL_RE, DOMAIN
+from .util import resolve_db_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,7 +95,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SQL sensor entry."""
 
-    db_url: str = entry.options[CONF_DB_URL]
+    db_url: str = resolve_db_url(hass, entry.options[CONF_DB_URL])
     name: str = entry.options[CONF_NAME]
     query_str: str = entry.options[CONF_QUERY]
     unit: str | None = entry.options.get(CONF_UNIT_OF_MEASUREMENT)

--- a/homeassistant/components/sql/util.py
+++ b/homeassistant/components/sql/util.py
@@ -1,0 +1,12 @@
+"""Utils for sql."""
+from __future__ import annotations
+
+from homeassistant.components.recorder import get_instance
+from homeassistant.core import HomeAssistant
+
+
+def resolve_db_url(hass: HomeAssistant, db_url: str) -> str:
+    """Return the db_url provided if not empty, otherwise return the recorder db_url."""
+    if bool(db_url and not db_url.isspace()):
+        return db_url
+    return get_instance(hass).db_url

--- a/homeassistant/components/sql/util.py
+++ b/homeassistant/components/sql/util.py
@@ -5,7 +5,7 @@ from homeassistant.components.recorder import get_instance
 from homeassistant.core import HomeAssistant
 
 
-def resolve_db_url(hass: HomeAssistant, db_url: str) -> str:
+def resolve_db_url(hass: HomeAssistant, db_url: str | None) -> str | None:
     """Return the db_url provided if not empty, otherwise return the recorder db_url."""
     if bool(db_url and not db_url.isspace()):
         return db_url

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -238,8 +238,9 @@ async def test_options_flow_name_previously_removed(hass: HomeAssistant) -> None
     )
     entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -222,7 +222,9 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     }
 
 
-async def test_options_flow_name_previously_removed(hass: HomeAssistant) -> None:
+async def test_options_flow_name_previously_removed(
+    hass: HomeAssistant, recorder_mock
+) -> None:
     """Test options config flow where the name was missing."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -238,9 +240,8 @@ async def test_options_flow_name_previously_removed(hass: HomeAssistant) -> None
     )
     entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -1,6 +1,4 @@
 """Test for SQL component Init."""
-from unittest.mock import patch
-
 from homeassistant import config_entries
 from homeassistant.components.recorder import get_instance
 from homeassistant.core import HomeAssistant
@@ -8,17 +6,15 @@ from homeassistant.core import HomeAssistant
 from . import init_integration
 
 
-async def test_setup_entry(hass: HomeAssistant) -> None:
+async def test_setup_entry(hass: HomeAssistant, recorder_mock) -> None:
     """Test setup entry."""
-    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
-        config_entry = await init_integration(hass)
+    config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_unload_entry(hass: HomeAssistant) -> None:
+async def test_unload_entry(hass: HomeAssistant, recorder_mock) -> None:
     """Test unload an entry."""
-    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
-        config_entry = await init_integration(hass)
+    config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -1,5 +1,8 @@
 """Test for SQL component Init."""
+from unittest.mock import patch
+
 from homeassistant import config_entries
+from homeassistant.components.recorder import get_instance
 from homeassistant.core import HomeAssistant
 
 from . import init_integration
@@ -7,15 +10,55 @@ from . import init_integration
 
 async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setup entry."""
-    config_entry = await init_integration(hass)
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unload an entry."""
-    config_entry = await init_integration(hass)
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+
+async def test_remove_configured_db_url_if_not_needed_when_not_needed(
+    hass: HomeAssistant,
+    recorder_mock,
+):
+    """Test configured db_url is replaced with None if matching the recorder db."""
+    recorder_db_url = get_instance(hass).db_url
+
+    config = {
+        "db_url": recorder_db_url,
+        "query": "SELECT 5 as value",
+        "column": "value",
+        "name": "count_tables",
+    }
+
+    config_entry = await init_integration(hass, config)
+
+    assert config_entry.options.get("db_url") is None
+
+
+async def test_remove_configured_db_url_if_not_needed_when_needed(
+    hass: HomeAssistant,
+    recorder_mock,
+):
+    """Test configured db_url is not replaced if it differs from the recorder db."""
+    db_url = "mssql://"
+
+    config = {
+        "db_url": db_url,
+        "query": "SELECT 5 as value",
+        "column": "value",
+        "name": "count_tables",
+    }
+
+    config_entry = await init_integration(hass, config)
+
+    assert config_entry.options.get("db_url") == db_url

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -24,7 +24,9 @@ async def test_query(hass: HomeAssistant) -> None:
         "column": "value",
         "name": "Select value SQL query",
     }
-    await init_integration(hass, config)
+
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        await init_integration(hass, config)
 
     state = hass.states.get("sensor.select_value_sql_query")
     assert state.state == "5"
@@ -64,7 +66,9 @@ async def test_query_value_template(hass: HomeAssistant) -> None:
         "name": "count_tables",
         "value_template": "{{ value | int }}",
     }
-    await init_integration(hass, config)
+
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        await init_integration(hass, config)
 
     state = hass.states.get("sensor.count_tables")
     assert state.state == "5"
@@ -79,7 +83,9 @@ async def test_query_value_template_invalid(hass: HomeAssistant) -> None:
         "name": "count_tables",
         "value_template": "{{ value | dontwork }}",
     }
-    await init_integration(hass, config)
+
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        await init_integration(hass, config)
 
     state = hass.states.get("sensor.count_tables")
     assert state.state == "5.01"
@@ -93,7 +99,9 @@ async def test_query_limit(hass: HomeAssistant) -> None:
         "column": "value",
         "name": "Select value SQL query",
     }
-    await init_integration(hass, config)
+
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        await init_integration(hass, config)
 
     state = hass.states.get("sensor.select_value_sql_query")
     assert state.state == "5"
@@ -110,7 +118,9 @@ async def test_query_no_value(
         "column": "value",
         "name": "count_tables",
     }
-    await init_integration(hass, config)
+
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        await init_integration(hass, config)
 
     state = hass.states.get("sensor.count_tables")
     assert state.state == STATE_UNKNOWN
@@ -132,7 +142,7 @@ async def test_query_mssql_no_result(
     with patch("homeassistant.components.sql.sensor.sqlalchemy"), patch(
         "homeassistant.components.sql.sensor.sqlalchemy.text",
         return_value="SELECT TOP 1 5 as value where 1=2",
-    ):
+    ), patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
         await init_integration(hass, config)
 
     state = hass.states.get("sensor.count_tables")
@@ -184,7 +194,7 @@ async def test_invalid_url_setup(
     with patch(
         "homeassistant.components.sql.sensor.sqlalchemy.create_engine",
         side_effect=SQLAlchemyError(url),
-    ):
+    ), patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -215,8 +225,9 @@ async def test_invalid_url_on_update(
 
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.sql.remove_configured_db_url_if_not_needed"):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.sql.sensor.sqlalchemy.engine.cursor.CursorResult",

--- a/tests/components/sql/test_util.py
+++ b/tests/components/sql/test_util.py
@@ -1,0 +1,20 @@
+"""Test the sql utils."""
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.sql.util import resolve_db_url
+from homeassistant.core import HomeAssistant
+
+
+async def test_resolve_db_url_when_none_configured(hass: HomeAssistant, recorder_mock):
+    """Test return recorder db_url if provided db_url is None."""
+    db_url = None
+    resolved_url = resolve_db_url(hass, db_url)
+
+    assert resolved_url == get_instance(hass).db_url
+
+
+async def test_resolve_db_url_when_configured(hass: HomeAssistant):
+    """Test return provided db_url if it's set."""
+    db_url = "mssql://"
+    resolved_url = resolve_db_url(hass, db_url)
+
+    assert resolved_url == db_url


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When saving the sql integration configuration via the configuration flow and the database URL field is empty, the connection string to the HA database must be used. However, even when HA has a different database configured the default SQLite database path is picked. This causes the error "SQL Query invalid". 

- The db url field is always optional now.
- If config has no db url, the entity will get the recorder db url on sensor platform setup. 
- For existing sql integrations: on setup entry it checks if the configured db url matches the actual recorder one. If so, the config value is updated to None.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
