### PR TITLE
Revert "Add return code to integration application credentials in config flow"

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -25,7 +25,6 @@ from homeassistant import config_entries
 from homeassistant.components import http
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.loader import async_get_application_credentials
 
 from .aiohttp_client import async_get_clientsession
 from .network import NoURLAvailableError
@@ -240,8 +239,6 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
             return await self.async_step_auth()
 
         if not implementations:
-            if self.DOMAIN in await async_get_application_credentials(self.hass):
-                return self.async_abort(reason="missing_credentials")
             return self.async_abort(reason="missing_configuration")
 
         req = http.current_request.get()

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -71,7 +71,6 @@
         "webhook_not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages.",
         "oauth2_error": "Received invalid token data.",
         "oauth2_missing_configuration": "The component is not configured. Please follow the documentation.",
-        "oauth2_missing_credentials": "The integration requires application credentials.",
         "oauth2_authorize_url_timeout": "Timeout generating authorize URL.",
         "oauth2_no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
         "reauth_successful": "Re-authentication was successful",

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -327,7 +327,7 @@ async def test_missing_configuration(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result.get("type") == "abort"
-    assert result.get("reason") == "missing_credentials"
+    assert result.get("reason") == "missing_configuration"
 
 
 @pytest.mark.parametrize("google_config", [None])
@@ -342,7 +342,7 @@ async def test_missing_configuration_yaml_empty(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result.get("type") == "abort"
-    assert result.get("reason") == "missing_credentials"
+    assert result.get("reason") == "missing_configuration"
 
 
 async def test_wrong_configuration(

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -31,14 +31,14 @@ async def test_abort_if_no_configuration(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_credentials"
+    assert result["reason"] == "missing_configuration"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=BLANK_ZEROCONF_INFO
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_credentials"
+    assert result["reason"] == "missing_configuration"
 
 
 async def test_zeroconf_abort_if_existing_entry(hass):

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_abort_if_no_configuration(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_credentials"
+    assert result["reason"] == "missing_configuration"
 
 
 async def test_abort_if_existing_entry(hass: HomeAssistant):

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -114,17 +114,6 @@ async def test_abort_if_no_implementation(hass, flow_handler):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_missing_credentials_for_domain(hass, flow_handler):
-    """Check flow abort for integration supporting application credentials."""
-    flow = flow_handler()
-    flow.hass = hass
-
-    with patch("homeassistant.loader.APPLICATION_CREDENTIALS", [TEST_DOMAIN]):
-        result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "missing_credentials"
-
-
 async def test_abort_if_authorization_timeout(
     hass, flow_handler, local_impl, current_request_with_host
 ):


### PR DESCRIPTION
Reverts home-assistant/core#71986

I realize I should not have merged this before the frontend PR was ready, since it adds a new return code that the frontend is not yet handling.  An alternative would be to add existing strings to all the existing application credentials (e.g. just have the new error message without the new frontend behavior) so we can start using it now without the new frontend behavior.