### PR TITLE
Draft: Support filtering state changes attributed to a service call

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -194,6 +194,7 @@ class EntityComponent:
         schema: dict[str, Any] | vol.Schema,
         func: str | Callable[..., Any],
         required_features: list[int] | None = None,
+        context_filter: entity.ContextFilter | None = None,
     ) -> None:
         """Register an entity service."""
         if isinstance(schema, dict):
@@ -202,7 +203,12 @@ class EntityComponent:
         async def handle_service(call: ServiceCall) -> None:
             """Handle the service."""
             await service.entity_service_call(
-                self.hass, self._platforms.values(), func, call, required_features
+                self.hass,
+                self._platforms.values(),
+                func,
+                call,
+                required_features,
+                context_filter,
             )
 
         self.hass.services.async_register(self.domain, name, handle_service, schema)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -49,6 +49,7 @@ from . import (
     entity_registry,
     template,
 )
+from .entity import ContextFilter
 from .typing import ConfigType, TemplateVarsType
 
 if TYPE_CHECKING:
@@ -549,6 +550,7 @@ async def entity_service_call(  # noqa: C901
     func: str | Callable[..., Any],
     call: ServiceCall,
     required_features: Iterable[int] | None = None,
+    context_filter: ContextFilter | None = None,
 ) -> None:
     """Handle an entity service call.
 
@@ -679,7 +681,9 @@ async def entity_service_call(  # noqa: C901
         [
             asyncio.create_task(
                 entity.async_request_call(
-                    _handle_entity_call(hass, entity, func, data, call.context)
+                    _handle_entity_call(
+                        hass, entity, func, data, call.context, context_filter
+                    )
                 )
             )
             for entity in entities
@@ -713,9 +717,10 @@ async def _handle_entity_call(
     func: str | Callable[..., Any],
     data: dict | ServiceCall,
     context: Context,
+    context_filter: ContextFilter | None = None,
 ) -> None:
     """Handle calling service method."""
-    entity.async_set_context(context)
+    entity.async_set_context(context, context_filter)
     _current_entity.set(entity.entity_id)
 
     if isinstance(func, str):

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -49,11 +49,10 @@ from . import (
     entity_registry,
     template,
 )
-from .entity import ContextFilter
 from .typing import ConfigType, TemplateVarsType
 
 if TYPE_CHECKING:
-    from .entity import Entity
+    from .entity import ContextFilter, Entity
     from .entity_platform import EntityPlatform
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support filtering state changes attributed to a service call, to help avoid false positives in the logbook

The false positives are caused by *any* state change within a 5s window of firing off a service call being attributed to that service call.

As an example of a false positive, consider an automation "Morning lights" turning some lights on in the morning.
If the same light is turned off by something else at around the same time as the automation runs, the logbook will currently unhelpfully claim something like this:
![image](https://user-images.githubusercontent.com/14281572/169251597-0195a506-6713-44ed-bef6-cfd7ed41a67d.png)

This is really confusing, sending users off on a wild goose chase trying to understand why their "Wakeup lights" automation is turning lights off sometimes.

This PR has a proposal for how that could be achieved, with `switch` entity services as an example

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
