### PR TITLE
Add back description and location to calendar endpoint

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -341,6 +341,8 @@ class CalendarEventView(http.HomeAssistantView):
             [
                 {
                     "summary": event.summary,
+                    "description": event.description,
+                    "location": event.location,
                     "start": _get_api_date(event.start),
                     "end": _get_api_date(event.end),
                 }

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -39,6 +39,8 @@ def calendar_data_future() -> CalendarEvent:
         start=one_hour_from_now,
         end=one_hour_from_now + datetime.timedelta(minutes=60),
         summary="Future Event",
+        description="Future Description",
+        location="Future Location",
     )
 
 

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -90,6 +90,8 @@ class LegacyDemoCalendar(CalendarEventDevice):
                 ).isoformat()
             },
             "summary": "Future Event",
+            "description": "Future Description",
+            "location": "Future Location",
         }
 
     @property

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -937,5 +937,7 @@ async def test_get_events_custom_calendars(hass, calendar, get_api_events):
             "end": {"dateTime": "2017-11-27T10:00:00-08:00"},
             "start": {"dateTime": "2017-11-27T09:00:00-08:00"},
             "summary": "This is a normal event",
+            "location": "Hamburg",
+            "description": "Surprisingly rainy",
         }
     ]

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -57,3 +57,5 @@ async def test_events_http_api_shim(hass, hass_client):
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert events[0]["summary"] == "Future Event"
+    assert events[0]["description"] == "Future Description"
+    assert events[0]["location"] == "Future Location"

--- a/tests/components/twentemilieu/test_calendar.py
+++ b/tests/components/twentemilieu/test_calendar.py
@@ -79,4 +79,6 @@ async def test_api_events(
         "start": {"date": "2022-01-06"},
         "end": {"date": "2022-01-06"},
         "summary": "Christmas Tree Pickup",
+        "description": None,
+        "location": None,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/home-assistant/core/pull/68843 has removed most of the properties from the calendar API, including the description and location of the event.

While this change was good to conform to what frontend displays at the moment, it also broke many other use cases of this API.

As far as I'm aware, this API is the only way at the moment to query list of the future calendar events. Several of my automations depend on that (such as scheduling various things in the morning depending on my calendar throughout the day). However, removal of most of the properties broke those integrations.

This PR adds back description and location to the calendar API, un-breaking it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/68843 https://github.com/home-assistant/core/issues/71581
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1332

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository. (# 71838 and # 71837. They are tiny PRs like mine, so If figure it is only fair)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
