### PR TITLE
Chunk large logbook queries and add an end_time to the api so we stop sending events

### DIFF
--- a/homeassistant/components/logbook/models.py
+++ b/homeassistant/components/logbook/models.py
@@ -59,7 +59,7 @@ class LazyEventPartialState:
             )
 
 
-@dataclass
+@dataclass(frozen=True)
 class EventAsRow:
     """Convert an event to a row."""
 

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -264,7 +264,7 @@ async def ws_event_stream(
     )
 
     if end_time and end_time <= utc_now:
-        # Not live stream
+        # Not live stream but we it might be a big query
         connection.subscriptions[msg["id"]] = callback(lambda: None)
         connection.send_result(msg["id"])
         # Fetch everything from history

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -28,7 +28,7 @@ from .models import async_event_to_row
 from .processor import EventProcessor
 
 MAX_PENDING_LOGBOOK_EVENTS = 2048
-EVENT_COALESCE_TIME = 0.5
+EVENT_COALESCE_TIME = 0.35
 MAX_RECORDER_WAIT = 10
 # minimum size that we will split the query
 BIG_QUERY_HOURS = 25

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -289,9 +289,9 @@ async def ws_event_stream(
     @callback
     def _unsub(*time: Any) -> None:
         """Unsubscribe from all events."""
-        for subscription in live_stream.subscriptions:
+        for subscription in subscriptions:
             subscription()
-        live_stream.subscriptions.clear()
+        subscriptions.clear()
         if live_stream.task:
             live_stream.task.cancel()
         if live_stream.end_time_unsub:

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -242,12 +242,14 @@ async def ws_event_stream(
 
     end_time_str = msg.get("end_time")
     end_time: dt | None = None
-    if end_time_str and (end_time := dt_util.parse_datetime(end_time_str)):
+    if end_time_str:
+        if not (end_time := dt_util.parse_datetime(end_time_str)):
+            connection.send_error(msg_id, "invalid_end_time", "Invalid end_time")
+            return
         end_time = dt_util.as_utc(end_time)
-
-    if end_time and end_time < start_time:
-        connection.send_error(msg_id, "invalid_end_time", "Invalid end_time")
-        return
+        if end_time < start_time:
+            connection.send_error(msg_id, "invalid_end_time", "Invalid end_time")
+            return
 
     device_ids = msg.get("device_ids")
     entity_ids = msg.get("entity_ids")

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -31,9 +31,9 @@ MAX_PENDING_LOGBOOK_EVENTS = 2048
 EVENT_COALESCE_TIME = 0.5
 MAX_RECORDER_WAIT = 10
 # minimum size that we will split the query
-BIG_QUERY_HOURS = 6
+BIG_QUERY_HOURS = 13
 # how many hours to deliver in the first chunk when we split the query
-BIG_QUERY_RECENT_HOURS = 3
+BIG_QUERY_RECENT_HOURS = 12
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -31,9 +31,9 @@ MAX_PENDING_LOGBOOK_EVENTS = 2048
 EVENT_COALESCE_TIME = 0.5
 MAX_RECORDER_WAIT = 10
 # minimum size that we will split the query
-BIG_QUERY_HOURS = 13
+BIG_QUERY_HOURS = 25
 # how many hours to deliver in the first chunk when we split the query
-BIG_QUERY_RECENT_HOURS = 12
+BIG_QUERY_RECENT_HOURS = 24
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class LogbookLiveStream:
-    """The a logbook live stream."""
+    """Track a logbook live stream."""
 
     stream_queue: asyncio.Queue[Event]
     subscriptions: list[CALLBACK_TYPE]

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -15,6 +15,7 @@ from homeassistant.components.websocket_api import messages
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.components.websocket_api.const import JSON_DUMP
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_point_in_utc_time
 import homeassistant.util.dt as dt_util
 
 from .helpers import (
@@ -28,6 +29,10 @@ from .processor import EventProcessor
 MAX_PENDING_LOGBOOK_EVENTS = 2048
 EVENT_COALESCE_TIME = 0.5
 MAX_RECORDER_WAIT = 10
+# minimum size that we will split the query
+BIG_QUERY_HOURS = 6
+# how many hours to deliver in the first chunk when we split the query
+BIG_QUERY_RECENT_HOURS = 3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +42,77 @@ def async_setup(hass: HomeAssistant) -> None:
     """Set up the logbook websocket API."""
     websocket_api.async_register_command(hass, ws_get_events)
     websocket_api.async_register_command(hass, ws_event_stream)
+
+
+async def _async_send_historical_events(
+    hass: HomeAssistant,
+    is_big_query: bool,
+    connection: ActiveConnection,
+    msg_id: int,
+    start_time: dt,
+    end_time: dt,
+    formatter: Callable[[int, Any], dict[str, Any]],
+    event_processor: EventProcessor,
+) -> dt | None:
+    """Select historical data from the database and deliver it to the websocket.
+
+    If the query is considered a big query we will split the request into
+    two chunks so that they get the recent events first and the select
+    that is expected to take a long time comes in after to ensure
+    they are not stuck at a loading screen and can start looking at
+    the data right away.
+
+    This function returns the time of the most recent event we sent to the
+    websocket.
+    """
+    if not is_big_query:
+        message, last_event_time = await _async_get_ws_formatted_events(
+            hass,
+            msg_id,
+            start_time,
+            end_time,
+            formatter,
+            event_processor,
+        )
+        # If there is no last_time, there are no historical
+        # results, but we still send an empty message so
+        # consumers of the api know their request was
+        # answered but there were no results
+        connection.send_message(message)
+        return last_event_time
+
+    # This is a big query so we deliver
+    # the first three hours and then
+    # we fetch the old data
+    recent_query_start = start_time - timedelta(hours=BIG_QUERY_RECENT_HOURS)
+    recent_message, recent_query_last_event_time = await _async_get_ws_formatted_events(
+        hass,
+        msg_id,
+        recent_query_start,
+        end_time,
+        formatter,
+        event_processor,
+    )
+
+    if recent_query_last_event_time:
+        connection.send_message(recent_message)
+    older_message, older_query_last_event_time = await _async_get_ws_formatted_events(
+        hass,
+        msg_id,
+        start_time,
+        recent_query_start,
+        formatter,
+        event_processor,
+    )
+    # If there is no last_time, there are no historical
+    # results, but we still send an empty message so
+    # consumers of the api know their request was
+    # answered but there were no results
+    if older_query_last_event_time or not recent_query_last_event_time:
+        connection.send_message(older_message)
+
+    # Returns the time of the newest event
+    return recent_query_last_event_time or older_query_last_event_time
 
 
 async def _async_get_ws_formatted_events(
@@ -116,6 +192,7 @@ async def _async_events_consumer(
     {
         vol.Required("type"): "logbook/event_stream",
         vol.Required("start_time"): str,
+        vol.Optional("end_time"): str,
         vol.Optional("entity_ids"): [str],
         vol.Optional("device_ids"): [str],
     }
@@ -135,11 +212,25 @@ async def ws_event_stream(
         connection.send_error(msg["id"], "invalid_start_time", "Invalid start_time")
         return
 
+    end_time_str = msg.get("end_time")
+    end_time: dt | None = None
+    if end_time_str and (end_time := dt_util.parse_datetime(end_time_str)):
+        end_time = dt_util.as_utc(end_time)
+
+    if end_time and end_time < start_time:
+        connection.send_error(msg["id"], "invalid_end_time", "Invalid end_time")
+        return
+
     device_ids = msg.get("device_ids")
     entity_ids = msg.get("entity_ids")
     if entity_ids:
         entity_ids = async_filter_entities(hass, entity_ids)
     event_types = async_determine_event_types(hass, entity_ids, device_ids)
+    is_big_query = (
+        not entity_ids
+        and not device_ids
+        and ((end_time or utc_now) - start_time) > timedelta(hours=BIG_QUERY_HOURS)
+    )
 
     event_processor = EventProcessor(
         hass,
@@ -151,9 +242,27 @@ async def ws_event_stream(
         include_entity_name=False,
     )
 
-    stream_queue: asyncio.Queue[Event] = asyncio.Queue(MAX_PENDING_LOGBOOK_EVENTS)
+    if end_time and end_time <= utc_now:
+        connection.subscriptions[msg["id"]] = callback(lambda: None)
+        connection.send_result(msg["id"])
+        # Fetch everything from history
+        await _async_send_historical_events(
+            hass,
+            is_big_query,
+            connection,
+            msg["id"],
+            start_time,
+            end_time,
+            messages.event_message,
+            event_processor,
+        )
+        return
+
     subscriptions: list[CALLBACK_TYPE] = []
+    stream_queue: asyncio.Queue[Event] = asyncio.Queue(MAX_PENDING_LOGBOOK_EVENTS)
     setup_complete_future: asyncio.Future[dt] = asyncio.Future()
+    end_time_unsub: CALLBACK_TYPE | None = None
+
     task = asyncio.create_task(
         _async_events_consumer(
             setup_complete_future,
@@ -164,13 +273,19 @@ async def ws_event_stream(
         )
     )
 
-    def _unsub() -> None:
+    @callback
+    def _unsub(*time: Any) -> None:
         """Unsubscribe from all events."""
         for subscription in subscriptions:
             subscription()
         subscriptions.clear()
         if task:
             task.cancel()
+        if end_time_unsub:
+            end_time_unsub()
+
+    if end_time:
+        end_time_unsub = async_track_point_in_utc_time(hass, _unsub, end_time)
 
     @callback
     def _queue_or_cancel(event: Event) -> None:
@@ -184,27 +299,25 @@ async def ws_event_stream(
             )
             _unsub()
 
-    async_subscribe_events(
-        hass, subscriptions, _queue_or_cancel, event_types, entity_ids, device_ids
-    )
+        async_subscribe_events(
+            hass, subscriptions, _queue_or_cancel, event_types, entity_ids, device_ids
+        )
+
     subscriptions_setup_complete_time = dt_util.utcnow()
     connection.subscriptions[msg["id"]] = _unsub
     connection.send_result(msg["id"])
-
     # Fetch everything from history
-    message, last_event_time = await _async_get_ws_formatted_events(
+    last_event_time = await _async_send_historical_events(
         hass,
+        is_big_query,
+        connection,
         msg["id"],
         start_time,
         subscriptions_setup_complete_time,
         messages.event_message,
         event_processor,
     )
-    # If there is no last_time there are no historical
-    # results, but we still send an empty message so
-    # consumers of the api know their request was
-    # answered but there were no results
-    connection.send_message(message)
+
     try:
         await asyncio.wait_for(
             get_instance(hass).async_block_till_done(), MAX_RECORDER_WAIT

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -809,6 +809,252 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
 
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
+async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
+    hass, recorder_mock, hass_ws_client
+):
+    """Test subscribe/unsubscribe logbook stream with specific entities and an end_time."""
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
+
+    await hass.async_block_till_done()
+    init_count = sum(hass.bus.async_listeners().values())
+    hass.states.async_set("light.small", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_OFF)
+    state: State = hass.states.get("binary_sensor.is_light")
+    await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json(
+        {
+            "id": 7,
+            "type": "logbook/event_stream",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(seconds=0.5)).isoformat(),
+            "entity_ids": ["light.small", "binary_sensor.is_light"],
+        }
+    )
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"] == [
+        {
+            "entity_id": "binary_sensor.is_light",
+            "state": "off",
+            "when": state.last_updated.timestamp(),
+        }
+    ]
+
+    hass.states.async_set("light.alpha", STATE_ON)
+    hass.states.async_set("light.alpha", STATE_OFF)
+    hass.states.async_set("light.small", STATE_OFF, {"effect": "help", "color": "blue"})
+
+    await hass.async_block_till_done()
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"] == [
+        {
+            "entity_id": "light.small",
+            "state": "off",
+            "when": ANY,
+        },
+    ]
+
+    hass.states.async_remove("light.alpha")
+    hass.states.async_remove("light.small")
+    await hass.async_block_till_done()
+
+    await asyncio.sleep(0.5)
+    # These states should not be sent since we should be unsubscribed
+    hass.states.async_set("light.small", STATE_ON)
+    hass.states.async_set("light.small", STATE_OFF)
+    await hass.async_block_till_done()
+
+    await websocket_client.send_json(
+        {"id": 8, "type": "unsubscribe_events", "subscription": 7}
+    )
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+
+    assert msg["id"] == 8
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    # Check our listener got unsubscribed
+    assert sum(hass.bus.async_listeners().values()) == init_count
+
+
+@patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
+async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
+    hass, recorder_mock, hass_ws_client
+):
+    """Test subscribe/unsubscribe logbook stream with specific entities in the past."""
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
+
+    await hass.async_block_till_done()
+    init_count = sum(hass.bus.async_listeners().values())
+    hass.states.async_set("light.small", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_OFF)
+    state: State = hass.states.get("binary_sensor.is_light")
+    await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json(
+        {
+            "id": 7,
+            "type": "logbook/event_stream",
+            "start_time": now.isoformat(),
+            "end_time": (dt_util.utcnow() - timedelta(microseconds=1)).isoformat(),
+            "entity_ids": ["light.small", "binary_sensor.is_light"],
+        }
+    )
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"] == [
+        {
+            "entity_id": "binary_sensor.is_light",
+            "state": "off",
+            "when": state.last_updated.timestamp(),
+        }
+    ]
+
+    # These states should not be sent since we should be unsubscribed
+    # since we only asked for the past
+    hass.states.async_set("light.small", STATE_ON)
+    hass.states.async_set("light.small", STATE_OFF)
+    await hass.async_block_till_done()
+
+    await websocket_client.send_json(
+        {"id": 8, "type": "unsubscribe_events", "subscription": 7}
+    )
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+
+    assert msg["id"] == 8
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    # Check our listener got unsubscribed
+    assert sum(hass.bus.async_listeners().values()) == init_count
+
+
+@patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
+async def test_subscribe_unsubscribe_logbook_stream_big_query(
+    hass, recorder_mock, hass_ws_client
+):
+    """Test subscribe/unsubscribe logbook stream with specific entities."""
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, comp, {})
+            for comp in ("homeassistant", "logbook", "automation", "script")
+        ]
+    )
+
+    await hass.async_block_till_done()
+    init_count = sum(hass.bus.async_listeners().values())
+    hass.states.async_set("light.small", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_OFF)
+    state: State = hass.states.get("binary_sensor.is_light")
+    await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json(
+        {
+            "id": 7,
+            "type": "logbook/event_stream",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(seconds=0.5)).isoformat(),
+            "entity_ids": ["light.small", "binary_sensor.is_light"],
+        }
+    )
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"] == [
+        {
+            "entity_id": "binary_sensor.is_light",
+            "state": "off",
+            "when": state.last_updated.timestamp(),
+        }
+    ]
+
+    hass.states.async_set("light.alpha", STATE_ON)
+    hass.states.async_set("light.alpha", STATE_OFF)
+    hass.states.async_set("light.small", STATE_OFF, {"effect": "help", "color": "blue"})
+
+    await hass.async_block_till_done()
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"] == [
+        {
+            "entity_id": "light.small",
+            "state": "off",
+            "when": ANY,
+        },
+    ]
+
+    hass.states.async_remove("light.alpha")
+    hass.states.async_remove("light.small")
+    await hass.async_block_till_done()
+
+    await asyncio.sleep(0.5)
+    # These states should not be sent since we should be unsubscribed
+    hass.states.async_set("light.small", STATE_ON)
+    hass.states.async_set("light.small", STATE_OFF)
+    await hass.async_block_till_done()
+
+    await websocket_client.send_json(
+        {"id": 8, "type": "unsubscribe_events", "subscription": 7}
+    )
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+
+    assert msg["id"] == 8
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    # Check our listener got unsubscribed
+    assert sum(hass.bus.async_listeners().values()) == init_count
+
+
+@patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_device(
     hass, recorder_mock, hass_ws_client
 ):

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -837,7 +837,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
             "id": 7,
             "type": "logbook/event_stream",
             "start_time": now.isoformat(),
