### PR TITLE
Add metadata to logbook live stream websocket endpoint

### DIFF
--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -1090,6 +1090,7 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
+    assert msg["event"]["partial"] is True
     assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.four_days_ago",
@@ -1097,6 +1098,13 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
             "when": four_day_old_state.last_updated.timestamp(),
         }
     ]
+
+    # And finally a response without partial set to indicate no more
+    # historical data is coming
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"]["events"] == []
 
     await websocket_client.send_json(
         {"id": 8, "type": "unsubscribe_events", "subscription": 7}

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -492,13 +492,16 @@ async def test_subscribe_unsubscribe_logbook_stream(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.is_light",
             "state": "off",
             "when": state.last_updated.timestamp(),
         }
     ]
+    assert msg["event"]["start_time"] == now.timestamp()
+    assert msg["event"]["end_time"] > msg["event"]["start_time"]
+    assert msg["event"]["partial"] is True
 
     hass.states.async_set("light.alpha", "on")
     hass.states.async_set("light.alpha", "off")
@@ -520,7 +523,14 @@ async def test_subscribe_unsubscribe_logbook_stream(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert "partial" not in msg["event"]["events"]
+    assert msg["event"]["events"] == []
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert "partial" not in msg["event"]["events"]
+    assert msg["event"]["events"] == [
         {
             "entity_id": "light.alpha",
             "state": "off",
@@ -560,7 +570,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "context_id": ANY,
             "domain": "automation",
@@ -624,7 +634,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "context_id": "ac5bd62de45711eaaeb351041eec8dd9",
             "context_user_id": "b400facee45711eaa9308bfd3d19e474",
@@ -686,7 +696,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
     msg = await websocket_client.receive_json()
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "context_domain": "automation",
             "context_entity_id": "automation.alarm",
@@ -716,7 +726,7 @@ async def test_subscribe_unsubscribe_logbook_stream(
     msg = await websocket_client.receive_json()
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "context_domain": "automation",
             "context_entity_id": "automation.alarm",
@@ -788,7 +798,10 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert "start_time" in msg["event"]
+    assert "end_time" in msg["event"]
+    assert msg["event"]["partial"] is True
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.is_light",
             "state": "off",
@@ -805,7 +818,16 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert "start_time" in msg["event"]
+    assert "end_time" in msg["event"]
+    assert "partial" not in msg["event"]
+    assert msg["event"]["events"] == []
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert "partial" not in msg["event"]
+    assert msg["event"]["events"] == [
         {
             "entity_id": "light.small",
             "state": "off",
@@ -871,7 +893,8 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["partial"] is True
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.is_light",
             "state": "off",
@@ -888,7 +911,14 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert "partial" not in msg["event"]
+    assert msg["event"]["events"] == []
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert "partial" not in msg["event"]
+    assert msg["event"]["events"] == [
         {
             "entity_id": "light.small",
             "state": "off",
@@ -962,7 +992,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.is_light",
             "state": "off",
@@ -1048,7 +1078,7 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.is_light",
             "state": "on",
@@ -1060,7 +1090,7 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.four_days_ago",
             "state": "off",
@@ -1123,7 +1153,7 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == []
+    assert msg["event"]["events"] == []
 
     hass.bus.async_fire("mock_event", {"device_id": device.id})
     await hass.async_block_till_done()
@@ -1131,7 +1161,7 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {"domain": "test", "message": "is on fire", "name": "device name", "when": ANY}
     ]
 
@@ -1250,7 +1280,7 @@ async def test_live_stream_with_one_second_commit_interval(
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    recieved_rows.extend(msg["event"])
+    recieved_rows.extend(msg["event"]["events"])
 
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "6"})
 
@@ -1262,7 +1292,7 @@ async def test_live_stream_with_one_second_commit_interval(
         msg = await asyncio.wait_for(websocket_client.receive_json(), 2.5)
         assert msg["id"] == 7
         assert msg["type"] == "event"
-        recieved_rows.extend(msg["event"])
+        recieved_rows.extend(msg["event"]["events"])
 
     # Make sure we get rows back in order
     assert recieved_rows == [
@@ -1326,7 +1356,7 @@ async def test_subscribe_disconnected(hass, recorder_mock, hass_ws_client):
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {
             "entity_id": "binary_sensor.is_light",
             "state": "off",
@@ -1437,7 +1467,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == []
+    assert msg["event"]["events"] == []
 
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "1"})
     await hass.async_block_till_done()
@@ -1445,7 +1475,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {"domain": "test", "message": "1", "name": "device name", "when": ANY}
     ]
 
@@ -1455,7 +1485,7 @@ async def test_recorder_is_far_behind(hass, recorder_mock, hass_ws_client, caplo
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    assert msg["event"] == [
+    assert msg["event"]["events"] == [
         {"domain": "test", "message": "2", "name": "device name", "when": ANY}
     ]
 


### PR DESCRIPTION
Frontend PR https://github.com/home-assistant/frontend/pull/12755


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The response format has changed:
```
{
  'events': list[...],
  'start_time': float | None
  'end_time': float | None
  'partial': bool
}
```

`events` now contains the event stream
`start_time` is the start time of the query against the historical data (only present for historical data)
`end_time` is the end time of the query against the historical data (only present for historical data)
`partial` if present indicates more historical data is coming in a future message.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
