### PR TITLE
Moehlenhoff alpha2 sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -725,6 +725,7 @@ omit =
     homeassistant/components/moehlenhoff_alpha2/__init__.py
     homeassistant/components/moehlenhoff_alpha2/climate.py
     homeassistant/components/moehlenhoff_alpha2/const.py
+    homeassistant/components/moehlenhoff_alpha2/sensor.py
     homeassistant/components/motion_blinds/__init__.py
     homeassistant/components/motion_blinds/const.py
     homeassistant/components/motion_blinds/cover.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -723,6 +723,7 @@ omit =
     homeassistant/components/modem_callerid/button.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/moehlenhoff_alpha2/__init__.py
+    homeassistant/components/moehlenhoff_alpha2/binary_sensor.py
     homeassistant/components/moehlenhoff_alpha2/climate.py
     homeassistant/components/moehlenhoff_alpha2/const.py
     homeassistant/components/moehlenhoff_alpha2/sensor.py

--- a/homeassistant/components/moehlenhoff_alpha2/__init__.py
+++ b/homeassistant/components/moehlenhoff_alpha2/__init__.py
@@ -17,7 +17,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.BINARY_SENSOR]
 
 UPDATE_INTERVAL = timedelta(seconds=60)
 

--- a/homeassistant/components/moehlenhoff_alpha2/__init__.py
+++ b/homeassistant/components/moehlenhoff_alpha2/__init__.py
@@ -17,7 +17,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 UPDATE_INTERVAL = timedelta(seconds=60)
 
@@ -65,10 +65,16 @@ class Alpha2BaseCoordinator(DataUpdateCoordinator[dict[str, dict]]):
             update_interval=UPDATE_INTERVAL,
         )
 
-    async def _async_update_data(self) -> dict[str, dict]:
+    async def _async_update_data(self) -> dict[str, dict[str, dict]]:
         """Fetch the latest data from the source."""
         await self.base.update_data()
-        return {ha["ID"]: ha for ha in self.base.heat_areas if ha.get("ID")}
+        return {
+            "heat_areas": {ha["ID"]: ha for ha in self.base.heat_areas if ha.get("ID")},
+            "heat_controls": {
+                hc["ID"]: hc for hc in self.base.heat_controls if hc.get("ID")
+            },
+            "io_devices": {io["ID"]: io for io in self.base.io_devices if io.get("ID")},
+        }
 
     def get_cooling(self) -> bool:
         """Return if cooling mode is enabled."""

