### PR TITLE
Clean up accessing entity_registry.async_get_registry helper via hass

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -9,6 +9,7 @@ from logging import getLogger
 from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import models
@@ -303,11 +304,9 @@ class AuthStore:
 
     async def _async_load_task(self) -> None:
         """Load the users."""
-        [ent_reg, dev_reg, data] = await asyncio.gather(
-            self.hass.helpers.entity_registry.async_get_registry(),
-            self.hass.helpers.device_registry.async_get_registry(),
-            self._store.async_load(),
-        )
+        dev_reg = dr.async_get(self.hass)
+        ent_reg = er.async_get(self.hass)
+        data = await self._store.async_load()
 
         # Make sure that we're not overriding data if 2 loads happened at the
         # same time

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -8,9 +8,8 @@ from homeassistant.components.device_automation.const import (
 )
 from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.const import CONF_ENTITY_ID, CONF_FOR, CONF_TYPE
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import get_device_class
-from homeassistant.helpers.entity_registry import async_entries_for_device
 
 from . import DOMAIN, BinarySensorDeviceClass
 
@@ -280,11 +279,11 @@ async def async_attach_trigger(hass, config, action, automation_info):
 async def async_get_triggers(hass, device_id):
     """List device triggers."""
     triggers = []
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entries = [
         entry
-        for entry in async_entries_for_device(entity_registry, device_id)
+        for entry in er.async_entries_for_device(entity_registry, device_id)
         if entry.domain == DOMAIN
     ]
 

