### PR TITLE
Cleanup nest async methods that do not need to actually await

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -54,6 +54,7 @@ from . import api, config_flow
 from .const import (
     CONF_PROJECT_ID,
     CONF_SUBSCRIBER_ID,
+    DATA_DEVICE_MANAGER,
     DATA_NEST_CONFIG,
     DATA_SDM,
     DATA_SUBSCRIBER,
@@ -63,8 +64,8 @@ from .events import EVENT_NAME_MAP, NEST_EVENT
 from .legacy import async_setup_legacy, async_setup_legacy_entry
 from .media_source import (
     async_get_media_event_store,
+    async_get_media_source_devices,
     async_get_transcoder,
-    get_media_source_devices,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -205,7 +206,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from err
 
     try:
-        await subscriber.async_get_device_manager()
+        device_manager = await subscriber.async_get_device_manager()
     except ApiException as err:
         if DATA_NEST_UNAVAILABLE not in hass.data[DOMAIN]:
             _LOGGER.error("Device manager error: %s", err)
@@ -215,6 +216,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN].pop(DATA_NEST_UNAVAILABLE, None)
     hass.data[DOMAIN][DATA_SUBSCRIBER] = subscriber
+    hass.data[DOMAIN][DATA_DEVICE_MANAGER] = device_manager
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
@@ -232,6 +234,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(DATA_SUBSCRIBER)
+        hass.data[DOMAIN].pop(DATA_DEVICE_MANAGER)
         hass.data[DOMAIN].pop(DATA_NEST_UNAVAILABLE, None)
 
     return unload_ok
@@ -275,7 +278,7 @@ class NestEventViewBase(HomeAssistantView, ABC):
             if not user.permissions.check_entity(entry.entity_id, POLICY_READ):
                 raise Unauthorized(entity_id=entry.entity_id)
 
-        devices = await get_media_source_devices(self.hass)
+        devices = async_get_media_source_devices(self.hass)
         if not (nest_device := devices.get(device_id)):
             return self._json_error(
                 f"No Nest Device found for '{device_id}'", HTTPStatus.NOT_FOUND

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -43,7 +43,7 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the cameras."""
 
-    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     entities = []
     for device in device_manager.devices.values():
         if (

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -15,6 +15,7 @@ from google_nest_sdm.camera_traits import (
     StreamingProtocol,
 )
 from google_nest_sdm.device import Device
+from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.exceptions import ApiException
 
 from homeassistant.components.camera import Camera, CameraEntityFeature

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -21,13 +21,13 @@ from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.camera.const import StreamType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-from .const import DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_DEVICE_MANAGER, DOMAIN
 from .device_info import NestDeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,14 +43,7 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the cameras."""
 
-    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
-    try:
-        device_manager = await subscriber.async_get_device_manager()
-    except ApiException as err:
-        raise PlatformNotReady from err
-
-    # Fetch initial data so we have data when entities subscribe.
-
+    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     entities = []
     for device in device_manager.devices.values():
         if (

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -5,7 +5,6 @@ from typing import Any, cast
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import FanTrait, TemperatureTrait
-from google_nest_sdm.exceptions import ApiException
 from google_nest_sdm.thermostat_traits import (
     ThermostatEcoTrait,
     ThermostatHeatCoolTrait,
@@ -30,11 +29,10 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_DEVICE_MANAGER, DOMAIN
 from .device_info import NestDeviceInfo
 
 # Mapping for sdm.devices.traits.ThermostatMode mode field
@@ -80,12 +78,7 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the client entities."""
 
-    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
-    try:
-        device_manager = await subscriber.async_get_device_manager()
-    except ApiException as err:
-        raise PlatformNotReady from err
-
+    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     entities = []
     for device in device_manager.devices.values():
         if ThermostatHvacTrait.NAME in device.traits:

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -78,7 +78,7 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the client entities."""
 
-    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     entities = []
     for device in device_manager.devices.values():
         if ThermostatHvacTrait.NAME in device.traits:

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from google_nest_sdm.device import Device
+from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.device_traits import FanTrait, TemperatureTrait
 from google_nest_sdm.thermostat_traits import (
     ThermostatEcoTrait,

--- a/homeassistant/components/nest/const.py
+++ b/homeassistant/components/nest/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "nest"
 DATA_SDM = "sdm"
 DATA_SUBSCRIBER = "subscriber"
+DATA_DEVICE_MANAGER = "device_manager"
 DATA_NEST_CONFIG = "nest_config"
 
 WEB_AUTH_DOMAIN = DOMAIN

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -1,8 +1,6 @@
 """Provides device automations for Nest."""
 from __future__ import annotations
 
-from typing import Any
-
 from google_nest_sdm.device_manager import DeviceManager
 import voluptuous as vol
 

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -17,7 +17,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_DEVICE_MANAGER, DOMAIN
 from .events import DEVICE_TRAIT_TRIGGER_MAP, NEST_EVENT
 
 DEVICE = "device"
@@ -42,14 +42,12 @@ def async_get_nest_device_id(hass: HomeAssistant, device_id: str) -> str | None:
     return None
 
 
-async def async_get_device_trigger_types(
+@callback
+def async_get_device_trigger_types(
     hass: HomeAssistant, nest_device_id: str
 ) -> list[str]:
     """List event triggers supported for a Nest device."""
-    # All devices should have already been loaded so any failures here are
-    # "shouldn't happen" cases
-    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
-    device_manager = await subscriber.async_get_device_manager()
+    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     if not (nest_device := device_manager.devices.get(nest_device_id)):
         raise InvalidDeviceAutomationConfig(f"Nest device not found {nest_device_id}")
 
@@ -69,7 +67,7 @@ async def async_get_triggers(
     nest_device_id = async_get_nest_device_id(hass, device_id)
     if not nest_device_id:
         raise InvalidDeviceAutomationConfig(f"Device not found {device_id}")
-    trigger_types = await async_get_device_trigger_types(hass, nest_device_id)
+    trigger_types = async_get_device_trigger_types(hass, nest_device_id)
     return [
         {
             CONF_PLATFORM: DEVICE,

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -47,7 +47,7 @@ def async_get_device_trigger_types(
     hass: HomeAssistant, nest_device_id: str
 ) -> list[str]:
     """List event triggers supported for a Nest device."""
-    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     if not (nest_device := device_manager.devices.get(nest_device_id)):
         raise InvalidDeviceAutomationConfig(f"Nest device not found {nest_device_id}")
 

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -1,6 +1,9 @@
 """Provides device automations for Nest."""
 from __future__ import annotations
 
+from typing import Any
+
+from google_nest_sdm.device_manager import DeviceManager
 import voluptuous as vol
 
 from homeassistant.components.automation import (

--- a/homeassistant/components/nest/diagnostics.py
+++ b/homeassistant/components/nest/diagnostics.py
@@ -6,43 +6,39 @@ from typing import Any
 
 from google_nest_sdm import diagnostics
 from google_nest_sdm.device import Device
+from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.device_traits import InfoTrait
-from google_nest_sdm.exceptions import ApiException
 
 from homeassistant.components.camera import diagnostics as camera_diagnostics
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DATA_SDM, DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_DEVICE_MANAGER, DATA_SDM, DOMAIN
 
 REDACT_DEVICE_TRAITS = {InfoTrait.NAME}
 
 
-async def _get_nest_devices(
+@callback
+def _async_get_nest_devices(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict[str, Device]:
     """Return dict of available devices."""
     if DATA_SDM not in config_entry.data:
         return {}
 
-    if DATA_SUBSCRIBER not in hass.data[DOMAIN]:
+    if DATA_DEVICE_MANAGER not in hass.data[DOMAIN]:
         return {}
 
-    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
-    device_manager = await subscriber.async_get_device_manager()
-    devices: dict[str, Device] = device_manager.devices
-    return devices
+    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    return device_manager.devices
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    try:
-        nest_devices = await _get_nest_devices(hass, config_entry)
-    except ApiException as err:
-        return {"error": str(err)}
+    nest_devices = _async_get_nest_devices(hass, config_entry)
     if not nest_devices:
         return {}
     data: dict[str, Any] = {
@@ -65,10 +61,7 @@ async def async_get_device_diagnostics(
     device: DeviceEntry,
 ) -> dict:
     """Return diagnostics for a device."""
-    try:
-        nest_devices = await _get_nest_devices(hass, config_entry)
-    except ApiException as err:
-        return {"error": str(err)}
+    nest_devices = _async_get_nest_devices(hass, config_entry)
     nest_device_id = next(iter(device.identifiers))[1]
     nest_device = nest_devices.get(nest_device_id)
     return nest_device.get_diagnostics() if nest_device else {}

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -273,7 +273,7 @@ def async_get_media_source_devices(hass: HomeAssistant) -> Mapping[str, Device]:
     if DATA_DEVICE_MANAGER not in hass.data[DOMAIN]:
         # Integration unloaded, or is legacy nest integration
         return {}
-    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     device_registry = dr.async_get(hass)
     devices = {}
     for device in device_manager.devices.values():

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -50,13 +50,13 @@ from homeassistant.components.media_source.models import (
     MediaSourceItem,
     PlayMedia,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import dt as dt_util
 
-from .const import DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_DEVICE_MANAGER, DOMAIN
 from .device_info import NestDeviceInfo
 from .events import EVENT_NAME_MAP, MEDIA_SOURCE_EVENT_TITLE_MAP
 
@@ -267,13 +267,13 @@ async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     return NestMediaSource(hass)
 
 
-async def get_media_source_devices(hass: HomeAssistant) -> Mapping[str, Device]:
+@callback
+def async_get_media_source_devices(hass: HomeAssistant) -> Mapping[str, Device]:
     """Return a mapping of device id to eligible Nest event media devices."""
-    if DATA_SUBSCRIBER not in hass.data[DOMAIN]:
+    if DATA_DEVICE_MANAGER not in hass.data[DOMAIN]:
         # Integration unloaded, or is legacy nest integration
         return {}
-    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
-    device_manager = await subscriber.async_get_device_manager()
+    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     device_registry = dr.async_get(hass)
     devices = {}
     for device in device_manager.devices.values():
@@ -339,7 +339,7 @@ class NestMediaSource(MediaSource):
         media_id: MediaId | None = parse_media_id(item.identifier)
         if not media_id:
             raise Unresolvable("No identifier specified for MediaSourceItem")
-        devices = await self.devices()
+        devices = async_get_media_source_devices(self.hass)
         if not (device := devices.get(media_id.device_id)):
             raise Unresolvable(
                 "Unable to find device with identifier: %s" % item.identifier
@@ -376,7 +376,7 @@ class NestMediaSource(MediaSource):
         _LOGGER.debug(
             "Browsing media for identifier=%s, media_id=%s", item.identifier, media_id
         )
-        devices = await self.devices()
+        devices = async_get_media_source_devices(self.hass)
         if media_id is None:
             # Browse the root and return child devices
             browse_root = _browse_root()
@@ -442,10 +442,6 @@ class NestMediaSource(MediaSource):
                 "Unable to find event with identiifer: %s" % item.identifier
             )
         return _browse_image_event(media_id, device, single_image)
-
-    async def devices(self) -> Mapping[str, Device]:
-        """Return all event media related devices."""
-        return await get_media_source_devices(self.hass)
 
 
 async def _async_get_clip_preview_sessions(

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -25,6 +25,7 @@ import os
 
 from google_nest_sdm.camera_traits import CameraClipPreviewTrait, CameraEventImageTrait
 from google_nest_sdm.device import Device
+from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.event import EventImageType, ImageEventBase
 from google_nest_sdm.event_media import (
     ClipPreviewSession,

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -5,7 +5,6 @@ import logging
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import HumidityTrait, TemperatureTrait
-from google_nest_sdm.exceptions import ApiException
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -15,10 +14,9 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_DEVICE_MANAGER, DOMAIN
 from .device_info import NestDeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,13 +35,7 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the sensors."""
 
-    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
-    try:
-        device_manager = await subscriber.async_get_device_manager()
-    except ApiException as err:
-        _LOGGER.warning("Failed to get devices: %s", err)
-        raise PlatformNotReady from err
-
+    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     entities: list[SensorEntity] = []
     for device in device_manager.devices.values():
         if TemperatureTrait.NAME in device.traits:

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -35,7 +35,7 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the sensors."""
 
-    device_manager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
     entities: list[SensorEntity] = []
     for device in device_manager.devices.values():
         if TemperatureTrait.NAME in device.traits:

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 
 from google_nest_sdm.device import Device
+from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.device_traits import HumidityTrait, TemperatureTrait
 
 from homeassistant.components.sensor import (

--- a/tests/components/nest/test_diagnostics.py
+++ b/tests/components/nest/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from google_nest_sdm.exceptions import ApiException, SubscriberException
+from google_nest_sdm.exceptions import SubscriberException
 import pytest
 
 from homeassistant.components.nest.const import DOMAIN
@@ -137,34 +137,6 @@ async def test_setup_susbcriber_failure(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {}
-
-
-async def test_device_manager_failure(
-    hass,
-    hass_client,
-    config_entry,
-    setup_platform,
-    create_device,
-):
-    """Test configuration error."""
-    create_device.create(raw_data=DEVICE_API_DATA)
-    await setup_platform()
-    assert config_entry.state is ConfigEntryState.LOADED
-
-    device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, NEST_DEVICE_ID)})
-    assert device is not None
-
-    with patch(
-        "homeassistant.components.nest.diagnostics._get_nest_devices",
-        side_effect=ApiException("Device manager failure"),
-    ):
-        assert await get_diagnostics_for_config_entry(
-            hass, hass_client, config_entry
-        ) == {"error": "Device manager failure"}
-        assert await get_diagnostics_for_device(
-            hass, hass_client, config_entry, device
-        ) == {"error": "Device manager failure"}
 
 
 @pytest.mark.parametrize("nest_test_config", [TEST_CONFIG_LEGACY])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup nest async methods that do not actually need to await. The nest subscriber creates the device manager at startup lazily, however once created it doesn't actually change. Instead of grabbing the subscriber everywhere we can grab pass
the device manager to avoid unnecessary awaits that aren't actually awaiting, and remove unnecessary error handling code.

See the underlying method [async_get_device_manager](https://github.com/allenporter/python-google-nest-sdm/blob/60c2da77edf3ef082a01e43f1e8ea0d894af9034/google_nest_sdm/google_nest_subscriber.py#L478) in `google-nest-sdm` for getting device manager which is just a lazy initialized task. There are no other side effects of calling that method.

This is motivated by unblocking #72090 trigger cleanup.

There are opportunities for additional nest lookup device cleanup, but leaving that out to help focus reviewing correctness of this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
