### PR TITLE
Bump zwave-js-server-python to 0.37.0

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -114,8 +114,7 @@ DRY_RUN = "dry_run"
 # constants for inclusion
 INCLUSION_STRATEGY = "inclusion_strategy"
 
-# Remove type ignore when bumping library to 0.37.0
-INCLUSION_STRATEGY_NOT_SMART_START: dict[  # type: ignore[misc]
+INCLUSION_STRATEGY_NOT_SMART_START: dict[
     int,
     Literal[
         InclusionStrategy.DEFAULT,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -238,7 +238,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         if self._current_mode is None or self._current_mode.value is None:
             # Thermostat(valve) with no support for setting a mode is considered heating-only
             return [ThermostatSetpointType.HEATING]
-        return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])  # type: ignore[no-any-return]
+        return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])
 
     @property
     def temperature_unit(self) -> str:

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -326,7 +326,9 @@ async def async_get_action_capabilities(
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
                             CommandClass(cc.id).value: cc.name
-                            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore[no-any-return]
+                            for cc in sorted(
+                                node.command_classes, key=lambda cc: cc.name
+                            )
                         }
                     ),
                     vol.Required(ATTR_PROPERTY): cv.string,

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -221,7 +221,9 @@ async def async_get_condition_capabilities(
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
                             CommandClass(cc.id).value: cc.name
-                            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore[no-any-return]
+                            for cc in sorted(
+                                node.command_classes, key=lambda cc: cc.name
+                            )
                             if cc.id != CommandClass.CONFIGURATION
                         }
                     ),

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -534,7 +534,9 @@ async def async_get_trigger_capabilities(
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
                             CommandClass(cc.id).value: cc.name
-                            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore[no-any-return]
+                            for cc in sorted(
+                                node.command_classes, key=lambda cc: cc.name
+                            )
                             if cc.id != CommandClass.CONFIGURATION
                         }
                     ),

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -505,7 +505,7 @@ class ConfigurableFanValueMappingDataTemplate(
         self, value: ZwaveValue
     ) -> dict[str, ZwaveConfigurationValue | None]:
         """Resolve helper class data for a discovered value."""
-        zwave_value = cast(  # type: ignore[redundant-cast]
+        zwave_value = cast(
             Union[ZwaveConfigurationValue, None],
             self._get_value_from_id(value.node, self.configuration_option),
         )

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.36.1"],
+  "requirements": ["zwave-js-server-python==0.37.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["usb", "http", "websocket_api"],
   "iot_class": "local_push",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2528,7 +2528,7 @@ zigpy==0.45.1
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.36.1
+zwave-js-server-python==0.37.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1665,7 +1665,7 @@ zigpy-znp==0.7.0
 zigpy==0.45.1
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.36.1
+zwave-js-server-python==0.37.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.4

--- a/tests/components/zwave_js/fixtures/aeon_smart_switch_6_state.json
+++ b/tests/components/zwave_js/fixtures/aeon_smart_switch_6_state.json
@@ -51,7 +51,14 @@
       "index": 0,
       "installerIcon": 1792,
       "userIcon": 1792,
-      "commandClasses": []
+      "commandClasses": [
+        {
+          "id": 50,
+          "name": "Meter",
+          "version": 3,
+          "isSecure": false
+        }
+      ]
     }
   ],
   "values": [

--- a/tests/components/zwave_js/fixtures/climate_danfoss_lc_13_state.json
+++ b/tests/components/zwave_js/fixtures/climate_danfoss_lc_13_state.json
@@ -126,7 +126,63 @@
   "endpoints": [
     {
       "nodeId": 5,
-      "index": 0
+      "index": 0,
+      "commandClasses": [
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 70,
+          "name": "Climate Control Schedule",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 117,
+          "name": "Protection",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 132,
+          "name": "Wake Up",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 143,
+          "name": "Multi Command",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
     }
   ],
   "values": [

--- a/tests/components/zwave_js/fixtures/climate_radio_thermostat_ct100_plus_different_endpoints_state.json
+++ b/tests/components/zwave_js/fixtures/climate_radio_thermostat_ct100_plus_different_endpoints_state.json
@@ -62,7 +62,123 @@
         },
         "mandatorySupportedCCs": [32, 114, 64, 67, 134],
         "mandatoryControlledCCs": []
-      }
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 5,
+          "isSecure": false
+        },
+        {
+          "id": 64,
+          "name": "Thermostat Mode",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 66,
+          "name": "Thermostat Operating State",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 68,
+          "name": "Thermostat Fan Mode",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 69,
+          "name": "Thermostat Fan State",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 96,
+          "name": "Multi Channel",
+          "version": 4,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 3,
+          "isSecure": false
+        }
+      ]
     },
     {
       "nodeId": 26,
@@ -82,7 +198,123 @@
         },
         "mandatorySupportedCCs": [32, 114, 64, 67, 134],
         "mandatoryControlledCCs": []
-      }
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 5,
+          "isSecure": false
+        },
+        {
+          "id": 64,
+          "name": "Thermostat Mode",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 66,
+          "name": "Thermostat Operating State",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 68,
+          "name": "Thermostat Fan Mode",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 69,
+          "name": "Thermostat Fan State",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 96,
+          "name": "Multi Channel",
+          "version": 4,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 3,
+          "isSecure": false
+        }
+      ]
     },
     {
       "nodeId": 26,
@@ -102,7 +334,123 @@
         },
         "mandatorySupportedCCs": [32, 49],
         "mandatoryControlledCCs": []