-            "end_time": (now + timedelta(seconds=0.5)).isoformat(),
+            "end_time": (now + timedelta(seconds=0.25)).isoformat(),
             "entity_ids": ["light.small", "binary_sensor.is_light"],
         }
     )

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -479,12 +479,12 @@ async def test_subscribe_unsubscribe_logbook_stream(
         {"id": 7, "type": "logbook/event_stream", "start_time": now.isoformat()}
     )
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -512,7 +512,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
 
     hass.states.async_set("light.zulu", "on", {"effect": "help", "color": "blue"})
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -544,7 +544,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -604,7 +604,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
 
     await hass.async_block_till_done()
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -716,7 +716,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}
     )
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
 
     assert msg["id"] == 8
     assert msg["type"] == TYPE_RESULT
@@ -758,12 +758,12 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
         }
     )
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -780,7 +780,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
 
     await hass.async_block_till_done()
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -798,7 +798,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}
     )
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
 
     assert msg["id"] == 8
     assert msg["type"] == TYPE_RESULT
@@ -836,7 +836,7 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
         }
     )
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
@@ -847,7 +847,7 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
     # and its not a failure case. This is useful
     # in the frontend so we can tell the user there
     # are no results vs waiting for them to appear
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == []
@@ -855,7 +855,7 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
     hass.bus.async_fire("mock_event", {"device_id": device.id})
     await hass.async_block_till_done()
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -865,7 +865,7 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}
     )
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
 
     assert msg["id"] == 8
     assert msg["type"] == TYPE_RESULT
