### PR TITLE
Reduce logbook websocket payload size and parse json attributes via the DBM

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -40,7 +40,6 @@ from homeassistant.const import (
     ATTR_SERVICE,
     EVENT_CALL_SERVICE,
     EVENT_LOGBOOK_ENTRY,
-    EVENT_STATE_CHANGED,
 )
 from homeassistant.core import (
     Context,
@@ -65,14 +64,12 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util
 
-from .queries import statement_for_request
+from .queries import PSUEDO_EVENT_STATE_CHANGED, statement_for_request
 
 _LOGGER = logging.getLogger(__name__)
 
-FRIENDLY_NAME_JSON_EXTRACT = re.compile('"friendly_name": ?"([^"]+)"')
 ENTITY_ID_JSON_EXTRACT = re.compile('"entity_id": ?"([^"]+)"')
 DOMAIN_JSON_EXTRACT = re.compile('"domain": ?"([^"]+)"')
-ICON_JSON_EXTRACT = re.compile('"icon": ?"([^"]+)"')
 ATTR_MESSAGE = "message"
 
 DOMAIN = "logbook"
@@ -235,6 +232,7 @@ def _ws_formatted_get_events(
                 entities_filter,
                 context_id,
                 True,
+                False,
             ),
         )
     )
@@ -368,6 +366,7 @@ class LogbookView(HomeAssistantView):
                     self.entities_filter,
                     context_id,
                     False,
+                    True,
                 )
             )
 
@@ -385,6 +384,7 @@ def _humanify(
     ],
     entity_name_cache: EntityNameCache,
     format_time: Callable[[Row], Any],
+    include_entity_name: bool = True,
 ) -> Generator[dict[str, Any], None, None]:
     """Generate a converted list of events into entries."""
     # Continuous sensors, will be excluded from the logbook
@@ -419,13 +419,13 @@ def _humanify(
             continue
         event_type = row.event_type
         if event_type == EVENT_CALL_SERVICE or (
-            event_type != EVENT_STATE_CHANGED
+            event_type is not PSUEDO_EVENT_STATE_CHANGED
             and entities_filter is not None
             and not _keep_row(row, event_type)
         ):
             continue
 
-        if event_type == EVENT_STATE_CHANGED:
+        if event_type == PSUEDO_EVENT_STATE_CHANGED:
             entity_id = row.entity_id
             assert entity_id is not None
             # Skip continuous sensors
@@ -439,14 +439,15 @@ def _humanify(
 
             data = {
                 LOGBOOK_ENTRY_WHEN: format_time(row),
-                LOGBOOK_ENTRY_NAME: entity_name_cache.get(entity_id, row),
                 LOGBOOK_ENTRY_STATE: row.state,
                 LOGBOOK_ENTRY_ENTITY_ID: entity_id,
             }
-            if icon := _row_attributes_extract(row, ICON_JSON_EXTRACT):
+            if include_entity_name:
+                data[LOGBOOK_ENTRY_NAME] = entity_name_cache.get(entity_id, row)
+            if icon := row.icon:
                 data[LOGBOOK_ENTRY_ICON] = icon
 
-            context_augmenter.augment(data, row, context_id)
+            context_augmenter.augment(data, row, context_id, include_entity_name)
             yield data
 
         elif event_type in external_events:
@@ -454,7 +455,7 @@ def _humanify(
             data = describe_event(event_cache.get(row))
             data[LOGBOOK_ENTRY_WHEN] = format_time(row)
             data[LOGBOOK_ENTRY_DOMAIN] = domain
-            context_augmenter.augment(data, row, context_id)
+            context_augmenter.augment(data, row, context_id, include_entity_name)
             yield data
 
         elif event_type == EVENT_LOGBOOK_ENTRY:
@@ -474,7 +475,7 @@ def _humanify(
                 LOGBOOK_ENTRY_DOMAIN: entry_domain,
                 LOGBOOK_ENTRY_ENTITY_ID: entry_entity_id,
             }
-            context_augmenter.augment(data, row, context_id)
+            context_augmenter.augment(data, row, context_id, include_entity_name)
             yield data
 
 
@@ -487,6 +488,7 @@ def _get_events(
     entities_filter: EntityFilter | Callable[[str], bool] | None = None,
     context_id: str | None = None,
     timestamp: bool = False,
+    include_entity_name: bool = True,
 ) -> list[dict[str, Any]]:
     """Get events for a period of time."""
     assert not (
@@ -540,6 +542,7 @@ def _get_events(
                 external_events,
                 entity_name_cache,
                 format_time,
+                include_entity_name,
             )
         )
 
@@ -562,7 +565,9 @@ class ContextAugmenter:
         self.external_events = external_events
         self.event_cache = event_cache
 
-    def augment(self, data: dict[str, Any], row: Row, context_id: str) -> None:
+    def augment(
+        self, data: dict[str, Any], row: Row, context_id: str, include_entity_name: bool
+    ) -> None:
         """Augment data from the row and cache."""
         if context_user_id := row.context_user_id:
             data[CONTEXT_USER_ID] = context_user_id
@@ -589,9 +594,10 @@ class ContextAugmenter:
         # State change
         if context_entity_id := context_row.entity_id:
             data[CONTEXT_ENTITY_ID] = context_entity_id
-            data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
-                context_entity_id, context_row
-            )
+            if include_entity_name:
+                data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
+                    context_entity_id, context_row
+                )
             data[CONTEXT_EVENT_TYPE] = event_type
             return
 
@@ -619,9 +625,10 @@ class ContextAugmenter:
         if not (attr_entity_id := described.get(ATTR_ENTITY_ID)):
             return
         data[CONTEXT_ENTITY_ID] = attr_entity_id
-        data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
-            attr_entity_id, context_row
-        )
+        if include_entity_name:
+            data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
+                attr_entity_id, context_row
+            )
 
 
 def _is_sensor_continuous(ent_reg: er.EntityRegistry, entity_id: str) -> bool:
