### PR TITLE
Add support for cover positions in bond

### DIFF
--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -223,6 +223,20 @@ BUTTONS: tuple[BondButtonEntityDescription, ...] = (
         mutually_exclusive=Action.OPEN,
         argument=None,
     ),
+    BondButtonEntityDescription(
+        key=Action.INCREASE_POSITION,
+        name="Increase Position",
+        icon="mdi:plus-box",
+        mutually_exclusive=Action.SET_POSITION,
+        argument=STEP_SIZE,
+    ),
+    BondButtonEntityDescription(
+        key=Action.DECREASE_POSITION,
+        name="Decrease Position",
+        icon="mdi:minus-box",
+        mutually_exclusive=Action.SET_POSITION,
+        argument=STEP_SIZE,
+    ),
 )
 
 

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -6,6 +6,7 @@ from typing import Any
 from bond_api import Action, BPUPSubscriptions, DeviceType
 
 from homeassistant.components.cover import (
+    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -18,6 +19,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import BPUP_SUBS, DOMAIN, HUB
 from .entity import BondEntity
 from .utils import BondDevice, BondHub
+
+
+def _bond_to_hass_position(bond_position: int) -> int:
+    """Convert bond 0-open 100-closed to hass 0-closed 100-open."""
+    return abs(bond_position - 100)
+
+
+def _hass_to_bond_position(hass_position: int) -> int:
+    """Convert hass 0-closed 100-open to bond 0-open 100-closed."""
+    return 100 - hass_position
 
 
 async def async_setup_entry(
@@ -50,6 +61,8 @@ class BondCover(BondEntity, CoverEntity):
         """Create HA entity representing Bond cover."""
         super().__init__(hub, device, bpup_subs)
         supported_features = 0
+        if self._device.supports_set_position():
+            supported_features |= CoverEntityFeature.SET_POSITION
         if self._device.supports_open():
             supported_features |= CoverEntityFeature.OPEN
         if self._device.supports_close():
@@ -67,8 +80,15 @@ class BondCover(BondEntity, CoverEntity):
 
     def _apply_state(self, state: dict) -> None:
         cover_open = state.get("open")
-        self._attr_is_closed = (
-            True if cover_open == 0 else False if cover_open == 1 else None
+        self._attr_is_closed = None if cover_open is None else cover_open == 0
+        if (bond_position := state.get("position")) is not None:
+            self._attr_current_cover_position = _bond_to_hass_position(bond_position)
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Set the cover position."""
+        await self._hub.bond.action(
+            self._device.device_id,
+            Action.set_position(_hass_to_bond_position(kwargs[ATTR_POSITION])),
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -82,6 +82,10 @@ class BondDevice:
         """Return True if this device supports any of the direction related commands."""
         return self._has_any_action({Action.SET_DIRECTION})
 
+    def supports_set_position(self) -> bool:
+        """Return True if this device supports setting the position."""
+        return self._has_any_action({Action.SET_POSITION})
+
     def supports_open(self) -> bool:
         """Return True if this device supports opening."""
         return self._has_any_action({Action.OPEN})

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -4,15 +4,22 @@ from datetime import timedelta
 from bond_api import Action, DeviceType
 
 from homeassistant import core
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN, STATE_CLOSED
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    STATE_CLOSED,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
     SERVICE_OPEN_COVER_TILT,
+    SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
+    STATE_OPEN,
     STATE_UNKNOWN,
 )
 from homeassistant.helpers import entity_registry as er
@@ -35,6 +42,15 @@ def shades(name: str):
         "name": name,
         "type": DeviceType.MOTORIZED_SHADES,
         "actions": ["Open", "Close", "Hold"],
+    }
+
+
+def shades_with_position(name: str):
+    """Create motorized shades that supports set position."""
+    return {
+        "name": name,
+        "type": DeviceType.MOTORIZED_SHADES,
+        "actions": [Action.OPEN, Action.CLOSE, Action.HOLD, Action.SET_POSITION],
     }
 
 
@@ -236,3 +252,64 @@ async def test_cover_available(hass: core.HomeAssistant):
     await help_test_entity_available(
         hass, COVER_DOMAIN, shades("name-1"), "cover.name_1"
     )
+
+
+async def test_set_position_cover(hass: core.HomeAssistant):
+    """Tests that set position cover command delegates to API."""
+    await setup_platform(
+        hass,
+        COVER_DOMAIN,
+        shades_with_position("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    with patch_bond_action() as mock_hold, patch_bond_device_state(
+        return_value={"position": 0, "open": 1}
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: "cover.name_1", ATTR_POSITION: 100},
+            blocking=True,
+        )
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+
+    mock_hold.assert_called_once_with("test-device-id", Action.set_position(0))
+    entity_state = hass.states.get("cover.name_1")
+    assert entity_state.state == STATE_OPEN
+    assert entity_state.attributes[ATTR_CURRENT_POSITION] == 100
+
+    with patch_bond_action() as mock_hold, patch_bond_device_state(
+        return_value={"position": 100, "open": 0}
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: "cover.name_1", ATTR_POSITION: 0},
+            blocking=True,
+        )
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+
+    mock_hold.assert_called_once_with("test-device-id", Action.set_position(100))
+    entity_state = hass.states.get("cover.name_1")
+    assert entity_state.state == STATE_CLOSED
+    assert entity_state.attributes[ATTR_CURRENT_POSITION] == 0
+
+    with patch_bond_action() as mock_hold, patch_bond_device_state(
+        return_value={"position": 40, "open": 1}
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: "cover.name_1", ATTR_POSITION: 60},
+            blocking=True,
+        )
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+
+    mock_hold.assert_called_once_with("test-device-id", Action.set_position(40))
+    entity_state = hass.states.get("cover.name_1")
+    assert entity_state.state == STATE_OPEN
+    assert entity_state.attributes[ATTR_CURRENT_POSITION] == 60


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for cover positions in bond

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
