### PR TITLE
Add support for AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint to Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -2,7 +2,11 @@
 from pyoverkiz.enums.ui import UIWidget
 
 from .atlantic_electrical_heater import AtlanticElectricalHeater
+from .atlantic_electrical_heater_with_adjustable_temperature_setpoint import (
+    AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
+)
 
 WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: AtlanticElectricalHeater,
+    UIWidget.ATLANTIC_ELECTRICAL_HEATER_WITH_ADJUSTABLE_TEMPERATURE_SETPOINT: AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
 }

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -1,23 +1,17 @@
 """Support for Atlantic Electrical Heater With Adjustable Temperature Setpoint."""
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
-from homeassistant.components.climate import (
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-    ClimateEntity,
-)
+from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
     PRESET_BOOST,
     PRESET_COMFORT,
     PRESET_ECO,
     PRESET_NONE,
+    HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
@@ -29,7 +23,7 @@ PRESET_FROST_PROTECTION = "frost_protection"
 PRESET_PROG = "prog"
 
 # Map OVERKIZ presets to Home Assistant presets
-OVERKIZ_TO_PRESET_MODE = {
+OVERKIZ_TO_PRESET_MODE: dict[str, str] = {
     OverkizCommandParam.OFF: PRESET_NONE,
     OverkizCommandParam.FROSTPROTECTION: PRESET_FROST_PROTECTION,
     OverkizCommandParam.ECO: PRESET_ECO,
@@ -42,13 +36,13 @@ OVERKIZ_TO_PRESET_MODE = {
 PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
 
 # Map OVERKIZ HVAC modes to Home Assistant HVAC modes
-OVERKIZ_TO_HVAC_MODE = {
-    OverkizCommandParam.ON: HVAC_MODE_HEAT,
-    OverkizCommandParam.OFF: HVAC_MODE_OFF,
-    OverkizCommandParam.AUTO: HVAC_MODE_AUTO,
-    "basic": HVAC_MODE_HEAT,
-    OverkizCommandParam.STANDBY: HVAC_MODE_OFF,
-    OverkizCommandParam.INTERNAL: HVAC_MODE_AUTO,
+OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
+    OverkizCommandParam.ON: HVACMode.HEAT,
+    OverkizCommandParam.OFF: HVACMode.OFF,
+    OverkizCommandParam.AUTO: HVACMode.AUTO,
+    OverkizCommandParam.BASIC: HVACMode.HEAT,
+    OverkizCommandParam.STANDBY: HVACMode.OFF,
+    OverkizCommandParam.INTERNAL: HVACMode.AUTO,
 }
 
 HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
@@ -62,7 +56,9 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
     _attr_preset_modes = [*PRESET_MODE_TO_OVERKIZ]
     _attr_temperature_unit = TEMP_CELSIUS
-    _attr_supported_features = SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
+    _attr_supported_features = (
+        ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
+    )
 
     def __init__(
         self, device_url: str, coordinator: OverkizDataUpdateCoordinator
@@ -76,12 +72,14 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         """Return hvac operation ie. heat, cool mode."""
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
             return OVERKIZ_TO_HVAC_MODE[
-                self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
+                cast(str, self.executor.select_state(OverkizState.CORE_OPERATING_MODE))
             ]
         if OverkizState.CORE_ON_OFF in self.device.states:
             return OVERKIZ_TO_HVAC_MODE[
-                self.executor.select_state(OverkizState.CORE_ON_OFF)
+                cast(str, self.executor.select_state(OverkizState.CORE_ON_OFF))
             ]
+
+        return HVACMode.OFF
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
@@ -90,7 +88,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
                 OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
             )
         else:
-            if hvac_mode == HVAC_MODE_OFF:
+            if hvac_mode == HVACMode.OFF:
                 await self.executor.async_execute_command(
                     OverkizCommand.OFF,
                 )
@@ -103,12 +101,12 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         return OVERKIZ_TO_PRESET_MODE[
-            self.executor.select_state(OverkizState.IO_TARGET_HEATING_LEVEL)
+            cast(str, self.executor.select_state(OverkizState.IO_TARGET_HEATING_LEVEL))
         ]
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        if [PRESET_AUTO, PRESET_PROG] in preset_mode:
+        if preset_mode in [PRESET_AUTO, PRESET_PROG]:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_OPERATING_MODE, PRESET_MODE_TO_OVERKIZ[preset_mode]
             )
@@ -120,7 +118,9 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature."""
-        return self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+        return cast(
+            float, self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+        )
 
     @property
     def current_temperature(self) -> float | None:
@@ -130,7 +130,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
 
         return None
 
-    async def async_set_temperature(self, **kwargs) -> None:
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
 

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -1,0 +1,139 @@
+"""Support for Atlantic Electrical Heater With Adjustable Temperature Setpoint."""
+from __future__ import annotations
+
+from typing import cast
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from homeassistant.components.climate import (
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+    ClimateEntity,
+)
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_NONE,
+)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+from ..coordinator import OverkizDataUpdateCoordinator
+from ..entity import OverkizEntity
+
+PRESET_AUTO = "auto"
+PRESET_FROST_PROTECTION = "frost_protection"
+PRESET_PROG = "prog"
+
+# Map OVERKIZ presets to Home Assistant presets
+OVERKIZ_TO_PRESET_MODE = {
+    OverkizCommandParam.OFF: PRESET_NONE,
+    OverkizCommandParam.FROSTPROTECTION: PRESET_FROST_PROTECTION,
+    OverkizCommandParam.ECO: PRESET_ECO,
+    OverkizCommandParam.COMFORT: PRESET_COMFORT,
+    OverkizCommandParam.AUTO: PRESET_AUTO,
+    OverkizCommandParam.BOOST: PRESET_BOOST,
+    OverkizCommandParam.INTERNAL: PRESET_PROG,
+}
+
+PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
+
+# Map OVERKIZ HVAC modes to Home Assistant HVAC modes
+OVERKIZ_TO_HVAC_MODE = {
+    OverkizCommandParam.ON: HVAC_MODE_HEAT,
+    OverkizCommandParam.OFF: HVAC_MODE_OFF,
+    OverkizCommandParam.AUTO: HVAC_MODE_AUTO,
+    "basic": HVAC_MODE_HEAT,
+    OverkizCommandParam.STANDBY: HVAC_MODE_OFF,
+    OverkizCommandParam.INTERNAL: HVAC_MODE_AUTO,
+}
+
+HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+
+
+class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
+    OverkizEntity, ClimateEntity
+):
+    """Representation of Atlantic Electrical Heater With Adjustable Temperature Setpoint."""
+
+    _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
+    _attr_preset_modes = [*PRESET_MODE_TO_OVERKIZ]
+    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_supported_features = SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Init method."""
+        super().__init__(device_url, coordinator)
+        self.temperature_device = self.executor.linked_device(2)
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+        if OverkizState.CORE_OPERATING_MODE in self.device.states:
+            return OVERKIZ_TO_HVAC_MODE[
+                self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
+            ]
+        if OverkizState.CORE_ON_OFF in self.device.states:
+            return OVERKIZ_TO_HVAC_MODE[
+                self.executor.select_state(OverkizState.CORE_ON_OFF)
+            ]
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        if OverkizState.CORE_OPERATING_MODE in self.device.states:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
+            )
+        else:
+            if hvac_mode == HVAC_MODE_OFF:
+                await self.executor.async_execute_command(
+                    OverkizCommand.OFF,
+                )
+            else:
+                await self.executor.async_execute_command(
+                    OverkizCommand.SET_HEATING_LEVEL, OverkizCommandParam.COMFORT
+                )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return OVERKIZ_TO_PRESET_MODE[
+            self.executor.select_state(OverkizState.IO_TARGET_HEATING_LEVEL)
+        ]
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if [PRESET_AUTO, PRESET_PROG] in preset_mode:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_OPERATING_MODE, PRESET_MODE_TO_OVERKIZ[preset_mode]
+            )
+        else:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_HEATING_LEVEL, PRESET_MODE_TO_OVERKIZ[preset_mode]
+            )
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the temperature."""
+        return self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+            return cast(float, temperature.value)
+
+        return None
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new temperature."""
+        temperature = kwargs[ATTR_TEMPERATURE]
+
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_TARGET_TEMPERATURE, temperature
+        )

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -37,6 +37,10 @@ class OverkizExecutor:
         """Return Overkiz device linked to this entity."""
         return self.coordinator.data[self.device_url]
 
+    def linked_device(self, index: int) -> Device:
+        """Return Overkiz device sharing the same base url."""
+        return self.coordinator.data[f"{self.base_device_url}#{index}"]
+
     def select_command(self, *commands: str) -> str | None:
         """Select first existing command in a list of commands."""
         existing_commands = self.device.definition.commands


### PR DESCRIPTION
## Proposed change
Part of the efforts to support all Overkiz climate devices. This time the AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint, where only the mode can be changed.

This device is pretty complex, hopefully the code and logic is clear enough.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
