### PR TITLE
Better handling of balboa spa connection

### DIFF
--- a/homeassistant/components/balboa/__init__.py
+++ b/homeassistant/components/balboa/__init__.py
@@ -66,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def keep_alive(now: datetime) -> None:
         """Keep alive task."""
         _LOGGER.debug("Keep alive")
-        await spa.spa_configured()
+        await spa.send_mod_ident_req()
 
     entry.async_on_unload(
         async_track_time_interval(hass, keep_alive, KEEP_ALIVE_INTERVAL)

--- a/homeassistant/components/balboa/__init__.py
+++ b/homeassistant/components/balboa/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     SIGNAL_UPDATE,
 )
 
+KEEP_ALIVE_INTERVAL = timedelta(minutes=1)
 SYNC_TIME_INTERVAL = timedelta(days=1)
 
 
@@ -31,7 +32,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.debug("Attempting to connect to %s", host)
     spa = BalboaSpaWifi(host)
-
     connected = await spa.connect()
     if not connected:
         _LOGGER.error("Failed to connect to spa at %s", host)
@@ -39,11 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = spa
 
-    # send config requests, and then listen until we are configured.
-    await spa.send_mod_ident_req()
-    await spa.send_panel_req(0, 1)
-
-    async def _async_balboa_update_cb():
+    async def _async_balboa_update_cb() -> None:
         """Primary update callback called from pybalboa."""
         _LOGGER.debug("Primary update callback triggered")
         async_dispatcher_send(hass, SIGNAL_UPDATE.format(entry.entry_id))
@@ -52,12 +48,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     spa.new_data_cb = _async_balboa_update_cb
 
     _LOGGER.debug("Starting listener and monitor tasks")
-    asyncio.create_task(spa.listen())
+    monitoring_tasks = [asyncio.create_task(spa.listen())]
     await spa.spa_configured()
-    asyncio.create_task(spa.check_connection_status())
+    monitoring_tasks.append(asyncio.create_task(spa.check_connection_status()))
+
+    def stop_monitoring() -> None:
+        """Stop monitoring the spa connection."""
+        _LOGGER.debug("Canceling listener and monitor tasks")
+        for task in monitoring_tasks:
+            task.cancel()
+
+    entry.async_on_unload(stop_monitoring)
 
     # At this point we have a configured spa.
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    async def keep_alive(now: datetime) -> None:
+        """Keep alive task."""
+        _LOGGER.debug("Keep alive")
+        await spa.spa_configured()
+
+    entry.async_on_unload(
+        async_track_time_interval(hass, keep_alive, KEEP_ALIVE_INTERVAL)
+    )
 
     # call update_listener on startup and for options change as well.
     await async_setup_time_sync(hass, entry)
@@ -68,13 +81,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-
     _LOGGER.debug("Disconnecting from spa")
-    spa = hass.data[DOMAIN][entry.entry_id]
-    await spa.disconnect()
+    spa: BalboaSpaWifi = hass.data[DOMAIN][entry.entry_id]
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+
+    await spa.disconnect()
 
     return unload_ok
 
@@ -90,9 +103,9 @@ async def async_setup_time_sync(hass: HomeAssistant, entry: ConfigEntry) -> None
         return
 
     _LOGGER.debug("Setting up daily time sync")
-    spa = hass.data[DOMAIN][entry.entry_id]
+    spa: BalboaSpaWifi = hass.data[DOMAIN][entry.entry_id]
 
-    async def sync_time(now: datetime):
+    async def sync_time(now: datetime) -> None:
         _LOGGER.debug("Syncing time with Home Assistant")
         await spa.set_time(time.strptime(str(dt_util.now()), "%Y-%m-%d %H:%M:%S.%f%z"))
 

--- a/homeassistant/components/balboa/config_flow.py
+++ b/homeassistant/components/balboa/config_flow.py
@@ -1,12 +1,16 @@
 """Config flow for Balboa Spa Client integration."""
+from __future__ import annotations
+
 import asyncio
+from typing import Any
 
 from pybalboa import BalboaSpaWifi
 import voluptuous as vol
 
-from homeassistant import config_entries, core, exceptions
+from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import _LOGGER, CONF_SYNC_TIME, DOMAIN
@@ -14,9 +18,8 @@ from .const import _LOGGER, CONF_SYNC_TIME, DOMAIN
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 
 
-async def validate_input(hass: core.HomeAssistant, data):
+async def validate_input(data: dict[str, Any]) -> dict[str, str]:
     """Validate the user input allows us to connect."""
-
     _LOGGER.debug("Attempting to connect to %s", data[CONF_HOST])
     spa = BalboaSpaWifi(data[CONF_HOST])
     connected = await spa.connect()
@@ -24,16 +27,12 @@ async def validate_input(hass: core.HomeAssistant, data):
     if not connected:
         raise CannotConnect
 
-    # send config requests, and then listen until we are configured.
-    await spa.send_mod_ident_req()
-    await spa.send_panel_req(0, 1)
-
-    asyncio.create_task(spa.listen())
-
+    task = asyncio.create_task(spa.listen())
     await spa.spa_configured()
 
     mac_addr = format_mac(spa.get_macaddr())
     model = spa.get_model_name()
+    task.cancel()
     await spa.disconnect()
 
     return {"title": model, "formatted_mac": mac_addr}
@@ -46,17 +45,21 @@ class BalboaSpaClientFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
         """Get the options flow for this handler."""
         return BalboaSpaClientOptionsFlowHandler(config_entry)
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             try:
-                info = await validate_input(self.hass, user_input)
+                info = await validate_input(user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
@@ -79,11 +82,13 @@ class CannotConnect(exceptions.HomeAssistantError):
 class BalboaSpaClientOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle Balboa Spa Client options."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize Balboa Spa Client options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage Balboa Spa Client options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This prevents having to restart Home Assistant to fully disconnect from a balboa spa. Otherwise, even after a disconnect, the `listen` and `check_connection_status` tasks will continue to run and try to reconnect because they haven't been canceled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