@@ -735,7 +742,7 @@ class EntityNameCache:
             friendly_name := current_state.attributes.get(ATTR_FRIENDLY_NAME)
         ):
             self._names[entity_id] = friendly_name
-        elif extracted_name := _row_attributes_extract(row, FRIENDLY_NAME_JSON_EXTRACT):
+        elif extracted_name := row.friendly_name:
             self._names[entity_id] = extracted_name
         else:
             return split_entity_id(entity_id)[1].replace("_", " ")

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -742,8 +742,6 @@ class EntityNameCache:
             friendly_name := current_state.attributes.get(ATTR_FRIENDLY_NAME)
         ):
             self._names[entity_id] = friendly_name
-        elif extracted_name := row.friendly_name:
-            self._names[entity_id] = extracted_name
         else:
             return split_entity_id(entity_id)[1].replace("_", " ")
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -444,7 +444,7 @@ def _humanify(
             }
             if include_entity_name:
                 data[LOGBOOK_ENTRY_NAME] = entity_name_cache.get(entity_id, row)
-            if icon := row.icon:
+            if icon := row.icon or row.old_format_icon:
                 data[LOGBOOK_ENTRY_ICON] = icon
 
             context_augmenter.augment(data, row, context_id, include_entity_name)

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -425,7 +425,7 @@ def _humanify(
         ):
             continue
 
