### PR TITLE
Change default name of motion blind TDBU entities so they can be auto renamed

### DIFF
--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -182,7 +182,7 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
         else:
             via_device = (DOMAIN, blind._gateway.mac)
             connections = {}
-            name = f"{blind.blind_type}-{blind.mac[12:]}"
+            name = f"{blind.blind_type} {blind.mac[12:]}"
             sw_version = None
 
         self._attr_device_class = device_class
@@ -364,7 +364,7 @@ class MotionTDBUDevice(MotionPositionDevice):
         super().__init__(coordinator, blind, device_class, sw_version)
         self._motor = motor
         self._motor_key = motor[0]
-        self._attr_name = f"{blind.blind_type}-{motor}-{blind.mac[12:]}"
+        self._attr_name = f"{blind.blind_type} {blind.mac[12:]} {motor}"
         self._attr_unique_id = f"{blind.mac}-{motor}"
 
         if self._motor not in ["Bottom", "Top", "Combined"]:

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -55,9 +55,9 @@ class MotionBatterySensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
 
         if blind.device_type in DEVICE_TYPES_WIFI:
-            name = f"{blind.blind_type}-battery"
+            name = f"{blind.blind_type} battery"
         else:
-            name = f"{blind.blind_type}-battery-{blind.mac[12:]}"
+            name = f"{blind.blind_type} {blind.mac[12:]} battery"
 
         self._blind = blind
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, blind.mac)})
@@ -104,9 +104,9 @@ class MotionTDBUBatterySensor(MotionBatterySensor):
         super().__init__(coordinator, blind)
 
         if blind.device_type in DEVICE_TYPES_WIFI:
-            name = f"{blind.blind_type}-{motor}-battery"
+            name = f"{blind.blind_type} {motor} battery"
         else:
-            name = f"{blind.blind_type}-{motor}-battery-{blind.mac[12:]}"
+            name = f"{blind.blind_type} {blind.mac[12:]} {motor} battery"
 
         self._motor = motor
         self._attr_unique_id = f"{blind.mac}-{motor}-battery"
@@ -147,7 +147,7 @@ class MotionSignalStrengthSensor(CoordinatorEntity, SensorEntity):
         elif device.device_type in DEVICE_TYPES_WIFI:
             name = f"{device.blind_type} signal strength"
         else:
-            name = f"{device.blind_type} signal strength - {device.mac[12:]}"
+            name = f"{device.blind_type} {device.mac[12:]} signal strength"
 
         self._device = device
         self._device_type = device_type


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Change the default name of motion blind TDBU entities so they can be automatically renamed.

My MotionBlinds bridge has crashed several times which then requires all the blinds to be added again. The entities for the TDBU blinds were never renamed after renaming a TDBU blind. This PR changes the naming of the entities so that they will be automatically renamed when the device is renamed.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #52281
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
