### PR TITLE
Raw rest response attribute for REST sensor

### DIFF
--- a/homeassistant/components/rest/const.py
+++ b/homeassistant/components/rest/const.py
@@ -5,11 +5,15 @@ DOMAIN = "rest"
 DEFAULT_METHOD = "GET"
 DEFAULT_VERIFY_SSL = True
 DEFAULT_FORCE_UPDATE = False
+DEFAULT_INCLUDE_RAW_ATTR = False
 
 DEFAULT_BINARY_SENSOR_NAME = "REST Binary Sensor"
 DEFAULT_SENSOR_NAME = "REST Sensor"
 CONF_JSON_ATTRS = "json_attributes"
 CONF_JSON_ATTRS_PATH = "json_attributes_path"
+CONF_RAW_ATTR = "include_raw_attribute"
+
+ATTR_RAW = "raw"
 
 REST_IDX = "rest_idx"
 PLATFORM_IDX = "platform_idx"

--- a/homeassistant/components/rest/schema.py
+++ b/homeassistant/components/rest/schema.py
@@ -38,8 +38,10 @@ import homeassistant.helpers.config_validation as cv
 from .const import (
     CONF_JSON_ATTRS,
     CONF_JSON_ATTRS_PATH,
+    CONF_RAW_ATTR,
     DEFAULT_BINARY_SENSOR_NAME,
     DEFAULT_FORCE_UPDATE,
+    DEFAULT_INCLUDE_RAW_ATTR,
     DEFAULT_METHOD,
     DEFAULT_SENSOR_NAME,
     DEFAULT_VERIFY_SSL,
@@ -73,6 +75,7 @@ SENSOR_SCHEMA = {
     vol.Optional(CONF_JSON_ATTRS_PATH): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+    vol.Optional(CONF_RAW_ATTR, default=DEFAULT_INCLUDE_RAW_ATTR): cv.boolean,
 }
 
 BINARY_SENSOR_SCHEMA = {

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -202,7 +202,11 @@ class RestSensor(RestEntity, SensorEntity):
             if not self._attributes:
                 self._attributes = {}
             # Add the raw API response as an attribute
-            self._attributes[ATTR_RAW] = json.loads(value)
+            if value:
+                try:
+                    self._attributes[ATTR_RAW] = json.loads(value)
+                except ValueError:
+                    self._attributes[ATTR_RAW] = value
 
         if value is not None and self._value_template is not None:
             value = self._value_template.async_render_with_possible_json_value(

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -494,6 +494,38 @@ async def test_update_with_raw_attr(hass):
 
 
 @respx.mock
+async def test_update_with_raw_attr_no_json(hass):
+    """Test 'raw' JSON result attribute is added."""
+
+    respx.get("http://localhost").respond(
+        status_code=HTTPStatus.OK,
+        json="Something other than JSON",
+    )
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rest",
+                "resource": "http://localhost",
+                "method": "GET",
+                "value_template": "{{ value_json.key }}",
+                "include_raw_attribute": "true",
+                "name": "foo",
+                "unit_of_measurement": DATA_MEGABYTES,
+                "verify_ssl": "true",
+                "timeout": 30,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all("sensor")) == 1
+
+    state = hass.states.get("sensor.foo")
+    assert state.attributes["raw"] == "Something other than JSON"
+
+
+@respx.mock
 async def test_update_with_no_template(hass):
     """Test update when there is no value template."""
 

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -461,6 +461,39 @@ async def test_update_with_json_attrs(hass):
 
 
 @respx.mock
+async def test_update_with_raw_attr(hass):
+    """Test 'raw' JSON result attribute is added."""
+
+    respx.get("http://localhost").respond(
+        status_code=HTTPStatus.OK,
+        json={"key": "some_json_value"},
+    )
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rest",
+                "resource": "http://localhost",
+                "method": "GET",
+                "value_template": "{{ value_json.key }}",
+                "include_raw_attribute": "true",
+                "name": "foo",
+                "unit_of_measurement": DATA_MEGABYTES,
+                "verify_ssl": "true",
+                "timeout": 30,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all("sensor")) == 1
+
+    state = hass.states.get("sensor.foo")
+    assert state.state == "some_json_value"
+    assert state.attributes["raw"] == {"key": "some_json_value"}
+
+
+@respx.mock
 async def test_update_with_no_template(hass):
     """Test update when there is no value template."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a flag to the REST sensor that will add the _raw_ REST response to a sensor attribute named 'raw'.

This would be usefull when the entire response is required but is not guaranteed to fit in the constrained 255 character count for the sensor state.
In addition this resolves issues around extracting usefull data from the response as attributes, when e.g. the response is a list from which multiple values are desired to be available as sensor attributes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [Link](https://github.com/home-assistant/home-assistant.io/pull/22807)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
