### PR TITLE
Refactors UniFi Protect doorbell services

### DIFF
--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -179,28 +179,20 @@ class ProtectData:
             )
 
         def _unsubscribe() -> None:
-            self.async_unsubscribe_device_id(entry, device, update_callback)
+            self.async_unsubscribe_device_id(device.id, update_callback)
 
         return _unsubscribe
 
     @callback
     def async_unsubscribe_device_id(
         self,
-        entry: RegistryEntry,
-        device: ProtectAdoptableDeviceModel,
+        device_id: str,
         update_callback: CALLBACK_TYPE,
     ) -> None:
         """Remove a callback subscriber."""
-        self._subscriptions[device.id].remove(update_callback)
-        if not self._subscriptions[device.id]:
-            del self._subscriptions[device.id]
-        if entry.unique_id in self._entity_to_ufp_device_map:
-            del self._entity_to_ufp_device_map[entry.unique_id]
-        if (
-            entry.device_id is not None
-            and entry.device_id in self._device_to_ufp_device_map
-        ):
-            del self._device_to_ufp_device_map[entry.device_id]
+        self._subscriptions[device_id].remove(update_callback)
+        if not self._subscriptions[device_id]:
+            del self._subscriptions[device_id]
         if not self._subscriptions and self._unsub_interval:
             self._unsub_interval()
             self._unsub_interval = None
@@ -236,6 +228,6 @@ class ProtectData:
 
         ref = self._device_to_ufp_device_map.get(device_id)
         if ref is None:
-            return None  # pragma: no cover
+            return None
 
         return self._async_get_device_from_ref(ref)

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -170,11 +170,11 @@ class ProtectData:
             )
         self._subscriptions.setdefault(device.id, []).append(update_callback)
         assert device.model is not None
-        self._entity_to_device_map[entry.unique_id] = ProtectDeviceRef(
+        self._entity_to_ufp_device_map[entry.unique_id] = ProtectDeviceRef(
             device.model, device.id
         )
         if entry.device_id is not None:
-            self._device_to_device_map[entry.device_id] = ProtectDeviceRef(
+            self._device_to_ufp_device_map[entry.device_id] = ProtectDeviceRef(
                 device.model, device.id
             )
 
@@ -194,13 +194,13 @@ class ProtectData:
         self._subscriptions[device.id].remove(update_callback)
         if not self._subscriptions[device.id]:
             del self._subscriptions[device.id]
-        if entry.unique_id in self._entity_to_device_map:
-            del self._entity_to_device_map[entry.unique_id]
+        if entry.unique_id in self._entity_to_ufp_device_map:
+            del self._entity_to_ufp_device_map[entry.unique_id]
         if (
             entry.device_id is not None
-            and entry.device_id in self._device_to_device_map
+            and entry.device_id in self._device_to_ufp_device_map
         ):
-            del self._device_to_device_map[entry.device_id]
+            del self._device_to_ufp_device_map[entry.device_id]
         if not self._subscriptions and self._unsub_interval:
             self._unsub_interval()
             self._unsub_interval = None
@@ -234,19 +234,7 @@ class ProtectData:
     ) -> ProtectAdoptableDeviceModel | NVR | None:
         """Get UniFi Protect device from HA device ID."""
 
-        ref = self._device_to_device_map.get(device_id)
-        if ref is None:
-            return None  # pragma: no cover
-
-        return self._async_get_device_from_ref(ref)
-
-    @callback
-    def async_get_ufp_device_from_entity(
-        self, unique_id: str
-    ) -> ProtectAdoptableDeviceModel | NVR | None:
-        """Get UniFi Protect device from HA entity unique ID."""
-
-        ref = self._entity_to_device_map.get(unique_id)
+        ref = self._device_to_ufp_device_map.get(device_id)
         if ref is None:
             return None  # pragma: no cover
 

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -46,8 +46,8 @@ class ProtectData:
         self._hass = hass
         self._update_interval = update_interval
         self._subscriptions: dict[str, list[CALLBACK_TYPE]] = {}
-        self._entity_to_device_map: dict[str, ProtectDeviceRef] = {}
-        self._device_to_device_map: dict[str, ProtectDeviceRef] = {}
+        self._entity_to_ufp_device_map: dict[str, ProtectDeviceRef] = {}
+        self._device_to_ufp_device_map: dict[str, ProtectDeviceRef] = {}
         self._unsub_interval: CALLBACK_TYPE | None = None
         self._unsub_websocket: CALLBACK_TYPE | None = None
 

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -21,6 +21,7 @@ from pyunifiprotect.data.nvr import NVR
 from homeassistant.core import callback
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+import homeassistant.helpers.entity_registry as er
 
 from .const import ATTR_EVENT_SCORE, DEFAULT_ATTRIBUTION, DEFAULT_BRAND, DOMAIN
 from .data import ProtectData
@@ -175,9 +176,16 @@ class ProtectDeviceEntity(Entity):
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
+
+        assert self.entity_id is not None
+        registry = er.async_get(self.hass)
+        entry = registry.async_get(self.entity_id)
+        assert entry is not None
         self.async_on_remove(
             self.data.async_subscribe_device_id(
-                self.device.id, self._async_updated_event
+                entry,
+                self.device,
+                self._async_updated_event,
             )
         )
 

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Generic, TypeVar
 
-from pyunifiprotect.data import ProtectDeviceModel
+from pyunifiprotect.data import ModelType, ProtectDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 
@@ -15,6 +15,14 @@ from .utils import get_nested_attr
 _LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=ProtectDeviceModel)
