### PR TITLE
Fix reversed raise_on_progress in baf config_flow

### DIFF
--- a/homeassistant/components/baf/config_flow.py
+++ b/homeassistant/components/baf/config_flow.py
@@ -54,7 +54,7 @@ class BAFFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         uuid = properties["uuid"]
         model = properties["model"]
         name = properties["name"]
-        await self.async_set_unique_id(uuid, raise_on_progress=False)
+        await self.async_set_unique_id(uuid)
         self._abort_if_unique_id_configured(updates={CONF_IP_ADDRESS: ip_address})
         self.discovery = BAFDiscovery(ip_address, name, uuid, model)
         return await self.async_step_discovery_confirm()
@@ -98,7 +98,9 @@ class BAFFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(device.dns_sd_uuid)
+                await self.async_set_unique_id(
+                    device.dns_sd_uuid, raise_on_progress=False
+                )
                 self._abort_if_unique_id_configured(
                     updates={CONF_IP_ADDRESS: ip_address}
                 )

--- a/tests/components/baf/__init__.py
+++ b/tests/components/baf/__init__.py
@@ -1,1 +1,37 @@
 """Tests for the Big Ass Fans integration."""
+
+
+import asyncio
+
+from aiobafi6 import Device
+
+MOCK_UUID = "1234"
+MOCK_NAME = "Living Room Fan"
+
+
+class MockBAFDevice(Device):
+    """A simple mock for a BAF Device."""
+
+    def __init__(self, async_wait_available_side_effect=None):
+        """Init simple mock."""
+        self._async_wait_available_side_effect = async_wait_available_side_effect
+
+    @property
+    def dns_sd_uuid(self):
+        """Mock the unique id."""
+        return MOCK_UUID
+
+    @property
+    def name(self):
+        """Mock the name of the device."""
+        return MOCK_NAME
+
+    async def async_wait_available(self):
+        """Mock async_wait_available."""
+        if self._async_wait_available_side_effect:
+            raise self._async_wait_available_side_effect
+        return
+
+    def async_run(self):
+        """Mock async_run."""
+        return asyncio.Future()

--- a/tests/components/baf/test_config_flow.py
+++ b/tests/components/baf/test_config_flow.py
@@ -12,7 +12,18 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
+from . import MOCK_NAME, MOCK_UUID, MockBAFDevice
+
 from tests.common import MockConfigEntry
+
+
+def _patch_device_config_flow(side_effect=None):
+    """Mock out the BAF Device object."""
+
+    def _create_mock_baf(*args, **kwargs):
+        return MockBAFDevice(side_effect)
+
+    return patch("homeassistant.components.baf.config_flow.Device", _create_mock_baf)
 
 
 async def test_form_user(hass):
@@ -24,9 +35,7 @@ async def test_form_user(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch("homeassistant.components.baf.config_flow.Device.async_run",), patch(
-        "homeassistant.components.baf.config_flow.Device.async_wait_available",
-    ), patch(
+    with _patch_device_config_flow(), patch(
         "homeassistant.components.baf.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -37,7 +46,7 @@ async def test_form_user(hass):
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "127.0.0.1"
+    assert result2["title"] == MOCK_NAME
     assert result2["data"] == {CONF_IP_ADDRESS: "127.0.0.1"}
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -48,10 +57,7 @@ async def test_form_cannot_connect(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("homeassistant.components.baf.config_flow.Device.async_run",), patch(
-        "homeassistant.components.baf.config_flow.Device.async_wait_available",
-        side_effect=asyncio.TimeoutError,
-    ):
+    with _patch_device_config_flow(asyncio.TimeoutError):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_IP_ADDRESS: "127.0.0.1"},
@@ -67,10 +73,7 @@ async def test_form_unknown_exception(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("homeassistant.components.baf.config_flow.Device.async_run",), patch(
-        "homeassistant.components.baf.config_flow.Device.async_wait_available",
-        side_effect=Exception,
-    ):
+    with _patch_device_config_flow(Exception):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_IP_ADDRESS: "127.0.0.1"},
@@ -92,7 +95,7 @@ async def test_zeroconf_discovery(hass):
             hostname="mock_hostname",
             name="testfan",
             port=None,
-            properties={"name": "My Fan", "model": "Haiku", "uuid": "1234"},
+            properties={"name": "My Fan", "model": "Haiku", "uuid": MOCK_UUID},
             type="mock_type",
         ),
     )
@@ -118,7 +121,7 @@ async def test_zeroconf_discovery(hass):
 async def test_zeroconf_updates_existing_ip(hass):
     """Test we can setup from zeroconf discovery."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_IP_ADDRESS: "127.0.0.2"}, unique_id="1234"
+        domain=DOMAIN, data={CONF_IP_ADDRESS: "127.0.0.2"}, unique_id=MOCK_UUID
     )
     entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
@@ -130,7 +133,7 @@ async def test_zeroconf_updates_existing_ip(hass):
             hostname="mock_hostname",
             name="testfan",
             port=None,
-            properties={"name": "My Fan", "model": "Haiku", "uuid": "1234"},
+            properties={"name": "My Fan", "model": "Haiku", "uuid": MOCK_UUID},
             type="mock_type",
         ),
     )
@@ -150,9 +153,48 @@ async def test_zeroconf_rejects_ipv6(hass):
             hostname="mock_hostname",
             name="testfan",
             port=None,
-            properties={"name": "My Fan", "model": "Haiku", "uuid": "1234"},
+            properties={"name": "My Fan", "model": "Haiku", "uuid": MOCK_UUID},
             type="mock_type",
         ),
     )
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "ipv6_not_supported"
+
+
+async def test_user_flow_is_not_blocked_by_discovery(hass):
+    """Test we can setup from the user flow when there is also a discovery."""
+    discovery_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="127.0.0.1",
+            addresses=["127.0.0.1"],
+            hostname="mock_hostname",
+            name="testfan",
+            port=None,
+            properties={"name": "My Fan", "model": "Haiku", "uuid": MOCK_UUID},
+            type="mock_type",
+        ),
+    )
+    assert discovery_result["type"] == RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with _patch_device_config_flow(), patch(
+        "homeassistant.components.baf.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_IP_ADDRESS: "127.0.0.1"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == MOCK_NAME
+    assert result2["data"] == {CONF_IP_ADDRESS: "127.0.0.1"}
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix reversed raise_on_progress in baf config_flow
https://github.com/home-assistant/core/pull/71498#discussion_r875553842


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
