### PR TITLE
Remove combined translations / optional markers from Konnected

### DIFF
--- a/homeassistant/components/konnected/strings.json
+++ b/homeassistant/components/konnected/strings.json
@@ -63,7 +63,7 @@
         "description": "{zone} options",
         "data": {
           "type": "Binary Sensor Type",
-          "name": "[%key:common::config_flow::data::name%] (optional)",
+          "name": "[%key:common::config_flow::data::name%]",
           "inverse": "Invert the open/close state"
         }
       },
@@ -72,19 +72,19 @@
         "description": "{zone} options",
         "data": {
           "type": "Sensor Type",
-          "name": "[%key:common::config_flow::data::name%] (optional)",
-          "poll_interval": "Poll Interval (minutes) (optional)"
+          "name": "[%key:common::config_flow::data::name%]",
+          "poll_interval": "Poll Interval (minutes)"
         }
       },
       "options_switch": {
         "title": "Configure Switchable Output",
         "description": "{zone} options: state {state}",
         "data": {
-          "name": "[%key:common::config_flow::data::name%] (optional)",
+          "name": "[%key:common::config_flow::data::name%]",
           "activation": "Output when on",
-          "momentary": "Pulse duration (ms) (optional)",
-          "pause": "Pause between pulses (ms) (optional)",
-          "repeat": "Times to repeat (-1=infinite) (optional)",
+          "momentary": "Pulse duration (ms)",
+          "pause": "Pause between pulses (ms)",
+          "repeat": "Times to repeat (-1=infinite)",
           "more_states": "Configure additional states for this zone"
         }
       },
@@ -95,7 +95,7 @@
           "discovery": "Respond to discovery requests on your network",
           "blink": "Blink panel LED on when sending state change",
           "override_api_host": "Override default Home Assistant API host panel URL",
-          "api_host": "Override API host URL (optional)"
+          "api_host": "Override API host URL"
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes strings that use combined translation references and translations with an "Optional" marker (as those are already marked optional in the config flow schema).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
