### PR TITLE
Include context state in logbook responses to improve localization

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -40,7 +40,6 @@ from homeassistant.const import (
     ATTR_SERVICE,
     EVENT_CALL_SERVICE,
     EVENT_LOGBOOK_ENTRY,
-    EVENT_STATE_CHANGED,
 )
 from homeassistant.core import (
     Context,
@@ -682,7 +681,6 @@ class ContextAugmenter:
                 data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
                     context_entity_id, context_row
                 )
-            data[CONTEXT_EVENT_TYPE] = EVENT_STATE_CHANGED
             return
 
         # Call service

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -40,6 +40,7 @@ from homeassistant.const import (
     ATTR_SERVICE,
     EVENT_CALL_SERVICE,
     EVENT_LOGBOOK_ENTRY,
+    EVENT_STATE_CHANGED,
 )
 from homeassistant.core import (
     Context,
@@ -87,6 +88,7 @@ CONTEXT_ENTITY_ID = "context_entity_id"
 CONTEXT_ENTITY_ID_NAME = "context_entity_id_name"
 CONTEXT_EVENT_TYPE = "context_event_type"
 CONTEXT_DOMAIN = "context_domain"
+CONTEXT_STATE = "context_state"
 CONTEXT_SERVICE = "context_service"
 CONTEXT_NAME = "context_name"
 CONTEXT_MESSAGE = "context_message"
@@ -674,12 +676,13 @@ class ContextAugmenter:
 
         # State change
         if context_entity_id := context_row.entity_id:
+            data[CONTEXT_STATE] = context_row.state
             data[CONTEXT_ENTITY_ID] = context_entity_id
             if self.include_entity_name:
                 data[CONTEXT_ENTITY_ID_NAME] = self.entity_name_cache.get(
                     context_entity_id, context_row
                 )
-            data[CONTEXT_EVENT_TYPE] = event_type
+            data[CONTEXT_EVENT_TYPE] = EVENT_STATE_CHANGED
             return
 
         # Call service

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     EVENT_LOGBOOK_ENTRY,
+    EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
 )
@@ -2738,3 +2739,66 @@ async def test_logbook_select_entities_context_id(hass, recorder_mock, hass_clie
     assert json_dict[3]["context_domain"] == "light"
     assert json_dict[3]["context_service"] == "turn_off"
     assert json_dict[3]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
+
+
+async def test_get_events_with_context_state(hass, hass_ws_client, recorder_mock):
+    """Test logbook get_events with a context state."""
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.states.async_set("binary_sensor.is_light", STATE_ON)
+    hass.states.async_set("light.kitchen1", STATE_OFF)
+    hass.states.async_set("light.kitchen2", STATE_OFF)
+
+    context = ha.Context(
+        id="ac5bd62de45711eaaeb351041eec8dd9",
+        user_id="b400facee45711eaa9308bfd3d19e474",
+    )
+    hass.states.async_set("binary_sensor.is_light", STATE_OFF, context=context)
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        "light.kitchen1", STATE_ON, {"brightness": 100}, context=context
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        "light.kitchen2", STATE_ON, {"brightness": 200}, context=context
+    )
+    await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client()
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "logbook/get_events",
+            "start_time": now.isoformat(),
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["id"] == 1
+    results = response["result"]
+    assert results[1]["entity_id"] == "binary_sensor.is_light"
+    assert results[1]["state"] == "off"
+    assert "context_state" not in results[1]
+    assert results[2]["entity_id"] == "light.kitchen1"
+    assert results[2]["state"] == "on"
+    assert results[2]["context_entity_id"] == "binary_sensor.is_light"
+    assert results[2]["context_state"] == "off"
+    assert results[2]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+    assert results[2]["context_event_type"] == EVENT_STATE_CHANGED
+    assert results[3]["entity_id"] == "light.kitchen2"
+    assert results[3]["state"] == "on"
+    assert results[3]["context_entity_id"] == "binary_sensor.is_light"
+    assert results[3]["context_state"] == "off"
+    assert results[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+    assert results[3]["context_event_type"] == EVENT_STATE_CHANGED

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -32,7 +32,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     EVENT_LOGBOOK_ENTRY,
-    EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
 )
@@ -2795,10 +2794,10 @@ async def test_get_events_with_context_state(hass, hass_ws_client, recorder_mock
     assert results[2]["context_entity_id"] == "binary_sensor.is_light"
     assert results[2]["context_state"] == "off"
     assert results[2]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
-    assert results[2]["context_event_type"] == EVENT_STATE_CHANGED
+    assert "context_event_type" not in results[2]
     assert results[3]["entity_id"] == "light.kitchen2"
     assert results[3]["state"] == "on"
     assert results[3]["context_entity_id"] == "binary_sensor.is_light"
     assert results[3]["context_state"] == "off"
     assert results[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
-    assert results[3]["context_event_type"] == EVENT_STATE_CHANGED
+    assert "context_event_type" not in results[3]


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include context state in logbook responses to improve localization

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
