### PR TITLE
Exclude last_changed when same as last_updated for history websocket api

### DIFF
--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -19,7 +19,7 @@ from sqlalchemy.sql.expression import literal
 
 from homeassistant.components import recorder
 from homeassistant.components.websocket_api.const import (
-    COMPRESSED_STATE_LAST_CHANGED,
+    COMPRESSED_STATE_LAST_UPDATED,
     COMPRESSED_STATE_STATE,
 )
 from homeassistant.core import HomeAssistant, State, split_entity_id
@@ -662,12 +662,12 @@ def _sorted_states_to_dict(
         _process_timestamp: Callable[
             [datetime], float | str
         ] = process_datetime_to_timestamp
-        attr_last_changed = COMPRESSED_STATE_LAST_CHANGED
+        attr_time = COMPRESSED_STATE_LAST_UPDATED
         attr_state = COMPRESSED_STATE_STATE
     else:
         state_class = LazyState  # type: ignore[assignment]
         _process_timestamp = process_timestamp_to_utc_isoformat
-        attr_last_changed = LAST_CHANGED_KEY
+        attr_time = LAST_CHANGED_KEY
         attr_state = STATE_KEY
 
     result: dict[str, list[State | dict[str, Any]]] = defaultdict(list)
@@ -742,7 +742,7 @@ def _sorted_states_to_dict(
                     #
                     # We use last_updated for for last_changed since its the same
                     #
-                    attr_last_changed: _process_timestamp(row.last_updated),
+                    attr_time: _process_timestamp(row.last_updated),
                 }
             )
             prev_state = state

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -798,23 +798,21 @@ def row_to_compressed_state(
     start_time: datetime | None = None,
 ) -> dict[str, Any]:
     """Convert a database row to a compressed state."""
-    if start_time:
-        last_changed = last_updated = start_time.timestamp()
-    else:
-        row_last_updated: datetime = row.last_updated
-        if (
-            not (row_changed_changed := row.last_changed)
-            or row_last_updated == row_changed_changed
-        ):
-            last_changed = last_updated = process_datetime_to_timestamp(
-                row_last_updated
-            )
-        else:
-            last_changed = process_datetime_to_timestamp(row_changed_changed)
-            last_updated = process_datetime_to_timestamp(row_last_updated)
-    return {
+    comp_state = {
         COMPRESSED_STATE_STATE: row.state,
         COMPRESSED_STATE_ATTRIBUTES: decode_attributes_from_row(row, attr_cache),
-        COMPRESSED_STATE_LAST_CHANGED: last_changed,
-        COMPRESSED_STATE_LAST_UPDATED: last_updated,
     }
+    if start_time:
+        comp_state[COMPRESSED_STATE_LAST_UPDATED] = start_time.timestamp()
+    else:
+        row_last_updated: datetime = row.last_updated
+        comp_state[COMPRESSED_STATE_LAST_UPDATED] = process_datetime_to_timestamp(
+            row_last_updated
+        )
+        if (
+            row_changed_changed := row.last_changed
+        ) and row_last_updated != row_changed_changed:
+            comp_state[COMPRESSED_STATE_LAST_CHANGED] = process_datetime_to_timestamp(
+                row_changed_changed
+            )
+    return comp_state

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -1133,11 +1133,12 @@ async def test_history_during_period(hass, hass_ws_client, recorder_mock):
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {}
     assert isinstance(sensor_test_history[0]["lu"], float)
-    assert isinstance(sensor_test_history[0]["lc"], float)
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
     assert "a" not in sensor_test_history[1]
     assert sensor_test_history[1]["s"] == "off"
-    assert isinstance(sensor_test_history[1]["lc"], float)
+    assert isinstance(sensor_test_history[1]["lu"], float)
+    assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[2]["s"] == "on"
     assert sensor_test_history[2]["a"] == {}
@@ -1163,10 +1164,11 @@ async def test_history_during_period(hass, hass_ws_client, recorder_mock):
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {"any": "attr"}
     assert isinstance(sensor_test_history[0]["lu"], float)
-    assert isinstance(sensor_test_history[0]["lc"], float)
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[1]["s"] == "off"
-    assert isinstance(sensor_test_history[1]["lc"], float)
+    assert isinstance(sensor_test_history[1]["lu"], float)
+    assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
     assert sensor_test_history[1]["a"] == {"any": "attr"}
 
     assert sensor_test_history[4]["s"] == "on"
@@ -1193,10 +1195,11 @@ async def test_history_during_period(hass, hass_ws_client, recorder_mock):
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {"any": "attr"}
     assert isinstance(sensor_test_history[0]["lu"], float)
-    assert isinstance(sensor_test_history[0]["lc"], float)
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[1]["s"] == "off"
-    assert isinstance(sensor_test_history[1]["lc"], float)
+    assert isinstance(sensor_test_history[1]["lu"], float)
+    assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
     assert sensor_test_history[1]["a"] == {"any": "attr"}
 
     assert sensor_test_history[2]["s"] == "on"
@@ -1331,11 +1334,11 @@ async def test_history_during_period_significant_domain(
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {}
     assert isinstance(sensor_test_history[0]["lu"], float)
-    assert isinstance(sensor_test_history[0]["lc"], float)
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
     assert "a" in sensor_test_history[1]
     assert sensor_test_history[1]["s"] == "off"
-    assert isinstance(sensor_test_history[1]["lc"], float)
+    assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[4]["s"] == "on"
     assert sensor_test_history[4]["a"] == {}
@@ -1361,10 +1364,11 @@ async def test_history_during_period_significant_domain(
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {"temperature": "1"}
     assert isinstance(sensor_test_history[0]["lu"], float)
-    assert isinstance(sensor_test_history[0]["lc"], float)
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[1]["s"] == "off"
-    assert isinstance(sensor_test_history[1]["lc"], float)
+    assert isinstance(sensor_test_history[1]["lu"], float)
+    assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
     assert sensor_test_history[1]["a"] == {"temperature": "2"}
 
     assert sensor_test_history[4]["s"] == "on"
@@ -1391,10 +1395,11 @@ async def test_history_during_period_significant_domain(
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {"temperature": "1"}
     assert isinstance(sensor_test_history[0]["lu"], float)
-    assert isinstance(sensor_test_history[0]["lc"], float)
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[1]["s"] == "off"
-    assert isinstance(sensor_test_history[1]["lc"], float)
+    assert isinstance(sensor_test_history[1]["lu"], float)
+    assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
     assert sensor_test_history[1]["a"] == {"temperature": "2"}
 
     assert sensor_test_history[2]["s"] == "off"
@@ -1429,7 +1434,7 @@ async def test_history_during_period_significant_domain(
     assert sensor_test_history[0]["s"] == "on"
     assert sensor_test_history[0]["a"] == {"temperature": "5"}
     assert sensor_test_history[0]["lu"] == later.timestamp()
-    assert sensor_test_history[0]["lc"] == later.timestamp()
+    assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
 
 async def test_history_during_period_bad_start_time(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Suggested here https://github.com/home-assistant/core/pull/71843#pullrequestreview-973093343

- The last_changed (lc) field is no longer sent
  when its the same as the last_updated (lu) field

Not a breaking change since the history websocket api is only in dev

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