@@ -934,7 +934,7 @@ async def test_live_stream_with_one_second_commit_interval(
     )
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "4"})
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
@@ -942,7 +942,7 @@ async def test_live_stream_with_one_second_commit_interval(
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "5"})
 
     recieved_rows = []
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     recieved_rows.extend(msg["event"])
@@ -973,7 +973,7 @@ async def test_live_stream_with_one_second_commit_interval(
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}
     )
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
 
     assert msg["id"] == 8
     assert msg["type"] == TYPE_RESULT
@@ -1013,12 +1013,12 @@ async def test_subscribe_disconnected(hass, recorder_mock, hass_ws_client):
         }
     )
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -1071,7 +1071,7 @@ async def test_stream_consumer_stop_processing(hass, recorder_mock, hass_ws_clie
         )
         await async_wait_recording_done(hass)
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
@@ -1118,7 +1118,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
         }
     )
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
@@ -1129,7 +1129,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     # and its not a failure case. This is useful
     # in the frontend so we can tell the user there
     # are no results vs waiting for them to appear
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == []
@@ -1137,7 +1137,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "1"})
     await hass.async_block_till_done()
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -1147,7 +1147,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "2"})
     await hass.async_block_till_done()
 
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
@@ -1157,7 +1157,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}
     )
-    msg = await websocket_client.receive_json()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
 
     assert msg["id"] == 8
     assert msg["type"] == TYPE_RESULT

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -970,7 +970,11 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
 async def test_subscribe_unsubscribe_logbook_stream_big_query(
     hass, recorder_mock, hass_ws_client
 ):