--- a/homeassistant/components/moehlenhoff_alpha2/binary_sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/binary_sensor.py
@@ -1,0 +1,56 @@
+"""Support for Alpha2 IO device battery sensors."""
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import Alpha2BaseCoordinator
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add Alpha2 sensor entities from a config_entry."""
+
+    coordinator: Alpha2BaseCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        Alpha2IODeviceBatterySensor(coordinator, io_device_id)
+        for io_device_id, io_device in coordinator.data["io_devices"].items()
+        if io_device["_HEATAREA_ID"]
+    )
+
+
+class Alpha2IODeviceBatterySensor(
+    CoordinatorEntity[Alpha2BaseCoordinator], BinarySensorEntity
+):
+    """Alpha2 IO device battery binary sensor."""
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: Alpha2BaseCoordinator, io_device_id: str) -> None:
+        """Initialize Alpha2IODeviceBatterySensor."""
+        super().__init__(coordinator)
+        self.io_device_id = io_device_id
+        self._attr_unique_id = f"{io_device_id}:battery"
+        io_device = self.coordinator.data["io_devices"][io_device_id]
+        heat_area = self.coordinator.data["heat_areas"][io_device["_HEATAREA_ID"]]
+        self._attr_name = (
+            f"{heat_area['HEATAREA_NAME']} IO device {io_device['NR']} battery"
+        )
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        # 0=empty, 1=weak, 2=good
+        return self.coordinator.data["io_devices"][self.io_device_id]["BATTERY"] < 2

--- a/homeassistant/components/moehlenhoff_alpha2/climate.py
+++ b/homeassistant/components/moehlenhoff_alpha2/climate.py
@@ -29,7 +29,8 @@ async def async_setup_entry(
     coordinator: Alpha2BaseCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     async_add_entities(
-        Alpha2Climate(coordinator, heat_area_id) for heat_area_id in coordinator.data
+        Alpha2Climate(coordinator, heat_area_id)
+        for heat_area_id in coordinator.data["heat_areas"]
     )
 
 
@@ -55,22 +56,32 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
     @property
     def name(self) -> str:
         """Return the name of the climate device."""
-        return self.coordinator.data[self.heat_area_id]["HEATAREA_NAME"]
+        return self.coordinator.data["heat_areas"][self.heat_area_id]["HEATAREA_NAME"]
 
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        return float(self.coordinator.data[self.heat_area_id].get("T_TARGET_MIN", 0.0))
+        return float(
+            self.coordinator.data["heat_areas"][self.heat_area_id].get(
+                "T_TARGET_MIN", 0.0
+            )
+        )
 
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        return float(self.coordinator.data[self.heat_area_id].get("T_TARGET_MAX", 30.0))
+        return float(
+            self.coordinator.data["heat_areas"][self.heat_area_id].get(
+                "T_TARGET_MAX", 30.0
+            )
+        )
 
     @property
     def current_temperature(self) -> float:
         """Return the current temperature."""
-        return float(self.coordinator.data[self.heat_area_id].get("T_ACTUAL", 0.0))
+        return float(
+            self.coordinator.data["heat_areas"][self.heat_area_id].get("T_ACTUAL", 0.0)
+        )
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -86,7 +97,9 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation."""
-        if not self.coordinator.data[self.heat_area_id]["_HEATCTRL_STATE"]:
+        if not self.coordinator.data["heat_areas"][self.heat_area_id][
+            "_HEATCTRL_STATE"
+        ]:
             return HVACAction.IDLE
         if self.coordinator.get_cooling():
             return HVACAction.COOLING
@@ -95,7 +108,9 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
-        return float(self.coordinator.data[self.heat_area_id].get("T_TARGET", 0.0))
+        return float(
+            self.coordinator.data["heat_areas"][self.heat_area_id].get("T_TARGET", 0.0)
+        )
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperatures."""
@@ -109,9 +124,9 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
     @property
     def preset_mode(self) -> str:
         """Return the current preset mode."""
-        if self.coordinator.data[self.heat_area_id]["HEATAREA_MODE"] == 1:
+        if self.coordinator.data["heat_areas"][self.heat_area_id]["HEATAREA_MODE"] == 1:
             return PRESET_DAY
-        if self.coordinator.data[self.heat_area_id]["HEATAREA_MODE"] == 2:
+        if self.coordinator.data["heat_areas"][self.heat_area_id]["HEATAREA_MODE"] == 2:
             return PRESET_NIGHT
         return PRESET_AUTO
 

--- a/homeassistant/components/moehlenhoff_alpha2/climate.py
+++ b/homeassistant/components/moehlenhoff_alpha2/climate.py
@@ -52,11 +52,9 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
         super().__init__(coordinator)
         self.heat_area_id = heat_area_id
         self._attr_unique_id = heat_area_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the climate device."""
-        return self.coordinator.data["heat_areas"][self.heat_area_id]["HEATAREA_NAME"]
+        self._attr_name = self.coordinator.data["heat_areas"][heat_area_id][
+            "HEATAREA_NAME"
+        ]
 
     @property
     def min_temp(self) -> float:

--- a/homeassistant/components/moehlenhoff_alpha2/manifest.json
+++ b/homeassistant/components/moehlenhoff_alpha2/manifest.json
@@ -3,7 +3,7 @@
   "name": "Möhlenhoff Alpha 2",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/moehlenhoff_alpha2",