+
+
+@dataclass
+class ProtectDeviceRef:
+    """UniFi Protect device ref."""
+
+    model: ModelType
+    device_id: str
 
 
 @dataclass

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, Final
 
 from pyunifiprotect.data import (
     NVR,
@@ -49,7 +49,8 @@ from .models import ProtectRequiredKeysMixin, T
 
 _LOGGER = logging.getLogger(__name__)
 OBJECT_TYPE_NONE = "none"
-DEVICE_CLASS_DETECTION = "unifiprotect__detection"
+DEVICE_CLASS_DETECTION: Final = "unifiprotect__detection"
+DEVICE_CLASS_CAP_SENSOR: Final = "unifiprotect__cap_sensor"
 
 
 @dataclass
@@ -313,6 +314,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         icon="mdi:harddisk",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        device_class=DEVICE_CLASS_CAP_SENSOR,
         ufp_value="storage_stats.utilization",
         precision=2,
     ),

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -61,8 +61,7 @@ def _async_get_ufp_instance(hass: HomeAssistant, device_id: str) -> ProtectData:
     ]
 
     if not ufp_instances:
-        # should not be possible unless user manually enters a bad device ID
-        raise HomeAssistantError(  # pragma: no cover
+        raise HomeAssistantError(
             f"No UniFi Protect Config Entry found for device ID: {device_id}"
         )
 

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -1,12 +1,9 @@
 """UniFi Protect Integration services."""
 from __future__ import annotations
 
-import asyncio
 import functools
-from typing import Any
 
 from pydantic import ValidationError
-from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.exceptions import BadRequest
 import voluptuous as vol
 
@@ -19,7 +16,6 @@ from homeassistant.helpers.service import async_extract_referenced_entity_ids
 
 from .const import ATTR_MESSAGE, DOMAIN
 from .data import ProtectData
-from .utils import _async_unifi_mac_from_hass
 
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
@@ -42,93 +38,78 @@ DOORBELL_TEXT_SCHEMA = vol.All(
 )
 
 
-def _async_all_ufp_instances(hass: HomeAssistant) -> list[ProtectApiClient]:
+def _async_all_ufp_instances(hass: HomeAssistant) -> list[ProtectData]:
     """All active UFP instances."""
     return [
-        data.api for data in hass.data[DOMAIN].values() if isinstance(data, ProtectData)
+        data for data in hass.data[DOMAIN].values() if isinstance(data, ProtectData)
     ]
 
 
 @callback
-def _async_get_macs_for_device(device_entry: dr.DeviceEntry) -> list[str]:
-    return [
-        _async_unifi_mac_from_hass(cval)
-        for ctype, cval in device_entry.connections
-        if ctype == dr.CONNECTION_NETWORK_MAC
-    ]
-
-
-@callback
-def _async_get_ufp_instances(
-    hass: HomeAssistant, device_id: str
-) -> tuple[dr.DeviceEntry, ProtectApiClient]:
+def _async_get_ufp_instance(hass: HomeAssistant, device_id: str) -> ProtectData:
     device_registry = dr.async_get(hass)
     if not (device_entry := device_registry.async_get(device_id)):
         raise HomeAssistantError(f"No device found for device id: {device_id}")
 
     if device_entry.via_device_id is not None:
-        return _async_get_ufp_instances(hass, device_entry.via_device_id)
+        return _async_get_ufp_instance(hass, device_entry.via_device_id)
 
-    macs = _async_get_macs_for_device(device_entry)
     ufp_instances = [
-        i for i in _async_all_ufp_instances(hass) if i.bootstrap.nvr.mac in macs
+        i
+        for i in _async_all_ufp_instances(hass)
+        if i.async_get_ufp_device_from_device(device_id) is not None
     ]
 
     if not ufp_instances:
         # should not be possible unless user manually enters a bad device ID
         raise HomeAssistantError(  # pragma: no cover
-            f"No UniFi Protect NVR found for device ID: {device_id}"
+            f"No UniFi Protect Config Entry found for device ID: {device_id}"
         )
 
-    return device_entry, ufp_instances[0]
+    return ufp_instances[0]
 
 
 @callback
 def _async_get_protect_from_call(
     hass: HomeAssistant, call: ServiceCall
-) -> list[tuple[dr.DeviceEntry, ProtectApiClient]]:
+) -> tuple[ProtectData, str]:
     referenced = async_extract_referenced_entity_ids(hass, call)
 
