### PR TITLE
Fix last state in history minimal respones when all the states at the end are skipped

### DIFF
--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -695,8 +695,6 @@ def _sorted_states_to_dict(
             prev_state = first_state.state
             ent_results.append(state_class(first_state, attr_cache))
 
-        initial_state_count = len(ent_results)
-        row = None
         for row in group:
             # With minimal response we do not care about attribute
             # changes so we can filter out duplicate states
@@ -715,12 +713,6 @@ def _sorted_states_to_dict(
                 }
             )
             prev_state = state
-
-        if row and len(ent_results) != initial_state_count:
-            # There was at least one state change
-            # replace the last minimal state with
-            # a full state
-            ent_results[-1] = state_class(row, attr_cache)
 
     # If there are no states beyond the initial state,
     # the state a was never popped from initial_states

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -61,23 +61,30 @@ def test_get_significant_states_minimal_response(hass_history):
     hist = get_significant_states(
         hass, zero, four, filters=history.Filters(), minimal_response=True
     )
+    entites_with_reducable_states = [
+        "media_player.test",
+        "media_player.test3",
+    ]
 
-    # The second media_player.test state is reduced
+    # All states for media_player.test state are reduced
     # down to last_changed and state when minimal_response
+    # is set except for the first state.
     # is set.  We use JSONEncoder to make sure that are
     # pre-encoded last_changed is always the same as what
     # will happen with encoding a native state
-    input_state = states["media_player.test"][1]
-    orig_last_changed = json.dumps(
-        process_timestamp(input_state.last_changed),
-        cls=JSONEncoder,
-    ).replace('"', "")
-    orig_state = input_state.state
-    states["media_player.test"][1] = {
-        "last_changed": orig_last_changed,
-        "state": orig_state,
-    }
-
+    for entity_id in entites_with_reducable_states:
+        entity_states = states[entity_id]
+        for state_idx in range(1, len(entity_states)):
+            input_state = entity_states[state_idx]
+            orig_last_changed = orig_last_changed = json.dumps(
+                process_timestamp(input_state.last_changed),
+                cls=JSONEncoder,
+            ).replace('"', "")
+            orig_state = input_state.state
+            entity_states[state_idx] = {
+                "last_changed": orig_last_changed,
+                "state": orig_state,
+            }
     assert states == hist
 
 
@@ -616,6 +623,9 @@ async def test_fetch_period_api_with_minimal_response(hass, recorder_mock, hass_
     hass.states.async_set("sensor.power", 50, {"attr": "any"})
     await async_wait_recording_done(hass)
     hass.states.async_set("sensor.power", 23, {"attr": "any"})
+    last_changed = hass.states.get("sensor.power").last_changed
+    await async_wait_recording_done(hass)
+    hass.states.async_set("sensor.power", 23, {"attr": "any"})
     await async_wait_recording_done(hass)
     client = await hass_client()
     response = await client.get(
@@ -634,9 +644,13 @@ async def test_fetch_period_api_with_minimal_response(hass, recorder_mock, hass_
     assert "entity_id" not in state_list[1]
     assert state_list[1]["state"] == "50"
 
-    assert state_list[2]["entity_id"] == "sensor.power"
-    assert state_list[2]["attributes"] == {}
+    assert "attributes" not in state_list[2]
+    assert "entity_id" not in state_list[2]
     assert state_list[2]["state"] == "23"
+    assert state_list[2]["last_changed"] == json.dumps(
+        process_timestamp(last_changed),
+        cls=JSONEncoder,
+    ).replace('"', "")
 
 
 async def test_fetch_period_api_with_no_timestamp(hass, hass_client, recorder_mock):
@@ -1131,7 +1145,7 @@ async def test_history_during_period(hass, hass_ws_client, recorder_mock):
     assert "lc" not in sensor_test_history[1]  # skipped if the same a last_updated (lu)
 
     assert sensor_test_history[2]["s"] == "on"
-    assert sensor_test_history[2]["a"] == {}
+    assert "a" not in sensor_test_history[2]
 
     await client.send_json(
         {


### PR DESCRIPTION
Needs Frontend PR https://github.com/home-assistant/frontend/pull/12732

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Needed to fix https://github.com/home-assistant/frontend/pull/12728#issuecomment-1132019181

Before
<img width="725" alt="Screen_Shot_2022-05-19_at_12_47_36" src="https://user-images.githubusercontent.com/663432/169364784-9476e3ce-971b-4130-8702-f29b9c8a6acc.png">

After

<img width="746" alt="Screen_Shot_2022-05-19_at_14_10_31" src="https://user-images.githubusercontent.com/663432/169384192-6a27b850-db8e-42e5-81d5-b08d27460583.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
