### PR TITLE
Clean up accessing intent helpers via hass

### DIFF
--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -11,13 +11,15 @@ INTENT_CLOSE_COVER = "HassCloseCover"
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the cover intents."""
-    hass.helpers.intent.async_register(
+    intent.async_register(
+        hass,
         intent.ServiceIntentHandler(
             INTENT_OPEN_COVER, DOMAIN, SERVICE_OPEN_COVER, "Opened {}"
-        )
+        ),
     )
-    hass.helpers.intent.async_register(
+    intent.async_register(
+        hass,
         intent.ServiceIntentHandler(
             INTENT_CLOSE_COVER, DOMAIN, SERVICE_CLOSE_COVER, "Closed {}"
-        )
+        ),
     )

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -187,11 +187,16 @@ class HangoutsBot:
                 if not (match := matcher.match(text)):
                     continue
                 if intent_type == INTENT_HELP:
-                    return await self.hass.helpers.intent.async_handle(
-                        DOMAIN, intent_type, {"conv_id": {"value": conv_id}}, text
+                    return await intent.async_handle(
+                        self.hass,
+                        DOMAIN,
+                        intent_type,
+                        {"conv_id": {"value": conv_id}},
+                        text,
                     )
 
-                return await self.hass.helpers.intent.async_handle(
+                return await intent.async_handle(
+                    self.hass,
                     DOMAIN,
                     intent_type,
                     {"conv_id": {"value": conv_id}}

--- a/homeassistant/components/humidifier/intent.py
+++ b/homeassistant/components/humidifier/intent.py
@@ -22,8 +22,8 @@ INTENT_MODE = "HassHumidifierMode"
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the humidifier intents."""
-    hass.helpers.intent.async_register(HumidityHandler())
-    hass.helpers.intent.async_register(SetModeHandler())
+    intent.async_register(hass, HumidityHandler())
+    intent.async_register(hass, SetModeHandler())
 
 
 class HumidityHandler(intent.IntentHandler):