-    instances: list[tuple[dr.DeviceEntry, ProtectApiClient]] = []
-    for device_id in referenced.referenced_devices:
-        instances.append(_async_get_ufp_instances(hass, device_id))
+    if len(referenced.referenced_devices) == 0:
+        raise HomeAssistantError("No referenced devices")  # pragma: no cover
 
-    return instances
-
-
-async def _async_call_nvr(
-    instances: list[tuple[dr.DeviceEntry, ProtectApiClient]],
-    method: str,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    try:
-        await asyncio.gather(
-            *(getattr(i.bootstrap.nvr, method)(*args, **kwargs) for _, i in instances)
-        )
-    except (BadRequest, ValidationError) as err:
-        raise HomeAssistantError(str(err)) from err
+    device_id = referenced.referenced_devices.pop()
+    return _async_get_ufp_instance(hass, device_id), device_id
 
 
 async def add_doorbell_text(hass: HomeAssistant, call: ServiceCall) -> None:
     """Add a custom doorbell text message."""
     message: str = call.data[ATTR_MESSAGE]
-    instances = _async_get_protect_from_call(hass, call)
-    await _async_call_nvr(instances, "add_custom_doorbell_message", message)
+    instance, _ = _async_get_protect_from_call(hass, call)
+    try:
+        await instance.api.bootstrap.nvr.add_custom_doorbell_message(message)
+    except (BadRequest, ValidationError) as err:
+        raise HomeAssistantError(str(err)) from err
 
 
 async def remove_doorbell_text(hass: HomeAssistant, call: ServiceCall) -> None:
     """Remove a custom doorbell text message."""
     message: str = call.data[ATTR_MESSAGE]
-    instances = _async_get_protect_from_call(hass, call)
-    await _async_call_nvr(instances, "remove_custom_doorbell_message", message)
+    instance, _ = _async_get_protect_from_call(hass, call)
+    try:
+        await instance.api.bootstrap.nvr.remove_custom_doorbell_message(message)
+    except (BadRequest, ValidationError) as err:
+        raise HomeAssistantError(str(err)) from err
 
 
 async def set_default_doorbell_text(hass: HomeAssistant, call: ServiceCall) -> None:
     """Set the default doorbell text message."""
     message: str = call.data[ATTR_MESSAGE]
-    instances = _async_get_protect_from_call(hass, call)
-    await _async_call_nvr(instances, "set_default_doorbell_message", message)
+    instance, _ = _async_get_protect_from_call(hass, call)
+    try:
+        await instance.api.bootstrap.nvr.set_default_doorbell_message(message)
+    except (BadRequest, ValidationError) as err:
+        raise HomeAssistantError(str(err)) from err
 
 
 def async_setup_services(hass: HomeAssistant) -> None:

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -74,9 +74,6 @@ def _async_get_protect_from_call(
 ) -> tuple[ProtectData, str]:
     referenced = async_extract_referenced_entity_ids(hass, call)
 
-    if len(referenced.referenced_devices) == 0:
-        raise HomeAssistantError("No referenced devices")  # pragma: no cover
-
     device_id = referenced.referenced_devices.pop()
     return _async_get_ufp_instance(hass, device_id), device_id
 

--- a/homeassistant/components/unifiprotect/services.yaml
+++ b/homeassistant/components/unifiprotect/services.yaml
@@ -9,6 +9,8 @@ add_doorbell_text:
       selector:
         device:
           integration: unifiprotect
+          entity:
+            device_class: unifiprotect__cap_sensor
     message:
       name: Custom Message
       description: New custom message to add for Doorbells. Must be less than 30 characters.
@@ -27,6 +29,8 @@ remove_doorbell_text:
       selector:
         device:
           integration: unifiprotect
+          entity:
+            device_class: unifiprotect__cap_sensor
     message:
       name: Custom Message
       description: Existing custom message to remove for Doorbells.
@@ -45,6 +49,8 @@ set_default_doorbell_text:
       selector:
         device:
           integration: unifiprotect
+          entity:
+            device_class: unifiprotect__cap_sensor
     message:
       name: Default Message
       description: The default message for your Doorbell. Must be less than 30 characters.

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -181,3 +181,21 @@ async def test_set_default_doorbell_text(
         blocking=True,
     )
     nvr.set_default_doorbell_message.assert_called_once_with("Test Message")
+
+
+async def test_set_default_doorbell_text(
+    hass: HomeAssistant, device: dr.DeviceEntry, mock_entry: MockEntityFixture
+):
+    """Test set_default_doorbell_text service."""
+
+    nvr = mock_entry.api.bootstrap.nvr
+    nvr.__fields__["set_default_doorbell_message"] = Mock()
+    nvr.set_default_doorbell_message = AsyncMock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_DEFAULT_DOORBELL_TEXT,
+        {ATTR_DEVICE_ID: device.id, ATTR_MESSAGE: "Test Message"},
+        blocking=True,
+    )
+    nvr.set_default_doorbell_message.assert_called_once_with("Test Message")

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -72,7 +72,7 @@ async def test_global_service_bad_device(
     assert not nvr.add_custom_doorbell_message.called
 
 
-async def test_global_service_exception(
+async def test_add_doorbell_text_exception(
     hass: HomeAssistant, device: dr.DeviceEntry, mock_entry: MockEntityFixture
 ):
     """Test global service, unexpected error."""
@@ -109,6 +109,25 @@ async def test_add_doorbell_text(
     nvr.add_custom_doorbell_message.assert_called_once_with("Test Message")
 
 
+async def test_remove_doorbell_text_exception(
+    hass: HomeAssistant, device: dr.DeviceEntry, mock_entry: MockEntityFixture
+):
+    """Test global service, unexpected error."""
+
+    nvr = mock_entry.api.bootstrap.nvr
+    nvr.__fields__["remove_custom_doorbell_message"] = Mock()
+    nvr.remove_custom_doorbell_message = AsyncMock(side_effect=BadRequest)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_REMOVE_DOORBELL_TEXT,
+            {ATTR_DEVICE_ID: device.id, ATTR_MESSAGE: "Test Message"},
+            blocking=True,
+        )
+    assert nvr.remove_custom_doorbell_message.called
+
+
 async def test_remove_doorbell_text(
     hass: HomeAssistant, subdevice: dr.DeviceEntry, mock_entry: MockEntityFixture
 ):
@@ -125,6 +144,25 @@ async def test_remove_doorbell_text(
         blocking=True,
     )
     nvr.remove_custom_doorbell_message.assert_called_once_with("Test Message")
+
+
+async def test_set_default_doorbell_text_exception(
+    hass: HomeAssistant, device: dr.DeviceEntry, mock_entry: MockEntityFixture
+):
+    """Test global service, unexpected error."""
+
+    nvr = mock_entry.api.bootstrap.nvr
+    nvr.__fields__["set_default_doorbell_message"] = Mock()
+    nvr.set_default_doorbell_message = AsyncMock(side_effect=BadRequest)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_DEFAULT_DOORBELL_TEXT,
+            {ATTR_DEVICE_ID: device.id, ATTR_MESSAGE: "Test Message"},
+            blocking=True,
+        )
+    assert nvr.set_default_doorbell_message.called
 
 
 async def test_set_default_doorbell_text(

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -181,21 +181,3 @@ async def test_set_default_doorbell_text(
         blocking=True,
     )
     nvr.set_default_doorbell_message.assert_called_once_with("Test Message")
-
-
-async def test_set_default_doorbell_text(
-    hass: HomeAssistant, device: dr.DeviceEntry, mock_entry: MockEntityFixture
-):
-    """Test set_default_doorbell_text service."""
-
-    nvr = mock_entry.api.bootstrap.nvr
-    nvr.__fields__["set_default_doorbell_message"] = Mock()
-    nvr.set_default_doorbell_message = AsyncMock()
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_DEFAULT_DOORBELL_TEXT,
-        {ATTR_DEVICE_ID: device.id, ATTR_MESSAGE: "Test Message"},
-        blocking=True,
-    )
-    nvr.set_default_doorbell_message.assert_called_once_with("Test Message")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds UniFi Protect device lookups using either a HA entity unique ID or a HA device ID. There is still a bit of missing code coverage, but it will all be fixed up in the next PR to add a new service for Chime devices. Refactors the existing doorbell services to use these new device lookups.

Also adds a custom device class to a sensor that is promised to be enabled by default for all UniFi OS consoles so the device selector can limit to _just_ the UniFi OS consoles added by the UniFi Protect integration (not a breaking change since the any device added by the UniFi Protect integration should still work).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
