### PR TITLE
Stop updating google_calendars.yaml if it does not already exist

### DIFF
--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -171,9 +171,16 @@ def config_entry_token_expiry(token_expiry: datetime.datetime) -> float:
 
 
 @pytest.fixture
+def config_entry_options() -> dict[str, Any] | None:
+    """Fixture to set initial config entry options."""
+    return None
+
+
+@pytest.fixture
 def config_entry(
     token_scopes: list[str],
     config_entry_token_expiry: float,
+    config_entry_options: dict[str, Any] | None,
 ) -> MockConfigEntry:
     """Fixture to create a config entry for the integration."""
     return MockConfigEntry(
@@ -188,6 +195,7 @@ def config_entry(
                 "expires_at": config_entry_token_expiry,
             },
         },
+        options=config_entry_options,
     )
 
 

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 import datetime
 from typing import Any, Generator, TypeVar
-from unittest.mock import mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 from aiohttp.client_exceptions import ClientError
 from gcal_sync.auth import API_BASE_URL
@@ -104,11 +104,11 @@ def calendars_config(calendars_config_entity: dict[str, Any]) -> list[dict[str, 
 def mock_calendars_yaml(
     hass: HomeAssistant,
     calendars_config: list[dict[str, Any]],
-) -> None:
+) -> Generator[Mock, None, None]:
     """Fixture that prepares the google_calendars.yaml mocks."""
     mocked_open_function = mock_open(read_data=yaml.dump(calendars_config))
     with patch("homeassistant.components.google.open", mocked_open_function):
-        yield
+        yield mocked_open_function
 
 
 class FakeStorage:

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -572,14 +572,16 @@ async def test_opaque_event(
     assert (len(events) > 0) == expect_visible_event
 
 
+@pytest.mark.parametrize("mock_test_setup", [None])
 async def test_scan_calendar_error(
     hass,
     component_setup,
     test_api_calendar,
     mock_calendars_list,
+    config_entry,
 ):
     """Test that the calendar update handles a server error."""
-
+    config_entry.add_to_hass(hass)
     mock_calendars_list({}, exc=ClientError())
     assert await component_setup()
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.google import (
     SERVICE_ADD_EVENT,
     SERVICE_SCAN_CALENDARS,
 )
+from homeassistant.components.google.const import CONF_CALENDAR_ACCESS
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant, State
@@ -229,7 +230,10 @@ async def test_found_calendar_from_api(
     assert not hass.states.get(TEST_YAML_ENTITY)
 
 
-@pytest.mark.parametrize("calendars_config,google_config", [([], {})])
+@pytest.mark.parametrize(
+    "calendars_config,google_config,config_entry_options",
+    [([], {}, {CONF_CALENDAR_ACCESS: "read_write"})],
+)
 async def test_load_application_credentials(
     hass: HomeAssistant,
     component_setup: ComponentSetup,

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -611,7 +611,7 @@ async def test_expired_token_requires_reauth(
 
 
 @pytest.mark.parametrize(
-    "calendars_config,write_calls",
+    "calendars_config,expect_write_calls",
     [
         (
             [

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -6,7 +6,7 @@ import datetime
 import http
 import time
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -608,3 +608,48 @@ async def test_expired_token_requires_reauth(
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
     assert flows[0]["step_id"] == "reauth_confirm"
+
+
+@pytest.mark.parametrize(
+    "calendars_config",
+    [
+        [
+            {
+                "cal_id": "ignored",
+                "entities": {"device_id": "existing", "name": "existing"},
+            }
+        ],
+        [],
+    ],
+    ids=["has_yaml", "no_yaml"],
+)
+async def test_calendar_yaml_update(
+    hass: HomeAssistant,
+    component_setup: ComponentSetup,
+    mock_calendars_yaml: Mock,
+    mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
+    setup_config_entry: MockConfigEntry,
+    calendars_config: dict[str, Any],
+) -> None:
+    """Test updating the yaml file with a new calendar."""
+
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
+    assert await component_setup()
+
+    mock_calendars_yaml().read.assert_called()
+    if calendars_config:
+        mock_calendars_yaml().write.assert_called()
+    else:
+        # Config is not updated if it does not already exist
+        mock_calendars_yaml().write.assert_not_called()
+
+    state = hass.states.get(TEST_API_ENTITY)
+    assert state
+    assert state.name == TEST_API_ENTITY_NAME
+    assert state.state == STATE_OFF
+
+    # No yaml config loaded that overwrites the entity name
+    assert not hass.states.get(TEST_YAML_ENTITY)

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -644,11 +644,7 @@ async def test_calendar_yaml_update(
     assert await component_setup()
 
     mock_calendars_yaml().read.assert_called()
-    if expect_write_calls:
-        mock_calendars_yaml().write.assert_called()
-    else:
-        # Config is not updated if it does not already exist
-        mock_calendars_yaml().write.assert_not_called()
+    mock_calendars_yaml().write.called is expect_write_calls
 
     state = hass.states.get(TEST_API_ENTITY)
     assert state

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -611,15 +611,18 @@ async def test_expired_token_requires_reauth(
 
 
 @pytest.mark.parametrize(
-    "calendars_config",
+    "calendars_config,write_calls",
     [
-        [
-            {
-                "cal_id": "ignored",
-                "entities": {"device_id": "existing", "name": "existing"},
-            }
-        ],
-        [],
+        (
+            [
+                {
+                    "cal_id": "ignored",
+                    "entities": {"device_id": "existing", "name": "existing"},
+                }
+            ],
+            True,
+        ),
+        ([], False),
     ],
     ids=["has_yaml", "no_yaml"],
 )
@@ -632,6 +635,7 @@ async def test_calendar_yaml_update(
     mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
     calendars_config: dict[str, Any],
+    expect_write_calls: bool,
 ) -> None:
     """Test updating the yaml file with a new calendar."""
 
@@ -640,7 +644,7 @@ async def test_calendar_yaml_update(
     assert await component_setup()
 
     mock_calendars_yaml().read.assert_called()
-    if calendars_config:
+    if expect_write_calls:
         mock_calendars_yaml().write.assert_called()
     else:
         # Config is not updated if it does not already exist


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not create `google_calendars.yaml` if it does not already exist. Exist behavior is preserved if it already exists. Also add a lock so that only one task at a time may update the file. 

Also adds additional test coverage to make CI pass.

This is another step towards moving away from yaml configuration to better support multiple config entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22882

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