@@ -39,8 +39,8 @@ class HumidityHandler(intent.IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-        state = hass.helpers.intent.async_match_state(
-            slots["name"]["value"], hass.states.async_all(DOMAIN)
+        state = intent.async_match_state(
+            hass, slots["name"]["value"], hass.states.async_all(DOMAIN)
         )
 
         service_data = {ATTR_ENTITY_ID: state.entity_id}
@@ -83,7 +83,8 @@ class SetModeHandler(intent.IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-        state = hass.helpers.intent.async_match_state(
+        state = intent.async_match_state(
+            hass,
             slots["name"]["value"],
             hass.states.async_all(DOMAIN),
         )

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -19,20 +19,23 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass, DOMAIN, _async_process_intent
     )
 
-    hass.helpers.intent.async_register(
+    intent.async_register(
+        hass,
         intent.ServiceIntentHandler(
             intent.INTENT_TURN_ON, HA_DOMAIN, SERVICE_TURN_ON, "Turned {} on"
-        )
+        ),
     )
-    hass.helpers.intent.async_register(
+    intent.async_register(
+        hass,
         intent.ServiceIntentHandler(
             intent.INTENT_TURN_OFF, HA_DOMAIN, SERVICE_TURN_OFF, "Turned {} off"
-        )
+        ),
     )
-    hass.helpers.intent.async_register(
+    intent.async_register(
+        hass,
         intent.ServiceIntentHandler(
             intent.INTENT_TOGGLE, HA_DOMAIN, SERVICE_TOGGLE, "Toggled {}"
-        )
+        ),
     )
 
     return True

--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -21,7 +21,7 @@ INTENT_SET = "HassLightSet"
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the light intents."""
-    hass.helpers.intent.async_register(SetIntentHandler())
+    intent.async_register(hass, SetIntentHandler())
 
 
 def _test_supports_color(state: State) -> None:
@@ -56,8 +56,8 @@ class SetIntentHandler(intent.IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-        state = hass.helpers.intent.async_match_state(
-            slots["name"]["value"], hass.states.async_all(DOMAIN)
+        state = intent.async_match_state(
+            hass, slots["name"]["value"], hass.states.async_all(DOMAIN)
         )
 
         service_data = {ATTR_ENTITY_ID: state.entity_id}

--- a/tests/components/humidifier/test_intent.py
+++ b/tests/components/humidifier/test_intent.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.helpers.intent import IntentHandleError
+from homeassistant.helpers.intent import IntentHandleError, async_handle
 
 from tests.common import async_mock_service
 
@@ -29,7 +29,8 @@ async def test_intent_set_humidity(hass):
     turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
     await intent.async_setup_intents(hass)
 
-    result = await hass.helpers.intent.async_handle(
+    result = await async_handle(
+        hass,
         "test",
         intent.INTENT_HUMIDITY,
         {"name": {"value": "Bedroom humidifier"}, "humidity": {"value": "50"}},
@@ -56,7 +57,8 @@ async def test_intent_set_humidity_and_turn_on(hass):
     turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
     await intent.async_setup_intents(hass)
 
-    result = await hass.helpers.intent.async_handle(
+    result = await async_handle(
+        hass,
         "test",
         intent.INTENT_HUMIDITY,
         {"name": {"value": "Bedroom humidifier"}, "humidity": {"value": "50"}},
@@ -97,7 +99,8 @@ async def test_intent_set_mode(hass):
     turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
     await intent.async_setup_intents(hass)
 
-    result = await hass.helpers.intent.async_handle(
+    result = await async_handle(
+        hass,
         "test",
         intent.INTENT_MODE,
         {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
@@ -134,7 +137,8 @@ async def test_intent_set_mode_and_turn_on(hass):
     turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
     await intent.async_setup_intents(hass)
 
-    result = await hass.helpers.intent.async_handle(
+    result = await async_handle(
+        hass,
         "test",
         intent.INTENT_MODE,
         {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
@@ -168,7 +172,8 @@ async def test_intent_set_mode_tests_feature(hass):
     await intent.async_setup_intents(hass)
 
     try:
-        await hass.helpers.intent.async_handle(
+        await async_handle(
+            hass,
             "test",
             intent.INTENT_MODE,
             {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
@@ -196,7 +201,8 @@ async def test_intent_set_unknown_mode(hass):
     await intent.async_setup_intents(hass)
 
     try:
-        await hass.helpers.intent.async_handle(
+        await async_handle(
+            hass,
             "test",
             intent.INTENT_MODE,
             {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "eco"}},

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -2,7 +2,7 @@
 from homeassistant.components import light
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
-from homeassistant.helpers.intent import IntentHandleError
+from homeassistant.helpers.intent import IntentHandleError, async_handle
 
 from tests.common import async_mock_service
 
@@ -16,7 +16,8 @@ async def test_intent_set_color(hass):
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
     await intent.async_setup_intents(hass)
 
-    result = await hass.helpers.intent.async_handle(
+    result = await async_handle(
+        hass,
         "test",
         intent.INTENT_SET,
         {"name": {"value": "Hello"}, "color": {"value": "blue"}},
@@ -40,7 +41,8 @@ async def test_intent_set_color_tests_feature(hass):
     await intent.async_setup_intents(hass)
 
     try:
-        await hass.helpers.intent.async_handle(
+        await async_handle(
+            hass,
             "test",
             intent.INTENT_SET,
             {"name": {"value": "Hello"}, "color": {"value": "blue"}},
@@ -61,7 +63,8 @@ async def test_intent_set_color_and_brightness(hass):
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
     await intent.async_setup_intents(hass)
 
-    result = await hass.helpers.intent.async_handle(
+    result = await async_handle(
+        hass,
         "test",
         intent.INTENT_SET,
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR cleans up the use of accessing intent helpers via the hass object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
