### PR TITLE
Enforce type hints on device_automation platform

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -202,7 +202,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigType",
         },
-        return_type="GetAutomationCapabilitiesResult",
+        return_type="dict[str, Schema]",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_action"],
@@ -211,7 +211,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="GetAutomationsResult",
+        return_type="list[dict[str, str]] | list[dict[str, Any]]",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_condition"],
@@ -238,7 +238,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigType",
         },
-        return_type="GetAutomationCapabilitiesResult",
+        return_type="dict[str, Schema]",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_condition"],
@@ -247,7 +247,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="GetAutomationsResult",
+        return_type="list[dict[str, str]] | list[dict[str, Any]]",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_tracker"],
@@ -316,7 +316,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigType",
         },
-        return_type="GetAutomationCapabilitiesResult",
+        return_type="dict[str, Schema]",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_trigger"],
@@ -325,7 +325,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="GetAutomationsResult",
+        return_type="list[dict[str, str]] | list[dict[str, Any]]",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["diagnostics"],

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -211,7 +211,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="list[dict[str, str]] | list[dict[str, Any]]",
+        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_condition"],
@@ -247,7 +247,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="list[dict[str, str]] | list[dict[str, Any]]",
+        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_tracker"],
@@ -325,7 +325,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="list[dict[str, str]] | list[dict[str, Any]]",
+        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["diagnostics"],

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -177,12 +177,23 @@ _METHOD_MATCH: list[TypeHintMatch] = [
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_action"],
-        function_name="async_get_actions",
+        function_name="async_validate_action_config",
         arg_types={
             0: "HomeAssistant",
-            1: "str",
+            1: "ConfigType",
         },
-        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
+        return_type="ConfigType",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["device_action"],
+        function_name="async_call_action_from_config",
+        arg_types={
+            0: "HomeAssistant",
+            1: "ConfigType",
+            2: "TemplateVarsType",
+            3: "Context | None",
+        },
+        return_type=None,
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_action"],
@@ -191,16 +202,34 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigType",
         },
-        return_type="dict[str, Schema]",
+        return_type="GetAutomationCapabilitiesResult",
     ),
     TypeHintMatch(
-        module_filter=_MODULE_FILTERS["device_condition"],
-        function_name="async_get_conditions",
+        module_filter=_MODULE_FILTERS["device_action"],
+        function_name="async_get_actions",
         arg_types={
             0: "HomeAssistant",
             1: "str",
         },
-        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
+        return_type="GetAutomationsResult",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["device_condition"],
+        function_name="async_validate_condition_config",
+        arg_types={
+            0: "HomeAssistant",
+            1: "ConfigType",
+        },
+        return_type="ConfigType",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["device_condition"],
+        function_name="async_condition_from_config",
+        arg_types={
+            0: "HomeAssistant",
+            1: "ConfigType",
+        },
+        return_type="ConditionCheckerType",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_condition"],
@@ -209,7 +238,16 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigType",
         },
-        return_type="dict[str, Schema]",
+        return_type="GetAutomationCapabilitiesResult",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["device_condition"],
+        function_name="async_get_conditions",
+        arg_types={
+            0: "HomeAssistant",
+            1: "str",
+        },
+        return_type="GetAutomationsResult",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_tracker"],
@@ -253,12 +291,23 @@ _METHOD_MATCH: list[TypeHintMatch] = [
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_trigger"],
-        function_name="async_get_triggers",
+        function_name="async_validate_condition_config",
         arg_types={
             0: "HomeAssistant",
-            1: "str",
+            1: "ConfigType",
         },
-        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
+        return_type="ConfigType",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["device_trigger"],
+        function_name="async_attach_trigger",
+        arg_types={
+            0: "HomeAssistant",
+            1: "ConfigType",
+            2: "AutomationActionType",
+            3: "AutomationTriggerInfo",
+        },
+        return_type="CALLBACK_TYPE",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_trigger"],
@@ -267,7 +316,16 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigType",
         },
-        return_type="dict[str, Schema]",
+        return_type="GetAutomationCapabilitiesResult",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["device_trigger"],
+        function_name="async_get_triggers",
+        arg_types={
+            0: "HomeAssistant",
+            1: "str",
+        },
+        return_type="GetAutomationsResult",
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["diagnostics"],

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -182,7 +182,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="list[dict[str, str]]",
+        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_action"],
@@ -200,7 +200,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="list[dict[str, str]]",
+        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_condition"],
@@ -258,7 +258,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "str",
         },
-        return_type="list[dict[str, str]]",
+        return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["device_trigger"],

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -15,6 +15,32 @@ from . import assert_adds_messages, assert_no_messages
 
 
 @pytest.mark.parametrize(
+    ("string", "expected_x", "expected_y", "expected_z", "expected_a"),
+    [
+        ("list[dict[str, str]]", "list", "dict", "str", "str"),
+        ("list[dict[str, Any]]", "list", "dict", "str", "Any"),
+    ],
+)
+def test_regex_x_of_y_of_z_comma_a(
+    hass_enforce_type_hints: ModuleType,
+    string: str,
+    expected_x: str,
+    expected_y: str,
+    expected_z: str,
+    expected_a: str,
+) -> None:
+    """Test x_of_y_of_z_comma_a regexes."""
+    matchers: dict[str, re.Pattern] = hass_enforce_type_hints._TYPE_HINT_MATCHERS
+
+    assert (match := matchers["x_of_y_of_z_comma_a"].match(string))
+    assert match.group(0) == string
+    assert match.group(1) == expected_x
+    assert match.group(2) == expected_y
+    assert match.group(3) == expected_z
+    assert match.group(4) == expected_a
+
+
+@pytest.mark.parametrize(
     ("string", "expected_x", "expected_y", "expected_z"),
     [
         ("Callable[..., None]", "Callable", "...", "None"),

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -191,3 +191,52 @@ def test_valid_discovery_info(
 
     with assert_no_messages(linter):
         type_hint_checker.visit_asyncfunctiondef(func_node)
+
+
+def test_invalid_list_dict_str_any(
+    linter: UnittestLinter, type_hint_checker: BaseChecker
+) -> None:
+    """Ensure invalid hints are rejected for discovery_info."""
+    type_hint_checker.module = "homeassistant.components.pylint_test.device_trigger"
+    func_node = astroid.extract_node(
+        """
+    async def async_get_triggers( #@
+        hass: HomeAssistant,
+        device_id: str
+    ) -> list:
+        pass
+    """
+    )
+
+    with assert_adds_messages(
+        linter,
+        pylint.testutils.MessageTest(
+            msg_id="hass-return-type",
+            node=func_node,
+            args=["list[dict[str, str]]", "list[dict[str, Any]]"],
+            line=2,
+            col_offset=0,
+            end_line=2,
+            end_col_offset=28,
+        ),
+    ):
+        type_hint_checker.visit_asyncfunctiondef(func_node)
+
+
+def test_valid_list_dict_str_any(
+    linter: UnittestLinter, type_hint_checker: BaseChecker
+) -> None:
+    """Ensure valid hints are accepted for discovery_info."""
+    type_hint_checker.module = "homeassistant.components.pylint_test.device_trigger"
+    func_node = astroid.extract_node(
+        """
+    async def async_get_triggers( #@
+        hass: HomeAssistant,
+        device_id: str
+    ) -> list[dict[str, Any]]:
+        pass
+    """
+    )
+
+    with assert_no_messages(linter):
+        type_hint_checker.visit_asyncfunctiondef(func_node)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enforce type hints on device_automation platforms:
- `device_action`
- `device_condition`
- `device_trigger`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
