### PR TITLE
Add Neato application credentials platform and deprecate configuration.yaml

### DIFF
--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -2,10 +2,14 @@
 import logging
 
 import aiohttp
-from pybotvac import Account, Neato
+from pybotvac import Account
 from pybotvac.exceptions import NeatoException
 import voluptuous as vol
 
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
@@ -13,7 +17,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from . import api, config_flow
+from . import api
 from .const import NEATO_CONFIG, NEATO_DOMAIN, NEATO_LOGIN
 from .hub import NeatoHub
 
@@ -21,14 +25,17 @@ _LOGGER = logging.getLogger(__name__)
 
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        NEATO_DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_CLIENT_ID): cv.string,
-                vol.Required(CONF_CLIENT_SECRET): cv.string,
-            }
-        )
-    },
+    vol.All(
+        cv.deprecated(NEATO_DOMAIN),
+        {
+            NEATO_DOMAIN: vol.Schema(
+                {
+                    vol.Required(CONF_CLIENT_ID): cv.string,
+                    vol.Required(CONF_CLIENT_SECRET): cv.string,
+                }
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -43,17 +50,20 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return True
 
     hass.data[NEATO_CONFIG] = config[NEATO_DOMAIN]
-    vendor = Neato()
-    config_flow.OAuth2FlowHandler.async_register_implementation(
+    await async_import_client_credential(
         hass,
-        api.NeatoImplementation(
-            hass,
-            NEATO_DOMAIN,
+        NEATO_DOMAIN,
+        ClientCredential(
             config[NEATO_DOMAIN][CONF_CLIENT_ID],
             config[NEATO_DOMAIN][CONF_CLIENT_SECRET],
-            vendor.auth_endpoint,
-            vendor.token_endpoint,
         ),
+    )
+    _LOGGER.warning(
+        "Configuration of Neato integration in YAML is deprecated and "
+        "will be removed in a future release; Your existing OAuth "
+        "Application Credentials have been imported into the UI "
+        "automatically and can be safely removed from your "
+        "configuration.yaml file"
     )
 
     return True

--- a/homeassistant/components/neato/api.py
+++ b/homeassistant/components/neato/api.py
@@ -7,6 +7,7 @@ from typing import Any
 import pybotvac
 
 from homeassistant import config_entries, core
+from homeassistant.components.application_credentials import AuthImplementation
 from homeassistant.helpers import config_entry_oauth2_flow
 
 
@@ -35,7 +36,7 @@ class ConfigEntryAuth(pybotvac.OAuthSession):  # type: ignore[misc]
         return self.session.token["access_token"]  # type: ignore[no-any-return]
 
 
-class NeatoImplementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
+class NeatoImplementation(AuthImplementation):
     """Neato implementation of LocalOAuth2Implementation.
 
     We need this class because we have to add client_secret and scope to the authorization request.

--- a/homeassistant/components/neato/application_credentials.py
+++ b/homeassistant/components/neato/application_credentials.py
@@ -1,0 +1,28 @@
+"""Application credentials platform for neato."""
+
+from pybotvac import Neato
+
+from homeassistant.components.application_credentials import (
+    AuthorizationServer,
+    ClientCredential,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+
+from . import api
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant, auth_domain: str, credential: ClientCredential
+) -> config_entry_oauth2_flow.AbstractOAuth2Implementation:
+    """Return auth implementation for a custom auth implementation."""
+    vendor = Neato()
+    return api.NeatoImplementation(
+        hass,
+        auth_domain,
+        credential,
+        AuthorizationServer(
+            authorize_url=vendor.auth_endpoint,
+            token_url=vendor.token_endpoint,
+        ),
+    )

--- a/homeassistant/components/neato/manifest.json
+++ b/homeassistant/components/neato/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/neato",
   "requirements": ["pybotvac==0.0.23"],
   "codeowners": ["@dshokouhi", "@Santobert"],
-  "dependencies": ["auth"],
+  "dependencies": ["application_credentials"],
   "iot_class": "cloud_polling",
   "loggers": ["pybotvac"]
 }

--- a/homeassistant/generated/application_credentials.py
+++ b/homeassistant/generated/application_credentials.py
@@ -9,6 +9,7 @@ APPLICATION_CREDENTIALS = [
     "geocaching",
     "google",
     "home_connect",
+    "neato",
     "netatmo",
     "spotify",
     "xbox",

--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -27,7 +27,6 @@ async def test_full_flow(
         "neato",
         {
             "neato": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET},
-            "http": {"base_url": "https://example.com"},
         },
     )
 
@@ -99,7 +98,6 @@ async def test_reauth(
         "neato",
         {
             "neato": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET},
-            "http": {"base_url": "https://example.com"},
         },
     )
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The configuration of the OAuth application credentials for the Neato integration has migrated to configuration via the UI. Configuring Neato OAuth application credentials via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing OAuth application credentials in the YAML configuration are automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Neato application credentials platform and deprecate configuration.yaml

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Related arch discussion https://github.com/home-assistant/architecture/discussions/692

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
