### PR TITLE
Cleanup deprecated async_get_registry in tests

### DIFF
--- a/tests/components/efergy/test_init.py
+++ b/tests/components/efergy/test_init.py
@@ -49,7 +49,7 @@ async def test_async_setup_entry_auth_failed(hass: HomeAssistant):
 async def test_device_info(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
     """Test device info."""
     entry = await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
 

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -68,7 +68,7 @@ async def test_update_failed(
 async def test_device_info(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
     """Test device info."""
     entry = await async_init_integration(hass, aioclient_mock)
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
 

--- a/tests/components/hyperion/test_camera.py
+++ b/tests/components/hyperion/test_camera.py
@@ -200,7 +200,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == HYPERION_MODEL_NAME
     assert device.name == TEST_INSTANCE_1["friendly_name"]
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -1331,7 +1331,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == HYPERION_MODEL_NAME
     assert device.name == TEST_INSTANCE_1["friendly_name"]
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -172,7 +172,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == HYPERION_MODEL_NAME
     assert device.name == TEST_INSTANCE_1["friendly_name"]
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/insteon/test_api_device.py
+++ b/tests/components/insteon/test_api_device.py
@@ -17,7 +17,7 @@ from homeassistant.components.insteon.api.device import (
     async_device_name,
 )
 from homeassistant.components.insteon.const import DOMAIN, MULTIPLE
-from homeassistant.helpers.device_registry import async_get_registry
+from homeassistant.helpers import device_registry as dr
 
 from .const import MOCK_USER_INPUT_PLM
 from .mock_devices import MockDevices
@@ -40,7 +40,7 @@ async def _async_setup(hass, hass_ws_client):
     devices = MockDevices()
     await devices.async_load()
 
-    dev_reg = await async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
     # Create device registry entry for mock node
     ha_device = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -94,7 +94,7 @@ async def test_no_insteon_device(hass, hass_ws_client):
     devices = MockDevices()
     await devices.async_load()
 
-    dev_reg = await async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
     # Create device registry entry for a Insteon device not in the Insteon devices list
     ha_device_1 = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -6,10 +6,8 @@ from homeassistant.components.knx.const import CONF_STATE_ADDRESS, CONF_SYNC_STA
 from homeassistant.components.knx.schema import BinarySensorSchema
 from homeassistant.const import CONF_ENTITY_CATEGORY, CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
-)
 from homeassistant.util import dt
 
 from .conftest import KNXTestKit
@@ -35,7 +33,7 @@ async def test_binary_sensor_entity_category(hass: HomeAssistant, knx: KNXTestKi
     await knx.assert_read("1/1/1")
     await knx.receive_response("1/1/1", True)
 
-    registry = await async_get_entity_registry(hass)
+    registry = er.async_get(hass)
     entity = registry.async_get("binary_sensor.test_normal")
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
 

--- a/tests/components/knx/test_scene.py
+++ b/tests/components/knx/test_scene.py
@@ -4,10 +4,8 @@ from homeassistant.components.knx.const import KNX_ADDRESS
 from homeassistant.components.knx.schema import SceneSchema
 from homeassistant.const import CONF_ENTITY_CATEGORY, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
-)
 
 from .conftest import KNXTestKit
 
@@ -28,7 +26,7 @@ async def test_activate_knx_scene(hass: HomeAssistant, knx: KNXTestKit):
     )
     assert len(hass.states.async_all()) == 1
 
-    registry = await async_get_entity_registry(hass)
+    registry = er.async_get(hass)
     entity = registry.async_get("scene.test")
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
     assert entity.unique_id == "1/1/1_24"

--- a/tests/components/mikrotik/test_init.py
+++ b/tests/components/mikrotik/test_init.py
@@ -76,7 +76,7 @@ async def test_unload_entry(hass):
     entry.add_to_hass(hass)
 
     with patch.object(mikrotik, "MikrotikHub") as mock_hub, patch(
-        "homeassistant.helpers.device_registry.async_get_registry",
+        "homeassistant.helpers.device_registry.async_get",
         return_value=Mock(),
     ):
         mock_hub.return_value.async_setup = AsyncMock(return_value=True)

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -42,7 +42,6 @@ from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.device_registry import async_get_registry
 import homeassistant.util.dt as dt_util
 
 from . import (
@@ -138,8 +137,8 @@ async def test_setup_camera_new_data_same(hass: HomeAssistant) -> None:
 
 async def test_setup_camera_new_data_camera_removed(hass: HomeAssistant) -> None:
     """Test a data refresh with a removed camera."""
-    device_registry = await async_get_registry(hass)
-    entity_registry = await er.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
@@ -328,7 +327,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     assert device.model == MOTIONEYE_MANUFACTURER
     assert device.name == TEST_CAMERA_NAME
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -80,7 +80,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
     client = create_mock_motioneye_client()
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -301,7 +301,7 @@ async def test_async_browse_media_images_success(hass: HomeAssistant) -> None:
     client = create_mock_motioneye_client()
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -353,7 +353,7 @@ async def test_async_resolve_media_success(hass: HomeAssistant) -> None:
 
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -391,7 +391,7 @@ async def test_async_resolve_media_failure(hass: HomeAssistant) -> None:
 
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},

--- a/tests/components/motioneye/test_sensor.py
+++ b/tests/components/motioneye/test_sensor.py
@@ -91,7 +91,7 @@ async def test_sensor_device_info(hass: HomeAssistant) -> None:
     device = device_registry.async_get_device({device_identifer})
     assert device
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -196,7 +196,7 @@ async def test_switch_device_info(hass: HomeAssistant) -> None:
     device = device_registry.async_get_device({device_identifer})
     assert device
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entities_from_device = [
         entry.entity_id
         for entry in er.async_entries_for_device(entity_registry, device.id)

--- a/tests/components/motioneye/test_web_hooks.py
+++ b/tests/components/motioneye/test_web_hooks.py
@@ -67,7 +67,7 @@ async def test_setup_camera_without_webhook(hass: HomeAssistant) -> None:
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
     )
@@ -122,7 +122,7 @@ async def test_setup_camera_with_wrong_webhook(
         )
         await hass.async_block_till_done()
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
     )
