### PR TITLE
Deprecate google calendar configuration.yaml

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -101,6 +101,7 @@ homeassistant.components.geo_location.*
 homeassistant.components.geocaching.*
 homeassistant.components.gios.*
 homeassistant.components.goalzero.*
+homeassistant.components.google.*
 homeassistant.components.greeneye_monitor.*
 homeassistant.components.group.*
 homeassistant.components.guardian.*

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -117,6 +117,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 _SINGLE_CALSEARCH_CONFIG = vol.All(
     cv.deprecated(CONF_MAX_RESULTS),
+    cv.deprecated(CONF_TRACK),
     vol.Schema(
         {
             vol.Required(CONF_NAME): cv.string,
@@ -409,7 +410,6 @@ def get_calendar_info(
             CONF_CAL_ID: calendar["id"],
             CONF_ENTITIES: [
                 {
-                    CONF_TRACK: True,
                     CONF_NAME: calendar["summary"],
                     CONF_DEVICE_ID: generate_entity_id(
                         "{}", calendar["summary"], hass=hass

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -97,18 +97,21 @@ PLATFORMS = ["calendar"]
 
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_CLIENT_ID): cv.string,
-                vol.Required(CONF_CLIENT_SECRET): cv.string,
-                vol.Optional(CONF_TRACK_NEW, default=True): cv.boolean,
-                vol.Optional(CONF_CALENDAR_ACCESS, default="read_write"): cv.enum(
-                    FeatureAccess
-                ),
-            }
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.Schema(
+                {
+                    vol.Required(CONF_CLIENT_ID): cv.string,
+                    vol.Required(CONF_CLIENT_SECRET): cv.string,
+                    vol.Optional(CONF_TRACK_NEW, default=True): cv.boolean,
+                    vol.Optional(CONF_CALENDAR_ACCESS, default="read_write"): cv.enum(
+                        FeatureAccess
+                    ),
+                }
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -160,6 +163,11 @@ ADD_EVENT_SERVICE_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Google component."""
+    hass.data.setdefault(DOMAIN, {})
+
+    if DOMAIN not in config:
+        return True
+
     conf = config.get(DOMAIN, {})
     hass.data[DOMAIN] = {DATA_CONFIG: conf}
 
@@ -189,11 +197,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 },
             )
         )
+
+    _LOGGER.warning(
+        "Configuration of Google Calendar in YAML in configuration.yaml is "
+        "is deprecated and will be removed in a future release; Your existing "
+        "OAuth Application Credentials and other settings have been imported "
+        "into the UI automatically and can be safely removed from your "
+        "configuration.yaml file"
+    )
+
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Google from a config entry."""
+    async_upgrade_entry(hass, entry)
+
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
             hass, entry
@@ -216,8 +235,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err
 
-    access = get_feature_access(hass)
-    if access.scope not in session.token.get("scope", []):
+    access = FeatureAccess[entry.options[CONF_CALENDAR_ACCESS]]
+    token_scopes = session.token.get("scope", [])
+    if access.scope not in token_scopes:
+        _LOGGER.debug("Scope '%s' not in scopes '%s'", access.scope, token_scopes)
         raise ConfigEntryAuthFailed(
             "Required scopes are not available, reauth required"
         )
@@ -226,15 +247,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     hass.data[DOMAIN][DATA_SERVICE] = calendar_service
 
-    track_new = hass.data[DOMAIN][DATA_CONFIG].get(CONF_TRACK_NEW, True)
-    await async_setup_services(hass, track_new, calendar_service)
+    await async_setup_services(hass, calendar_service)
     # Only expose the add event service if we have the correct permissions
     if access is FeatureAccess.read_write:
         await async_setup_add_event_service(hass, calendar_service)
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
+    # Reload entry when options are updated
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     return True
+
+
+def async_upgrade_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Upgrade the config entry if needed."""
+    if DATA_CONFIG not in hass.data[DOMAIN] and entry.options:
+        return
+
+    options = (
+        entry.options
+        if entry.options
+        else {
+            CONF_CALENDAR_ACCESS: get_feature_access(hass).name,
+        }
+    )
+    disable_new_entities = (
+        not hass.data[DOMAIN].get(DATA_CONFIG, {}).get(CONF_TRACK_NEW, True)
+    )
+    hass.config_entries.async_update_entry(
+        entry,
+        options=options,
+        pref_disable_new_entities=disable_new_entities,
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -242,9 +287,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when it changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
 async def async_setup_services(
     hass: HomeAssistant,
-    track_new: bool,
     calendar_service: GoogleCalendarService,
 ) -> None:
     """Set up the service listeners."""
@@ -256,10 +305,7 @@ async def async_setup_services(
     async def _found_calendar(calendar_item: Calendar) -> None:
         calendar = get_calendar_info(
             hass,
-            {
-                **calendar_item.dict(exclude_unset=True),
-                CONF_TRACK: track_new,
-            },
+            calendar_item.dict(exclude_unset=True),
         )
         calendar_id = calendar_item.id
         # Populate the yaml file with all discovered calendars
@@ -363,7 +409,7 @@ def get_calendar_info(
             CONF_CAL_ID: calendar["id"],
             CONF_ENTITIES: [
                 {
-                    CONF_TRACK: calendar["track"],
+                    CONF_TRACK: True,
                     CONF_NAME: calendar["summary"],
                     CONF_DEVICE_ID: generate_entity_id(
                         "{}", calendar["summary"], hass=hass

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -164,8 +164,6 @@ ADD_EVENT_SERVICE_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Google component."""
-    hass.data.setdefault(DOMAIN, {})
-
     if DOMAIN not in config:
         return True
 
@@ -212,8 +210,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Google from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
     async_upgrade_entry(hass, entry)
-
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
             hass, entry

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 import datetime
 import logging
 import time
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from gcal_sync.auth import AbstractAuth
@@ -76,12 +76,12 @@ class DeviceFlow:
     @property
     def verification_url(self) -> str:
         """Return the verification url that the user should visit to enter the code."""
-        return self._device_flow_info.verification_url
+        return self._device_flow_info.verification_url  # type: ignore[no-any-return]
 
     @property
     def user_code(self) -> str:
         """Return the code that the user should enter at the verification url."""
-        return self._device_flow_info.user_code
+        return self._device_flow_info.user_code  # type: ignore[no-any-return]
 
     async def start_exchange_task(
         self, finished_cb: Callable[[Credentials | None], Awaitable[None]]
@@ -131,10 +131,13 @@ def get_feature_access(hass: HomeAssistant) -> FeatureAccess:
     """Return the desired calendar feature access."""
     # This may be called during config entry setup without integration setup running when there
     # is no google entry in configuration.yaml
-    return (
-        hass.data.get(DOMAIN, {})
-        .get(DATA_CONFIG, {})
-        .get(CONF_CALENDAR_ACCESS, DEFAULT_FEATURE_ACCESS)
+    return cast(
+        FeatureAccess,
+        (
+            hass.data.get(DOMAIN, {})
+            .get(DATA_CONFIG, {})
+            .get(CONF_CALENDAR_ACCESS, DEFAULT_FEATURE_ACCESS)
+        ),
     )
 
 
@@ -157,7 +160,7 @@ async def async_create_device_flow(
     return DeviceFlow(hass, oauth_flow, device_flow_info)
 
 
-class ApiAuthImpl(AbstractAuth):
+class ApiAuthImpl(AbstractAuth):  # type: ignore[misc]
     """Authentication implementation for google calendar api library."""
 
     def __init__(
@@ -172,10 +175,10 @@ class ApiAuthImpl(AbstractAuth):
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         await self._session.async_ensure_token_valid()
-        return self._session.token["access_token"]
+        return cast(str, self._session.token["access_token"])
 
 
-class AccessTokenAuthImpl(AbstractAuth):
+class AccessTokenAuthImpl(AbstractAuth):  # type: ignore[misc]
     """Authentication implementation used during config flow, without refresh.
 
     This exists to allow the config flow to use the API before it has fully

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -89,14 +89,25 @@ def _async_setup_entities(
 ) -> None:
     calendar_service = hass.data[DOMAIN][DATA_SERVICE]
     entities = []
+    num_entities = len(disc_info[CONF_ENTITIES])
     for data in disc_info[CONF_ENTITIES]:
-        if not data[CONF_TRACK]:
-            continue
-        entity_id = generate_entity_id(
-            ENTITY_ID_FORMAT, data[CONF_DEVICE_ID], hass=hass
-        )
+        entity_enabled = data[CONF_TRACK]
+        entity_name = data[CONF_DEVICE_ID]
+        entity_id = generate_entity_id(ENTITY_ID_FORMAT, entity_name, hass=hass)
+        calendar_id = disc_info[CONF_CAL_ID]
+        if num_entities > 1:
+            # The google_calendars.yaml file lets users add multiple entities for
+            # the same calendar id and needs additional disambiguation
+            unique_id = f"{calendar_id}-{entity_name}"
+        else:
+            unique_id = calendar_id
         entity = GoogleCalendarEntity(
-            calendar_service, disc_info[CONF_CAL_ID], data, entity_id
+            calendar_service,
+            disc_info[CONF_CAL_ID],
+            data,
+            entity_id,
+            unique_id,
+            entity_enabled,
         )
         entities.append(entity)
 
@@ -112,6 +123,8 @@ class GoogleCalendarEntity(CalendarEntity):
         calendar_id: str,
         data: dict[str, Any],
         entity_id: str,
+        unique_id: str,
+        entity_enabled: bool,
     ) -> None:
         """Create the Calendar event device."""
         self._calendar_service = calendar_service
@@ -123,6 +136,8 @@ class GoogleCalendarEntity(CalendarEntity):
         self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
         self._offset_value: timedelta | None = None
         self.entity_id = entity_id
+        self._attr_unique_id = unique_id
+        self._attr_entity_registry_enabled_default = entity_enabled
 
     @property
     def extra_state_attributes(self) -> dict[str, bool]:

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -1,4 +1,5 @@
 """Support for Google Calendar Search binary sensors."""
+
 from __future__ import annotations
 
 import copy
@@ -91,7 +92,7 @@ def _async_setup_entities(
     entities = []
     num_entities = len(disc_info[CONF_ENTITIES])
     for data in disc_info[CONF_ENTITIES]:
-        entity_enabled = data[CONF_TRACK]
+        entity_enabled = data.get(CONF_TRACK, True)
         entity_name = data[CONF_DEVICE_ID]
         entity_id = generate_entity_id(ENTITY_ID_FORMAT, entity_name, hass=hass)
         calendar_id = disc_info[CONF_CAL_ID]
@@ -167,7 +168,7 @@ class GoogleCalendarEntity(CalendarEntity):
         """Return True if the event is visible."""
         if self._ignore_availability:
             return True
-        return event.transparency == OPAQUE
+        return event.transparency == OPAQUE  # type: ignore[no-any-return]
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -181,7 +181,9 @@ class OAuth2FlowHandler(
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
         """Create an options flow."""
         return OptionsFlowHandler(config_entry)
 
@@ -189,11 +191,13 @@ class OAuth2FlowHandler(
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Google Calendar options flow."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/google/strings.json
+++ b/homeassistant/components/google/strings.json
@@ -32,9 +32,7 @@
     "step": {
       "init": {
         "data": {
-          "calendar_access": "Home Assistant access to Google Calendar",
-          "read_only": "Read-only access",
-          "read_write": "Read/Write access"
+          "calendar_access": "Home Assistant access to Google Calendar"
         }
       }
     }

--- a/homeassistant/components/google/strings.json
+++ b/homeassistant/components/google/strings.json
@@ -27,5 +27,16 @@
     "progress": {
       "exchange": "To link your Google account, visit the [{url}]({url}) and enter code:\n\n{user_code}"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "calendar_access": "Home Assistant access to Google Calendar",
+          "read_only": "Read-only access",
+          "read_write": "Read/Write access"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/google/translations/en.json
+++ b/homeassistant/components/google/translations/en.json
@@ -27,5 +27,14 @@
                 "title": "Reauthenticate Integration"
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "calendar_access": "Home Assistant access to Google Calendar"
+                }
+            }
+        }
     }
 }

--- a/mypy.ini
+++ b/mypy.ini
@@ -874,6 +874,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.google.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.greeneye_monitor.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.google.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.util.dt import utcnow
@@ -143,6 +144,7 @@ async def test_full_flow_yaml_creds(
             "token_type": "Bearer",
         },
     }
+    assert result.get("options") == {"calendar_access": "read_write"}
 
     assert len(mock_setup.mock_calls) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -205,6 +207,7 @@ async def test_full_flow_application_creds(
             "token_type": "Bearer",
         },
     }
+    assert result.get("options") == {"calendar_access": "read_write"}
 
     assert len(mock_setup.mock_calls) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -441,7 +444,12 @@ async def test_reauth_flow(
     assert await component_setup()
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=config_entry.data
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": config_entry.entry_id,
+        },
+        data=config_entry.data,
     )
     assert result["type"] == "form"
     assert result["step_id"] == "reauth_confirm"
@@ -523,3 +531,66 @@ async def test_title_lookup_failure(
     assert len(mock_setup.mock_calls) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
+
+
+async def test_options_flow_triggers_reauth(
+    hass: HomeAssistant,
+    component_setup: ComponentSetup,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    config_entry.add_to_hass(hass)
+    await component_setup()
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.options == {"calendar_access": "read_write"}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    data_schema = result["data_schema"].schema
+    assert set(data_schema) == {"calendar_access"}
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "calendar_access": "read_only",
+        },
+    )
+    assert result["type"] == "create_entry"
+
+    await hass.async_block_till_done()
+    assert config_entry.options == {"calendar_access": "read_only"}
+    # Re-auth flow was initiated because access level changed
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"
+
+
+async def test_options_flow_no_changes(
+    hass: HomeAssistant,
+    component_setup: ComponentSetup,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    config_entry.add_to_hass(hass)
+    await component_setup()
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.options == {"calendar_access": "read_write"}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "calendar_access": "read_write",
+        },
+    )
+    assert result["type"] == "create_entry"
+
+    await hass.async_block_till_done()
+    assert config_entry.options == {"calendar_access": "read_write"}
+    # Re-auth flow was initiated because access level changed
+    assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -46,7 +46,7 @@ HassApi = Callable[[], Awaitable[dict[str, Any]]]
 
 def assert_state(actual: State | None, expected: State | None) -> None:
     """Assert that the two states are equal."""
-    if actual is None:
+    if actual is None or expected is None:
         assert actual == expected
         return
     assert actual.entity_id == expected.entity_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Google Calendars integration configuration.yaml has been migrated to configuration via the UI, and
has been deprecated and will be removed in a future Home Assistant release. 

Your existing OAuth application credentials in the YAML configuration are automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

All entity tracking state has been migrated to use the standard Home Assistant entity enable/disable features in the user interface and system options.

Note that `google_calendars.yaml` is still supported.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Deprecate googel calendar configuration.yaml. The features are:
- OAuth was already moved to application credentials
- "track_new" which now uses entity state with disable/enable
- "calendar_access" which is configurable in an option flow


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22844

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
