### PR TITLE
Suppress Upnp error in SamsungTV resubscribe

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -12,6 +12,7 @@ from async_upnp_client.client import UpnpDevice, UpnpService, UpnpStateVariable
 from async_upnp_client.client_factory import UpnpFactory
 from async_upnp_client.exceptions import (
     UpnpActionResponseError,
+    UpnpCommunicationError,
     UpnpConnectionError,
     UpnpError,
     UpnpResponseError,
@@ -307,7 +308,7 @@ class SamsungTVDevice(MediaPlayerEntity):
 
     async def _async_resubscribe_dmr(self) -> None:
         assert self._dmr_device
-        with contextlib.suppress(UpnpConnectionError, UpnpResponseError):
+        with contextlib.suppress(UpnpCommunicationError):
             await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
 
     async def _async_shutdown_dmr(self) -> None:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -311,7 +311,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         try:
             await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
         except UpnpCommunicationError as err:
-            LOGGER.debug("Device rejected re-subscription: %r", err)
+            LOGGER.debug("Device rejected re-subscription: %r", err, exc_info=True)
 
     async def _async_shutdown_dmr(self) -> None:
         """Handle removal."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -308,8 +308,10 @@ class SamsungTVDevice(MediaPlayerEntity):
 
     async def _async_resubscribe_dmr(self) -> None:
         assert self._dmr_device
-        with contextlib.suppress(UpnpCommunicationError):
+        try:
             await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
+        except UpnpCommunicationError as err:
+            LOGGER.debug("Device rejected re-subscription: %r", err)
 
     async def _async_shutdown_dmr(self) -> None:
         """Handle removal."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -307,7 +307,7 @@ class SamsungTVDevice(MediaPlayerEntity):
 
     async def _async_resubscribe_dmr(self) -> None:
         assert self._dmr_device
-        with contextlib.suppress(UpnpConnectionError):
+        with contextlib.suppress(UpnpConnectionError, UpnpResponseError):
             await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
 
     async def _async_shutdown_dmr(self) -> None:

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -6,6 +6,8 @@ from unittest.mock import DEFAULT as DEFAULT_MOCK, AsyncMock, Mock, call, patch
 
 from async_upnp_client.exceptions import (
     UpnpActionResponseError,
+    UpnpCommunicationError,
+    UpnpConnectionError,
     UpnpError,
     UpnpResponseError,
 )
@@ -1505,3 +1507,49 @@ async def test_upnp_re_subscribe_events(
     assert state.state == STATE_ON
     assert dmr_device.async_subscribe_services.call_count == 2
     assert dmr_device.async_unsubscribe_services.call_count == 1
+
+
+@pytest.mark.usefixtures("rest_api", "upnp_notify_server")
+@pytest.mark.parametrize(
+    "error",
+    {UpnpConnectionError(), UpnpCommunicationError(), UpnpResponseError(status=400)},
+)
+async def test_upnp_failed_re_subscribe_events(
+    hass: HomeAssistant,
+    remotews: Mock,
+    dmr_device: Mock,
+    mock_now: datetime,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+) -> None:
+    """Test for Upnp event feedback."""
+    await setup_samsungtv_entry(hass, MOCK_ENTRY_WS)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+    assert dmr_device.async_subscribe_services.call_count == 1
+    assert dmr_device.async_unsubscribe_services.call_count == 0
+
+    with patch.object(
+        remotews, "start_listening", side_effect=WebSocketException("Boom")
+    ), patch.object(remotews, "is_alive", return_value=False):
+        next_update = mock_now + timedelta(minutes=5)
+        with patch("homeassistant.util.dt.utcnow", return_value=next_update):
+            async_fire_time_changed(hass, next_update)
+            await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
+    assert dmr_device.async_subscribe_services.call_count == 1
+    assert dmr_device.async_unsubscribe_services.call_count == 1
+
+    next_update = mock_now + timedelta(minutes=10)
+    with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch.object(
+        dmr_device, "async_subscribe_services", side_effect=error
+    ):
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+    assert "Device rejected re-subscription" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Suppress `UpnpResponseError` and `UpnpCommunicationError` errors in SamsungTV resubscribe

```
2022-05-13 14:36:30 ERROR (MainThread) [homeassistant.helpers.entity] Update for media_player.samsung_tv fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 515, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 743, in async_device_update
    raise exc
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/media_player.py", line 222, in async_update
    await asyncio.gather(*startup_tasks)
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/media_player.py", line 311, in _async_resubscribe_dmr
    await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
  File "/usr/local/lib/python3.9/site-packages/async_upnp_client/profiles/profile.py", line 356, in async_subscribe_services
    new_sid, timeout = await self._event_handler.async_subscribe(
  File "/usr/local/lib/python3.9/site-packages/async_upnp_client/event_handler.py", line 202, in async_subscribe
    raise UpnpResponseError(status=response_status, headers=response_headers)
async_upnp_client.exceptions.UpnpResponseError: Did not receive HTTP 200 but 400
b''
```
and
```
2022-05-16 14:26:43 ERROR (MainThread) [homeassistant.helpers.entity] Update for media_player.samsung_tv fails
Traceback (most recent call last):
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/async_upnp_client/aiohttp.py", line 179, in _async_http_request
    resp_body = await response.read()
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 1036, in read
    self._body = await self.content.read()
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/aiohttp/streams.py", line 375, in read
    block = await self.readany()
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/aiohttp/streams.py", line 397, in readany
    await self._wait("readany")
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/aiohttp/streams.py", line 304, in _wait
    await waiter
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/homeassistant/helpers/entity.py", line 515, in async_update_ha_state
    await self.async_device_update()
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/homeassistant/helpers/entity.py", line 743, in async_device_update
    raise exc
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/homeassistant/components/samsungtv/media_player.py", line 222, in async_update
    await asyncio.gather(*startup_tasks)
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/homeassistant/components/samsungtv/media_player.py", line 311, in _async_resubscribe_dmr
    await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/async_upnp_client/profiles/profile.py", line 356, in async_subscribe_services
    new_sid, timeout = await self._event_handler.async_subscribe(
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/async_upnp_client/event_handler.py", line 195, in async_subscribe
    response_status, response_headers, _ = await self._requester.async_http_request(
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/async_upnp_client/aiohttp.py", line 140, in async_http_request
    return await self._async_http_request(method, url, headers, body)
  File "/opt/homeassistant/venv_3.9/lib/python3.9/site-packages/async_upnp_client/aiohttp.py", line 206, in _async_http_request
    raise UpnpCommunicationError(str(err)) from err
async_upnp_client.exceptions.UpnpCommunicationError: ('Response payload is not completed', None)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71833
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
