### PR TITLE
Improve tests of devolo_home_network

### DIFF
--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -33,7 +33,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant):
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_device")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_device")
 async def test_update_attached_to_router(hass: HomeAssistant):
     """Test state change of a attached_to_router binary sensor device."""
     state_key = f"{DOMAIN}.{CONNECTED_TO_ROUTER}"
@@ -42,12 +42,6 @@ async def test_update_attached_to_router(hass: HomeAssistant):
     er = entity_registry.async_get(hass)
 
     await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Enable entity
-    er.async_update_entity(state_key, disabled_by=None)
-    await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)

--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -21,7 +21,7 @@ from .const import PLCNET_ATTACHED
 from tests.common import async_fire_time_changed
 
 
-@pytest.mark.usefixtures("mock_device", "mock_zeroconf")
+@pytest.mark.usefixtures("mock_device")
 async def test_binary_sensor_setup(hass: HomeAssistant):
     """Test default setup of the binary sensor component."""
     entry = configure_integration(hass)
@@ -33,7 +33,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant):
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_device", "mock_zeroconf")
+@pytest.mark.usefixtures("mock_device")
 async def test_update_attached_to_router(hass: HomeAssistant):
     """Test state change of a attached_to_router binary sensor device."""
     state_key = f"{DOMAIN}.{CONNECTED_TO_ROUTER}"

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -71,17 +71,13 @@ async def test_update_connected_wifi_clients(hass: HomeAssistant):
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_device")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_device")
 async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
     """Test state change of a neighboring_wifi_networks sensor device."""
     state_key = f"{DOMAIN}.neighboring_wifi_networks"
     entry = configure_integration(hass)
     er = entity_registry.async_get(hass)
     await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    er.async_update_entity(state_key, disabled_by=None)
-    await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -112,17 +108,13 @@ async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_device")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_device")
 async def test_update_connected_plc_devices(hass: HomeAssistant):
     """Test state change of a connected_plc_devices sensor device."""
     state_key = f"{DOMAIN}.connected_plc_devices"
     entry = configure_integration(hass)
     er = entity_registry.async_get(hass)
     await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    er.async_update_entity(state_key, disabled_by=None)
-    await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -21,7 +21,6 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_sensor_setup(hass: HomeAssistant):
     """Test default setup of the sensor component."""
     entry = configure_integration(hass)
@@ -36,7 +35,6 @@ async def test_sensor_setup(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_device")
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_update_connected_wifi_clients(hass: HomeAssistant):
     """Test state change of a connected_wifi_clients sensor device."""
     state_key = f"{DOMAIN}.connected_wifi_clients"
@@ -74,84 +72,82 @@ async def test_update_connected_wifi_clients(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_device")
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
     """Test state change of a neighboring_wifi_networks sensor device."""
     state_key = f"{DOMAIN}.neighboring_wifi_networks"
     entry = configure_integration(hass)
+    er = entity_registry.async_get(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    er.async_update_entity(state_key, disabled_by=None)
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == "1"
+    assert er.async_get(state_key).entity_category is EntityCategory.DIAGNOSTIC
+
+    # Emulate device failure
     with patch(
-        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-        return_value=True,
+        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_get_wifi_neighbor_access_points",
+        side_effect=DeviceUnavailable,
     ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == "1"
-
-        er = entity_registry.async_get(hass)
-        assert er.async_get(state_key).entity_category is EntityCategory.DIAGNOSTIC
-
-        # Emulate device failure
-        with patch(
-            "devolo_plc_api.device_api.deviceapi.DeviceApi.async_get_wifi_neighbor_access_points",
-            side_effect=DeviceUnavailable,
-        ):
-            async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
-            await hass.async_block_till_done()
-
-            state = hass.states.get(state_key)
-            assert state is not None
-            assert state.state == STATE_UNAVAILABLE
-
-        # Emulate state change
         async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
         state = hass.states.get(state_key)
         assert state is not None
-        assert state.state == "1"
+        assert state.state == STATE_UNAVAILABLE
 
-        await hass.config_entries.async_unload(entry.entry_id)
+    # Emulate state change
+    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == "1"
+
+    await hass.config_entries.async_unload(entry.entry_id)
 
 
 @pytest.mark.usefixtures("mock_device")
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_update_connected_plc_devices(hass: HomeAssistant):
     """Test state change of a connected_plc_devices sensor device."""
     state_key = f"{DOMAIN}.connected_plc_devices"
     entry = configure_integration(hass)
+    er = entity_registry.async_get(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    er.async_update_entity(state_key, disabled_by=None)
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == "1"
+    assert er.async_get(state_key).entity_category is EntityCategory.DIAGNOSTIC
+
+    # Emulate device failure
     with patch(
-        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-        return_value=True,
+        "devolo_plc_api.plcnet_api.plcnetapi.PlcNetApi.async_get_network_overview",
+        side_effect=DeviceUnavailable,
     ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == "1"
-
-        er = entity_registry.async_get(hass)
-        assert er.async_get(state_key).entity_category is EntityCategory.DIAGNOSTIC
-
-        # Emulate device failure
-        with patch(
-            "devolo_plc_api.plcnet_api.plcnetapi.PlcNetApi.async_get_network_overview",
-            side_effect=DeviceUnavailable,
-        ):
-            async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
-            await hass.async_block_till_done()
-
-            state = hass.states.get(state_key)
-            assert state is not None
-            assert state.state == STATE_UNAVAILABLE
-
-        # Emulate state change
         async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
         state = hass.states.get(state_key)
         assert state is not None
-        assert state.state == "1"
+        assert state.state == STATE_UNAVAILABLE
 
-        await hass.config_entries.async_unload(entry.entry_id)
+    # Emulate state change
+    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == "1"
+
+    await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The review of  #60301 showed a few nice improvements to the tests that I want to apply to the existing platform, too. Additionally,  #59932 added an autouse fixture for zeroconf, so that there is no need to mark each test individually.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
