### PR TITLE
Check if attributes are present in new_state before accessing them

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -191,16 +191,16 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             old_state = event.data.get("old_state")
             new_state = event.data.get("new_state")
 
-            if (
-                new_state is None
-                or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            if new_state is None or new_state.state in (
+                STATE_UNKNOWN,
+                STATE_UNAVAILABLE,
             ):
                 return
 
             # We may want to update our state before an early return,
             # based on the source sensor's unit_of_measurement
             # or device_class.
-            update_state = False            
+            update_state = False
             unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
             if unit is not None:
                 new_unit_of_measurement = self._unit_template.format(unit)
@@ -219,12 +219,12 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             if update_state:
                 self.async_write_ha_state()
 
-            if (
-                old_state is None
-                or old_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            if old_state is None or old_state.state in (
+                STATE_UNKNOWN,
+                STATE_UNAVAILABLE,
             ):
                 return
-                
+
             try:
                 # integration as the Riemann integral of previous measures.
                 area = 0

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -191,18 +191,22 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             old_state = event.data.get("old_state")
             new_state = event.data.get("new_state")
 
+            if (
+                new_state is None
+                or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            ):
+                return
+
             # We may want to update our state before an early return,
             # based on the source sensor's unit_of_measurement
             # or device_class.
-            update_state = False
-
-            if new_state.attributes:
-                unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-                if unit is not None:
-                    new_unit_of_measurement = self._unit_template.format(unit)
-                    if self._unit_of_measurement != new_unit_of_measurement:
-                        self._unit_of_measurement = new_unit_of_measurement
-                        update_state = True
+            update_state = False            
+            unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            if unit is not None:
+                new_unit_of_measurement = self._unit_template.format(unit)
+                if self._unit_of_measurement != new_unit_of_measurement:
+                    self._unit_of_measurement = new_unit_of_measurement
+                    update_state = True
 
             if (
                 self.device_class is None
@@ -217,12 +221,10 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
 
             if (
                 old_state is None
-                or new_state is None
                 or old_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-                or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
             ):
                 return
-
+                
             try:
                 # integration as the Riemann integral of previous measures.
                 area = 0

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -196,12 +196,13 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             # or device_class.
             update_state = False
 
-            unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-            if unit is not None:
-                new_unit_of_measurement = self._unit_template.format(unit)
-                if self._unit_of_measurement != new_unit_of_measurement:
-                    self._unit_of_measurement = new_unit_of_measurement
-                    update_state = True
+            if new_state.attributes:
+                unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                if unit is not None:
+                    new_unit_of_measurement = self._unit_template.format(unit)
+                    if self._unit_of_measurement != new_unit_of_measurement:
+                        self._unit_of_measurement = new_unit_of_measurement
+                        update_state = True
 
             if (
                 self.device_class is None

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     ENERGY_WATT_HOUR,
     POWER_KILO_WATT,
     POWER_WATT,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     TIME_SECONDS,
 )
@@ -348,6 +349,15 @@ async def test_units(hass):
 
     # Testing the sensor ignored the source sensor's units until
     # they became valid
+    assert state.attributes.get("unit_of_measurement") == ENERGY_WATT_HOUR
+
+    # When source state goes to None / Unknown, expect an early exit without
+    # changes to the state or unit_of_measurement
+    hass.states.async_set(entity_id, STATE_UNAVAILABLE, None)
+    await hass.async_block_till_done()
+
+    new_state = hass.states.get("sensor.integration")
+    assert state == new_state
     assert state.attributes.get("unit_of_measurement") == ENERGY_WATT_HOUR
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Not every update that causes `calc_integration` to run is guaranteed to contain attributes. Example: when reloading template sensors, they may briefly exist in an _unknown_ state.
This change first checks if attributes are present in the new state, before attempting to access them.
Fixes #71684.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71684
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