--- a/homeassistant/components/device_automation/entity.py
+++ b/homeassistant/components/device_automation/entity.py
@@ -12,8 +12,7 @@ from homeassistant.components.automation import (
 from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.const import CONF_ENTITY_ID, CONF_FOR, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity_registry import async_entries_for_device
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from . import DEVICE_TRIGGER_BASE_SCHEMA
@@ -68,11 +67,11 @@ async def _async_get_automations(
 ) -> list[dict[str, str]]:
     """List device automations."""
     automations: list[dict[str, str]] = []
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entries = [
         entry
-        for entry in async_entries_for_device(entity_registry, device_id)
+        for entry in er.async_entries_for_device(entity_registry, device_id)
         if entry.domain == domain
     ]
 

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -20,8 +20,11 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
-from homeassistant.helpers import condition, config_validation as cv
-from homeassistant.helpers.entity_registry import async_entries_for_device
+from homeassistant.helpers import (
+    condition,
+    config_validation as cv,
+    entity_registry as er,
+)
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
 from . import DEVICE_TRIGGER_BASE_SCHEMA, entity
@@ -187,11 +190,11 @@ async def _async_get_automations(
 ) -> list[dict[str, str]]:
     """List device automations."""
     automations: list[dict[str, str]] = []
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entries = [
         entry
-        for entry in async_entries_for_device(entity_registry, device_id)
+        for entry in er.async_entries_for_device(entity_registry, device_id)
         if entry.domain == domain
     ]
 

--- a/homeassistant/components/emulated_kasa/__init__.py
+++ b/homeassistant/components/emulated_kasa/__init__.py
@@ -14,8 +14,8 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.template import Template, is_template_string
 from homeassistant.helpers.typing import ConfigType
 
@@ -79,7 +79,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def validate_configs(hass, entity_configs):
     """Validate that entities exist and ensure templates are ready to use."""
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     for entity_id, entity_config in entity_configs.items():
         if (state := hass.states.get(entity_id)) is None:
             _LOGGER.debug("Entity not found: %s", entity_id)
@@ -108,7 +108,7 @@ async def validate_configs(hass, entity_configs):
             _LOGGER.debug("No power value defined for: %s", entity_id)
 
 
-def get_system_unique_id(entity: RegistryEntry):
+def get_system_unique_id(entity: er.RegistryEntry):
     """Determine the system wide unique_id for an entity."""
     return f"{entity.platform}.{entity.domain}.{entity.unique_id}"
 

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -297,7 +298,7 @@ def setup_service_functions(hass: HomeAssistant, broker):
         """Set the zone override (setpoint)."""
         entity_id = call.data[ATTR_ENTITY_ID]
 
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         registry_entry = registry.async_get(entity_id)
 
         if registry_entry is None or registry_entry.platform != DOMAIN:

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import (
@@ -146,7 +146,7 @@ def setup_service_functions(hass: HomeAssistant, broker):
         """Set the system mode."""
         entity_id = call.data[ATTR_ENTITY_ID]
 
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         registry_entry = registry.async_get(entity_id)
 
         if registry_entry is None or registry_entry.platform != DOMAIN:

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -167,10 +168,9 @@ class ControllerManager:
 
     async def connect_listeners(self):
         """Subscribe to events of interest."""
-        self._device_registry, self._entity_registry = await asyncio.gather(
-            self._hass.helpers.device_registry.async_get_registry(),
-            self._hass.helpers.entity_registry.async_get_registry(),
-        )
+        self._device_registry = dr.async_get(self._hass)
+        self._entity_registry = er.async_get(self._hass)
+
         # Handle controller events
         self._signals.append(
             self.controller.dispatcher.connect(

--- a/homeassistant/components/homekit/aidmanager.py
+++ b/homeassistant/components/homekit/aidmanager.py
@@ -17,7 +17,7 @@ import random
 from fnvhash import fnv1a_32
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
 
 from .util import get_aid_storage_filename_for_entry_id
@@ -34,7 +34,7 @@ AID_MIN = 2
 AID_MAX = 18446744073709551615
 
 
-def get_system_unique_id(entity: RegistryEntry) -> str:
+def get_system_unique_id(entity: er.RegistryEntry) -> str:
     """Determine the system wide unique_id for an entity."""
     return f"{entity.platform}.{entity.domain}.{entity.unique_id}"
 
@@ -74,13 +74,11 @@ class AccessoryAidStorage:
         self.allocated_aids: set[int] = set()
         self._entry_id = entry_id
         self.store: Store | None = None
-        self._entity_registry: EntityRegistry | None = None
+        self._entity_registry: er.EntityRegistry | None = None
 
     async def async_initialize(self) -> None:
         """Load the latest AID data."""
-        self._entity_registry = (
-            await self.hass.helpers.entity_registry.async_get_registry()
-        )
+        self._entity_registry = er.async_get(self.hass)
         aidstore = get_aid_storage_filename_for_entry_id(self._entry_id)
         self.store = Store(self.hass, AID_MANAGER_STORAGE_VERSION, aidstore)
 

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -42,7 +42,7 @@ from homeassistant.exceptions import (
     HomeAssistantError,
     Unauthorized,
 )
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.helpers.typing import ConfigType
 
@@ -266,7 +266,7 @@ class NestEventViewBase(HomeAssistantView, ABC):
     ) -> web.StreamResponse:
         """Start a GET request."""
         user = request[KEY_HASS_USER]
-        entity_registry = await self.hass.helpers.entity_registry.async_get_registry()
+        entity_registry = er.async_get(self.hass)
         for entry in async_entries_for_device(entity_registry, device_id):
             if not user.permissions.check_entity(entry.entity_id, POLICY_READ):
                 raise Unauthorized(entity_id=entry.entity_id)

--- a/homeassistant/components/risco/sensor.py
+++ b/homeassistant/components/risco/sensor.py
@@ -3,6 +3,7 @@ from homeassistant.components.binary_sensor import DOMAIN as BS_DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -75,9 +76,7 @@ class RiscoSensor(CoordinatorEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._entity_registry = (
-            await self.hass.helpers.entity_registry.async_get_registry()
-        )
+        self._entity_registry = er.async_get(self.hass)
         self.async_on_remove(
             self.coordinator.async_add_listener(self._refresh_from_coordinator)
         )

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.typing import ConfigType
@@ -313,10 +314,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     # 1 -> 2: Unique ID format changed, so delete and re-import:
     if version == 1:
-        dev_reg = await hass.helpers.device_registry.async_get_registry()
+        dev_reg = dr.async_get(hass)
         dev_reg.async_clear_config_entry(config_entry.entry_id)
 
-        en_reg = await hass.helpers.entity_registry.async_get_registry()
+        en_reg = er.async_get(hass)
         en_reg.async_clear_config_entry(config_entry.entry_id)
 
         version = config_entry.version = 2

--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -16,13 +16,12 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import (
     get_capability,
     get_device_class,
     get_unit_of_measurement,
 )
-from homeassistant.helpers.entity_registry import async_entries_for_device
 
 from . import ATTR_STATE_CLASS, DOMAIN, SensorDeviceClass
 
@@ -159,11 +158,11 @@ async def async_attach_trigger(hass, config, action, automation_info):
 async def async_get_triggers(hass, device_id):
     """List device triggers."""
     triggers = []
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entries = [
         entry
-        for entry in async_entries_for_device(entity_registry, device_id)
+        for entry in er.async_entries_for_device(entity_registry, device_id)
         if entry.domain == DOMAIN
     ]
 

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -19,7 +19,11 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers import (
+    aiohttp_client,
+    config_validation as cv,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -234,7 +238,7 @@ class SeventeenTrackPackageSensor(SensorEntity):
         """Remove entity itself."""
         await self.async_remove(force_remove=True)
 
-        reg = await self.hass.helpers.entity_registry.async_get_registry()
+        reg = er.async_get(self.hass)
         entity_id = reg.async_get_entity_id(
             "sensor",
             "seventeentrack",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -11,7 +11,7 @@ from aioshelly.rpc_device import RpcDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry, singleton
+from homeassistant.helpers import device_registry, entity_registry, singleton
 from homeassistant.helpers.typing import EventType
 from homeassistant.util.dt import utcnow
 
@@ -34,7 +34,7 @@ async def async_remove_shelly_entity(
     hass: HomeAssistant, domain: str, unique_id: str
 ) -> None:
     """Remove a Shelly entity."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = entity_registry.async_get(hass)
     entity_id = entity_reg.async_get_entity_id(domain, DOMAIN, unique_id)
     if entity_id:
         LOGGER.debug("Removing entity: %s", entity_id)

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -20,6 +20,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDeviceClass, SwitchEnt
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     DeviceEntryType,
@@ -27,7 +28,6 @@ from homeassistant.helpers.device_registry import (
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
@@ -65,8 +65,10 @@ async def async_setup_entry(
 
     # Store previously known POE control entities in case their POE are turned off.
     known_poe_clients = []
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    for entry in async_entries_for_config_entry(entity_registry, config_entry.entry_id):
+    entity_registry = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    ):
 
         if not entry.unique_id.startswith(POE_SWITCH):
             continue

--- a/homeassistant/components/vera/config_flow.py
+++ b/homeassistant/components/vera/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, CONF_LIGHTS, CONF_SOURCE
 from homeassistant.core import callback
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers import entity_registry as er
 
 from .const import CONF_CONTROLLER, CONF_LEGACY_UNIQUE_ID, DOMAIN
 
@@ -119,9 +119,7 @@ class VeraFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # If there are entities with the legacy unique_id, then this imported config
         # should also use the legacy unique_id for entity creation.
-        entity_registry: EntityRegistry = (
-            await self.hass.helpers.entity_registry.async_get_registry()
-        )
+        entity_registry = er.async_get(self.hass)
         use_legacy_unique_id = (
             len(
                 [

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -41,7 +41,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers import config_entry_oauth2_flow, entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import (
     AUTH_CALLBACK_PATH,
     AbstractOAuth2Implementation,
@@ -49,7 +49,6 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
 )
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt
@@ -918,9 +917,7 @@ async def async_get_entity_id(
     hass: HomeAssistant, attribute: WithingsAttribute, user_id: int
 ) -> str | None:
     """Get an entity id for a user's attribute."""
-    entity_registry: EntityRegistry = (
-        await hass.helpers.entity_registry.async_get_registry()
-    )
+    entity_registry = er.async_get(hass)
     unique_id = get_attribute_unique_id(attribute, user_id)
 
     entity_id = entity_registry.async_get_entity_id(

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -791,7 +791,7 @@ def verify_domain_control(
                     user_id=call.context.user_id,
                 )
 
-            reg = await hass.helpers.entity_registry.async_get_registry()
+            reg = entity_registry.async_get(hass)
 
             authorized = False
 

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -236,9 +236,9 @@ async def test_loading_race_condition(hass):
     """Test only one storage load called when concurrent loading occurred ."""
     store = auth_store.AuthStore(hass)
     with patch(
-        "homeassistant.helpers.entity_registry.async_get_registry"
+        "homeassistant.helpers.entity_registry.async_get"
     ) as mock_ent_registry, patch(
-        "homeassistant.helpers.device_registry.async_get_registry"
+        "homeassistant.helpers.device_registry.async_get"
     ) as mock_dev_registry, patch(
         "homeassistant.helpers.storage.Store.async_load", return_value=None
     ) as mock_load:

--- a/tests/components/kraken/test_sensor.py
+++ b/tests/components/kraken/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.kraken.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType
 import homeassistant.util.dt as dt_util
 
@@ -52,7 +53,7 @@ async def test_sensor(hass):
         )
         entry.add_to_hass(hass)
 
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
 
         # Pre-create registry entries for disabled by default sensors
         registry.async_get_or_create(

--- a/tests/components/lcn/test_cover.py
+++ b/tests/components/lcn/test_cover.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockModuleConnection
 
@@ -35,7 +36,7 @@ async def test_setup_lcn_cover(hass, entry, lcn_connection):
 
 async def test_entity_attributes(hass, entry, lcn_connection):
     """Test the attributes of an entity."""
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entity_outputs = entity_registry.async_get("cover.cover_outputs")
 

--- a/tests/components/lcn/test_light.py
+++ b/tests/components/lcn/test_light.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockModuleConnection
 
@@ -54,7 +55,7 @@ async def test_entity_state(hass, lcn_connection):
 
 async def test_entity_attributes(hass, entry, lcn_connection):
     """Test the attributes of an entity."""
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entity_output = entity_registry.async_get("light.light_output1")
 

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockModuleConnection
 
@@ -34,7 +35,7 @@ async def test_setup_lcn_switch(hass, lcn_connection):
 
 async def test_entity_attributes(hass, entry, lcn_connection):
     """Test the attributes of an entity."""
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entity_output = entity_registry.async_get("switch.switch_output1")
 

--- a/tests/components/nws/test_sensor.py
+++ b/tests/components/nws/test_sensor.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant.components.nws.const import ATTRIBUTION, DOMAIN, SENSOR_TYPES
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNKNOWN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
@@ -33,7 +34,7 @@ async def test_imperial_metric(
     hass, units, result_observation, result_forecast, mock_simple_nws, no_weather
 ):
     """Test with imperial and metric units."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     for description in SENSOR_TYPES:
         registry.async_get_or_create(
@@ -66,7 +67,7 @@ async def test_none_values(hass, mock_simple_nws, no_weather):
     instance = mock_simple_nws.return_value
     instance.observation = NONE_OBSERVATION
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     for description in SENSOR_TYPES:
         registry.async_get_or_create(

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,6 +1,7 @@
 """The tests for Octoptint binary sensor module."""
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
@@ -16,7 +17,7 @@ async def test_sensors(hass):
     }
     await init_integration(hass, "binary_sensor", printer=printer)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get("binary_sensor.octoprint_printing")
     assert state is not None
@@ -37,7 +38,7 @@ async def test_sensors_printer_offline(hass):
     """Test the underlying sensors when the printer is offline."""
     await init_integration(hass, "binary_sensor", printer=None)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get("binary_sensor.octoprint_printing")
     assert state is not None

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.util import dt
 
@@ -97,9 +98,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         """Set up things to be run when tests are started."""
         self.hass = await async_test_home_assistant(None)
-        self.entity_registry = (
-            await self.hass.helpers.entity_registry.async_get_registry()
-        )
+        self.entity_registry = er.async_get(self.hass)
 
         # Patch the api client
         self.picnic_patcher = patch("homeassistant.components.picnic.PicnicAPI")

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -2,14 +2,15 @@
 
 from homeassistant.components.plex.const import DOMAIN
 from homeassistant.const import Platform
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 
 async def test_cleanup_orphaned_devices(hass, entry, setup_plex_server):
     """Test cleaning up orphaned devices on startup."""
     test_device_id = {(DOMAIN, "temporary_device_123")}
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     test_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -44,8 +45,8 @@ async def test_migrate_transient_devices(
     non_plexweb_device_id = {(DOMAIN, "1234567890123456-com-plexapp-android")}
     plex_client_service_device_id = {(DOMAIN, "plex.tv-clients")}
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     # Pre-create devices and entities to test device migration
     plexweb_device = device_registry.async_get_or_create(

--- a/tests/components/prosegur/test_alarm_control_panel.py
+++ b/tests/components/prosegur/test_alarm_control_panel.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_UNAVAILABLE,
 )
-from homeassistant.helpers import entity_component
+from homeassistant.helpers import entity_component, entity_registry as er
 
 from .common import CONTRACT, setup_platform
 
@@ -49,7 +49,7 @@ def mock_status(request):
 async def test_entity_registry(hass, mock_auth, mock_status):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(PROSEGUR_ALARM_ENTITY)
     # Prosegur alarm device unique_id is the contract id associated to the alarm account

--- a/tests/components/subaru/test_lock.py
+++ b/tests/components/subaru/test_lock.py
@@ -13,6 +13,7 @@ from homeassistant.components.subaru.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import MOCK_API
 
@@ -23,7 +24,7 @@ DEVICE_ID = "lock.test_vehicle_2_door_locks"
 
 async def test_device_exists(hass, ev_entry):
     """Test subaru lock entity exists."""
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry
 

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
 from .common import (
@@ -76,7 +77,7 @@ async def test_attributes(hass: HomeAssistant) -> None:
         mock_request.assert_called_once()
         assert state.attributes.get(ATTR_FRIENDLY_NAME) == "test"
 
-        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        entity_registry = er.async_get(hass)
         entry = entity_registry.async_get(ENTITY_ID)
         # TotalConnect partition #1 alarm device unique_id is the location_id
         assert entry.unique_id == LOCATION_ID


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

ℹ️ Needs #72004, as this PR exposes that issue (mypy failure).

This PR cleans up the use of accessing the entity registry helper via the hass object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