-    """Test subscribe/unsubscribe logbook stream with specific entities."""
+    """Test subscribe/unsubscribe logbook stream and ask for a large time frame.
+
+    We should get the data for the first 24 hours in the first message, and
+    anything older will come in a followup message.
+    """
     now = dt_util.utcnow()
     await asyncio.gather(
         *[

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from datetime import timedelta
 from unittest.mock import ANY, patch
 
+from freezegun import freeze_time
 import pytest
 
 from homeassistant import core
@@ -980,21 +981,34 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
 
     await hass.async_block_till_done()
     init_count = sum(hass.bus.async_listeners().values())
-    hass.states.async_set("light.small", STATE_ON)
-    hass.states.async_set("binary_sensor.is_light", STATE_ON)
-    hass.states.async_set("binary_sensor.is_light", STATE_OFF)
-    state: State = hass.states.get("binary_sensor.is_light")
-    await hass.async_block_till_done()
+    four_days_ago = now - timedelta(days=4)
+    five_days_ago = now - timedelta(days=5)
+
+    with freeze_time(four_days_ago):
+        hass.states.async_set("binary_sensor.four_days_ago", STATE_ON)
+        hass.states.async_set("binary_sensor.four_days_ago", STATE_OFF)
+        four_day_old_state: State = hass.states.get("binary_sensor.four_days_ago")
+        await hass.async_block_till_done()
 
     await async_wait_recording_done(hass)
+    # Verify our state was recorded in the past
+    assert (now - four_day_old_state.last_updated).total_seconds() > 86400 * 3
+
+    hass.states.async_set("binary_sensor.is_light", STATE_OFF)
+    hass.states.async_set("binary_sensor.is_light", STATE_ON)
+    current_state: State = hass.states.get("binary_sensor.is_light")
+
+    # Verify our new state was recorded in the recent timeframe
+    assert (now - current_state.last_updated).total_seconds() < 2
+
+    await async_wait_recording_done(hass)
+
     websocket_client = await hass_ws_client()
     await websocket_client.send_json(
         {
             "id": 7,
             "type": "logbook/event_stream",
-            "start_time": now.isoformat(),
-            "end_time": (now + timedelta(seconds=0.5)).isoformat(),
-            "entity_ids": ["light.small", "binary_sensor.is_light"],
+            "start_time": five_days_ago.isoformat(),
         }
     )
 
@@ -1003,43 +1017,29 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
+    # With a big query we get the current state first
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
         {
             "entity_id": "binary_sensor.is_light",
-            "state": "off",
-            "when": state.last_updated.timestamp(),
+            "state": "on",
+            "when": current_state.last_updated.timestamp(),
         }
     ]
 
-    hass.states.async_set("light.alpha", STATE_ON)
-    hass.states.async_set("light.alpha", STATE_OFF)
-    hass.states.async_set("light.small", STATE_OFF, {"effect": "help", "color": "blue"})
-
-    await hass.async_block_till_done()
-
+    # With a big query we get the old states second
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
     assert msg["event"] == [
         {
-            "entity_id": "light.small",
+            "entity_id": "binary_sensor.four_days_ago",
             "state": "off",
-            "when": ANY,
-        },
+            "when": four_day_old_state.last_updated.timestamp(),
+        }
     ]
