### PR TITLE
Add netgear speed test sensor

### DIFF
--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -12,6 +12,7 @@ CONF_CONSIDER_HOME = "consider_home"
 KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
 KEY_COORDINATOR_TRAFFIC = "coordinator_traffic"
+KEY_COORDINATOR_SPEED = "coordinator_speed"
 
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -207,7 +207,9 @@ class NetgearRouter:
     async def async_get_speed_test(self) -> dict[str, Any] | None:
         """Perform a speed test and get the results from the router."""
         async with self._api_lock:
-            return await self.hass.async_add_executor_job(self._api.get_new_speed_test_result)
+            return await self.hass.async_add_executor_job(
+                self._api.get_new_speed_test_result
+            )
 
     async def async_allow_block_device(self, mac: str, allow_block: str) -> None:
         """Allow or block a device connected to the router."""

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -204,6 +204,11 @@ class NetgearRouter:
         async with self._api_lock:
             return await self.hass.async_add_executor_job(self._api.get_traffic_meter)
 
+    async def async_get_speed_test(self) -> dict[str, Any] | None:
+        """Perform a speed test and get the results from the router."""
+        async with self._api_lock:
+            return await self.hass.async_add_executor_job(self._api.get_new_speed_test_result)
+
     async def async_allow_block_device(self, mac: str, allow_block: str) -> None:
         """Allow or block a device connected to the router."""
         async with self._api_lock:

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -351,7 +353,7 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, RestoreSensor):
         self._name = f"{router.device_name} {entity_description.name}"
         self._unique_id = f"{router.serial_number}-{entity_description.key}-{entity_description.index}"
 
-        self._value: StateType = None
+        self._value: StateType | date | datetime | Decimal = None
         self.async_update_device()
 
     @property

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -350,7 +351,7 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, RestoreSensor):
         self._name = f"{router.device_name} {entity_description.name}"
         self._unique_id = f"{router.serial_number}-{entity_description.key}-{entity_description.index}"
 
-        self._value: str | None = None
+        self._value: StateType = None
         self.async_update_device()
 
     @property

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import RestoreSensor
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -332,7 +332,7 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
             self._state = self._device[self._attribute]
 
 
-class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity):
+class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreSensor):
     """Representation of a device connected to a Netgear router."""
 
     _attr_entity_registry_enabled_default = False

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_MEGABYTES, PERCENTAGE, TIME_MILLISECONDS
+from homeassistant.const import DATA_MEGABYTES, DATA_RATE_MEGABYTES_PER_SECOND, PERCENTAGE, TIME_MILLISECONDS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -205,14 +205,14 @@ SENSOR_SPEED_TYPES = [
         key="NewOOKLAUplinkBandwidth",
         name="Uplink Bandwidth",
         entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
         icon="mdi:upload",
     ),
     NetgearSensorEntityDescription(
         key="NewOOKLADownlinkBandwidth",
         name="Downlink Bandwidth",
         entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
         icon="mdi:download",
     ),
     NetgearSensorEntityDescription(

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -1,6 +1,7 @@
 """Support for Netgear routers."""
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -348,7 +349,7 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity
         self._name = f"{router.device_name} {entity_description.name}"
         self._unique_id = f"{router.serial_number}-{entity_description.key}-{entity_description.index}"
 
-        self._value: str | None = None
+        self._value: Optional[str] = None
         self.async_update_device()
 
     @property

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -332,7 +332,7 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
             self._state = self._device[self._attribute]
 
 
-class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreSensor):
+class NetgearRouterSensorEntity(NetgearRouterEntity, RestoreSensor):
     """Representation of a device connected to a Netgear router."""
 
     _attr_entity_registry_enabled_default = False

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -1,5 +1,6 @@
 """Support for Netgear routers."""
 from __future__ import annotations
+
 from collections.abc import Callable
 from dataclasses import dataclass
 

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import DATA_MEGABYTES, DATA_RATE_MEGABYTES_PER_SECOND, 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, KEY_COORDINATOR, KEY_COORDINATOR_SPEED, KEY_COORDINATOR_TRAFFIC, KEY_ROUTER
@@ -317,7 +318,7 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
             self._state = self._device[self._attribute]
 
 
-class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity):
+class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity):
     """Representation of a device connected to a Netgear router."""
 
     _attr_entity_registry_enabled_default = False

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -349,7 +349,8 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity
         await super().async_added_to_hass()
         if self.coordinator.data is None:
             state = await self.async_get_last_state()
-            self._value = state.state
+            if state is not None:
+                self._value = state.state
 
     @callback
     def async_update_device(self) -> None:

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -1,6 +1,7 @@
 """Support for Netgear routers."""
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -348,7 +349,7 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity
         self._name = f"{router.device_name} {entity_description.name}"
         self._unique_id = f"{router.serial_number}-{entity_description.key}-{entity_description.index}"
 
-        self._value = None
+        self._value: Optional[float] = None
         self.async_update_device()
 
     @property

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -1,7 +1,7 @@
 """Support for Netgear routers."""
