### PR TITLE
Cleanup zha async method which is not awaiting

### DIFF
--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -160,7 +160,8 @@ def async_cluster_exists(hass, cluster_id):
     return False
 
 
-async def async_get_zha_device(hass, device_id):
+@callback
+def async_get_zha_device(hass, device_id):
     """Get a ZHA device for the given device registry id."""
     device_registry = dr.async_get(hass)
     registry_device = device_registry.async_get(device_id)

--- a/homeassistant/components/zha/device_action.py
+++ b/homeassistant/components/zha/device_action.py
@@ -61,7 +61,7 @@ async def async_get_actions(
 ) -> list[dict[str, str]]:
     """List device actions."""
     try:
-        zha_device = await async_get_zha_device(hass, device_id)
+        zha_device = async_get_zha_device(hass, device_id)
     except (KeyError, AttributeError):
         return []
     cluster_channels = [
@@ -89,7 +89,7 @@ async def _execute_service_based_action(
     action_type = config[CONF_TYPE]
     service_name = SERVICE_NAMES[action_type]
     try:
-        zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+        zha_device = async_get_zha_device(hass, config[CONF_DEVICE_ID])
     except (KeyError, AttributeError):
         return
 

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -28,7 +28,7 @@ async def async_validate_trigger_config(hass, config):
     if "zha" in hass.config.components:
         trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
         try:
-            zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+            zha_device = async_get_zha_device(hass, config[CONF_DEVICE_ID])
         except (KeyError, AttributeError) as err:
             raise InvalidDeviceAutomationConfig from err
         if (
@@ -44,7 +44,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
     try:
-        zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+        zha_device = async_get_zha_device(hass, config[CONF_DEVICE_ID])
     except (KeyError, AttributeError):
         return None
 
@@ -71,7 +71,7 @@ async def async_get_triggers(hass, device_id):
     Make sure the device supports device automations and
     if it does return the trigger list.
     """
-    zha_device = await async_get_zha_device(hass, device_id)
+    zha_device = async_get_zha_device(hass, device_id)
 
     if not zha_device.device_automation_triggers:
         return

--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -76,5 +76,5 @@ async def async_get_device_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry, device: dr.DeviceEntry
 ) -> dict:
     """Return diagnostics for a device."""
-    zha_device: ZHADevice = await async_get_zha_device(hass, device.id)
+    zha_device: ZHADevice = async_get_zha_device(hass, device.id)
     return async_redact_data(zha_device.zha_device_info, KEYS_TO_REDACT)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup zha async method which is not awaiting

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
