### PR TITLE
Add diagnostics for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/diagnostics.py
+++ b/homeassistant/components/unifiprotect/diagnostics.py
@@ -1,0 +1,21 @@
+"""Diagnostics support for UniFi Network."""
+from __future__ import annotations
+
+from typing import Any, cast
+
+from pyunifiprotect.test_util.anonymize import anonymize_data
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .data import ProtectData
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    data: ProtectData = hass.data[DOMAIN][config_entry.entry_id]
+    return cast(dict[str, Any], anonymize_data(data.api.bootstrap.unifi_dict()))

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -67,6 +67,19 @@ class MockBootstrap:
         """Fake process method for tests."""
         pass
 
+    def unifi_dict(self) -> dict[str, Any]:
+        """Return UniFi formatted dict representation of the NVR."""
+        return {
+            "nvr": self.nvr.unifi_dict(),
+            "cameras": [c.unifi_dict() for c in self.cameras.values()],
+            "lights": [c.unifi_dict() for c in self.lights.values()],
+            "sensors": [c.unifi_dict() for c in self.sensors.values()],
+            "viewers": [c.unifi_dict() for c in self.viewers.values()],
+            "liveviews": [c.unifi_dict() for c in self.liveviews.values()],
+            "doorlocks": [c.unifi_dict() for c in self.doorlocks.values()],
+            "chimes": [c.unifi_dict() for c in self.chimes.values()],
+        }
+
 
 @dataclass
 class MockEntityFixture:

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -1,0 +1,56 @@
+"""Test august diagnostics."""
+
+from pyunifiprotect.data import NVR, Light
+
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockEntityFixture
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant, mock_entry: MockEntityFixture, mock_light: Light, hass_client
+):
+    """Test generating diagnostics for a config entry."""
+
+    light1 = mock_light.copy()
+    light1._api = mock_entry.api
+    light1.name = "Test Light 1"
+    light1.id = "lightid1"
+
+    mock_entry.api.bootstrap.lights = {
+        light1.id: light1,
+    }
+    await hass.config_entries.async_setup(mock_entry.entry.entry_id)
+    await hass.async_block_till_done()
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, mock_entry.entry)
+
+    nvr_obj: NVR = mock_entry.api.bootstrap.nvr
+    # validate some of the data
+    assert "nvr" in diag and isinstance(diag["nvr"], dict)
+    nvr = diag["nvr"]
+    # should have been anonymized
+    assert nvr["id"] != nvr_obj.id
+    assert nvr["mac"] != nvr_obj.mac
+    assert nvr["host"] != str(nvr_obj.host)
+    # should have been kept
+    assert nvr["firmwareVersion"] == nvr_obj.firmware_version
+    assert nvr["version"] == str(nvr_obj.version)
+    assert nvr["type"] == nvr_obj.type
+
+    assert (
+        "lights" in diag
+        and isinstance(diag["lights"], list)
+        and len(diag["lights"]) == 1
+    )
+    light = diag["lights"][0]
+    # should have been anonymized
+    assert light["id"] != light1.id
+    assert light["name"] != light1.mac
+    assert light["mac"] != light1.mac
+    assert light["host"] != str(light1.host)
+    # should have been kept
+    assert light["firmwareVersion"] == light1.firmware_version
+    assert light["type"] == light1.type

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Test august diagnostics."""
+"""Test UniFi Protect diagnostics."""
 
 from pyunifiprotect.data import NVR, Light
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics for UniFi Protect

Full example output of diagnostics: https://github.com/briis/pyunifiprotect/blob/master/tests/sample_data/sample_bootstrap.json

Any of the values that look sensitive have been randomized so they are anonymous, but still the correct data type (for tests and the like). This is the same code that is used to generate all of the fixtures for the devices. [Anonymization code](https://github.com/briis/pyunifiprotect/blob/master/pyunifiprotect/test_util/anonymize.py)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