-  "requirements": ["moehlenhoff-alpha2==1.1.2"],
+  "requirements": ["moehlenhoff-alpha2==1.1.3"],
   "iot_class": "local_push",
   "codeowners": ["@j-a-n"]
 }

--- a/homeassistant/components/moehlenhoff_alpha2/manifest.json
+++ b/homeassistant/components/moehlenhoff_alpha2/manifest.json
@@ -3,7 +3,7 @@
   "name": "Möhlenhoff Alpha 2",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/moehlenhoff_alpha2",
-  "requirements": ["moehlenhoff-alpha2==1.1.3"],
+  "requirements": ["moehlenhoff-alpha2==1.2.0"],
   "iot_class": "local_push",
   "codeowners": ["@j-a-n"]
 }

--- a/homeassistant/components/moehlenhoff_alpha2/manifest.json
+++ b/homeassistant/components/moehlenhoff_alpha2/manifest.json
@@ -3,7 +3,7 @@
   "name": "Möhlenhoff Alpha 2",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/moehlenhoff_alpha2",
-  "requirements": ["moehlenhoff-alpha2==1.2.0"],
+  "requirements": ["moehlenhoff-alpha2==1.2.1"],
   "iot_class": "local_push",
   "codeowners": ["@j-a-n"]
 }

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -61,15 +61,25 @@ class Alpha2IODeviceBatterySensor(CoordinatorEntity, SensorEntity):
         )
 
     @property
-    def native_value(self) -> int:
-        """Return the current battery level percentage."""
+    def icon(self) -> str:
+        """Return the icon of the sensor."""
+        battery = self.coordinator.data["io_devices"][self.io_device_id]["BATTERY"]
+        if battery == 0:
+            return "mdi:battery-alert-variant-outline"
+        if battery == 1:
+            return "mdi:battery-low"
+        return "mdi:battery"
+
+    @property
+    def native_value(self) -> str:
+        """Return the current battery level."""
         battery = self.coordinator.data["io_devices"][self.io_device_id]["BATTERY"]
         # 0=empty, 1=weak, 2=good
         if battery == 0:
-            return 0
+            return "empty"
         if battery == 1:
