### PR TITLE
Add support for AtlanticPassAPCZoneControl to Overkiz integration 

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -2,7 +2,9 @@
 from pyoverkiz.enums.ui import UIWidget
 
 from .atlantic_electrical_heater import AtlanticElectricalHeater
+from .atlantic_pass_apc_zone_control import AtlanticPassAPCZoneControl
 
 WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: AtlanticElectricalHeater,
+    UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
 }

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
@@ -1,0 +1,47 @@
+"""Support for Atlantic Pass APC Zone Control."""
+from typing import cast
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+)
+from homeassistant.components.overkiz.entity import OverkizEntity
+from homeassistant.const import TEMP_CELSIUS
+
+# Map TaHoma HVAC modes to Home Assistant HVAC modes
+OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
+    OverkizCommandParam.HEATING: HVAC_MODE_HEAT,
+    OverkizCommandParam.DRYING: HVAC_MODE_DRY,
+    OverkizCommandParam.COOLING: HVAC_MODE_COOL,
+    OverkizCommandParam.STOP: HVAC_MODE_OFF,
+}
+
+HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+
+
+class AtlanticPassAPCZoneControl(OverkizEntity, ClimateEntity):
+    """Representation of Atlantic Pass APC Zone Control."""
+
+    _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
+    _attr_supported_features = 0
+    _attr_temperature_unit = TEMP_CELSIUS
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+        return OVERKIZ_TO_HVAC_MODE[
+            cast(
+                str, self.executor.select_state(OverkizState.IO_PASS_APC_OPERATING_MODE)
+            )
+        ]
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_PASS_APC_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
+        )

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
@@ -4,20 +4,15 @@ from typing import cast
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-)
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.components.overkiz.entity import OverkizEntity
 from homeassistant.const import TEMP_CELSIUS
 
 OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
-    OverkizCommandParam.HEATING: HVAC_MODE_HEAT,
-    OverkizCommandParam.DRYING: HVAC_MODE_DRY,
-    OverkizCommandParam.COOLING: HVAC_MODE_COOL,
-    OverkizCommandParam.STOP: HVAC_MODE_OFF,
+    OverkizCommandParam.HEATING: HVACMode.HEAT,
+    OverkizCommandParam.DRYING: HVACMode.DRY,
+    OverkizCommandParam.COOLING: HVACMode.COOL,
+    OverkizCommandParam.STOP: HVACMode.OFF,
 }
 
 HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
@@ -13,7 +13,6 @@ from homeassistant.components.climate.const import (
 from homeassistant.components.overkiz.entity import OverkizEntity
 from homeassistant.const import TEMP_CELSIUS
 
-# Map TaHoma HVAC modes to Home Assistant HVAC modes
 OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
     OverkizCommandParam.HEATING: HVAC_MODE_HEAT,
     OverkizCommandParam.DRYING: HVAC_MODE_DRY,

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control.py
@@ -27,7 +27,6 @@ class AtlanticPassAPCZoneControl(OverkizEntity, ClimateEntity):
     """Representation of Atlantic Pass APC Zone Control."""
 
     _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
-    _attr_supported_features = 0
     _attr_temperature_unit = TEMP_CELSIUS
 
     @property

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -62,6 +62,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIClass.WINDOW: Platform.COVER,
     UIWidget.ALARM_PANEL_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
+    UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIWidget.MY_FOX_ALARM_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.MY_FOX_SECURITY_CAMERA: Platform.SWITCH,  # widgetName, uiClass is Camera (not supported)


### PR DESCRIPTION
## Proposed change
Part of the efforts to support all Overkiz climate devices. This time the AtlanticPassAPCZoneControl, where only the mode can be changed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
