### PR TITLE
Fixing purging legacy rows and improve performance

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -127,10 +127,10 @@ class Events(Base):  # type: ignore[misc,valid-type]
         {"mysql_default_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"},
     )
     __tablename__ = TABLE_EVENTS
-    event_id = Column(Integer, Identity(), primary_key=True)  # no longer used
+    event_id = Column(Integer, Identity(), primary_key=True)
     event_type = Column(String(MAX_LENGTH_EVENT_EVENT_TYPE))
     event_data = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
-    origin = Column(String(MAX_LENGTH_EVENT_ORIGIN))  # no longer used
+    origin = Column(String(MAX_LENGTH_EVENT_ORIGIN))  # no longer used for new rows
     origin_idx = Column(SmallInteger)
     time_fired = Column(DATETIME_TYPE, index=True)
     context_id = Column(String(MAX_LENGTH_EVENT_CONTEXT_ID), index=True)
@@ -244,8 +244,10 @@ class States(Base):  # type: ignore[misc,valid-type]
     state_id = Column(Integer, Identity(), primary_key=True)
     entity_id = Column(String(MAX_LENGTH_STATE_ENTITY_ID))
     state = Column(String(MAX_LENGTH_STATE_STATE))
-    attributes = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
-    event_id = Column(
+    attributes = Column(
+        Text().with_variant(mysql.LONGTEXT, "mysql")
+    )  # no longer used for new rows
+    event_id = Column(  # no longer used for new rows
         Integer, ForeignKey("events.event_id", ondelete="CASCADE"), index=True
     )
     last_changed = Column(DATETIME_TYPE)

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -130,7 +130,7 @@ def _purge_states_and_attributes_ids(
 
     Returns true if there are more states to purge.
     """
-    remaining_state_ids = True
+    has_remaining_state_ids_to_purge = True
     # There are more states relative to attributes_ids so
     # we purge enough state ids to try to generate a full
     # size batch of them that will be around MAX_ROWS_TO_PURGE
@@ -140,7 +140,7 @@ def _purge_states_and_attributes_ids(
             session, purge_before
         )
         if not state_ids:
-            remaining_state_ids = False
+            has_remaining_state_ids_to_purge = False
             break
         _purge_state_ids(instance, session, state_ids)
         attributes_ids_batch = attributes_ids_batch | attributes_ids
@@ -150,7 +150,7 @@ def _purge_states_and_attributes_ids(
     ):
         _purge_batch_attributes_ids(instance, session, unused_attribute_ids_set)
 
-    return remaining_state_ids
+    return has_remaining_state_ids_to_purge
 
 
 def _purge_events_and_data_ids(
@@ -164,7 +164,7 @@ def _purge_events_and_data_ids(
 
     Returns true if there are more states to purge.
     """
-    remaining_event_ids = True
+    has_remaining_event_ids_to_purge = True
     # There are more events relative to data_ids so
     # we purge enough state ids to try to generate a full
     # size batch of them that will be around MAX_ROWS_TO_PURGE
@@ -172,7 +172,7 @@ def _purge_events_and_data_ids(
     for _ in range(events_batch_size):
         event_ids, data_ids = _select_event_data_ids_to_purge(session, purge_before)
         if not event_ids:
-            remaining_event_ids = False
+            has_remaining_event_ids_to_purge = False
             break
         _purge_event_ids(session, event_ids)
         data_ids_batch = data_ids_batch | data_ids
@@ -182,7 +182,7 @@ def _purge_events_and_data_ids(
     ):
         _purge_batch_data_ids(instance, session, unused_data_ids_set)
 
-    return remaining_event_ids
+    return has_remaining_event_ids_to_purge
 
 
 def _select_state_attributes_ids_to_purge(

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -155,14 +155,17 @@ def _select_state_attributes_ids_to_purge(
     session: Session, purge_before: datetime
 ) -> tuple[set[int], set[int]]:
     """Return sets of state and attribute ids to purge."""
-    states = session.execute(find_states_to_purge(purge_before)).all()
-    _LOGGER.debug("Selected %s state ids to remove", len(states))
     state_ids = set()
     attributes_ids = set()
-    for state in states:
+    for state in session.execute(find_states_to_purge(purge_before)).all():
         state_ids.add(state.state_id)
         if state.attributes_id:
             attributes_ids.add(state.attributes_id)
+    _LOGGER.debug(
+        "Selected %s state ids and %s attributes_ids to remove",
+        len(state_ids),
+        len(attributes_ids),
+    )
     return state_ids, attributes_ids
 
 
@@ -170,14 +173,15 @@ def _select_event_data_ids_to_purge(
     session: Session, purge_before: datetime
 ) -> tuple[set[int], set[int]]:
     """Return sets of event and data ids to purge."""
-    events = session.execute(find_events_to_purge(purge_before)).all()
-    _LOGGER.debug("Selected %s event ids to remove", len(events))
     event_ids = set()
     data_ids = set()
-    for event in events:
+    for event in session.execute(find_events_to_purge(purge_before)).all():
         event_ids.add(event.event_id)
         if event.data_id:
             data_ids.add(event.data_id)
+    _LOGGER.debug(
+        "Selected %s event ids and %s data_ids to remove", len(event_ids), len(data_ids)
+    )
     return event_ids, data_ids
 
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -83,10 +83,10 @@ def purge_old_data(
 
     with session_scope(session=instance.get_session()) as session:
         # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
-        remaining_state_ids = _purge_states_and_attributes_ids(
+        has_remaining_state_ids_to_purge = _purge_states_and_attributes_ids(
             instance, session, states_batch_size, purge_before, using_sqlite
         )
-        remaining_event_ids = _purge_events_and_data_ids(
+        has_remaining_event_ids_to_purge = _purge_events_and_data_ids(
             instance, session, events_batch_size, purge_before, using_sqlite
         )
         statistics_runs = _select_statistics_runs_to_purge(session, purge_before)
@@ -100,8 +100,8 @@ def purge_old_data(
             _purge_short_term_statistics(session, short_term_statistics)
 
         if (
-            remaining_state_ids
-            or remaining_event_ids
+            has_remaining_state_ids_to_purge
+            or has_remaining_event_ids_to_purge
             or statistics_runs
             or short_term_statistics
         ):

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -45,8 +45,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-DEFAULT_STATES_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
-DEFAULT_EVENTS_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
+DEFAULT_STATES_BATCHES_PER_PURGE = 20  # We expect ~95% de-dupe rate
+DEFAULT_EVENTS_BATCHES_PER_PURGE = 15  # We expect ~92% de-dupe rate
 
 
 def take(take_num: int, iterable: Iterable) -> list[Any]:

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_STATES_BATCHES_PER_PURGE = 20
-DEFAULT_EVENTS_BATCHES_PER_PURGE = 10
+DEFAULT_STATES_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
+DEFAULT_EVENTS_BATCHES_PER_PURGE = 8  # We expect ~80% de-dupe rate
 
 
 def take(take_num: int, iterable: Iterable) -> list[Any]:

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -45,11 +45,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-# Until we get rid of all the rows that are linked by event_id
-# we need to keep the state batch size smaller than the events
-# to ensure we do not delete an event row that is still connected
-# to a states row and get a foreign key constraint failure.
-DEFAULT_STATES_BATCHES_PER_PURGE = 7  # We expect ~90% de-dupe rate
+DEFAULT_STATES_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
 DEFAULT_EVENTS_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
 
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -84,7 +84,6 @@ def purge_old_data(
     with session_scope(session=instance.get_session()) as session:
         # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
         remaining_state_ids = True
-        remaining_event_ids = True
         # There are more states relative to attributes_ids so
         # we purge enough state ids to try to generate a full
         # size batch of them that will be around MAX_ROWS_TO_PURGE
@@ -104,6 +103,7 @@ def purge_old_data(
         ):
             _purge_batch_attributes_ids(instance, session, unused_attribute_ids_set)
 
+        remaining_event_ids = True
         # There are more events relative to data_ids so
         # we purge enough state ids to try to generate a full
         # size batch of them that will be around MAX_ROWS_TO_PURGE

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-STATES_BATCHES_PER_PURGE = 1
-EVENTS_BATCHES_PER_PURGE = 1
+STATES_BATCHES_PER_PURGE = 20
+EVENTS_BATCHES_PER_PURGE = 10
 
 
 def take(take_num: int, iterable: Iterable) -> list[Any]:
@@ -67,9 +67,9 @@ def purge_old_data(
     instance: Recorder,
     purge_before: datetime,
     repack: bool,
+    apply_filter: bool = False,
     events_batch_size: int = EVENTS_BATCHES_PER_PURGE,
     states_batch_size: int = STATES_BATCHES_PER_PURGE,
-    apply_filter: bool = False,
 ) -> bool:
     """Purge events and states older than purge_before.
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -42,6 +42,13 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Note that the batch size for states may
+# never exceed the batch size for events
+# since we could end up deleting an event
+# that was still linked to the a state
+# by the old event_id linkage if we delete
+# more events than states.
+
 DEFAULT_STATES_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
 DEFAULT_EVENTS_BATCHES_PER_PURGE = 8  # We expect ~80% de-dupe rate
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -30,6 +30,7 @@ from .queries import (
     disconnect_states_rows,
     find_events_to_purge,
     find_latest_statistics_runs_run_id,
+    find_legacy_event_state_and_attributes_and_data_ids_to_purge,
     find_short_term_statistics_to_purge,
     find_states_to_purge,
     find_statistics_runs_to_purge,
@@ -88,12 +89,19 @@ def purge_old_data(
 
     with session_scope(session=instance.get_session()) as session:
         # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
-        has_remaining_state_ids_to_purge = _purge_states_and_attributes_ids(
-            instance, session, states_batch_size, purge_before, using_sqlite
-        )
-        has_remaining_event_ids_to_purge = _purge_events_and_data_ids(
-            instance, session, events_batch_size, purge_before, using_sqlite
-        )
+        if has_legacy_rows_to_purge := _purge_legacy_format(
+            instance, session, purge_before, using_sqlite
+        ):
+            has_states_to_purge = has_states_to_purge = False
+        else:
+            # Once we are done purging legacy rows, we use the new method
+            has_states_to_purge = _purge_states_and_attributes_ids(
+                instance, session, states_batch_size, purge_before, using_sqlite
+            )
+            has_events_to_purge = _purge_events_and_data_ids(
+                instance, session, events_batch_size, purge_before, using_sqlite
+            )
+
         statistics_runs = _select_statistics_runs_to_purge(session, purge_before)
         short_term_statistics = _select_short_term_statistics_to_purge(
             session, purge_before
@@ -105,8 +113,9 @@ def purge_old_data(
             _purge_short_term_statistics(session, short_term_statistics)
 
         if (
-            has_remaining_state_ids_to_purge
-            or has_remaining_event_ids_to_purge
+            has_legacy_rows_to_purge
+            or has_states_to_purge
+            or has_events_to_purge
             or statistics_runs
             or short_term_statistics
         ):
@@ -122,6 +131,27 @@ def purge_old_data(
     if repack:
         repack_database(instance)
     return True
+
+
+def _purge_legacy_format(
+    instance: Recorder, session: Session, purge_before: datetime, using_sqlite: bool
+) -> bool:
+    """Purge rows that are still linked by the event_ids."""
+    (
+        event_ids,
+        state_ids,
+        attributes_ids,
+        data_ids,
+    ) = _select_legacy_event_state_and_attributes_and_data_ids_to_purge(
+        session, purge_before
+    )
+    if state_ids:
+        _purge_state_ids(instance, session, state_ids)
+    _purge_unused_attributes_ids(instance, session, attributes_ids, using_sqlite)
+    if event_ids:
+        _purge_event_ids(session, event_ids)
+    _purge_unused_data_ids(instance, session, data_ids, using_sqlite)
+    return bool(event_ids or state_ids or attributes_ids or data_ids)
 
 
 def _purge_states_and_attributes_ids(
@@ -151,10 +181,7 @@ def _purge_states_and_attributes_ids(
         _purge_state_ids(instance, session, state_ids)
         attributes_ids_batch = attributes_ids_batch | attributes_ids
 
-    if unused_attribute_ids_set := _select_unused_attributes_ids(
-        session, attributes_ids_batch, using_sqlite
-    ):
-        _purge_batch_attributes_ids(instance, session, unused_attribute_ids_set)
+    _purge_unused_attributes_ids(instance, session, attributes_ids_batch, using_sqlite)
 
     return has_remaining_state_ids_to_purge
 
@@ -184,10 +211,7 @@ def _purge_events_and_data_ids(
         _purge_event_ids(session, event_ids)
         data_ids_batch = data_ids_batch | data_ids
 
-    if unused_data_ids_set := _select_unused_event_data_ids(
-        session, data_ids_batch, using_sqlite
-    ):
-        _purge_batch_data_ids(instance, session, unused_data_ids_set)
+    _purge_unused_data_ids(instance, session, data_ids_batch, using_sqlite)
 
     return has_remaining_event_ids_to_purge
 
@@ -294,6 +318,18 @@ def _select_unused_attributes_ids(
     return to_remove
 
 
+def _purge_unused_attributes_ids(
+    instance: Recorder,
+    session: Session,
+    attributes_ids_batch: set[int],
+    using_sqlite: bool,
+) -> None:
+    if unused_attribute_ids_set := _select_unused_attributes_ids(
+        session, attributes_ids_batch, using_sqlite
+    ):
+        _purge_batch_attributes_ids(instance, session, unused_attribute_ids_set)
+
+
 def _select_unused_event_data_ids(
     session: Session, data_ids: set[int], using_sqlite: bool
 ) -> set[int]:
@@ -326,6 +362,16 @@ def _select_unused_event_data_ids(
     return to_remove
 
 
+def _purge_unused_data_ids(
+    instance: Recorder, session: Session, data_ids_batch: set[int], using_sqlite: bool
+) -> None:
+
+    if unused_data_ids_set := _select_unused_event_data_ids(
+        session, data_ids_batch, using_sqlite
+    ):
+        _purge_batch_data_ids(instance, session, unused_data_ids_set)
+
+
 def _select_statistics_runs_to_purge(
     session: Session, purge_before: datetime
 ) -> list[int]:
@@ -351,6 +397,34 @@ def _select_short_term_statistics_to_purge(
     ).all()
     _LOGGER.debug("Selected %s short term statistics to remove", len(statistics))
     return [statistic.id for statistic in statistics]
+
+
+def _select_legacy_event_state_and_attributes_and_data_ids_to_purge(
+    session: Session, purge_before: datetime
+) -> tuple[set[int], set[int], set[int], set[int]]:
+    """Return a list of event, state, and attribute ids to purge that are linked by the event_id.
+
+    We do not link these anymore since state_change events
+    do not exist in the events table anymore, however we
+    still need to be able to purge them.
+    """
+    events = session.execute(
+        find_legacy_event_state_and_attributes_and_data_ids_to_purge(purge_before)
+    ).all()
+    _LOGGER.debug("Selected %s event ids to remove", len(events))
+    event_ids = set()
+    state_ids = set()
+    attributes_ids = set()
+    data_ids = set()
+    for event in events:
+        event_ids.add(event.event_id)
+        if event.state_id:
+            state_ids.add(event.state_id)
+        if event.attributes_id:
+            attributes_ids.add(event.attributes_id)
+        if event.data_id:
+            data_ids.add(event.data_id)
+    return event_ids, state_ids, attributes_ids, data_ids
 
 
 def _purge_state_ids(instance: Recorder, session: Session, state_ids: set[int]) -> None:

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from datetime import datetime
-from itertools import zip_longest
+from functools import partial
+from itertools import islice, zip_longest
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import distinct
@@ -41,10 +42,34 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+STATES_BATCHES_PER_PURGE = 1
+EVENTS_BATCHES_PER_PURGE = 1
+
+
+def take(take_num: int, iterable: Iterable) -> list[Any]:
+    """Return first n items of the iterable as a list.
+
+    From itertools recipes
+    """
+    return list(islice(iterable, take_num))
+
+
+def chunked(iterable: Iterable, chunked_num: int) -> Iterable[Any]:
+    """Break *iterable* into lists of length *n*.
+
+    From more-itertools
+    """
+    return iter(partial(take, chunked_num, iter(iterable)), [])
+
 
 @retryable_database_job("purge")
 def purge_old_data(
-    instance: Recorder, purge_before: datetime, repack: bool, apply_filter: bool = False
+    instance: Recorder,
+    purge_before: datetime,
+    repack: bool,
+    events_batch_size: int = EVENTS_BATCHES_PER_PURGE,
+    states_batch_size: int = STATES_BATCHES_PER_PURGE,
+    apply_filter: bool = False,
 ) -> bool:
     """Purge events and states older than purge_before.
 
@@ -58,40 +83,60 @@ def purge_old_data(
 
     with session_scope(session=instance.get_session()) as session:
         # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
-        (
-            event_ids,
-            state_ids,
-            attributes_ids,
-            data_ids,
-        ) = _select_event_state_attributes_ids_data_ids_to_purge(session, purge_before)
+        remaining_state_ids = True
+        remaining_event_ids = True
+        # There are more states relative to attributes_ids so
+        # we purge enough state ids to try to generate a full
+        # size batch of them that will be around MAX_ROWS_TO_PURGE
+        attributes_ids_batch: set[int] = set()
+        for _ in range(states_batch_size):
+            state_ids, attributes_ids = _select_state_attributes_ids_to_purge(
+                session, purge_before
+            )
+            if not state_ids:
+                remaining_state_ids = False
+                break
+            _purge_state_ids(instance, session, state_ids)
+            attributes_ids_batch = attributes_ids_batch | attributes_ids
+
+        if unused_attribute_ids_set := _select_unused_attributes_ids(
+            session, attributes_ids_batch, using_sqlite
+        ):
+            _purge_batch_attributes_ids(instance, session, unused_attribute_ids_set)
+
+        # There are more events relative to data_ids so
+        # we purge enough state ids to try to generate a full
+        # size batch of them that will be around MAX_ROWS_TO_PURGE
+        data_ids_batch: set[int] = set()
+        for _ in range(events_batch_size):
+            event_ids, data_ids = _select_event_data_ids_to_purge(session, purge_before)
+            if not event_ids:
+                remaining_event_ids = False
+                break
+            _purge_event_ids(session, event_ids)
+            data_ids_batch = data_ids_batch | data_ids
+
+        if unused_data_ids_set := _select_unused_event_data_ids(
+            session, data_ids_batch, using_sqlite
+        ):
+            _purge_batch_data_ids(instance, session, unused_data_ids_set)
+
         statistics_runs = _select_statistics_runs_to_purge(session, purge_before)
         short_term_statistics = _select_short_term_statistics_to_purge(
             session, purge_before
         )
-
-        if state_ids:
-            _purge_state_ids(instance, session, state_ids)
-
-        if unused_attribute_ids_set := _select_unused_attributes_ids(
-            session, attributes_ids, using_sqlite
-        ):
-            _purge_attributes_ids(instance, session, unused_attribute_ids_set)
-
-        if event_ids:
-            _purge_event_ids(session, event_ids)
-
-        if unused_data_ids_set := _select_unused_event_data_ids(
-            session, data_ids, using_sqlite
-        ):
-            _purge_event_data_ids(instance, session, unused_data_ids_set)
-
         if statistics_runs:
             _purge_statistics_runs(session, statistics_runs)
 
         if short_term_statistics:
             _purge_short_term_statistics(session, short_term_statistics)
 
-        if state_ids or event_ids or statistics_runs or short_term_statistics:
+        if (
+            remaining_state_ids
+            or remaining_event_ids
+            or statistics_runs
+            or short_term_statistics
+        ):
             # Return false, as we might not be done yet.
             _LOGGER.debug("Purging hasn't fully completed yet")
             return False
@@ -106,27 +151,34 @@ def purge_old_data(
     return True
 
 
-def _select_event_state_attributes_ids_data_ids_to_purge(
+def _select_state_attributes_ids_to_purge(
     session: Session, purge_before: datetime
-) -> tuple[set[int], set[int], set[int], set[int]]:
-    """Return a list of event, state, and attribute ids to purge."""
-    events = session.execute(find_events_to_purge(purge_before)).all()
-    _LOGGER.debug("Selected %s event ids to remove", len(events))
+) -> tuple[set[int], set[int]]:
+    """Return sets of state and attribute ids to purge."""
     states = session.execute(find_states_to_purge(purge_before)).all()
     _LOGGER.debug("Selected %s state ids to remove", len(states))
-    event_ids = set()
     state_ids = set()
     attributes_ids = set()
+    for state in states:
+        state_ids.add(state.state_id)
+        if state.attributes_id:
+            attributes_ids.add(state.attributes_id)
+    return state_ids, attributes_ids
+
+
+def _select_event_data_ids_to_purge(
+    session: Session, purge_before: datetime
+) -> tuple[set[int], set[int]]:
+    """Return sets of event and data ids to purge."""
+    events = session.execute(find_events_to_purge(purge_before)).all()
+    _LOGGER.debug("Selected %s event ids to remove", len(events))
+    event_ids = set()
     data_ids = set()
     for event in events:
         event_ids.add(event.event_id)
         if event.data_id:
             data_ids.add(event.data_id)
-    for state in states:
-        state_ids.add(state.state_id)
-        if state.attributes_id:
-            attributes_ids.add(state.attributes_id)
-    return event_ids, state_ids, attributes_ids, data_ids
+    return event_ids, data_ids
 
 
 def _select_unused_attributes_ids(
@@ -327,24 +379,27 @@ def _evict_purged_attributes_from_attributes_cache(
         )
 
 
-def _purge_attributes_ids(
+def _purge_batch_attributes_ids(
     instance: Recorder, session: Session, attributes_ids: set[int]
 ) -> None:
-    """Delete old attributes ids."""
-    deleted_rows = session.execute(delete_states_attributes_rows(attributes_ids))
-    _LOGGER.debug("Deleted %s attribute states", deleted_rows)
+    """Delete old attributes ids in batches of MAX_ROWS_TO_PURGE."""
+    for attributes_ids_chunk in chunked(attributes_ids, MAX_ROWS_TO_PURGE):
+        deleted_rows = session.execute(
+            delete_states_attributes_rows(attributes_ids_chunk)
+        )
+        _LOGGER.debug("Deleted %s attribute states", deleted_rows)
 
     # Evict any entries in the state_attributes_ids cache referring to a purged state
     _evict_purged_attributes_from_attributes_cache(instance, attributes_ids)
 
 
-def _purge_event_data_ids(
+def _purge_batch_data_ids(
     instance: Recorder, session: Session, data_ids: set[int]
 ) -> None:
-    """Delete old event data ids."""
-
-    deleted_rows = session.execute(delete_event_data_rows(data_ids))
-    _LOGGER.debug("Deleted %s data events", deleted_rows)
+    """Delete old event data ids in batches of MAX_ROWS_TO_PURGE."""
+    for data_ids_chunk in chunked(data_ids, MAX_ROWS_TO_PURGE):
+        deleted_rows = session.execute(delete_event_data_rows(data_ids_chunk))
+        _LOGGER.debug("Deleted %s data events", deleted_rows)
 
     # Evict any entries in the event_data_ids cache referring to a purged state
     _evict_purged_data_from_data_cache(instance, data_ids)
@@ -438,7 +493,7 @@ def _purge_filtered_states(
     unused_attribute_ids_set = _select_unused_attributes_ids(
         session, {id_ for id_ in attributes_ids if id_ is not None}, using_sqlite
     )
-    _purge_attributes_ids(instance, session, unused_attribute_ids_set)
+    _purge_batch_attributes_ids(instance, session, unused_attribute_ids_set)
 
 
 def _purge_filtered_events(
@@ -466,7 +521,7 @@ def _purge_filtered_events(
     if unused_data_ids_set := _select_unused_event_data_ids(
         session, set(data_ids), using_sqlite
     ):
-        _purge_event_data_ids(instance, session, unused_data_ids_set)
+        _purge_batch_data_ids(instance, session, unused_data_ids_set)
     if EVENT_STATE_CHANGED in excluded_event_types:
         session.query(StateAttributes).delete(synchronize_session=False)
         instance._state_attributes_ids = {}  # pylint: disable=protected-access

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-STATES_BATCHES_PER_PURGE = 20
-EVENTS_BATCHES_PER_PURGE = 10
+DEFAULT_STATES_BATCHES_PER_PURGE = 20
+DEFAULT_EVENTS_BATCHES_PER_PURGE = 10
 
 
 def take(take_num: int, iterable: Iterable) -> list[Any]:
@@ -68,8 +68,8 @@ def purge_old_data(
     purge_before: datetime,
     repack: bool,
     apply_filter: bool = False,
-    events_batch_size: int = EVENTS_BATCHES_PER_PURGE,
-    states_batch_size: int = STATES_BATCHES_PER_PURGE,
+    events_batch_size: int = DEFAULT_EVENTS_BATCHES_PER_PURGE,
+    states_batch_size: int = DEFAULT_STATES_BATCHES_PER_PURGE,
 ) -> bool:
     """Purge events and states older than purge_before.
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -42,15 +42,13 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Note that the batch size for states may
-# never exceed the batch size for events
-# since we could end up deleting an event
-# that was still linked to the a state
-# by the old event_id linkage if we delete
-# more events than states.
 
+# Until we get rid of all the rows that are linked by event_id
+# we need to keep the batch sizes the same to handle databases
+# that do not have a on delete cascade setup correctly on the
+# FOREIGN KEY CONSTRAINT
 DEFAULT_STATES_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
-DEFAULT_EVENTS_BATCHES_PER_PURGE = 8  # We expect ~80% de-dupe rate
+DEFAULT_EVENTS_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
 
 
 def take(take_num: int, iterable: Iterable) -> list[Any]:

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -44,10 +44,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # Until we get rid of all the rows that are linked by event_id
-# we need to keep the batch sizes the same to handle databases
-# that do not have a on delete cascade setup correctly on the
-# FOREIGN KEY CONSTRAINT
-DEFAULT_STATES_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
+# we need to keep the state batch size smaller than the events
+# to ensure we do not delete an event row that is still connected
+# to a states row and get a foreign key constraint failure.
+DEFAULT_STATES_BATCHES_PER_PURGE = 7  # We expect ~90% de-dupe rate
 DEFAULT_EVENTS_BATCHES_PER_PURGE = 9  # We expect ~90% de-dupe rate
 
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -92,15 +92,21 @@ def purge_old_data(
         # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
         has_more_to_purge = False
         if _purging_legacy_format(session):
-            has_more_to_purge &= _purge_legacy_format(
+            _LOGGER.debug(
+                "Purge running in legacy format as there are states with event_id remaining"
+            )
+            has_more_to_purge |= _purge_legacy_format(
                 instance, session, purge_before, using_sqlite
             )
         else:
+            _LOGGER.debug(
+                "Purge running in new format as there are NO states with event_id remaining"
+            )
             # Once we are done purging legacy rows, we use the new method
-            has_more_to_purge &= _purge_states_and_attributes_ids(
+            has_more_to_purge |= _purge_states_and_attributes_ids(
                 instance, session, states_batch_size, purge_before, using_sqlite
             )
-            has_more_to_purge &= _purge_events_and_data_ids(
+            has_more_to_purge |= _purge_events_and_data_ids(
                 instance, session, events_batch_size, purge_before, using_sqlite
             )
 
@@ -183,7 +189,10 @@ def _purge_states_and_attributes_ids(
         attributes_ids_batch = attributes_ids_batch | attributes_ids
 
     _purge_unused_attributes_ids(instance, session, attributes_ids_batch, using_sqlite)
-
+    _LOGGER.debug(
+        "After purging states and attributes_ids remaining=%s",
+        has_remaining_state_ids_to_purge,
+    )
     return has_remaining_state_ids_to_purge
 
 
@@ -213,7 +222,10 @@ def _purge_events_and_data_ids(
         data_ids_batch = data_ids_batch | data_ids
 
     _purge_unused_data_ids(instance, session, data_ids_batch, using_sqlite)
-
+    _LOGGER.debug(
+        "After purging event and data_ids remaining=%s",
+        has_remaining_event_ids_to_purge,
+    )
     return has_remaining_event_ids_to_purge
 
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -132,8 +132,9 @@ def _purge_states_and_attributes_ids(
     """
     has_remaining_state_ids_to_purge = True
     # There are more states relative to attributes_ids so
-    # we purge enough state ids to try to generate a full
-    # size batch of them that will be around MAX_ROWS_TO_PURGE
+    # we purge enough state_ids to try to generate a full
+    # size batch of attributes_ids that will be around the size
+    # MAX_ROWS_TO_PURGE
     attributes_ids_batch: set[int] = set()
     for _ in range(states_batch_size):
         state_ids, attributes_ids = _select_state_attributes_ids_to_purge(
@@ -166,8 +167,9 @@ def _purge_events_and_data_ids(
     """
     has_remaining_event_ids_to_purge = True
     # There are more events relative to data_ids so
-    # we purge enough state ids to try to generate a full
-    # size batch of them that will be around MAX_ROWS_TO_PURGE
+    # we purge enough event_ids to try to generate a full
+    # size batch of data_ids that will be around the size
+    # MAX_ROWS_TO_PURGE
     data_ids_batch: set[int] = set()
     for _ in range(events_batch_size):
         event_ids, data_ids = _select_event_data_ids_to_purge(session, purge_before)

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -635,3 +635,8 @@ def find_legacy_event_state_and_attributes_and_data_ids_to_purge(
         .filter(Events.time_fired < purge_before)
         .limit(MAX_ROWS_TO_PURGE)
     )
+
+
+def find_legacy_row() -> StatementLambdaElement:
+    """Check if there are still states in the table with an event_id."""
+    return lambda_stmt(lambda: select(func.max(States.event_id)))

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -583,7 +583,6 @@ def find_events_to_purge(purge_before: datetime) -> StatementLambdaElement:
     return lambda_stmt(
         lambda: select(Events.event_id, Events.data_id)
         .filter(Events.time_fired < purge_before)
-        .filter(Events.data_id.is_not(None))  # new format only
         .limit(MAX_ROWS_TO_PURGE)
     )
 
@@ -593,7 +592,6 @@ def find_states_to_purge(purge_before: datetime) -> StatementLambdaElement:
     return lambda_stmt(
         lambda: select(States.state_id, States.attributes_id)
         .filter(States.last_updated < purge_before)
-        .filter(States.event_id.is_(None))  # new format only
         .limit(MAX_ROWS_TO_PURGE)
     )
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -235,12 +235,24 @@ async def test_purge_old_events(
         purge_before = dt_util.utcnow() - timedelta(days=4)
 
         # run purge_old_data()
-        finished = purge_old_data(instance, purge_before, repack=False)
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            repack=False,
+            events_batch_size=1,
+            states_batch_size=1,
+        )
         assert not finished
         assert events.count() == 2
 
         # we should only have 2 events left
-        finished = purge_old_data(instance, purge_before, repack=False)
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            repack=False,
+            events_batch_size=1,
+            states_batch_size=1,
+        )
         assert finished
         assert events.count() == 2
 
@@ -261,10 +273,22 @@ async def test_purge_old_recorder_runs(
         purge_before = dt_util.utcnow()
 
         # run purge_old_data()
-        finished = purge_old_data(instance, purge_before, repack=False)
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            repack=False,
+            events_batch_size=1,
+            states_batch_size=1,
+        )
         assert not finished
 
-        finished = purge_old_data(instance, purge_before, repack=False)
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            repack=False,
+            events_batch_size=1,
+            states_batch_size=1,
+        )
         assert finished
         assert recorder_runs.count() == 1
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -76,7 +76,13 @@ async def test_purge_old_states(
         purge_before = dt_util.utcnow() - timedelta(days=4)
 
         # run purge_old_data()
-        finished = purge_old_data(instance, purge_before, repack=False)
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            states_batch_size=1,
+            events_batch_size=1,
+            repack=False,
+        )
         assert not finished
         assert states.count() == 2
         assert state_attributes.count() == 1
@@ -96,7 +102,13 @@ async def test_purge_old_states(
 
         # run purge_old_data again
         purge_before = dt_util.utcnow()
-        finished = purge_old_data(instance, purge_before, repack=False)
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            states_batch_size=1,
+            events_batch_size=1,
+            repack=False,
+        )
         assert not finished
         assert states.count() == 0
         assert state_attributes.count() == 0

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm.session import Session
 from homeassistant.components import recorder
 from homeassistant.components.recorder.const import MAX_ROWS_TO_PURGE, SupportedDialect
 from homeassistant.components.recorder.models import (
+    EventData,
     Events,
     RecorderRuns,
     StateAttributes,
@@ -1307,7 +1308,7 @@ async def _add_test_states(hass: HomeAssistant):
             await set_state("test.recorder2", state, attributes=attributes)
 
 
-async def _add_test_events(hass: HomeAssistant):
+async def _add_test_events(hass: HomeAssistant, iterations: int = 1):
     """Add a few events for testing."""
     utcnow = dt_util.utcnow()
     five_days_ago = utcnow - timedelta(days=5)
@@ -1318,25 +1319,26 @@ async def _add_test_events(hass: HomeAssistant):
     await async_wait_recording_done(hass)
 
     with session_scope(hass=hass) as session:
-        for event_id in range(6):
-            if event_id < 2:
-                timestamp = eleven_days_ago
-                event_type = "EVENT_TEST_AUTOPURGE"
-            elif event_id < 4:
-                timestamp = five_days_ago
-                event_type = "EVENT_TEST_PURGE"
-            else:
-                timestamp = utcnow
-                event_type = "EVENT_TEST"
+        for _ in range(iterations):
+            for event_id in range(6):
+                if event_id < 2:
+                    timestamp = eleven_days_ago
+                    event_type = "EVENT_TEST_AUTOPURGE"
+                elif event_id < 4:
+                    timestamp = five_days_ago
+                    event_type = "EVENT_TEST_PURGE"
+                else:
+                    timestamp = utcnow
+                    event_type = "EVENT_TEST"
 
-            session.add(
-                Events(
-                    event_type=event_type,
-                    event_data=json.dumps(event_data),
-                    origin="LOCAL",
-                    time_fired=timestamp,
+                session.add(
+                    Events(
+                        event_type=event_type,
+                        event_data=json.dumps(event_data),
+                        origin="LOCAL",
+                        time_fired=timestamp,
+                    )
                 )
-            )
 
 
 async def _add_test_statistics(hass: HomeAssistant):
@@ -1452,3 +1454,56 @@ def _add_state_and_state_changed_event(
             time_fired=timestamp,
         )
     )
+
+
+async def test_purge_many_old_events(
+    hass: HomeAssistant, async_setup_recorder_instance: SetupRecorderInstanceT
+):
+    """Test deleting old events."""
+    instance = await async_setup_recorder_instance(hass)
+
+    await _add_test_events(hass, MAX_ROWS_TO_PURGE)
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
+        event_datas = session.query(EventData)
+        assert events.count() == MAX_ROWS_TO_PURGE * 6
+        assert event_datas.count() == 5
+
+        purge_before = dt_util.utcnow() - timedelta(days=4)
+
+        # run purge_old_data()
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            repack=False,
+            states_batch_size=3,
+            events_batch_size=3,
+        )
+        assert not finished
+        assert events.count() == MAX_ROWS_TO_PURGE * 3
+        assert event_datas.count() == 5
+
+        # we should only have 2 groups of events left
+        finished = purge_old_data(
+            instance,
+            purge_before,
+            repack=False,
+            states_batch_size=3,
+            events_batch_size=3,
+        )
+        assert finished
+        assert events.count() == MAX_ROWS_TO_PURGE * 2
+        assert event_datas.count() == 5
+
+        # we should now purge everything
+        finished = purge_old_data(
+            instance,
+            dt_util.utcnow(),
+            repack=False,
+            states_batch_size=20,
+            events_batch_size=20,
+        )
+        assert finished
+        assert events.count() == 0
+        assert event_datas.count() == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We need to continue to purge rows by the old method to avoid
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1819, in _execute_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.ForeignKeyViolation: update or delete on table "states" violates foreign key constraint "states_old_state_id_fkey" on table "states"
DETAIL:  Key (state_id)=(282692) is still referenced from table "states".
```

Once all the old rows are gone from the database we now switch to
and improved purge method which takes into account the shared attributes and event_data

The current design expected a 1:1 ratio of shared_attrs to states
and a 1:1 ratio of event_data to events.

We are de-duplicating at a rate of ~95% on average for state attributes
and ~92% for event data.  This change adjusts to purge method
to collect more data_ids and attributes_ids before doing a purge
of the shared ones to reduce the amount of delete calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
