### PR TITLE
Improve DEVICE_TRIGGERS typing in tasmota

### DIFF
--- a/homeassistant/components/tasmota/device_trigger.py
+++ b/homeassistant/components/tasmota/device_trigger.py
@@ -256,9 +256,11 @@ async def async_setup_trigger(
 async def async_remove_triggers(hass: HomeAssistant, device_id: str) -> None:
     """Cleanup any device triggers for a Tasmota device."""
     triggers = await async_get_triggers(hass, device_id)
-    device_triggers: dict[str, Trigger]
+
+    if not triggers:
+        return
+    device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
     for trig in triggers:
-        device_triggers = hass.data[DEVICE_TRIGGERS]
         device_trigger = device_triggers.pop(trig[CONF_DISCOVERY_ID])
         if device_trigger:
             discovery_hash = device_trigger.discovery_hash

--- a/homeassistant/components/tasmota/device_trigger.py
+++ b/homeassistant/components/tasmota/device_trigger.py
@@ -188,11 +188,10 @@ async def async_setup_trigger(
         _LOGGER.debug(
             "Got update for trigger with hash: %s '%s'", discovery_hash, trigger_config
         )
-        device_triggers: dict[str, Trigger]
+        device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
         if not trigger_config.is_active:
             # Empty trigger_config: Remove trigger
             _LOGGER.debug("Removing trigger: %s", discovery_hash)
-            device_triggers = hass.data[DEVICE_TRIGGERS]
             if discovery_id in device_triggers:
                 device_trigger = device_triggers[discovery_id]
                 assert device_trigger.tasmota_trigger
@@ -203,7 +202,6 @@ async def async_setup_trigger(
                     remove_update_signal()
             return
 
-        device_triggers = hass.data[DEVICE_TRIGGERS]
         device_trigger = device_triggers[discovery_id]
         assert device_trigger.tasmota_trigger
         if device_trigger.tasmota_trigger.config_same(trigger_config):

--- a/homeassistant/components/tasmota/device_trigger.py
+++ b/homeassistant/components/tasmota/device_trigger.py
@@ -188,10 +188,11 @@ async def async_setup_trigger(
         _LOGGER.debug(
             "Got update for trigger with hash: %s '%s'", discovery_hash, trigger_config
         )
-        device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
+        device_triggers: dict[str, Trigger]
         if not trigger_config.is_active:
             # Empty trigger_config: Remove trigger
             _LOGGER.debug("Removing trigger: %s", discovery_hash)
+            device_triggers = hass.data[DEVICE_TRIGGERS]
             if discovery_id in device_triggers:
                 device_trigger = device_triggers[discovery_id]
                 assert device_trigger.tasmota_trigger
@@ -202,6 +203,7 @@ async def async_setup_trigger(
                     remove_update_signal()
             return
 
+        device_triggers = hass.data[DEVICE_TRIGGERS]
         device_trigger = device_triggers[discovery_id]
         assert device_trigger.tasmota_trigger
         if device_trigger.tasmota_trigger.config_same(trigger_config):
@@ -256,8 +258,9 @@ async def async_setup_trigger(
 async def async_remove_triggers(hass: HomeAssistant, device_id: str) -> None:
     """Cleanup any device triggers for a Tasmota device."""
     triggers = await async_get_triggers(hass, device_id)
-    device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
+    device_triggers: dict[str, Trigger]
     for trig in triggers:
+        device_triggers = hass.data[DEVICE_TRIGGERS]
         device_trigger = device_triggers.pop(trig[CONF_DISCOVERY_ID])
         if device_trigger:
             discovery_hash = device_trigger.discovery_hash

--- a/homeassistant/components/tasmota/device_trigger.py
+++ b/homeassistant/components/tasmota/device_trigger.py
@@ -188,11 +188,13 @@ async def async_setup_trigger(
         _LOGGER.debug(
             "Got update for trigger with hash: %s '%s'", discovery_hash, trigger_config
         )
+        device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
         if not trigger_config.is_active:
             # Empty trigger_config: Remove trigger
             _LOGGER.debug("Removing trigger: %s", discovery_hash)
-            if discovery_id in hass.data[DEVICE_TRIGGERS]:
-                device_trigger = hass.data[DEVICE_TRIGGERS][discovery_id]
+            if discovery_id in device_triggers:
+                device_trigger = device_triggers[discovery_id]
+                assert device_trigger.tasmota_trigger
                 await device_trigger.tasmota_trigger.unsubscribe_topics()
                 device_trigger.detach_trigger()
                 clear_discovery_hash(hass, discovery_hash)
@@ -200,7 +202,8 @@ async def async_setup_trigger(
                     remove_update_signal()
             return
 
-        device_trigger = hass.data[DEVICE_TRIGGERS][discovery_id]
+        device_trigger = device_triggers[discovery_id]
+        assert device_trigger.tasmota_trigger
         if device_trigger.tasmota_trigger.config_same(trigger_config):
             # Unchanged payload: Ignore to avoid unnecessary unsubscribe / subscribe
             _LOGGER.debug("Ignoring unchanged update for: %s", discovery_hash)
@@ -209,6 +212,7 @@ async def async_setup_trigger(
         # Non-empty, changed trigger_config: Update trigger
         _LOGGER.debug("Updating trigger: %s", discovery_hash)
         device_trigger.tasmota_trigger.config_update(trigger_config)
+        assert remove_update_signal
         await device_trigger.update_tasmota_trigger(
             trigger_config, remove_update_signal
         )
@@ -230,7 +234,8 @@ async def async_setup_trigger(
 
     if DEVICE_TRIGGERS not in hass.data:
         hass.data[DEVICE_TRIGGERS] = {}
-    if discovery_id not in hass.data[DEVICE_TRIGGERS]:
+    device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
+    if discovery_id not in device_triggers:
         device_trigger = Trigger(
             hass=hass,
             device_id=device.id,
@@ -240,10 +245,10 @@ async def async_setup_trigger(
             type=tasmota_trigger.cfg.type,
             remove_update_signal=remove_update_signal,
         )
-        hass.data[DEVICE_TRIGGERS][discovery_id] = device_trigger
+        device_triggers[discovery_id] = device_trigger
     else:
         # This Tasmota trigger is wanted by device trigger(s), set them up
-        device_trigger = hass.data[DEVICE_TRIGGERS][discovery_id]
+        device_trigger = device_triggers[discovery_id]
         await device_trigger.set_tasmota_trigger(tasmota_trigger, remove_update_signal)
     await device_trigger.arm_tasmota_trigger()
 
@@ -251,14 +256,17 @@ async def async_setup_trigger(
 async def async_remove_triggers(hass: HomeAssistant, device_id: str) -> None:
     """Cleanup any device triggers for a Tasmota device."""
     triggers = await async_get_triggers(hass, device_id)
+    device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
     for trig in triggers:
-        device_trigger = hass.data[DEVICE_TRIGGERS].pop(trig[CONF_DISCOVERY_ID])
+        device_trigger = device_triggers.pop(trig[CONF_DISCOVERY_ID])
         if device_trigger:
             discovery_hash = device_trigger.discovery_hash
 
+            assert device_trigger.tasmota_trigger
             await device_trigger.tasmota_trigger.unsubscribe_topics()
             device_trigger.detach_trigger()
             clear_discovery_hash(hass, discovery_hash)
+            assert device_trigger.remove_update_signal
             device_trigger.remove_update_signal()
 
 
@@ -271,7 +279,8 @@ async def async_get_triggers(
     if DEVICE_TRIGGERS not in hass.data:
         return triggers
 
-    for discovery_id, trig in hass.data[DEVICE_TRIGGERS].items():
+    device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
+    for discovery_id, trig in device_triggers.items():
         if trig.device_id != device_id or trig.tasmota_trigger is None:
             continue
 
@@ -297,12 +306,13 @@ async def async_attach_trigger(
     """Attach a device trigger."""
     if DEVICE_TRIGGERS not in hass.data:
         hass.data[DEVICE_TRIGGERS] = {}
+    device_triggers: dict[str, Trigger] = hass.data[DEVICE_TRIGGERS]
     device_id = config[CONF_DEVICE_ID]
     discovery_id = config[CONF_DISCOVERY_ID]
 
-    if discovery_id not in hass.data[DEVICE_TRIGGERS]:
+    if discovery_id not in device_triggers:
         # The trigger has not (yet) been discovered, prepare it for later
-        hass.data[DEVICE_TRIGGERS][discovery_id] = Trigger(
+        device_triggers[discovery_id] = Trigger(
             hass=hass,
             device_id=device_id,
             discovery_hash=None,
@@ -311,5 +321,5 @@ async def async_attach_trigger(
             subtype=config[CONF_SUBTYPE],
             tasmota_trigger=None,
         )
-    trigger: Trigger = hass.data[DEVICE_TRIGGERS][discovery_id]
+    trigger: Trigger = device_triggers[discovery_id]
     return await trigger.add_trigger(action, automation_info)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve DEVICE_TRIGGERS typing in tasmota

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
