### PR TITLE
Fix ended session when there isn't any response from the user

### DIFF
--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -127,11 +127,6 @@ async def async_handle_message(hass, message):
 
 
 @HANDLERS.register("SessionEndedRequest")
-async def async_handle_session_end(hass, message):
-    """Handle a session end request."""
-    return None
-
-
 @HANDLERS.register("IntentRequest")
 @HANDLERS.register("LaunchRequest")
 async def async_handle_intent(hass, message):
@@ -151,6 +146,11 @@ async def async_handle_intent(hass, message):
         intent_name = (
             message.get("session", {}).get("application", {}).get("applicationId")
         )
+    elif req["type"] == "SessionEndedRequest":
+        app_id = message.get("session", {}).get("application", {}).get("applicationId")
+        intent_name = f"{app_id}.{req['type']}"
+        alexa_response.variables["reason"] = req["reason"]
+        alexa_response.variables["error"] = req.get("error")
     else:
         intent_name = alexa_intent_info["name"]
 

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -99,11 +99,13 @@ class ScriptIntentHandler(intent.IntentHandler):
                 speech[CONF_TYPE],
             )
 
-        if reprompt is not None and reprompt[CONF_TEXT].template:
-            response.async_set_reprompt(
-                reprompt[CONF_TEXT].async_render(slots, parse_result=False),
-                reprompt[CONF_TYPE],
-            )
+        if reprompt is not None:
+            text_reprompt = reprompt[CONF_TEXT].async_render(slots, parse_result=False)
+            if text_reprompt:
+                response.async_set_reprompt(
+                    text_reprompt,
+                    reprompt[CONF_TYPE],
+                )
 
         if card is not None:
             response.async_set_card(

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -490,8 +490,11 @@ async def test_intent_session_ended_request(alexa_client):
 
     req = await _intent_req(alexa_client, data)
     assert req.status == HTTPStatus.OK
-    text = await req.text()
-    assert text == ""
+    data = await req.json()
+    assert (
+        data["response"]["outputSpeech"]["text"]
+        == "This intent is not yet configured within Home Assistant."
+    )
 
 
 async def test_intent_from_built_in_intent_library(alexa_client):

--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -38,6 +38,8 @@ async def test_intent_script(hass):
 
     assert response.speech["plain"]["speech"] == "Good morning Paulus"
 
+    assert not (response.reprompt)
+
     assert response.card["simple"]["title"] == "Hello Paulus"
     assert response.card["simple"]["content"] == "Content for Paulus"
 
@@ -82,6 +84,52 @@ async def test_intent_script_wait_response(hass):
         response.reprompt["plain"]["reprompt"]
         == "I didn't hear you, Paulus... I said good morning!"
     )
+
+    assert response.card["simple"]["title"] == "Hello Paulus"
+    assert response.card["simple"]["content"] == "Content for Paulus"
+
+
+async def test_intent_script_falsy_reprompt(hass):
+    """Test intent scripts work."""
+    calls = async_mock_service(hass, "test", "service")
+
+    await async_setup_component(
+        hass,
+        "intent_script",
+        {
+            "intent_script": {
+                "HelloWorld": {
+                    "action": {
+                        "service": "test.service",
+                        "data_template": {"hello": "{{ name }}"},
+                    },
+                    "card": {
+                        "title": "Hello {{ name }}",
+                        "content": "Content for {{ name }}",
+                    },
+                    "speech": {
+                        "type": "ssml",
+                        "text": '<speak><amazon:effect name="whispered">Good morning {{ name }}</amazon:effect></speak>',
+                    },
+                    "reprompt": {"text": "{{ null }}"},
+                }
+            }
+        },
+    )
+
+    response = await intent.async_handle(
+        hass, "test", "HelloWorld", {"name": {"value": "Paulus"}}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data["hello"] == "Paulus"
+
+    assert (
+        response.speech["ssml"]["speech"]
+        == '<speak><amazon:effect name="whispered">Good morning Paulus</amazon:effect></speak>'
+    )
+
+    assert not (response.reprompt)
 
     assert response.card["simple"]["title"] == "Hello Paulus"
     assert response.card["simple"]["content"] == "Content for Paulus"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Add treatment of ended session when there isn't any response from the user
* Prevent from sending "reprompt" when its text evaluates to falsy value

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-types-reference.html#sessionendedrequest

https://github.com/home-assistant/core/pull/65256 introduced "reprompt" that keeps the session open for awhile in order to wait some response from the user.
It is working very well except when there isn't any response. This PR fixes it.

Tests executed:
tox -e py39 -- tests/components/alexa/test_intent.py
tox -e py39 -- tests/components/conversation/test_init.py
tox -e py39 -- tests/components/intent/test_init.py
tox -e py39 -- tests/components/intent_script/test_init.py
tox -e py39 -- tests/helpers/test_intent.py


- This PR fixes or closes issue: fixes #72153
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22908

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
