### PR TITLE
Add return code to integration application credentials in config flow

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -25,6 +25,7 @@ from homeassistant import config_entries
 from homeassistant.components import http
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.loader import async_get_application_credentials
 
 from .aiohttp_client import async_get_clientsession
 from .network import NoURLAvailableError
@@ -239,6 +240,8 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
             return await self.async_step_auth()
 
         if not implementations:
+            if self.DOMAIN in await async_get_application_credentials(self.hass):
+                return self.async_abort(reason="missing_credentials")
             return self.async_abort(reason="missing_configuration")
 
         req = http.current_request.get()

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -71,7 +71,7 @@
         "webhook_not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages.",
         "oauth2_error": "Received invalid token data.",
         "oauth2_missing_configuration": "The component is not configured. Please follow the documentation.",
-        "oauth2_missing_credentials": "The component requires application credentials.",
+        "oauth2_missing_credentials": "The integration requires application credentials.",
         "oauth2_authorize_url_timeout": "Timeout generating authorize URL.",
         "oauth2_no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
         "reauth_successful": "Re-authentication was successful",

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -71,6 +71,7 @@
         "webhook_not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages.",
         "oauth2_error": "Received invalid token data.",
         "oauth2_missing_configuration": "The component is not configured. Please follow the documentation.",
+        "oauth2_missing_credentials": "The component requires application credentials.",
         "oauth2_authorize_url_timeout": "Timeout generating authorize URL.",
         "oauth2_no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
         "reauth_successful": "Re-authentication was successful",

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -327,7 +327,7 @@ async def test_missing_configuration(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result.get("type") == "abort"
-    assert result.get("reason") == "missing_configuration"
+    assert result.get("reason") == "missing_credentials"
 
 
 @pytest.mark.parametrize("google_config", [None])
@@ -342,7 +342,7 @@ async def test_missing_configuration_yaml_empty(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result.get("type") == "abort"
-    assert result.get("reason") == "missing_configuration"
+    assert result.get("reason") == "missing_credentials"
 
 
 async def test_wrong_configuration(

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -31,14 +31,14 @@ async def test_abort_if_no_configuration(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_configuration"
+    assert result["reason"] == "missing_credentials"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=BLANK_ZEROCONF_INFO
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_configuration"
+    assert result["reason"] == "missing_credentials"
 
 
 async def test_zeroconf_abort_if_existing_entry(hass):

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_abort_if_no_configuration(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_configuration"
+    assert result["reason"] == "missing_credentials"
 
 
 async def test_abort_if_existing_entry(hass: HomeAssistant):

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -114,6 +114,17 @@ async def test_abort_if_no_implementation(hass, flow_handler):
     assert result["reason"] == "missing_configuration"
 
 
+async def test_missing_credentials_for_domain(hass, flow_handler):
+    """Check flow abort for integration supporting application credentials."""
+    flow = flow_handler()
+    flow.hass = hass
+
+    with patch("homeassistant.loader.APPLICATION_CREDENTIALS", [TEST_DOMAIN]):
+        result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "missing_credentials"
+
+
 async def test_abort_if_authorization_timeout(
     hass, flow_handler, local_impl, current_request_with_host
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add return code to integration application credentials in config flow. When no implementations are found, return `missing_credentials` when the integration supports application credentials. This will cause the frontend to handle and prompt the user to setup credentials, then restart the configuration flow which should then have an auth implementation.

Requires frontend PR https://github.com/home-assistant/frontend/pull/12708 is updated into core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Related architecture discussion https://github.com/home-assistant/architecture/discussions/692

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