@@ -175,7 +175,7 @@ async def test_setup_camera_with_old_webhook(
     )
     assert client.async_set_camera.called
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
     )
@@ -211,7 +211,7 @@ async def test_setup_camera_with_correct_webhook(
         hass, data={CONF_URL: TEST_URL, CONF_WEBHOOK_ID: "webhook_secret_id"}
     )
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={TEST_CAMERA_DEVICE_IDENTIFIER},
@@ -281,7 +281,7 @@ async def test_good_query(hass: HomeAssistant, hass_client_no_auth: Any) -> None
     """Test good callbacks."""
     await async_setup_component(hass, "http", {"http": {}})
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 
@@ -378,7 +378,7 @@ async def test_event_media_data(hass: HomeAssistant, hass_client_no_auth: Any) -
     """Test an event with a file path generates media data."""
     await async_setup_component(hass, "http", {"http": {}})
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -155,7 +155,7 @@ async def test_config_flow_entry_migrate(hass):
         "homeassistant.util.location.async_detect_location_info",
         return_value=MOCK_LOCATION,
     ), patch(
-        "homeassistant.helpers.entity_registry.async_get_registry",
+        "homeassistant.helpers.entity_registry.async_get",
         return_value=mock_e_registry,
     ):
         await ps4.async_migrate_entry(hass, mock_entry)

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -41,7 +41,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     entry = create_entry(hass)
     with patch_interface():
         await hass.config_entries.async_setup(entry.entry_id)
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     await hass.async_block_till_done()
     device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
 

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -29,7 +29,7 @@ async def device_fixture(hass: HomeAssistant, mock_entry: MockEntityFixture):
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)
     await hass.async_block_till_done()
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
 
     return list(device_registry.devices.values())[0]
 
@@ -48,7 +48,7 @@ async def subdevice_fixture(
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)
     await hass.async_block_till_done()
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
 
     return [d for d in device_registry.devices.values() if d.name != "UnifiProtect"][0]
 

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -11,10 +11,7 @@ from homeassistant.components.uptimerobot.const import (
 )
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import (
-    async_entries_for_config_entry,
-    async_get_registry,
-)
+from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt
 
 from .common import (
@@ -187,9 +184,9 @@ async def test_update_errors(hass: HomeAssistant, caplog: LogCaptureFixture):
 async def test_device_management(hass: HomeAssistant):
     """Test that we are adding and removing devices for monitors returned from the API."""
     mock_entry = await setup_uptimerobot_integration(hass)
-    dev_reg = await async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
 
-    devices = async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
+    devices = dr.async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
     assert len(devices) == 1
 
     assert devices[0].identifiers == {(DOMAIN, "1234")}
@@ -207,7 +204,7 @@ async def test_device_management(hass: HomeAssistant):
         async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
-    devices = async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
+    devices = dr.async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
     assert len(devices) == 2
     assert devices[0].identifiers == {(DOMAIN, "1234")}
     assert devices[1].identifiers == {(DOMAIN, "12345")}
@@ -224,7 +221,7 @@ async def test_device_management(hass: HomeAssistant):
         async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
-    devices = async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
+    devices = dr.async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
     assert len(devices) == 1
     assert devices[0].identifiers == {(DOMAIN, "1234")}
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -900,7 +900,7 @@ async def test_domain_control_unknown(hass, mock_entities):
         calls.append(call)
 
     with patch(
-        "homeassistant.helpers.entity_registry.async_get_registry",
+        "homeassistant.helpers.entity_registry.async_get",
         return_value=Mock(entities=mock_entities),
     ):
         protected_mock_service = service.verify_domain_control(hass, "test_domain")(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup deprecated async_get_registry in tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