+from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -349,7 +349,7 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity
         self._name = f"{router.device_name} {entity_description.name}"
         self._unique_id = f"{router.serial_number}-{entity_description.key}-{entity_description.index}"
 
-        self._value: Optional[str] = None
+        self._value: str | None = None
         self.async_update_device()
 
     @property

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -19,7 +20,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreSensor
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -8,14 +8,25 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_MEGABYTES, DATA_RATE_MEGABYTES_PER_SECOND, PERCENTAGE, TIME_MILLISECONDS
+from homeassistant.const import (
+    DATA_MEGABYTES,
+    DATA_RATE_MEGABYTES_PER_SECOND,
+    PERCENTAGE,
+    TIME_MILLISECONDS,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_COORDINATOR_SPEED, KEY_COORDINATOR_TRAFFIC, KEY_ROUTER
+from .const import (
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_COORDINATOR_SPEED,
+    KEY_COORDINATOR_TRAFFIC,
+    KEY_ROUTER,
+)
 from .router import NetgearDeviceEntity, NetgearRouter, NetgearRouterEntity
 
 SENSOR_TYPES = {
@@ -224,6 +235,7 @@ SENSOR_SPEED_TYPES = [
         icon="mdi:wan",
     ),
 ]
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -362,9 +362,9 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreSensor
         """Handle entity which will be added."""
         await super().async_added_to_hass()
         if self.coordinator.data is None:
-            state = await self.async_get_last_state()
-            if state is not None:
-                self._value = state.state
+            sensor_data = await self.async_get_last_sensor_data()
+            if sensor_data is not None:
+                self._value = sensor_data.native_value
 
     @callback
     def async_update_device(self) -> None:

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -1,7 +1,6 @@
 """Support for Netgear routers."""
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -349,7 +348,7 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity, RestoreEntity
         self._name = f"{router.device_name} {entity_description.name}"
         self._unique_id = f"{router.serial_number}-{entity_description.key}-{entity_description.index}"
 
-        self._value: Optional[float] = None
+        self._value: str | None = None
         self.async_update_device()
 
     @property

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -343,6 +343,13 @@ class NetgearRouterSensorEntity(NetgearRouterEntity, SensorEntity):
         """Return the state of the sensor."""
         return self._value
 
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        if self.coordinator.data is None:
+            state = await self.async_get_last_state()
+            self._value = state.state
+
     @callback
     def async_update_device(self) -> None:
         """Update the Netgear device."""

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DATA_MEGABYTES,
-    DATA_RATE_MEGABYTES_PER_SECOND,
+    DATA_RATE_MEGABITS_PER_SECOND,
     PERCENTAGE,
     TIME_MILLISECONDS,
 )
@@ -217,14 +217,14 @@ SENSOR_SPEED_TYPES = [
         key="NewOOKLAUplinkBandwidth",
         name="Uplink Bandwidth",
         entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
+        native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         icon="mdi:upload",
     ),
     NetgearSensorEntityDescription(
         key="NewOOKLADownlinkBandwidth",
         name="Downlink Bandwidth",
         entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
+        native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         icon="mdi:download",
     ),
     NetgearSensorEntityDescription(

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -8,13 +8,13 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_MEGABYTES, PERCENTAGE
+from homeassistant.const import DATA_MEGABYTES, PERCENTAGE, TIME_MILLISECONDS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_COORDINATOR_TRAFFIC, KEY_ROUTER
+from .const import DOMAIN, KEY_COORDINATOR, KEY_COORDINATOR_SPEED, KEY_COORDINATOR_TRAFFIC, KEY_ROUTER
 from .router import NetgearDeviceEntity, NetgearRouter, NetgearRouterEntity
 
 SENSOR_TYPES = {
@@ -200,6 +200,29 @@ SENSOR_TRAFFIC_TYPES = [
     ),
 ]
 
+SENSOR_SPEED_TYPES = [
+    NetgearSensorEntityDescription(
+        key="NewOOKLAUplinkBandwidth",
+        name="Uplink Bandwidth",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:upload",
+    ),
+    NetgearSensorEntityDescription(
+        key="NewOOKLADownlinkBandwidth",
+        name="Downlink Bandwidth",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:download",
+    ),
+    NetgearSensorEntityDescription(
+        key="AveragePing",
+        name="Average Ping",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=TIME_MILLISECONDS,
+        icon="mdi:wan",
+    ),
+]
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -208,6 +231,7 @@ async def async_setup_entry(
     router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
     coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
     coordinator_traffic = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_TRAFFIC]
+    coordinator_speed = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_SPEED]
 
     # Router entities
     router_entities = []
@@ -215,6 +239,11 @@ async def async_setup_entry(
     for description in SENSOR_TRAFFIC_TYPES:
         router_entities.append(
             NetgearRouterSensorEntity(coordinator_traffic, router, description)
+        )
+
+    for description in SENSOR_SPEED_TYPES:
+        router_entities.append(
+            NetgearRouterSensorEntity(coordinator_speed, router, description)
         )
 
     async_add_entities(router_entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add speed test sensor to Netgear

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22819

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
