### PR TITLE
Set user friendly name for Google Calendar config entry

### DIFF
--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -173,3 +173,25 @@ class ApiAuthImpl(AbstractAuth):
         """Return a valid access token."""
         await self._session.async_ensure_token_valid()
         return self._session.token["access_token"]
+
+
+class AccessTokenAuthImpl(AbstractAuth):
+    """Authentication implementation used during config flow, without refresh.
+
+    This exists to allow the config flow to use the API before it has fully
+    created a config entry required by OAuth2Session. This does not support
+    refreshing tokens, which is fine since it should have been just created.
+    """
+
+    def __init__(
+        self,
+        websession: aiohttp.ClientSession,
+        access_token: str,
+    ) -> None:
+        """Init the Google Calendar client library auth implementation."""
+        super().__init__(websession)
+        self._access_token = access_token
+
+    async def async_get_access_token(self) -> str:
+        """Return the access token."""
+        return self._access_token

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from gcal_sync.api import GoogleCalendarService
+from gcal_sync.exceptions import ApiException
 from oauth2client.client import Credentials
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import (
     DEVICE_AUTH_CREDS,
+    ApiAuthImpl,
     DeviceAuth,
     DeviceFlow,
     OAuthError,
@@ -130,7 +135,22 @@ class OAuth2FlowHandler(
             self.hass.config_entries.async_update_entry(entry, data=data)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reauth_successful")
-        return self.async_create_entry(title=self.flow_impl.name, data=data)
+
+        # Create a placeholder ConfigEntry to use since with the auth we've already created.
+        entry = ConfigEntry(version=1, domain=DOMAIN, title="", data=data, source="")
+        session = config_entry_oauth2_flow.OAuth2Session(
+            self.hass, entry, self.flow_impl
+        )
+        calendar_service = GoogleCalendarService(
+            ApiAuthImpl(async_get_clientsession(self.hass), session)
+        )
+        try:
+            primary_calendar = await calendar_service.async_get_calendar("primary")
+        except ApiException as err:
+            _LOGGER.debug("Error reading calendar primary calendar: %s", err)
+            primary_calendar = None
+        title = primary_calendar.id if primary_calendar else self.flow_impl.name
+        return self.async_create_entry(title=title, data=data)
 
     async def async_step_reauth(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set user friendly name for Google Calendar config entry based on the users email address.

This invoked the calender get API which has special handling for the `primary` calendar. The ID of the calendar is the users email address, which seems like the most appropriate configuration entry title.
https://developers.google.com/calendar/api/v3/reference/calendars/get

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
