### PR TITLE
Support requesting translations for multiple integrations in a single request

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -667,8 +667,7 @@ def websocket_get_themes(
         "type": "frontend/get_translations",
         vol.Required("language"): str,
         vol.Required("category"): str,
-        vol.Optional("integration"): str,
-        vol.Optional("integrations"): [str],
+        vol.Optional("integration"): vol.All(cv.ensure_list, [str]),
         vol.Optional("config_flow"): bool,
     }
 )
@@ -677,17 +676,11 @@ async def websocket_get_translations(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ) -> None:
     """Handle get translations command."""
-    integrations = None
-    if "integration" in msg:
-        integrations = {msg["integration"]}
-    elif "integrations" in msg:
-        integrations = set(msg["integrations"])
-
     resources = await async_get_translations(
         hass,
         msg["language"],
         msg["category"],
-        integrations,
+        msg.get("integration"),
         msg.get("config_flow"),
     )
     connection.send_message(

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -668,6 +668,7 @@ def websocket_get_themes(
         vol.Required("language"): str,
         vol.Required("category"): str,
         vol.Optional("integration"): str,
+        vol.Optional("integrations"): [str],
         vol.Optional("config_flow"): bool,
     }
 )
@@ -676,11 +677,17 @@ async def websocket_get_translations(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ) -> None:
     """Handle get translations command."""
