### PR TITLE
Allow zwave_js/network_status WS API to accept device or entry ID

### DIFF
--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -185,7 +185,7 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
     # Test sending command with no device ID or entry ID fails
     await ws_client.send_json(
         {
-            ID: 6,
+            ID: 7,
             TYPE: "zwave_js/network_status",
         }
     )

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -28,7 +28,10 @@ from zwave_js_server.model.controller import (
 )
 from zwave_js_server.model.node import Node
 
-from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
+from homeassistant.components.websocket_api.const import (
+    ERR_INVALID_FORMAT,
+    ERR_NOT_FOUND,
+)
 from homeassistant.components.zwave_js.api import (
     ADDITIONAL_PROPERTIES,
     APPLICATION_VERSION,
@@ -36,7 +39,6 @@ from homeassistant.components.zwave_js.api import (
     COMMAND_CLASS_ID,
     CONFIG,
     DEVICE_ID,
-    DEVICE_OR_ENTRY_ID,
     DSK,
     ENABLED,
     ENTRY_ID,
@@ -46,7 +48,6 @@ from homeassistant.components.zwave_js.api import (
     FORCE_CONSOLE,
     GENERIC_DEVICE_CLASS,
     ID,
-    ID_TYPE,
     INCLUSION_STRATEGY,
     INSTALLER_ICON_TYPE,
     LEVEL,
@@ -95,8 +96,7 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
             {
                 ID: 1,
                 TYPE: "zwave_js/network_status",
-                DEVICE_OR_ENTRY_ID: entry.entry_id,
-                ID_TYPE: ENTRY_ID,
+                ENTRY_ID: entry.entry_id,
             }
         )
         msg = await ws_client.receive_json()
@@ -117,8 +117,7 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
             {
                 ID: 2,
                 TYPE: "zwave_js/network_status",
-                DEVICE_OR_ENTRY_ID: device.id,
-                ID_TYPE: DEVICE_ID,
+                DEVICE_ID: device.id,
             }
         )
         msg = await ws_client.receive_json()
@@ -133,8 +132,7 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
         {
             ID: 3,
             TYPE: "zwave_js/network_status",
-            DEVICE_OR_ENTRY_ID: "fake_id",
-            ID_TYPE: ENTRY_ID,
+            ENTRY_ID: "fake_id",
         }
     )
     msg = await ws_client.receive_json()
@@ -147,8 +145,7 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
         {
             ID: 4,
             TYPE: "zwave_js/network_status",
-            DEVICE_OR_ENTRY_ID: "fake_id",
-            ID_TYPE: DEVICE_ID,
+            DEVICE_ID: "fake_id",
         }
     )
     msg = await ws_client.receive_json()
@@ -164,8 +161,7 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
         {
             ID: 5,
             TYPE: "zwave_js/network_status",
-            DEVICE_OR_ENTRY_ID: entry.entry_id,
-            ID_TYPE: ENTRY_ID,
+            ENTRY_ID: entry.entry_id,
         }
     )
     msg = await ws_client.receive_json()
@@ -178,14 +174,25 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
         {
             ID: 6,
             TYPE: "zwave_js/network_status",
-            DEVICE_OR_ENTRY_ID: device.id,
-            ID_TYPE: DEVICE_ID,
+            DEVICE_ID: device.id,
         }
     )
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_LOADED
+
+    # Test sending command with no device ID or entry ID fails
+    await ws_client.send_json(
+        {
+            ID: 6,
+            TYPE: "zwave_js/network_status",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_INVALID_FORMAT
 
 
 async def test_node_ready(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -36,6 +36,7 @@ from homeassistant.components.zwave_js.api import (
     COMMAND_CLASS_ID,
     CONFIG,
     DEVICE_ID,
+    DEVICE_OR_ENTRY_ID,
     DSK,
     ENABLED,
     ENTRY_ID,
@@ -45,6 +46,7 @@ from homeassistant.components.zwave_js.api import (
     FORCE_CONSOLE,
     GENERIC_DEVICE_CLASS,
     ID,
+    ID_TYPE,
     INCLUSION_STRATEGY,
     INSTALLER_ICON_TYPE,
     LEVEL,
@@ -82,14 +84,20 @@ def get_device(hass, node):
     return dev_reg.async_get_device({device_id})
 
 
-async def test_network_status(hass, integration, hass_ws_client):
+async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
     """Test the network status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
 
+    # Try API call with entry ID
     with patch("zwave_js_server.model.controller.Controller.async_get_state"):
         await ws_client.send_json(
-            {ID: 2, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
+            {
+                ID: 1,
+                TYPE: "zwave_js/network_status",
+                DEVICE_OR_ENTRY_ID: entry.entry_id,
+                ID_TYPE: ENTRY_ID,
+            }
         )
         msg = await ws_client.receive_json()
         result = msg["result"]
@@ -98,12 +106,81 @@ async def test_network_status(hass, integration, hass_ws_client):
     assert result["client"]["server_version"] == "1.0.0"
     assert result["controller"]["inclusion_state"] == InclusionState.IDLE
 
-    # Test sending command with not loaded entry fails
+    # Try API call with device ID
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(
+        identifiers={(DOMAIN, "3245146787-52")},
+    )
+    assert device
+    with patch("zwave_js_server.model.controller.Controller.async_get_state"):
+        await ws_client.send_json(
+            {
+                ID: 2,
+                TYPE: "zwave_js/network_status",
+                DEVICE_OR_ENTRY_ID: device.id,
+                ID_TYPE: DEVICE_ID,
+            }
+        )
+        msg = await ws_client.receive_json()
+        result = msg["result"]
+
+    assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
+    assert result["client"]["server_version"] == "1.0.0"
+    assert result["controller"]["inclusion_state"] == InclusionState.IDLE
+
+    # Test sending command with invalid config entry ID fails
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/network_status",
+            DEVICE_OR_ENTRY_ID: "fake_id",
+            ID_TYPE: ENTRY_ID,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with invalid device ID fails
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/network_status",
+            DEVICE_OR_ENTRY_ID: "fake_id",
+            ID_TYPE: DEVICE_ID,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with not loaded entry fails with config entry ID
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 3, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
+        {
+            ID: 5,
+            TYPE: "zwave_js/network_status",
+            DEVICE_OR_ENTRY_ID: entry.entry_id,
+            ID_TYPE: ENTRY_ID,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+    # Test sending command with not loaded entry fails with device ID
+    await ws_client.send_json(
+        {
+            ID: 6,
+            TYPE: "zwave_js/network_status",
+            DEVICE_OR_ENTRY_ID: device.id,
+            ID_TYPE: DEVICE_ID,
+        }
     )
     msg = await ws_client.receive_json()
 


### PR DESCRIPTION
## Proposed change
Addresses https://github.com/home-assistant/frontend/pull/12658#discussion_r875548221 in conjunction with the associated frontend PR https://github.com/home-assistant/frontend/pull/12735

Additional context: There are places in the frontend where we call this API from the context of the config entry, and places where we call it from the context of a device. Accepting both just lightens the load on the frontend by making the core do the necessary resolution


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/12735

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
