### PR TITLE
Support filtering state changes attributed to a service call (version 2)

### DIFF
--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import (
     ToggleEntity,
     ToggleEntityDescription,
+    async_false_filter,
     state_filter,
 )
 from homeassistant.helpers.entity_component import EntityComponent
@@ -78,7 +79,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     ) -> None:
         """Handle turning off a light."""
         # pylint: disable-next=protected-access
-        switch._context_filter = state_filter(STATE_OFF)
+        if switch.is_on:
+            switch.async_set_context_filter(state_filter(STATE_OFF))
+        else:
+            switch.async_set_context_filter(async_false_filter)
         await switch.async_turn_off()
 
     async def async_handle_switch_on_service(
@@ -86,7 +90,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     ) -> None:
         """Handle turning off a light."""
         # pylint: disable-next=protected-access
-        switch._context_filter = state_filter(STATE_ON)
+        if not switch.is_on:
+            switch.async_set_context_filter(state_filter(STATE_ON))
+        else:
+            switch.async_set_context_filter(async_false_filter)
         await switch.async_turn_on()
 
     async def async_handle_toggle_service(

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -79,7 +79,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Handle turning off a light."""
         # pylint: disable-next=protected-access
         switch._context_filter = state_filter(STATE_OFF)
-        await switch.async_turn_off(**call.data["params"])
+        await switch.async_turn_off()
 
     async def async_handle_switch_on_service(
         switch: SwitchEntity, call: ServiceCall
@@ -87,7 +87,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Handle turning off a light."""
         # pylint: disable-next=protected-access
         switch._context_filter = state_filter(STATE_ON)
-        await switch.async_turn_on(**call.data["params"])
+        await switch.async_turn_on()
 
     async def async_handle_toggle_service(
         switch: SwitchEntity, call: ServiceCall

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -134,11 +134,11 @@ async def test_switch_context_filtering(
     assert state.state == STATE_ON
     assert state.context is not context
 
-    # Change state to off again, the state change should be attributed to the context
+    # Change state to off again, the state change should not be attributed to the context
     entity.async_set_state(STATE_OFF)
     state = hass.states.get("switch.test1")
     assert state.state == STATE_OFF
-    assert state.context is context
+    assert state.context is not context
 
     # Bump time and change state, the state change should not be attributed to the context
     freezer.tick(timedelta(seconds=5.001))
@@ -177,11 +177,11 @@ async def test_switch_context_filtering(
     assert state.state == STATE_OFF
     assert state.context is not context
 
-    # Change state to on again, the state change should be attributed to the context
+    # Change state to on again, the state change should not be attributed to the context
     entity.async_set_state(STATE_ON)
     state = hass.states.get("switch.test1")
     assert state.state == STATE_ON
-    assert state.context is context
+    assert state.context is not context
 
     # Turn the switch on when it's already on
     context = core.Context(user_id=hass_admin_user.id)
@@ -193,13 +193,13 @@ async def test_switch_context_filtering(
         context,
     )
 
-    # Force update state to on, the state change should be attributed to the context
+    # Force update state to on, the state change should not be attributed to the context
     prev_state = state
     entity.async_set_state(STATE_ON)
     state = hass.states.get("switch.test1")
     assert state is not prev_state
     assert state.state == STATE_ON
-    assert state.context is context
+    assert state.context is not context
 
     # Change state to off, the state change should not be attributed to the context
     entity.async_set_state(STATE_OFF)
@@ -207,11 +207,11 @@ async def test_switch_context_filtering(
     assert state.state == STATE_OFF
     assert state.context is not context
 
-    # Change state back to on, the state change should be attributed to the context
+    # Change state back to on, the state change should not be attributed to the context
     entity.async_set_state(STATE_ON)
     state = hass.states.get("switch.test1")
     assert state.state == STATE_ON
-    assert state.context is context
+    assert state.context is not context
 
     # Change state to off again, the state change should not be attributed to the context
     entity.async_set_state(STATE_OFF)
@@ -229,13 +229,13 @@ async def test_switch_context_filtering(
         context,
     )
 
-    # Force update state to off, the state change should be attributed to the context
+    # Force update state to off, the state change should not be attributed to the context
     prev_state = state
     entity.async_set_state(STATE_OFF)
     state = hass.states.get("switch.test1")
     assert state is not prev_state
     assert state.state == STATE_OFF
-    assert state.context is context
+    assert state.context is not context
 
     # Change state to on, the state change should not be attributed to the context
     entity.async_set_state(STATE_ON)
@@ -243,11 +243,11 @@ async def test_switch_context_filtering(
     assert state.state == STATE_ON
     assert state.context is not context
 
-    # Change state back to off, the state change should be attributed to the context
+    # Change state back to off, the state change should not be attributed to the context
     entity.async_set_state(STATE_OFF)
     state = hass.states.get("switch.test1")
     assert state.state == STATE_OFF
-    assert state.context is context
+    assert state.context is not context
 
     # Change state to on again, the state change should not be attributed to the context
     entity.async_set_state(STATE_ON)

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -1,15 +1,17 @@
 """The tests for the Switch component."""
+from datetime import timedelta
+
 import pytest
 
 from homeassistant import core
 from homeassistant.components import switch
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 from tests.components.switch import common
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def entities(hass):
     """Initialize the test switch."""
     platform = getattr(hass.components, "test.switch")
@@ -72,3 +74,183 @@ async def test_switch_context(
     assert state2 is not None
     assert state.state != state2.state
     assert state2.context.user_id == hass_admin_user.id
+
+
+async def test_switch_context_filtering(
+    hass, hass_admin_user, enable_custom_integrations, freezer
+):
+    """Test that switch context works."""
+    platform = getattr(hass.components, "test.switch")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(
+        platform.MockToggleEntity("test1", STATE_ON, optimistic=False)
+    )
+
+    entity = platform.ENTITIES[0]
+    # Enable forced updates and turn off polling to get full control over state changes
+    entity._attr_force_update = True
+    entity._attr_should_poll = False
+
+    assert await async_setup_component(hass, "switch", {"switch": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    assert entity.entity_id == "switch.test1"
+
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+
+    # Turn the switch off when it's on
+    context = core.Context(user_id=hass_admin_user.id)
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.test1"},
+        True,
+        context,
+    )
+    # Make sure the switch is not optimistic
+    prev_state = state
+    state = hass.states.get("switch.test1")
+    assert state is prev_state
+
+    # Force update state to on, the state change should not be attributed to the context
+    prev_state = state
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state is not prev_state
+    assert state.state == STATE_ON
+    assert state.context is not context
+
+    # Change state to off, the state change should be attributed to the context
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is context
+
+    # Change state back to on, the state change should not be attributed to the context
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+    assert state.context is not context
+
+    # Change state to off again, the state change should be attributed to the context
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is context
+
+    # Bump time and change state, the state change should not be attributed to the context
+    freezer.tick(timedelta(seconds=5.001))
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is not context
+
+    # Turn the switch on when it's off
+    context = core.Context(user_id=hass_admin_user.id)
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.test1"},
+        True,
+        context,
+    )
+
+    # Force update state to off, the state change should not be attributed to the context
+    prev_state = state
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state is not prev_state
+    assert state.state == STATE_OFF
+    assert state.context is not context
+
+    # Change state to on, the state change should be attributed to the context
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+    assert state.context is context
+
+    # Change state back to off, the state change should not be attributed to the context
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is not context
+
+    # Change state to on again, the state change should be attributed to the context
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+    assert state.context is context
+
+    # Turn the switch on when it's already on
+    context = core.Context(user_id=hass_admin_user.id)
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.test1"},
+        True,
+        context,
+    )
+
+    # Force update state to on, the state change should be attributed to the context
+    prev_state = state
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state is not prev_state
+    assert state.state == STATE_ON
+    assert state.context is context
+
+    # Change state to off, the state change should not be attributed to the context
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is not context
+
+    # Change state back to on, the state change should be attributed to the context
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+    assert state.context is context
+
+    # Change state to off again, the state change should not be attributed to the context
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is not context
+
+    # Turn the switch off when it's already off
+    context = core.Context(user_id=hass_admin_user.id)
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.test1"},
+        True,
+        context,
+    )
+
+    # Force update state to off, the state change should be attributed to the context
+    prev_state = state
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state is not prev_state
+    assert state.state == STATE_OFF
+    assert state.context is context
+
+    # Change state to on, the state change should not be attributed to the context
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+    assert state.context is not context
+
+    # Change state back to off, the state change should be attributed to the context
+    entity.async_set_state(STATE_OFF)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_OFF
+    assert state.context is context
+
+    # Change state to on again, the state change should not be attributed to the context
+    entity.async_set_state(STATE_ON)
+    state = hass.states.get("switch.test1")
+    assert state.state == STATE_ON
+    assert state.context is not context


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support filtering state changes attributed to a service call, to help avoid false positives in the logbook

This PR has the same goal as #72084, but the implementation is a little bit different.

The false positives are caused by *any* state change within a 5s window of firing off a service call being attributed to that service call.

As an example of a false positive, consider an automation "Morning lights" turning some lights on in the morning.
If the same light is turned off by something else at around the same time as the automation runs, the logbook will currently unhelpfully claim something like this:
![image](https://user-images.githubusercontent.com/14281572/169251597-0195a506-6713-44ed-bef6-cfd7ed41a67d.png)

This is really confusing, sending users off on a wild goose chase trying to understand why their "Wakeup lights" automation is turning lights off sometimes.

This PR has a proposal for how that could be achieved, with `switch` entity services as an example

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
