### PR TITLE
Correct unit of measurement for Synology DSM volume sensors

### DIFF
--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_DISKS,
     DATA_MEGABYTES,
     DATA_RATE_KILOBYTES_PER_SECOND,
-    DATA_TERABYTES,
+    DATA_TEBIBYTES,
     PERCENTAGE,
     TEMP_CELSIUS,
 )
@@ -189,7 +189,7 @@ STORAGE_VOL_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoStorage.API_KEY,
         key="volume_size_total",
         name="Total Size",
-        native_unit_of_measurement=DATA_TERABYTES,
+        native_unit_of_measurement=DATA_TEBIBYTES,
         icon="mdi:chart-pie",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -198,7 +198,7 @@ STORAGE_VOL_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoStorage.API_KEY,
         key="volume_size_used",
         name="Used Space",
-        native_unit_of_measurement=DATA_TERABYTES,
+        native_unit_of_measurement=DATA_TEBIBYTES,
         icon="mdi:chart-pie",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -389,7 +389,7 @@ class SynoDSMStorageSensor(SynologyDSMDeviceEntity, SynoDSMSensor):
             return None
 
         # Data (disk space)
-        if self.native_unit_of_measurement == DATA_TERABYTES:
+        if self.native_unit_of_measurement == DATA_TEBIBYTES:
             return round(attr / 1024.0**4, 2)
 
         return attr

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -18,8 +18,8 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DISKS,
-    DATA_MEGABYTES,
-    DATA_RATE_KILOBYTES_PER_SECOND,
+    DATA_MEBIBYTES,
+    DATA_RATE_KIBIBYTES_PER_SECOND,
     DATA_TEBIBYTES,
     PERCENTAGE,
     TEMP_CELSIUS,
@@ -115,7 +115,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="memory_size",
         name="Memory Size",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_MEBIBYTES,
         icon="mdi:memory",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -124,7 +124,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="memory_cached",
         name="Memory Cached",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_MEBIBYTES,
         icon="mdi:memory",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -133,7 +133,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="memory_available_swap",
         name="Memory Available (Swap)",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_MEBIBYTES,
         icon="mdi:memory",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -141,7 +141,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="memory_available_real",
         name="Memory Available (Real)",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_MEBIBYTES,
         icon="mdi:memory",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -149,7 +149,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="memory_total_swap",
         name="Memory Total (Swap)",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_MEBIBYTES,
         icon="mdi:memory",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -157,7 +157,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="memory_total_real",
         name="Memory Total (Real)",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_MEBIBYTES,
         icon="mdi:memory",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -165,7 +165,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="network_up",
         name="Upload Throughput",
-        native_unit_of_measurement=DATA_RATE_KILOBYTES_PER_SECOND,
+        native_unit_of_measurement=DATA_RATE_KIBIBYTES_PER_SECOND,
         icon="mdi:upload",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -173,7 +173,7 @@ UTILISATION_SENSORS: tuple[SynologyDSMSensorEntityDescription, ...] = (
         api_key=SynoCoreUtilization.API_KEY,
         key="network_down",
         name="Download Throughput",
-        native_unit_of_measurement=DATA_RATE_KILOBYTES_PER_SECOND,
+        native_unit_of_measurement=DATA_RATE_KIBIBYTES_PER_SECOND,
         icon="mdi:download",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -347,11 +347,11 @@ class SynoDSMUtilSensor(SynoDSMSensor):
             return None
 
         # Data (RAM)
-        if self.native_unit_of_measurement == DATA_MEGABYTES:
+        if self.native_unit_of_measurement == DATA_MEBIBYTES:
             return round(attr / 1024.0**2, 1)
 
         # Network
-        if self.native_unit_of_measurement == DATA_RATE_KILOBYTES_PER_SECOND:
+        if self.native_unit_of_measurement == DATA_RATE_KIBIBYTES_PER_SECOND:
             return round(attr / 1024.0, 1)
 
         # CPU load average


### PR DESCRIPTION
## Breaking change
The units of measurement for all memory, storage and network utilization related sensors were corrected from decimal to its binary representations, since the values are calculated on a binary base (2^10 = 1024).

You may need to update the historic recorded units for these sensors via the statistics page under developer tools.

## Proposed change
When scaling by binary (i.e. 1024 instead of 1000), the unit should be tebibytes instead of terabytes. Note that as of Synology DSM 7.1, the Synology DSM Storage Manager incorrectly uses units of TB when it should use TiB, so DSM should _NOT_ be used as a trustworthy reference for correct units!


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- ~This PR fixes or closes issue:~ N/A
- ~This PR is related to issue:~ N/A
- ~Link to documentation pull request:~ N/A

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] ~Tests have been added to verify that the new code works.~ N/A, no new functionality added

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] [22790](https://github.com/home-assistant/home-assistant.io/pull/22790)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
