### PR TITLE
Drop GetAutomationsResult and GetAutomationCapabilitiesResult aliases

### DIFF
--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -7,10 +7,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_ID,
@@ -36,7 +33,7 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for Arcam FMJ Receiver control devices."""
     registry = entity_registry.async_get(hass)
     triggers = []

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 GetAutomationsResult = list[dict[str, Any]]
-GetAutomationCapabilitiesResult = dict[str, vol.Schema]
 
 DOMAIN = "device_automation"
 

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -44,8 +44,6 @@ if TYPE_CHECKING:
     ]
 
 # mypy: allow-untyped-calls, allow-untyped-defs
-GetAutomationsResult = list[dict[str, Any]]
-
 DOMAIN = "device_automation"
 
 DEVICE_TRIGGER_BASE_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(

--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import (
     DeviceAutomationType,
-    GetAutomationCapabilitiesResult,
     GetAutomationsResult,
     async_get_device_automation_platform,
 )
@@ -43,7 +42,7 @@ class DeviceAutomationActionProtocol(Protocol):
 
     def async_get_action_capabilities(
         self, hass: HomeAssistant, config: ConfigType
-    ) -> GetAutomationCapabilitiesResult | Awaitable[GetAutomationCapabilitiesResult]:
+    ) -> dict[str, vol.Schema] | Awaitable[dict[str, vol.Schema]]:
         """List action capabilities."""
 
     def async_get_actions(

--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -10,11 +10,7 @@ from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from . import (
-    DeviceAutomationType,
-    GetAutomationsResult,
-    async_get_device_automation_platform,
-)
+from . import DeviceAutomationType, async_get_device_automation_platform
 from .exceptions import InvalidDeviceAutomationConfig
 
 
@@ -47,7 +43,7 @@ class DeviceAutomationActionProtocol(Protocol):
 
     def async_get_actions(
         self, hass: HomeAssistant, device_id: str
-    ) -> GetAutomationsResult | Awaitable[GetAutomationsResult]:
+    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
         """List actions."""
 
 

--- a/homeassistant/components/device_automation/condition.py
+++ b/homeassistant/components/device_automation/condition.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import voluptuous as vol
 
@@ -11,11 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from . import (
-    DeviceAutomationType,
-    GetAutomationsResult,
-    async_get_device_automation_platform,
-)
+from . import DeviceAutomationType, async_get_device_automation_platform
 from .exceptions import InvalidDeviceAutomationConfig
 
 if TYPE_CHECKING:
@@ -47,7 +43,7 @@ class DeviceAutomationConditionProtocol(Protocol):
 
     def async_get_conditions(
         self, hass: HomeAssistant, device_id: str
-    ) -> GetAutomationsResult | Awaitable[GetAutomationsResult]:
+    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
         """List conditions."""
 
 

--- a/homeassistant/components/device_automation/condition.py
+++ b/homeassistant/components/device_automation/condition.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import (
     DeviceAutomationType,
-    GetAutomationCapabilitiesResult,
     GetAutomationsResult,
     async_get_device_automation_platform,
 )
@@ -43,7 +42,7 @@ class DeviceAutomationConditionProtocol(Protocol):
 
     def async_get_condition_capabilities(
         self, hass: HomeAssistant, config: ConfigType
-    ) -> GetAutomationCapabilitiesResult | Awaitable[GetAutomationCapabilitiesResult]:
+    ) -> dict[str, vol.Schema] | Awaitable[dict[str, vol.Schema]]:
         """List condition capabilities."""
 
     def async_get_conditions(

--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import voluptuous as vol
 
@@ -17,7 +17,6 @@ from homeassistant.helpers.typing import ConfigType
 from . import (
     DEVICE_TRIGGER_BASE_SCHEMA,
     DeviceAutomationType,
-    GetAutomationsResult,
     async_get_device_automation_platform,
 )
 from .exceptions import InvalidDeviceAutomationConfig
@@ -54,7 +53,7 @@ class DeviceAutomationTriggerProtocol(Protocol):
 
     def async_get_triggers(
         self, hass: HomeAssistant, device_id: str
-    ) -> GetAutomationsResult | Awaitable[GetAutomationsResult]:
+    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
         """List triggers."""
 
 

--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.typing import ConfigType
 from . import (
     DEVICE_TRIGGER_BASE_SCHEMA,
     DeviceAutomationType,
-    GetAutomationCapabilitiesResult,
     GetAutomationsResult,
     async_get_device_automation_platform,
 )
@@ -50,7 +49,7 @@ class DeviceAutomationTriggerProtocol(Protocol):
 
     def async_get_trigger_capabilities(
         self, hass: HomeAssistant, config: ConfigType
-    ) -> GetAutomationCapabilitiesResult | Awaitable[GetAutomationCapabilitiesResult]:
+    ) -> dict[str, vol.Schema] | Awaitable[dict[str, vol.Schema]]:
         """List trigger capabilities."""
 
     def async_get_triggers(

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -14,10 +14,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.typing import ConfigType
@@ -244,7 +241,7 @@ def async_fire_triggers(conn: HKDevice, events: dict[tuple[int, int], Any]):
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for homekit devices."""
 
     if device_id not in hass.data.get(TRIGGERS, {}):

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -7,10 +7,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -350,7 +347,7 @@ async def async_validate_trigger_config(
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for lutron caseta devices."""
     triggers = []
 

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -8,10 +8,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -66,7 +63,7 @@ def async_get_device_trigger_types(
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for a Nest device."""
     nest_device_id = async_get_nest_device_id(hass, device_id)
     if not nest_device_id:

--- a/homeassistant/components/netatmo/device_trigger.py
+++ b/homeassistant/components/netatmo/device_trigger.py
@@ -7,10 +7,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -101,7 +98,7 @@ async def async_validate_trigger_config(
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for Netatmo devices."""
     registry = entity_registry.async_get(hass)
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -10,8 +10,7 @@ from homeassistant.components.automation import (
     AutomationTriggerInfo,
 )
 from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
+    DEVICE_TRIGGER_BASE_SCHEMA
 )
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
@@ -111,9 +110,9 @@ async def async_validate_trigger_config(
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for Shelly devices."""
-    triggers: GetAutomationsResult = []
+    triggers: list[dict[str, str]] = []
 
     if rpc_wrapper := get_rpc_device_wrapper(hass, device_id):
         input_triggers = get_rpc_input_triggers(rpc_wrapper.device)

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -9,9 +9,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )

--- a/homeassistant/components/webostv/device_trigger.py
+++ b/homeassistant/components/webostv/device_trigger.py
@@ -7,10 +7,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-    GetAutomationsResult,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -61,7 +58,7 @@ async def async_validate_trigger_config(
 
 async def async_get_triggers(
     _hass: HomeAssistant, device_id: str
-) -> GetAutomationsResult:
+) -> list[dict[str, str]]:
     """List device triggers for device."""
     triggers = []
     base_trigger = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop `GetAutomationsResult` and `GetAutomationCapabilitiesResult` type aliases, following discussions in https://github.com/home-assistant/core/pull/72163#issuecomment-1133865649

This is an alternative to all the reversal PRs from #72325 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
