### PR TITLE
Include initial state in history_stats count

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -156,7 +156,7 @@ class HistoryStats:
         )
         last_state_change_timestamp = start_timestamp
         elapsed = 0.0
-        changes_to_match_state = 0
+        changes_to_match_state = 1 if previous_state_matches else 0
 
         # Make calculations
         for item in self._history_current_period:

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -19,7 +19,7 @@ class HistoryStatsState:
     """The current stats of the history stats."""
 
     hours_matched: float | None
-    changes_to_match_state: int | None
+    match_count: int | None
     period: tuple[datetime.datetime, datetime.datetime]
 
 
@@ -121,14 +121,12 @@ class HistoryStats:
             self._state = HistoryStatsState(None, None, self._period)
             return self._state
 
-        hours_matched, changes_to_match_state = self._async_compute_hours_and_changes(
+        hours_matched, match_count = self._async_compute_hours_and_changes(
             now_timestamp,
             current_period_start_timestamp,
             current_period_end_timestamp,
         )
-        self._state = HistoryStatsState(
-            hours_matched, changes_to_match_state, self._period
-        )
+        self._state = HistoryStatsState(hours_matched, match_count, self._period)
         return self._state
 
     def _update_from_database(
@@ -156,7 +154,7 @@ class HistoryStats:
         )
         last_state_change_timestamp = start_timestamp
         elapsed = 0.0
-        changes_to_match_state = 1 if previous_state_matches else 0
+        match_count = 1 if previous_state_matches else 0
 
         # Make calculations
         for item in self._history_current_period:
@@ -166,7 +164,7 @@ class HistoryStats:
             if previous_state_matches:
                 elapsed += state_change_timestamp - last_state_change_timestamp
             elif current_state_matches:
-                changes_to_match_state += 1
+                match_count += 1
 
             previous_state_matches = current_state_matches
             last_state_change_timestamp = state_change_timestamp
@@ -178,4 +176,4 @@ class HistoryStats:
 
         # Save value in hours
         hours_matched = elapsed / 3600
-        return hours_matched, changes_to_match_state
+        return hours_matched, match_count

--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -166,4 +166,4 @@ class HistoryStatsSensor(HistoryStatsSensorBase):
         elif self._type == CONF_TYPE_RATIO:
             self._attr_native_value = pretty_ratio(state.hours_matched, state.period)
         elif self._type == CONF_TYPE_COUNT:
-            self._attr_native_value = state.changes_to_match_state
+            self._attr_native_value = state.match_count

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -438,7 +438,7 @@ async def test_measure(hass, recorder_mock):
 
     assert hass.states.get("sensor.sensor1").state == "0.83"
     assert hass.states.get("sensor.sensor2").state == "0.83"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 
@@ -519,7 +519,7 @@ async def test_async_on_entire_period(hass, recorder_mock):
 
     assert hass.states.get("sensor.on_sensor1").state == "1.0"
     assert hass.states.get("sensor.on_sensor2").state == "1.0"
-    assert hass.states.get("sensor.on_sensor3").state == "0"
+    assert hass.states.get("sensor.on_sensor3").state == "1"
     assert hass.states.get("sensor.on_sensor4").state == "100.0"
 
 
@@ -886,7 +886,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
     assert hass.states.get("sensor.sensor1").state == "0.0"
     assert hass.states.get("sensor.sensor2").state == "0.0"
-    assert hass.states.get("sensor.sensor3").state == "0"
+    assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "0.0"
 
     one_hour_in = start_time + timedelta(minutes=60)
@@ -896,7 +896,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
     assert hass.states.get("sensor.sensor1").state == "1.0"
     assert hass.states.get("sensor.sensor2").state == "1.0"
-    assert hass.states.get("sensor.sensor3").state == "0"
+    assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "50.0"
 
     turn_off_time = start_time + timedelta(minutes=90)
@@ -908,7 +908,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
     assert hass.states.get("sensor.sensor1").state == "1.5"
     assert hass.states.get("sensor.sensor2").state == "1.5"
-    assert hass.states.get("sensor.sensor3").state == "0"
+    assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "75.0"
 
     turn_back_on_time = start_time + timedelta(minutes=105)
@@ -918,7 +918,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
     assert hass.states.get("sensor.sensor1").state == "1.5"
     assert hass.states.get("sensor.sensor2").state == "1.5"
-    assert hass.states.get("sensor.sensor3").state == "0"
+    assert hass.states.get("sensor.sensor3").state == "1"
     assert hass.states.get("sensor.sensor4").state == "75.0"
 
     with freeze_time(turn_back_on_time):
@@ -927,7 +927,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
     assert hass.states.get("sensor.sensor1").state == "1.5"
     assert hass.states.get("sensor.sensor2").state == "1.5"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "75.0"
 
     end_time = start_time + timedelta(minutes=120)
@@ -937,7 +937,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
     assert hass.states.get("sensor.sensor1").state == "1.75"
     assert hass.states.get("sensor.sensor2").state == "1.75"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "87.5"
 
 
@@ -1198,7 +1198,7 @@ async def test_measure_sliding_window(hass, recorder_mock):
 
     assert hass.states.get("sensor.sensor1").state == "0.83"
     assert hass.states.get("sensor.sensor2").state == "0.83"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "41.7"
 
     past_next_update = start_time + timedelta(minutes=30)
@@ -1211,7 +1211,7 @@ async def test_measure_sliding_window(hass, recorder_mock):
 
     assert hass.states.get("sensor.sensor1").state == "0.83"
     assert hass.states.get("sensor.sensor2").state == "0.83"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "41.7"
 
 
@@ -1291,7 +1291,7 @@ async def test_measure_from_end_going_backwards(hass, recorder_mock):
 
     assert hass.states.get("sensor.sensor1").state == "0.83"
     assert hass.states.get("sensor.sensor2").state == "0.83"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
     past_next_update = start_time + timedelta(minutes=30)
@@ -1304,7 +1304,7 @@ async def test_measure_from_end_going_backwards(hass, recorder_mock):
 
     assert hass.states.get("sensor.sensor1").state == "0.83"
     assert hass.states.get("sensor.sensor2").state == "0.83"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 
@@ -1385,7 +1385,7 @@ async def test_measure_cet(hass, recorder_mock):
 
     assert hass.states.get("sensor.sensor1").state == "0.83"
     assert hass.states.get("sensor.sensor2").state == "0.83"
-    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This restores the 2022.4 count behavior. 

 If its agreed that this is the correct behavior, I'll open a docs PR to adjust since:

https://www.home-assistant.io/integrations/history_stats/#sensor-type
The docs say the count should be
`How many times the integration you track was changed to the state you track`

The docs should probably say
`How many times the integration you track matched the state you track` since thats
how it worked in 2022.4


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71736
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
