### PR TITLE
ZHA Add entities for Lidl water valve quirk

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -106,10 +106,14 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
 
 @MULTI_MATCH(
     channel_names="tuya_manufacturer",
-    manufacturers={"_TZE200_htnnfasr",},
+    manufacturers={
+        "_TZE200_htnnfasr",
+    },
     stop_on_match_group="tuya_manufacturer",
 )
-class FrostLock(BinarySensor, id_suffix="frost lock"):
+class FrostLock(BinarySensor, id_suffix="frost_lock"):
+    """ZHA BinarySensor."""
+
     SENSOR_ATTR = "frost_lock"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.LOCK
 

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -104,20 +104,6 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
             self._state = attr_value
 
 
-@MULTI_MATCH(
-    channel_names="tuya_manufacturer",
-    manufacturers={
-        "_TZE200_htnnfasr",
-    },
-    stop_on_match_group="tuya_manufacturer",
-)
-class FrostLock(BinarySensor, id_suffix="frost_lock"):
-    """ZHA BinarySensor."""
-
-    SENSOR_ATTR = "frost_lock"
-    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.LOCK
-
-
 @MULTI_MATCH(channel_names=CHANNEL_ACCELEROMETER)
 class Accelerometer(BinarySensor):
     """ZHA BinarySensor."""
@@ -185,3 +171,16 @@ class IASZone(BinarySensor):
         value = await self._channel.get_attribute_value("zone_status")
         if value is not None:
             self._state = value & 3
+
+
+@MULTI_MATCH(
+    channel_names="tuya_manufacturer",
+    manufacturers={
+        "_TZE200_htnnfasr",
+    },
+)
+class FrostLock(BinarySensor, id_suffix="frost_lock"):
+    """ZHA BinarySensor."""
+
+    SENSOR_ATTR = "frost_lock"
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.LOCK

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -104,6 +104,16 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
             self._state = attr_value
 
 
+@MULTI_MATCH(
+    channel_names="tuya_manufacturer",
+    manufacturers={"_TZE200_htnnfasr",},
+    stop_on_match_group="tuya_manufacturer",
+)
+class FrostLock(BinarySensor, id_suffix="frost lock"):
+    SENSOR_ATTR = "frost_lock"
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.LOCK
+
+
 @MULTI_MATCH(channel_names=CHANNEL_ACCELEROMETER)
 class Accelerometer(BinarySensor):
     """ZHA BinarySensor."""

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -24,6 +24,9 @@ from .core.typing import ChannelType, ZhaDeviceType
 from .entity import ZhaEntity
 
 MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.BUTTON)
+CONFIG_DIAGNOSTIC_MATCH = functools.partial(
+    ZHA_ENTITIES.config_diagnostic_match, Platform.BUTTON
+)
 DEFAULT_DURATION = 5  # seconds
 
 _LOGGER = logging.getLogger(__name__)
@@ -108,7 +111,7 @@ class ZHAIdentifyButton(ZHAButton):
         return [DEFAULT_DURATION]
 
 
-class ZHAButtonAttribute(ZhaEntity, ButtonEntity):
+class ZHAAttributeButton(ZhaEntity, ButtonEntity):
     """Defines a ZHA button, which stes value to an attribute."""
 
     _attribute_name: str = None
@@ -140,14 +143,13 @@ class ZHAButtonAttribute(ZhaEntity, ButtonEntity):
             self.async_write_ha_state()
 
 
-@MULTI_MATCH(
+@CONFIG_DIAGNOSTIC_MATCH(
     channel_names="tuya_manufacturer",
     manufacturers={
         "_TZE200_htnnfasr",
     },
-    stop_on_match_group="tuya_manufacturer",
 )
-class FrostLockResetButton(ZHAButtonAttribute, id_suffix="reset_frost_lock"):
+class FrostLockResetButton(ZHAAttributeButton, id_suffix="reset_frost_lock"):
     """Defines a ZHA identify button."""
 
     _attribute_name = "frost_lock_reset"

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -147,7 +147,7 @@ class ZHAButtonAttribute(ZhaEntity, ButtonEntity):
     },
     stop_on_match_group="tuya_manufacturer",
 )
