### PR TITLE
Adjust config_flow type hints in amberelectric

### DIFF
--- a/homeassistant/components/amberelectric/config_flow.py
+++ b/homeassistant/components/amberelectric/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_TOKEN
-from homeassistant.data_entry_flow import FlowInput, FlowResult
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import CONF_SITE_ID, CONF_SITE_NAME, CONF_SITE_NMI, DOMAIN
 
@@ -43,7 +43,9 @@ class AmberElectricConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_API_TOKEN] = "unknown_error"
             return None
 
-    async def async_step_user(self, user_input: FlowInput | None = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
         """Step when user initializes a integration."""
         self._errors = {}
         self._sites = None
@@ -75,11 +77,14 @@ class AmberElectricConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_site(self, user_input: FlowInput | None = None) -> FlowResult:
+    async def async_step_site(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
         """Step to select site."""
         self._errors = {}
 
         assert self._sites is not None
+        assert self._api_token is not None
 
         api_token = self._api_token
         if user_input is not None:

--- a/homeassistant/components/amberelectric/config_flow.py
+++ b/homeassistant/components/amberelectric/config_flow.py
@@ -1,8 +1,6 @@
 """Config flow for the Amber Electric integration."""
 from __future__ import annotations
 
-from typing import Any
-
 import amberelectric
 from amberelectric.api import amber_api
 from amberelectric.model.site import Site
@@ -10,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_TOKEN
+from homeassistant.data_entry_flow import FlowInput, FlowResult
 
 from .const import CONF_SITE_ID, CONF_SITE_NAME, CONF_SITE_NMI, DOMAIN
 
@@ -44,7 +43,7 @@ class AmberElectricConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_API_TOKEN] = "unknown_error"
             return None
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+    async def async_step_user(self, user_input: FlowInput | None = None) -> FlowResult:
         """Step when user initializes a integration."""
         self._errors = {}
         self._sites = None
@@ -76,7 +75,7 @@ class AmberElectricConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_site(self, user_input: dict[str, Any] = None):
+    async def async_step_site(self, user_input: FlowInput | None = None) -> FlowResult:
         """Step to select site."""
         self._errors = {}
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -26,6 +26,8 @@ RESULT_TYPE_MENU = "menu"
 # Event that is fired when a flow is progressed via external or progress source.
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
 
+FlowInput = Mapping[str, Any]
+
 
 @dataclass
 class BaseServiceInfo:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -26,8 +26,6 @@ RESULT_TYPE_MENU = "menu"
 # Event that is fired when a flow is progressed via external or progress source.
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
 
-FlowInput = Mapping[str, Any]
-
 
 @dataclass
 class BaseServiceInfo:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~Add a `FlowInput` type that could be used on all ConfigFlow inputs:~
- ~`async def async_step_user(self, user_input: FlowInput | None = None) -> FlowResult:`~
- ~`async def async_step_init(self, user_input: FlowInput | None = None) -> FlowResult:`~
- ~`async def async_step_reauth(self, device_config: FlowInput) -> FlowResult:`~

~I adjusted Amber Electric to show how it would be used.~

Adjust config_flow type hints in amberelectric

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
