### PR TITLE
Add new methods to DeviceAutomationActionProtocol

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     ]
 
 # mypy: allow-untyped-calls, allow-untyped-defs
+GetAutomationsResult = list[dict[str, Any]]
+GetAutomationCapabilitiesResult = dict[str, vol.Schema]
 
 DOMAIN = "device_automation"
 

--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -31,7 +31,6 @@ class DeviceAutomationActionProtocol(Protocol):
         self, hass: HomeAssistant, config: ConfigType
     ) -> ConfigType:
         """Validate config."""
-        raise NotImplementedError
 
     async def async_call_action_from_config(
         self,
@@ -41,19 +40,16 @@ class DeviceAutomationActionProtocol(Protocol):
         context: Context | None,
     ) -> None:
         """Execute a device action."""
-        raise NotImplementedError
 
     def async_get_action_capabilities(
         self, hass: HomeAssistant, config: ConfigType
     ) -> GetAutomationCapabilitiesResult | Awaitable[GetAutomationCapabilitiesResult]:
         """List action capabilities."""
-        return {}
 
     def async_get_actions(
         self, hass: HomeAssistant, device_id: str
     ) -> GetAutomationsResult | Awaitable[GetAutomationsResult]:
         """List actions."""
-        return []
 
 
 async def async_validate_action_config(

--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -1,6 +1,7 @@
 """Device action validator."""
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from typing import Any, Protocol, cast
 
 import voluptuous as vol
@@ -9,7 +10,12 @@ from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from . import DeviceAutomationType, async_get_device_automation_platform
+from . import (
+    DeviceAutomationType,
+    GetAutomationCapabilitiesResult,
+    GetAutomationsResult,
+    async_get_device_automation_platform,
+)
 from .exceptions import InvalidDeviceAutomationConfig
 
 
@@ -36,6 +42,18 @@ class DeviceAutomationActionProtocol(Protocol):
     ) -> None:
         """Execute a device action."""
         raise NotImplementedError
+
+    def async_get_action_capabilities(
+        self, hass: HomeAssistant, config: ConfigType
+    ) -> GetAutomationCapabilitiesResult | Awaitable[GetAutomationCapabilitiesResult]:
+        """List action capabilities."""
+        return {}
+
+    def async_get_actions(
+        self, hass: HomeAssistant, device_id: str
+    ) -> GetAutomationsResult | Awaitable[GetAutomationsResult]:
+        """List actions."""
+        return []
 
 
 async def async_validate_action_config(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add composite types for device automation results
Add `async_get_action_capabilities` and `async_get_actions` to `DeviceAutomationActionProtocol`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