-class FrostLockResetButton(ZHAButtonAttribute, id_suffix="reset frost lock"):
+class FrostLockResetButton(ZHAButtonAttribute, id_suffix="reset_frost_lock"):
     """Defines a ZHA identify button."""
 
     _attribute_name = "frost_lock_reset"

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -37,6 +37,7 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.NUMBER)
 CONFIG_DIAGNOSTIC_MATCH = functools.partial(
     ZHA_ENTITIES.config_diagnostic_match, Platform.NUMBER
 )
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.NUMBER)
 
 
 UNITS = {
@@ -495,3 +496,29 @@ class StartUpCurrentLevelConfigurationEntity(
     _attr_min_value: float = 0x00
     _attr_max_value: float = 0xFF
     _zcl_attribute: str = "start_up_current_level"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="tuya_manufacturer",
+    manufacturers={"_TZE200_htnnfasr", },
+    stop_on_match_group="tuya_manufacturer",
+)
+class TimerDuration(
+    ZHANumberConfigurationEntity, id_suffix="timer_duration"
+):
+    """Representation of a ZHA timer duration configuration entity."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_min_value: float = 0x00
+    _attr_max_value: float = 0x257
+    _zcl_attribute: str = "timer_duration"
+
+    @property
+    def icon(self):
+        """Return the icon to be used for this entity."""
+        return ICONS.get(14, super().icon)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return UNITS.get(72)

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -512,11 +512,6 @@ class TimerDurationMinutes(ZHANumberConfigurationEntity, id_suffix="timer_durati
     _zcl_attribute: str = "timer_duration"
 
     @property
-    def icon(self):
-        """Return the icon to be used for this entity."""
-        return ICONS[14]
-
-    @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return UNITS[72]

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -37,7 +37,6 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.NUMBER)
 CONFIG_DIAGNOSTIC_MATCH = functools.partial(
     ZHA_ENTITIES.config_diagnostic_match, Platform.NUMBER
 )
-MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.NUMBER)
 
 
 UNITS = {
@@ -503,9 +502,8 @@ class StartUpCurrentLevelConfigurationEntity(
     manufacturers={
         "_TZE200_htnnfasr",
     },
-    stop_on_match_group="tuya_manufacturer",
 )
-class TimerDuration(ZHANumberConfigurationEntity, id_suffix="timer_duration"):
+class TimerDurationMinutes(ZHANumberConfigurationEntity, id_suffix="timer_duration"):
     """Representation of a ZHA timer duration configuration entity."""
 
     _attr_entity_category = EntityCategory.CONFIG
@@ -516,9 +514,9 @@ class TimerDuration(ZHANumberConfigurationEntity, id_suffix="timer_duration"):
     @property
     def icon(self):
         """Return the icon to be used for this entity."""
-        return ICONS.get(14, super().icon)
+        return ICONS[14]
 
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        return UNITS.get(72)
+        return UNITS[72]

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -500,12 +500,12 @@ class StartUpCurrentLevelConfigurationEntity(
 
 @CONFIG_DIAGNOSTIC_MATCH(
     channel_names="tuya_manufacturer",
-    manufacturers={"_TZE200_htnnfasr", },
+    manufacturers={
+        "_TZE200_htnnfasr",
+    },
     stop_on_match_group="tuya_manufacturer",
 )
-class TimerDuration(
-    ZHANumberConfigurationEntity, id_suffix="timer_duration"
-):
+class TimerDuration(ZHANumberConfigurationEntity, id_suffix="timer_duration"):
     """Representation of a ZHA timer duration configuration entity."""
 
     _attr_entity_category = EntityCategory.CONFIG

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -507,11 +507,8 @@ class TimerDurationMinutes(ZHANumberConfigurationEntity, id_suffix="timer_durati
     """Representation of a ZHA timer duration configuration entity."""
 
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon: str = ICONS[14]
     _attr_min_value: float = 0x00
     _attr_max_value: float = 0x257
+    _attr_unit_of_measurement: str | None = UNITS[72]
     _zcl_attribute: str = "timer_duration"
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit the value is expressed in."""
-        return UNITS[72]

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
     VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR,
     VOLUME_GALLONS,
     VOLUME_LITERS,
-    Platform,
+    Platform, TIME_MINUTES,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -179,6 +179,18 @@ class Sensor(ZhaEntity, SensorEntity):
                 float(value * self._multiplier) / self._divisor, self._decimals
             )
         return round(float(value * self._multiplier) / self._divisor)
+
+
+@MULTI_MATCH(
+    channel_names="tuya_manufacturer",
+    manufacturers={"_TZE200_htnnfasr",},
+    stop_on_match_group="tuya_manufacturer",
+)
+class TimeLeft(Sensor, id_suffix="time left"):
+    SENSOR_ATTR = "timer_time_left"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.DURATION
+    # _decimals: int = 0
+    _unit = TIME_MINUTES
 
 
 @MULTI_MATCH(

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -764,7 +764,7 @@ class LQISensor(RSSISensor, id_suffix="lqi"):
     },
     stop_on_match_group="tuya_manufacturer",
 )
-class TimeLeft(Sensor, id_suffix="time left"):
+class TimeLeft(Sensor, id_suffix="time_left"):
     """Sensor that displays time left value."""
 
     SENSOR_ATTR = "timer_time_left"

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -762,7 +762,6 @@ class LQISensor(RSSISensor, id_suffix="lqi"):
     manufacturers={
         "_TZE200_htnnfasr",
     },