-      }
+      },
+      "commandClasses": [
+        {
+          "id": 49,
+          "name": "Multilevel Sensor",
+          "version": 5,
+          "isSecure": false
+        },
+        {
+          "id": 64,
+          "name": "Thermostat Mode",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 66,
+          "name": "Thermostat Operating State",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 67,
+          "name": "Thermostat Setpoint",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 68,
+          "name": "Thermostat Fan Mode",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 69,
+          "name": "Thermostat Fan State",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 96,
+          "name": "Multi Channel",
+          "version": 4,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 3,
+          "isSecure": false
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 129,
+          "name": "Clock",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 3,
+          "isSecure": false
+        }
+      ]
     }
   ],
   "values": [

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1063,6 +1063,8 @@ async def test_get_provisioning_entries(hass, integration, client, hass_ws_clien
         {
             "dsk": "test",
             "security_classes": [SecurityClass.S2_UNAUTHENTICATED],
+            "requested_security_classes": None,
+            "status": 0,
             "additional_properties": {"fake": "test"},
         }
     ]
@@ -1151,6 +1153,8 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
         "max_inclusion_request_interval": 1,
         "uuid": "test",
         "supported_protocols": [Protocols.ZWAVE],
+        "status": 0,
+        "requested_security_classes": None,
         "additional_properties": {},
     }
 
@@ -3451,6 +3455,7 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
     client.async_send_command.return_value = {
         "updateAvailable": True,
         "newVersion": "test",
+        "installedVersion": "test",
     }
     await ws_client.send_json(
         {

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -1817,7 +1817,7 @@ async def test_invoke_cc_api(
                 device_radio_thermostat.id,
                 device_danfoss.id,
             ],
-            ATTR_COMMAND_CLASS: 132,
+            ATTR_COMMAND_CLASS: 67,
             ATTR_ENDPOINT: 0,
             ATTR_METHOD_NAME: "someMethod",
             ATTR_PARAMETERS: [1, 2],
@@ -1827,7 +1827,7 @@ async def test_invoke_cc_api(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "endpoint.invoke_cc_api"
-    assert args["commandClass"] == 132
+    assert args["commandClass"] == 67
     assert args["endpoint"] == 0
     assert args["methodName"] == "someMethod"
     assert args["args"] == [1, 2]
@@ -1839,7 +1839,7 @@ async def test_invoke_cc_api(
     assert len(client.async_send_command_no_wait.call_args_list) == 1
     args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "endpoint.invoke_cc_api"
-    assert args["commandClass"] == 132
+    assert args["commandClass"] == 67
     assert args["endpoint"] == 0
     assert args["methodName"] == "someMethod"
     assert args["args"] == [1, 2]
@@ -1870,7 +1870,7 @@ async def test_invoke_cc_api(
                 "select.living_connect_z_thermostat_local_protection_state",
                 "sensor.living_connect_z_thermostat_node_status",
             ],
-            ATTR_COMMAND_CLASS: 132,
+            ATTR_COMMAND_CLASS: 67,
             ATTR_METHOD_NAME: "someMethod",
             ATTR_PARAMETERS: [1, 2],
         },
@@ -1879,7 +1879,7 @@ async def test_invoke_cc_api(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "endpoint.invoke_cc_api"
-    assert args["commandClass"] == 132
+    assert args["commandClass"] == 67
     assert args["endpoint"] == 0
     assert args["methodName"] == "someMethod"
     assert args["args"] == [1, 2]
@@ -1891,7 +1891,7 @@ async def test_invoke_cc_api(
     assert len(client.async_send_command_no_wait.call_args_list) == 1
     args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "endpoint.invoke_cc_api"
-    assert args["commandClass"] == 132
+    assert args["commandClass"] == 67
     assert args["endpoint"] == 0
     assert args["methodName"] == "someMethod"
     assert args["args"] == [1, 2]
@@ -1916,7 +1916,7 @@ async def test_invoke_cc_api(
                     device_danfoss.id,
                     device_radio_thermostat.id,
                 ],
-                ATTR_COMMAND_CLASS: 132,
+                ATTR_COMMAND_CLASS: 67,
                 ATTR_ENDPOINT: 0,
                 ATTR_METHOD_NAME: "someMethod",
                 ATTR_PARAMETERS: [1, 2],
@@ -1926,7 +1926,7 @@ async def test_invoke_cc_api(
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "endpoint.invoke_cc_api"
-    assert args["commandClass"] == 132
+    assert args["commandClass"] == 67
     assert args["endpoint"] == 0
     assert args["methodName"] == "someMethod"
     assert args["args"] == [1, 2]
@@ -1938,7 +1938,7 @@ async def test_invoke_cc_api(
     assert len(client.async_send_command_no_wait.call_args_list) == 1
     args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "endpoint.invoke_cc_api"
-    assert args["commandClass"] == 132
+    assert args["commandClass"] == 67
     assert args["endpoint"] == 0
     assert args["methodName"] == "someMethod"
     assert args["args"] == [1, 2]


### PR DESCRIPTION
## Breaking change
With this release, you will need to update your zwave-js-server instance.
- If you use the zwave_js addon, you need to have at least version `0.1.60`.
- If you use the zwavejs2mqtt addon, you need to have at least version `0.41.0`.
- If you use the zwavejs2mqtt Docker container, you need to have at least version `6.10.0`.
- If you run your own Docker container, or some other installation method, you will need to update your zwave-js-server instance to at least `1.17.0`.

## Proposed change
Should only be merged after https://github.com/home-assistant/addons/pull/2492 is merged


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