+    integrations = None
+    if "integration" in msg:
+        integrations = {msg["integration"]}
+    elif "integrations" in msg:
+        integrations = set(msg["integrations"])
+
     resources = await async_get_translations(
         hass,
         msg["language"],
         msg["category"],
-        msg.get("integration"),
+        integrations,
         msg.get("config_flow"),
     )
     connection.send_message(

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -149,7 +149,7 @@ class UserOnboardingView(_BaseOnboardingView):
 
             # Create default areas using the users supplied language.
             translations = await async_get_translations(
-                data["language"], "area", {DOMAIN}
+                hass, data["language"], "area", {DOMAIN}
             )
 
             area_registry = await hass.helpers.area_registry.async_get_registry()

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -15,6 +15,7 @@ from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import callback
 from homeassistant.helpers.system_info import async_get_system_info
+from homeassistant.helpers.translation import async_get_translations
 
 from .const import (
     DEFAULT_AREAS,
@@ -147,8 +148,8 @@ class UserOnboardingView(_BaseOnboardingView):
                 await person.async_create_person(hass, data["name"], user_id=user.id)
 
             # Create default areas using the users supplied language.
-            translations = await hass.helpers.translation.async_get_translations(
-                data["language"], "area", DOMAIN
+            translations = await async_get_translations(
+                data["language"], "area", {DOMAIN}
             )
 
             area_registry = await hass.helpers.area_registry.async_get_registry()

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import ChainMap
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 import logging
 from typing import Any
 
@@ -286,7 +286,7 @@ async def async_get_translations(
     hass: HomeAssistant,
     language: str,
     category: str,
-    integrations: set[str] | None = None,
+    integrations: Iterable[str] | None = None,
     config_flow: bool | None = None,
 ) -> dict[str, Any]:
     """Return all backend translations.
@@ -298,7 +298,7 @@ async def async_get_translations(
     lock = hass.data.setdefault(TRANSLATION_LOAD_LOCK, asyncio.Lock())
 
     if integrations is not None:
-        components = integrations
+        components = set(integrations)
     elif config_flow:
         components = (await async_get_config_flows(hass)) - hass.config.components
     elif category == "state":

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -448,16 +448,16 @@ async def test_get_translations_for_integrations(hass, ws_client):
     """Test get_translations for integrations command."""
     with patch(
         "homeassistant.components.frontend.async_get_translations",
-        side_effect=lambda hass, lang, category, integrations, config_flow: {
+        side_effect=lambda hass, lang, category, integration, config_flow: {
             "lang": lang,
-            "integrations": integrations,
+            "integration": integration,
         },
     ):
         await ws_client.send_json(
             {
                 "id": 5,
                 "type": "frontend/get_translations",
-                "integrations": ["frontend", "http"],
+                "integration": ["frontend", "http"],
                 "language": "nl",
                 "category": "lang",
             }
@@ -467,7 +467,7 @@ async def test_get_translations_for_integrations(hass, ws_client):
     assert msg["id"] == 5
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
-    assert set(msg["result"]["resources"]["integrations"]) == {"frontend", "http"}
+    assert set(msg["result"]["resources"]["integration"]) == {"frontend", "http"}
 
 
 async def test_get_translations_for_single_integration(hass, ws_client):

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -467,9 +467,7 @@ async def test_get_translations_for_integrations(hass, ws_client):
     assert msg["id"] == 5
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
-    assert msg["result"] == {
-        "resources": {"lang": "nl", "integrations": ["frontend", "http"]}
-    }
+    assert set(msg["result"]["resources"]["integrations"]) == {"frontend", "http"}
 
 
 async def test_get_translations_for_single_integration(hass, ws_client):

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -424,7 +424,7 @@ async def test_get_translations(hass, ws_client):
     """Test get_translations command."""
     with patch(
         "homeassistant.components.frontend.async_get_translations",
-        side_effect=lambda hass, lang, category, integration, config_flow: {
+        side_effect=lambda hass, lang, category, integrations, config_flow: {
             "lang": lang
         },
     ):
@@ -442,6 +442,60 @@ async def test_get_translations(hass, ws_client):
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
     assert msg["result"] == {"resources": {"lang": "nl"}}
+
+
+async def test_get_translations_for_integrations(hass, ws_client):
+    """Test get_translations for integrations command."""
+    with patch(
+        "homeassistant.components.frontend.async_get_translations",
+        side_effect=lambda hass, lang, category, integrations, config_flow: {
+            "lang": lang,
+            "integrations": integrations,
+        },
+    ):
+        await ws_client.send_json(
+            {
+                "id": 5,
+                "type": "frontend/get_translations",
+                "integrations": ["frontend", "http"],
+                "language": "nl",
+                "category": "lang",
+            }
+        )
+        msg = await ws_client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    assert msg["result"] == {
+        "resources": {"lang": "nl", "integrations": ["frontend", "http"]}
+    }
+
+
+async def test_get_translations_for_single_integration(hass, ws_client):
+    """Test get_translations for integration command."""
+    with patch(
+        "homeassistant.components.frontend.async_get_translations",
+        side_effect=lambda hass, lang, category, integrations, config_flow: {
+            "lang": lang,
+            "integration": integrations,
+        },
+    ):
+        await ws_client.send_json(
+            {
+                "id": 5,
+                "type": "frontend/get_translations",
+                "integration": "http",
+                "language": "nl",
+                "category": "lang",
+            }
+        )
+        msg = await ws_client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    assert msg["result"] == {"resources": {"lang": "nl", "integration": ["http"]}}
 
 
 async def test_auth_load(hass):

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -290,10 +290,27 @@ async def test_translation_merging_loaded_apart(hass, caplog):
     assert "component.sensor.state.moon__phase.first_quarter" in translations
 
     translations = await translation.async_get_translations(
-        hass, "en", "state", integration="sensor"
+        hass, "en", "state", integrations={"sensor"}
     )
 
     assert "component.sensor.state.moon__phase.first_quarter" in translations
+
+
+async def test_translation_merging_loaded_together(hass, caplog):
+    """Test we merge translations of two integrations when they are loaded at the same time."""
+    hass.config.components.add("hue")
+    hass.config.components.add("homekit")
+    hue_translations = await translation.async_get_translations(
+        hass, "en", "config", integrations={"hue"}
+    )
+    homekit_translations = await translation.async_get_translations(
+        hass, "en", "config", integrations={"homekit"}
+    )
+
+    translations = await translation.async_get_translations(
+        hass, "en", "config", integrations={"hue", "homekit"}
+    )
+    assert translations == hue_translations | homekit_translations
 
 
 async def test_caching(hass):
@@ -320,14 +337,14 @@ async def test_caching(hass):
             )
 
     load_sensor_only = await translation.async_get_translations(
-        hass, "en", "state", integration="sensor"
+        hass, "en", "state", integrations={"sensor"}
     )
     assert load_sensor_only
     for key in load_sensor_only:
         assert key.startswith("component.sensor.state.")
 
     load_light_only = await translation.async_get_translations(
-        hass, "en", "state", integration="light"
+        hass, "en", "state", integrations={"light"}
     )
     assert load_light_only
     for key in load_light_only:
@@ -341,7 +358,7 @@ async def test_caching(hass):
         side_effect=translation._build_resources,
     ) as mock_build:
         load_sensor_only = await translation.async_get_translations(
-            hass, "en", "title", integration="sensor"
+            hass, "en", "title", integrations={"sensor"}
         )
         assert load_sensor_only
         for key in load_sensor_only:
@@ -349,12 +366,12 @@ async def test_caching(hass):
         assert len(mock_build.mock_calls) == 0
 
         assert await translation.async_get_translations(
-            hass, "en", "title", integration="sensor"
+            hass, "en", "title", integrations={"sensor"}
         )
         assert len(mock_build.mock_calls) == 0
 
         load_light_only = await translation.async_get_translations(
-            hass, "en", "title", integration="media_player"
+            hass, "en", "title", integrations={"media_player"}
         )
         assert load_light_only
         for key in load_light_only:


### PR DESCRIPTION
Frontend: https://github.com/home-assistant/frontend/pull/12704

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I finally got around to figuring out why the integrations page loaded slowly on many of my instances.

The goal is to reduce the number of requests when loading the integrations page when there are a number of discoveries.  As I have pages of these:
<img width="1308" alt="Screen Shot 2022-05-16 at 19 26 33" src="https://user-images.githubusercontent.com/663432/168703224-48f1181e-d95c-4fbd-8f1b-6e9930e5e73f.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