-    stop_on_match_group="tuya_manufacturer",
 )
 class TimeLeft(Sensor, id_suffix="time_left"):
     """Sensor that displays time left value."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     PRESSURE_HPA,
     TEMP_CELSIUS,
     TIME_HOURS,
+    TIME_MINUTES,
     TIME_SECONDS,
     VOLUME_CUBIC_FEET,
     VOLUME_CUBIC_METERS,
@@ -34,7 +35,7 @@ from homeassistant.const import (
     VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR,
     VOLUME_GALLONS,
     VOLUME_LITERS,
-    Platform, TIME_MINUTES,
+    Platform,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -179,18 +180,6 @@ class Sensor(ZhaEntity, SensorEntity):
                 float(value * self._multiplier) / self._divisor, self._decimals
             )
         return round(float(value * self._multiplier) / self._divisor)
-
-
-@MULTI_MATCH(
-    channel_names="tuya_manufacturer",
-    manufacturers={"_TZE200_htnnfasr",},
-    stop_on_match_group="tuya_manufacturer",
-)
-class TimeLeft(Sensor, id_suffix="time left"):
-    SENSOR_ATTR = "timer_time_left"
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.DURATION
-    # _decimals: int = 0
-    _unit = TIME_MINUTES
 
 
 @MULTI_MATCH(
@@ -766,3 +755,18 @@ class RSSISensor(Sensor, id_suffix="rssi"):
 @MULTI_MATCH(channel_names=CHANNEL_BASIC)
 class LQISensor(RSSISensor, id_suffix="lqi"):
     """LQI sensor for a device."""
+
+
+@MULTI_MATCH(
+    channel_names="tuya_manufacturer",
+    manufacturers={
+        "_TZE200_htnnfasr",
+    },
+    stop_on_match_group="tuya_manufacturer",
+)
+class TimeLeft(Sensor, id_suffix="time left"):
+    """Sensor that displays time left value."""
+
+    SENSOR_ATTR = "timer_time_left"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.DURATION
+    _unit = TIME_MINUTES

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -768,4 +768,5 @@ class TimeLeft(Sensor, id_suffix="time_left"):
 
     SENSOR_ATTR = "timer_time_left"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.DURATION
+    _attr_icon = "mdi:timer"
     _unit = TIME_MINUTES

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -1,11 +1,14 @@
 """Test ZHA button."""
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from freezegun import freeze_time
 import pytest
 from zigpy.const import SIG_EP_PROFILE
+from zigpy.exceptions import ZigbeeException
 import zigpy.profiles.zha as zha
+import zigpy.types as t
 import zigpy.zcl.clusters.general as general
+from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 import zigpy.zcl.clusters.security as security
 import zigpy.zcl.foundation as zcl_f
 
@@ -14,6 +17,7 @@ from homeassistant.components.button.const import SERVICE_PRESS
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
+    ENTITY_CATEGORY_CONFIG,
     ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_UNKNOWN,
 )
@@ -46,6 +50,35 @@ async def contact_sensor(hass, zigpy_device_mock, zha_device_joined_restored):
 
     zha_device = await zha_device_joined_restored(zigpy_device)
     return zha_device, zigpy_device.endpoints[1].identify
+
+
+@pytest.fixture
+async def tuya_water_valve(hass, zigpy_device_mock, zha_device_joined_restored):
+    """Tuya Water Valve fixture."""
+
+    class TuyaManufCluster(ManufacturerSpecificCluster):
+        """Tuya manufacturer specific cluster."""
+
+        cluster_id = 0xEF00
+        ep_attribute = "tuya_manufacturer"
+
+        attributes = {
+            0xEF01: ("frost_lock_reset", t.Bool),
+        }
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [general.Basic.cluster_id, TuyaManufCluster.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+            }
+        },
+        manufacturer="_TZE200_htnnfasr",
+    )
+
+    zha_device = await zha_device_joined_restored(zigpy_device)
+    return zha_device, zigpy_device.endpoints[1].tuya_manufacturer
 
 
 @freeze_time("2021-11-04 17:37:00", tz_offset=-1)
@@ -87,3 +120,52 @@ async def test_button(hass, contact_sensor):
     assert state
     assert state.state == "2021-11-04T16:37:00+00:00"
     assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.UPDATE
+
+
+async def test_frost_unlock(hass, tuya_water_valve):
+    """Test custom frost unlock zha button."""
+
+    entity_registry = er.async_get(hass)
+    zha_device, cluster = tuya_water_valve
+    assert cluster is not None
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.RESTART
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.entity_category == ENTITY_CATEGORY_CONFIG
+
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=mock_coro([0x00, zcl_f.Status.SUCCESS]),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert len(cluster.write_attributes.mock_calls) == 1
+        assert cluster.write_attributes.call_args == call({"frost_lock_reset": 0})
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.RESTART
+
+    cluster.write_attributes.reset_mock()
+    cluster.write_attributes.side_effect = ZigbeeException
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    assert len(cluster.write_attributes.mock_calls) == 1
+    assert cluster.write_attributes.call_args == call({"frost_lock_reset": 0})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nothing

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This exposes entities from manufucturer cluster in Parkside Water valve quirk https://github.com/zigpy/zha-device-handlers/pull/1574. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/zigpy/zha-device-handlers/pull/1574/files
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