-
-    hass.states.async_remove("light.alpha")
-    hass.states.async_remove("light.small")
-    await hass.async_block_till_done()
-
-    await asyncio.sleep(0.5)
-    # These states should not be sent since we should be unsubscribed
-    hass.states.async_set("light.small", STATE_ON)
-    hass.states.async_set("light.small", STATE_OFF)
-    await hass.async_block_till_done()
 
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -27,7 +27,11 @@ from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, SetupRecorderInstanceT
+from tests.common import (
+    MockConfigEntry,
+    SetupRecorderInstanceT,
+    async_fire_time_changed,
+)
 from tests.components.recorder.common import (
     async_block_recorder,
     async_recorder_block_till_done,
@@ -837,7 +841,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
             "id": 7,
             "type": "logbook/event_stream",
             "start_time": now.isoformat(),
-            "end_time": (now + timedelta(seconds=0.25)).isoformat(),
+            "end_time": (now + timedelta(minutes=10)).isoformat(),
             "entity_ids": ["light.small", "binary_sensor.is_light"],
         }
     )
@@ -879,7 +883,9 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
     hass.states.async_remove("light.small")
     await hass.async_block_till_done()
 
-    await asyncio.sleep(0.5)
+    async_fire_time_changed(hass, now + timedelta(minutes=11))
+    await hass.async_block_till_done()
+
     # These states should not be sent since we should be unsubscribed
     hass.states.async_set("light.small", STATE_ON)
     hass.states.async_set("light.small", STATE_OFF)
@@ -895,7 +901,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
     assert msg["success"]
 
     # Check our listener got unsubscribed
-    assert sum(hass.bus.async_listeners().values()) == init_count
+    assert sum(hass.bus.async_listeners().values()) <= init_count
 
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)


### PR DESCRIPTION
Frontend PR https://github.com/home-assistant/frontend/pull/12753

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Marks the RowAsEvent dataclass as frozen
- Avoids running the queue processor task if the connection gets unsubscribed before the results are delivered from the database
- If query asks for more than 25 hours of past data, we send the most recent 24 hours first, and the older data in a second response so they aren't waiting for the history.
- Supports an `end_time` in the past (useful with big queries) or future (for when to cut off streaming)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