-            return 20
-        return 100
+            return "weak"
+        return "good"
 
 
 class Alpha2HeatControlValveOpeningSensor(CoordinatorEntity, SensorEntity):

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -73,8 +73,6 @@ class Alpha2IODeviceBatterySensor(CoordinatorEntity[Alpha2BaseCoordinator], Sens
 class Alpha2HeatControlValveOpeningSensor(CoordinatorEntity[Alpha2BaseCoordinator], SensorEntity):
     """Alpha2 heat control valve opening sensor."""
 
-    coordinator: Alpha2BaseCoordinator
-
     _attr_native_unit_of_measurement = PERCENTAGE
 
     def __init__(

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
 class Alpha2IODeviceBatterySensor(CoordinatorEntity[Alpha2BaseCoordinator], SensorEntity):
     """Alpha2 IO device battery sensor."""
 
-    device_class = SensorDeviceClass.BATTERY
+    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
 
     def __init__(self, coordinator: Alpha2BaseCoordinator, io_device_id: str) -> None:

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class Alpha2IODeviceBatterySensor(CoordinatorEntity, SensorEntity):
+class Alpha2IODeviceBatterySensor(CoordinatorEntity[Alpha2BaseCoordinator], SensorEntity):
     """Alpha2 IO device battery sensor."""
 
     coordinator: Alpha2BaseCoordinator

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -1,0 +1,94 @@
+"""Support for Alpha2 base and IO device sensors."""
+import logging
+
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import Alpha2BaseCoordinator
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add Alpha2 sensor entities from a config_entry."""
+
+    coordinator: Alpha2BaseCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        Alpha2IODeviceBatterySensor(coordinator, io_device_id)
+        for io_device_id in coordinator.data["io_devices"]
+    )
+    # HEATCTRL atrribute ACTOR_PERCENT is not available in older firmware versions
+    async_add_entities(
+        Alpha2HeatControlValveOpeningSensor(coordinator, heat_control_id)
+        for heat_control_id, heat_control in coordinator.data["heat_controls"].items()
+        if heat_control["INUSE"] and heat_control.get("ACTOR_PERCENT") is not None
+    )
+
+
+class Alpha2IODeviceBatterySensor(CoordinatorEntity, SensorEntity):
+    """Alpha2 IO device battery sensor."""
+
+    coordinator: Alpha2BaseCoordinator
+
+    device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, coordinator: Alpha2BaseCoordinator, io_device_id: str) -> None:
+        """Initialize Alpha2IODeviceBatterySensor."""
+        super().__init__(coordinator)
+        self.io_device_id = io_device_id
+        self._attr_unique_id = f"{io_device_id}:battery"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the battery sensor."""
+        return f"Alpha2 IO device {self.io_device_id} battery"
+
+    @property
+    def native_value(self) -> int:
+        """Return the current battery level percentage."""
+        battery = self.coordinator.data["io_devices"][self.io_device_id]["BATTERY"]
+        # 0=empty, 1=weak, 2=good
+        if battery == 0:
+            return 0
+        if battery == 1:
+            return 20
+        return 100
+
+
+class Alpha2HeatControlValveOpeningSensor(CoordinatorEntity, SensorEntity):
+    """Alpha2 heat control valve opening sensor."""
+
+    coordinator: Alpha2BaseCoordinator
+
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(
+        self, coordinator: Alpha2BaseCoordinator, heat_control_id: str
+    ) -> None:
+        """Initialize Alpha2HeatControlValveOpeningSensor."""
+        super().__init__(coordinator)
+        self.heat_control_id = heat_control_id
+        self._attr_unique_id = f"{heat_control_id}:valve_opening"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the valve sensor."""
+        return f"Alpha2 heat control {self.heat_control_id} valve opening"
+
+    @property
+    def native_value(self) -> int:
+        """Return the current valve opening percentage."""
+        return self.coordinator.data["heat_controls"][self.heat_control_id][
+            "ACTOR_PERCENT"
+        ]

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -70,7 +70,7 @@ class Alpha2IODeviceBatterySensor(CoordinatorEntity[Alpha2BaseCoordinator], Sens
         return 100
 
 
-class Alpha2HeatControlValveOpeningSensor(CoordinatorEntity, SensorEntity):
+class Alpha2HeatControlValveOpeningSensor(CoordinatorEntity[Alpha2BaseCoordinator], SensorEntity):
     """Alpha2 heat control valve opening sensor."""
 
     coordinator: Alpha2BaseCoordinator

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -23,19 +23,22 @@ async def async_setup_entry(
 
     coordinator: Alpha2BaseCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    async_add_entities(
+    entities = [
         Alpha2IODeviceBatterySensor(coordinator, io_device_id)
         for io_device_id, io_device in coordinator.data["io_devices"].items()
         if io_device["_HEATAREA_ID"]
-    )
+    ]
+
     # HEATCTRL attribute ACTOR_PERCENT is not available in older firmware versions
-    async_add_entities(
+    entities.extend(
         Alpha2HeatControlValveOpeningSensor(coordinator, heat_control_id)
         for heat_control_id, heat_control in coordinator.data["heat_controls"].items()
         if heat_control["INUSE"]
         and heat_control["_HEATAREA_ID"]
         and heat_control.get("ACTOR_PERCENT") is not None
     )
+
+    async_add_entities(entities)
 
 
 class Alpha2IODeviceBatterySensor(CoordinatorEntity, SensorEntity):

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
         for io_device_id, io_device in coordinator.data["io_devices"].items()
         if io_device["_HEATAREA_ID"]
     )
-    # HEATCTRL atrribute ACTOR_PERCENT is not available in older firmware versions
+    # HEATCTRL attribute ACTOR_PERCENT is not available in older firmware versions
     async_add_entities(
         Alpha2HeatControlValveOpeningSensor(coordinator, heat_control_id)
         for heat_control_id, heat_control in coordinator.data["heat_controls"].items()

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -1,7 +1,7 @@
 """Support for Alpha2 base and IO device sensors."""
 import logging
 
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -44,8 +44,6 @@ async def async_setup_entry(
 class Alpha2IODeviceBatterySensor(CoordinatorEntity[Alpha2BaseCoordinator], SensorEntity):
     """Alpha2 IO device battery sensor."""
 
-    coordinator: Alpha2BaseCoordinator
-
     device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
 

--- a/homeassistant/components/moehlenhoff_alpha2/sensor.py
+++ b/homeassistant/components/moehlenhoff_alpha2/sensor.py
@@ -52,7 +52,7 @@ class Alpha2IODeviceBatterySensor(CoordinatorEntity, SensorEntity):
         self.io_device_id = io_device_id
         self._attr_unique_id = f"{io_device_id}:battery"
         io_device = self.coordinator.data["io_devices"][io_device_id]
-        heat_area = self.coordinator.data["heat_areas"].get(io_device["_HEATAREA_ID"])
+        heat_area = self.coordinator.data["heat_areas"][io_device["_HEATAREA_ID"]]
         self._attr_name = (
             f"{heat_area['HEATAREA_NAME']} IO device {io_device['NR']} battery"
         )
@@ -84,9 +84,7 @@ class Alpha2HeatControlValveOpeningSensor(CoordinatorEntity, SensorEntity):
         self.heat_control_id = heat_control_id
         self._attr_unique_id = f"{heat_control_id}:valve_opening"
         heat_control = self.coordinator.data["heat_controls"][heat_control_id]
-        heat_area = self.coordinator.data["heat_areas"].get(
-            heat_control["_HEATAREA_ID"]
-        )
+        heat_area = self.coordinator.data["heat_areas"][heat_control["_HEATAREA_ID"]]
         self._attr_name = f"{heat_area['HEATAREA_NAME']} heat control {heat_control['NR']} valve opening"
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1032,7 +1032,7 @@ minio==5.0.10
 mitemp_bt==0.0.5
 
 # homeassistant.components.moehlenhoff_alpha2
-moehlenhoff-alpha2==1.1.2
+moehlenhoff-alpha2==1.2.0
 
 # homeassistant.components.motion_blinds
 motionblinds==0.6.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1032,7 +1032,7 @@ minio==5.0.10
 mitemp_bt==0.0.5
 
 # homeassistant.components.moehlenhoff_alpha2
-moehlenhoff-alpha2==1.2.0
+moehlenhoff-alpha2==1.2.1
 
 # homeassistant.components.motion_blinds
 motionblinds==0.6.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -709,7 +709,7 @@ millheater==0.9.0
 minio==5.0.10
 
 # homeassistant.components.moehlenhoff_alpha2
-moehlenhoff-alpha2==1.2.0
+moehlenhoff-alpha2==1.2.1
 
 # homeassistant.components.motion_blinds
 motionblinds==0.6.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -709,7 +709,7 @@ millheater==0.9.0
 minio==5.0.10
 
 # homeassistant.components.moehlenhoff_alpha2
-moehlenhoff-alpha2==1.1.2
+moehlenhoff-alpha2==1.2.0
 
 # homeassistant.components.motion_blinds
 motionblinds==0.6.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds io device battery sensors and heat control valve opening sensors to the moehlenhoff_alpha2 integration.
Updated moehlenhoff-alpha2 to version 1.2.1 which adds support for reading heat control and io device information.
[Changes between moehlenhoff-alpha2 1.1.2 and 1.2.1](https://github.com/j-a-n/python-moehlenhoff-alpha2/compare/1.1.2...1.2.1)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71741, fixes #71742
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