-        if event_type == PSUEDO_EVENT_STATE_CHANGED:
+        if event_type is PSUEDO_EVENT_STATE_CHANGED:
             entity_id = row.entity_id
             assert entity_id is not None
             # Skip continuous sensors

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -336,6 +336,10 @@ def _select_states() -> Select:
     """Generate a states select that formats the states table as event rows."""
     return select(
         literal(value=None, type_=sqlalchemy.Text).label("event_id"),
+        # We use PSUEDO_EVENT_STATE_CHANGED aka None for
+        # state_changed events since it takes up less
+        # space in the response and every row has to be
+        # marked with the event_type
         literal(value=PSUEDO_EVENT_STATE_CHANGED, type_=sqlalchemy.String).label(
             "event_type"
         ),

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -34,6 +34,7 @@ UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 
 OLD_STATE = aliased(States, name="old_state")
 SHARED_ATTRS_JSON = type_coerce(StateAttributes.shared_attrs, JSON(none_as_null=True))
+OLD_FORMAT_ATTRS_JSON = type_coerce(States.attributes, JSON(none_as_null=True))
 
 PSUEDO_EVENT_STATE_CHANGED = None
 # Since we don't store event_types and None
@@ -58,6 +59,7 @@ STATE_COLUMNS = (
     States.state.label("state"),
     States.entity_id.label("entity_id"),
     SHARED_ATTRS_JSON["icon"].as_string().label("icon"),
+    OLD_FORMAT_ATTRS_JSON["icon"].as_string().label("old_format_icon"),
 )
 
 
@@ -66,6 +68,7 @@ EMPTY_STATE_COLUMNS = (
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
     literal(value=None, type_=sqlalchemy.String).label("icon"),
+    literal(value=None, type_=sqlalchemy.String).label("old_format_icon"),
 )
 
 

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from datetime import datetime as dt
 
 import sqlalchemy
-from sqlalchemy import lambda_stmt, select, union_all
+from sqlalchemy import JSON, lambda_stmt, select, type_coerce, union_all
 from sqlalchemy.orm import Query, aliased
 from sqlalchemy.sql.elements import ClauseList
 from sqlalchemy.sql.expression import literal
@@ -23,7 +23,6 @@ from homeassistant.components.recorder.models import (
     States,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import EVENT_STATE_CHANGED
 
 ENTITY_ID_JSON_TEMPLATE = '%"entity_id":"{}"%'
 
@@ -34,7 +33,15 @@ UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
 UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 
 OLD_STATE = aliased(States, name="old_state")
+SHARED_ATTRS_JSON = type_coerce(StateAttributes.shared_attrs, JSON(none_as_null=True))
 
+PSUEDO_EVENT_STATE_CHANGED = None
+# Since we don't store event_types and None
+# and we don't store state_changed in events
+# we use a NULL for state_changed events
+# when we synthesize them from the states table
+# since it avoids another column being sent
+# in the payload
 
 EVENT_COLUMNS = (
     Events.event_id.label("event_id"),
@@ -50,17 +57,17 @@ STATE_COLUMNS = (
     States.state_id.label("state_id"),
     States.state.label("state"),
     States.entity_id.label("entity_id"),
-    States.attributes.label("attributes"),
-    StateAttributes.shared_attrs.label("shared_attrs"),
+    SHARED_ATTRS_JSON["icon"].as_string().label("icon"),
 )
+
 
 EMPTY_STATE_COLUMNS = (
     literal(value=None, type_=sqlalchemy.String).label("state_id"),
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
-    literal(value=None, type_=sqlalchemy.Text).label("attributes"),
-    literal(value=None, type_=sqlalchemy.Text).label("shared_attrs"),
+    literal(value=None, type_=sqlalchemy.String).label("icon"),
 )
+
 
 EVENT_ROWS_NO_STATES = (
     *EVENT_COLUMNS,
@@ -326,7 +333,9 @@ def _select_states() -> Select:
     """Generate a states select that formats the states table as event rows."""
     return select(
         literal(value=None, type_=sqlalchemy.Text).label("event_id"),
-        literal(value=EVENT_STATE_CHANGED, type_=sqlalchemy.String).label("event_type"),
+        literal(value=PSUEDO_EVENT_STATE_CHANGED, type_=sqlalchemy.String).label(
+            "event_type"
+        ),
         literal(value=None, type_=sqlalchemy.Text).label("event_data"),
         States.last_updated.label("time_fired"),
         States.context_id.label("context_id"),

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from datetime import datetime as dt
 
 import sqlalchemy
-from sqlalchemy import JSON, lambda_stmt, select, type_coerce, union_all
+from sqlalchemy import JSON, Text, lambda_stmt, select, type_coerce, union_all
 from sqlalchemy.orm import Query, aliased
 from sqlalchemy.sql.elements import ClauseList
 from sqlalchemy.sql.expression import literal
@@ -33,8 +33,18 @@ UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
 UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 
 OLD_STATE = aliased(States, name="old_state")
-SHARED_ATTRS_JSON = type_coerce(StateAttributes.shared_attrs, JSON(none_as_null=True))
-OLD_FORMAT_ATTRS_JSON = type_coerce(States.attributes, JSON(none_as_null=True))
+
+JSON_VARIENT_CAST = Text().with_variant(
+    type_=JSON(none_as_null=True), dialect_name="postgresql"
+)
+
+SHARED_ATTRS_JSON = type_coerce(
+    StateAttributes.shared_attrs.cast(JSON_VARIENT_CAST), JSON(none_as_null=True)
+)
+OLD_FORMAT_ATTRS_JSON = type_coerce(
+    States.attributes.cast(JSON_VARIENT_CAST), JSON(none_as_null=True)
+)
+
 
 PSUEDO_EVENT_STATE_CHANGED = None
 # Since we don't store event_types and None

--- a/homeassistant/components/logbook/queries.py
+++ b/homeassistant/components/logbook/queries.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from datetime import datetime as dt
 
 import sqlalchemy
-from sqlalchemy import JSON, Text, lambda_stmt, select, type_coerce, union_all
+from sqlalchemy import JSON, lambda_stmt, select, type_coerce, union_all
 from sqlalchemy.orm import Query, aliased
 from sqlalchemy.sql.elements import ClauseList
 from sqlalchemy.sql.expression import literal
@@ -16,6 +16,7 @@ from homeassistant.components.proximity import DOMAIN as PROXIMITY_DOMAIN
 from homeassistant.components.recorder.filters import Filters
 from homeassistant.components.recorder.models import (
     ENTITY_ID_LAST_UPDATED_INDEX,
+    JSON_VARIENT_CAST,
     LAST_UPDATED_INDEX,
     EventData,
     Events,
@@ -34,9 +35,6 @@ UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 
 OLD_STATE = aliased(States, name="old_state")
 
-JSON_VARIENT_CAST = Text().with_variant(
-    type_=JSON(none_as_null=True), dialect_name="postgresql"
-)
 
 SHARED_ATTRS_JSON = type_coerce(
     StateAttributes.shared_attrs.cast(JSON_VARIENT_CAST), JSON(none_as_null=True)

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -102,6 +102,11 @@ class FAST_PYSQLITE_DATETIME(sqlite.DATETIME):  # type: ignore[misc]
         return lambda value: None if value is None else ciso8601.parse_datetime(value)
 
 
+JSON_VARIENT_CAST = (
+    Text()
+    .with_variant(postgresql.JSON(none_as_null=True), "postgresql")
+    .with_variant(mysql.LONGTEXT, "mysql")
+)
 DATETIME_TYPE = (
     DateTime(timezone=True)
     .with_variant(mysql.DATETIME(timezone=True, fsp=6), "mysql")

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -102,10 +102,8 @@ class FAST_PYSQLITE_DATETIME(sqlite.DATETIME):  # type: ignore[misc]
         return lambda value: None if value is None else ciso8601.parse_datetime(value)
 
 
-JSON_VARIENT_CAST = (
-    Text()
-    .with_variant(postgresql.JSON(none_as_null=True), "postgresql")
-    .with_variant(mysql.LONGTEXT, "mysql")
+JSON_VARIENT_CAST = Text().with_variant(
+    postgresql.JSON(none_as_null=True), "postgresql"
 )
 DATETIME_TYPE = (
     DateTime(timezone=True)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -338,6 +338,8 @@ def create_state_changed_event_from_old_new(
     row.domain = entity_id and ha.split_entity_id(entity_id)[0]
     row.context_only = False
     row.context_id = None
+    row.friendly_name = None
+    row.icon = None
     row.context_user_id = None
     row.context_parent_id = None
     row.old_state_id = old_state and 1

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -340,6 +340,7 @@ def create_state_changed_event_from_old_new(
     row.context_id = None
     row.friendly_name = None
     row.icon = None
+    row.old_format_icon = None
     row.context_user_id = None
     row.context_parent_id = None
     row.old_state_id = old_state and 1
@@ -721,7 +722,7 @@ async def test_logbook_entity_no_longer_in_state_machine(
     )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
-    assert json_dict[0]["name"] == "Alarm Control Panel"
+    assert json_dict[0]["name"] == "area 001"
 
 
 async def test_filter_continuous_sensor_values(

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -30,7 +30,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
-    EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
 )
@@ -327,7 +326,7 @@ def create_state_changed_event_from_old_new(
         ],
     )
 
-    row.event_type = EVENT_STATE_CHANGED
+    row.event_type = logbook.PSUEDO_EVENT_STATE_CHANGED
     row.event_data = "{}"
     row.shared_data = "{}"
     row.attributes = attributes_json


### PR DESCRIPTION
Requires home-assistant/frontend#12667

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- The entity name in logbook is now always shown with the
  current name instead of the old name if it
  was renamed. If the entity no longer exists
  we now show the original entity_id instead which
  aligns with the warning icon we already display on
  the frontend when a state is missing or removed.
   

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- The name of the entity is no longer sent to the websocket
  api. Not a breaking change since the websocket api is new
  in 2022.6

- We no longer parse attributes in python. This
  task is offloaded to the database since we only
  need it for the icon.

`JSON` type is supported on the DBMs we supported since 2015 (and 2016 for MSSQL but thats not supported)

MySQL 5.7+ ~2015  https://docs.sqlalchemy.org/en/14/dialects/mysql.html?highlight=json#sqlalchemy.dialects.mysql.JSON
SQLite 3.9+ ~2015 https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#sqlalchemy.dialects.sqlite.JSON
MSSQL 2016+ https://docs.sqlalchemy.org/en/14/dialects/mssql.html#sqlalchemy.dialects.mssql.JSON
PostgreSQL 9.2+ ~2012 https://www.postgresql.org/docs/9.2/datatype-json.html


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
