### PR TITLE
Remove google found_calendar service

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -261,16 +261,15 @@ async def async_setup_services(
                 CONF_TRACK: track_new,
             },
         )
-        # Only use the external calendar config file if it already exists
-        if calendars:
-            if calendar_item.id not in calendars:
-                calendars[calendar_item.id] = calendar
-                await hass.async_add_executor_job(
-                    update_config, hass.config.path(YAML_DEVICES), calendar
-                )
-            else:
-                # Prefer entity/name information from yaml, overriding api
-                calendar = calendars[calendar_item.id]
+        # Populate the yaml file with all discovered calendars
+        if calendar_item.id not in calendars:
+            calendars[calendar_item.id] = calendar
+            await hass.async_add_executor_job(
+                update_config, hass.config.path(YAML_DEVICES), calendar
+            )
+        else:
+            # Prefer entity/name information from yaml, overriding api
+            calendar = calendars[calendar_item.id]
         async_dispatcher_send(hass, DISCOVER_CALENDAR, calendar)
 
     created_calendars = set()

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -261,15 +261,16 @@ async def async_setup_services(
                 CONF_TRACK: track_new,
             },
         )
+        calendar_id = calendar_item.id
         # Populate the yaml file with all discovered calendars
-        if calendar_item.id not in calendars:
-            calendars[calendar_item.id] = calendar
+        if calendar_id not in calendars:
+            calendars[calendar_id] = calendar
             await hass.async_add_executor_job(
                 update_config, hass.config.path(YAML_DEVICES), calendar
             )
         else:
             # Prefer entity/name information from yaml, overriding api
-            calendar = calendars[calendar_item.id]
+            calendar = calendars[calendar_id]
         async_dispatcher_send(hass, DISCOVER_CALENDAR, calendar)
 
     created_calendars = set()

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -10,7 +10,7 @@ from typing import Any
 import aiohttp
 from gcal_sync.api import GoogleCalendarService
 from gcal_sync.exceptions import ApiException
-from gcal_sync.model import DateOrDatetime, Event
+from gcal_sync.model import Calendar, DateOrDatetime, Event
 from oauth2client.file import Storage
 import voluptuous as vol
 from voluptuous.error import Error as VoluptuousError
@@ -87,7 +87,6 @@ NOTIFICATION_TITLE = "Google Calendar Setup"
 GROUP_NAME_ALL_CALENDARS = "Google Calendar Sensors"
 
 SERVICE_SCAN_CALENDARS = "scan_for_calendars"
-SERVICE_FOUND_CALENDARS = "found_calendar"
 SERVICE_ADD_EVENT = "add_event"
 
 YAML_DEVICES = f"{DOMAIN}_calendars.yaml"
@@ -250,31 +249,31 @@ async def async_setup_services(
 ) -> None:
     """Set up the service listeners."""
 
-    created_calendars = set()
     calendars = await hass.async_add_executor_job(
         load_config, hass.config.path(YAML_DEVICES)
     )
 
-    async def _found_calendar(call: ServiceCall) -> None:
-        calendar = get_calendar_info(hass, call.data)
-        calendar_id = calendar[CONF_CAL_ID]
-
-        if calendar_id in created_calendars:
-            return
-        created_calendars.add(calendar_id)
-
-        # Populate the yaml file with all discovered calendars
-        if calendar_id not in calendars:
-            calendars[calendar_id] = calendar
-            await hass.async_add_executor_job(
-                update_config, hass.config.path(YAML_DEVICES), calendar
-            )
-        else:
-            # Prefer entity/name information from yaml, overriding api
-            calendar = calendars[calendar_id]
+    async def _found_calendar(calendar_item: Calendar) -> None:
+        calendar = get_calendar_info(
+            hass,
+            {
+                **calendar_item.dict(exclude_unset=True),
+                CONF_TRACK: track_new,
+            },
+        )
+        # Only use the external calendar config file if it already exists
+        if calendars:
+            if calendar_item.id not in calendars:
+                calendars[calendar_item.id] = calendar
+                await hass.async_add_executor_job(
+                    update_config, hass.config.path(YAML_DEVICES), calendar
+                )
+            else:
+                # Prefer entity/name information from yaml, overriding api
+                calendar = calendars[calendar_item.id]
         async_dispatcher_send(hass, DISCOVER_CALENDAR, calendar)
 
-    hass.services.async_register(DOMAIN, SERVICE_FOUND_CALENDARS, _found_calendar)
+    created_calendars = set()
 
     async def _scan_for_calendars(call: ServiceCall) -> None:
         """Scan for new calendars."""
@@ -284,11 +283,10 @@ async def async_setup_services(
             raise HomeAssistantError(str(err)) from err
         tasks = []
         for calendar_item in result.items:
-            calendar = calendar_item.dict(exclude_unset=True)
-            calendar[CONF_TRACK] = track_new
-            tasks.append(
-                hass.services.async_call(DOMAIN, SERVICE_FOUND_CALENDARS, calendar)
-            )
+            if calendar_item.id in created_calendars:
+                continue
+            created_calendars.add(calendar_item.id)
+            tasks.append(_found_calendar(calendar_item))
         await asyncio.gather(*tasks)
 
     hass.services.async_register(DOMAIN, SERVICE_SCAN_CALENDARS, _scan_for_calendars)

--- a/homeassistant/components/google/services.yaml
+++ b/homeassistant/components/google/services.yaml
@@ -1,6 +1,3 @@
-found_calendar:
-  name: Found Calendar
-  description: Add calendar if it has not been already discovered.
 scan_for_calendars:
   name: Scan for calendars
   description: Scan for new calendars.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `found_calendar` service has been removed from Google Calendars. This service is an internal implementation detail of the integration used for creating calendars found from the API, which is now no longer exposed as a service.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the google found_calendar service, which can be replaced with just a function call. This seems like an implementation detail exposed as a service unnecessarily which really shouldn't be used by anyone. That is, users shouldn't be using this to create arbitrary entities, and it probably wouldn't really work anyway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
