### PR TITLE
Bump pywemo==0.8.1

### DIFF
--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -1,6 +1,5 @@
 """Support for WeMo binary sensors."""
 import asyncio
-from typing import cast
 
 from pywemo import Insight, Maker, StandbyState
 
@@ -49,20 +48,21 @@ class MakerBinarySensor(WemoEntity, BinarySensorEntity):
     """Maker device's sensor port."""
 
     _name_suffix = "Sensor"
+    wemo: Maker
 
     @property
     def is_on(self) -> bool:
         """Return true if the Maker's sensor is pulled low."""
-        return cast(int, self.wemo.has_sensor) != 0 and self.wemo.sensor_state == 0
+        return self.wemo.has_sensor != 0 and self.wemo.sensor_state == 0
 
 
 class InsightBinarySensor(WemoBinarySensor):
     """Sensor representing the device connected to the Insight Switch."""
 
     _name_suffix = "Device"
+    wemo: Insight
 
     @property
     def is_on(self) -> bool:
         """Return true device connected to the Insight Switch is on."""
-        # Note: wemo.get_standby_state is a @property.
-        return super().is_on and self.wemo.get_standby_state == StandbyState.ON
+        return super().is_on and self.wemo.standby_state == StandbyState.ON

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Generator
 import contextlib
 import logging
-from typing import cast
 
 from pywemo.exceptions import ActionException
 
@@ -89,4 +88,4 @@ class WemoBinaryStateEntity(WemoEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the state is on."""
-        return cast(int, self.wemo.get_state()) != 0
+        return self.wemo.get_state() != 0

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import math
 from typing import Any
 
-from pywemo.ouimeaux_device.humidifier import DesiredHumidity, FanMode, Humidifier
+from pywemo import DesiredHumidity, FanMode, Humidifier
 import voluptuous as vol
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Belkin WeMo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wemo",
-  "requirements": ["pywemo==0.7.0"],
+  "requirements": ["pywemo==0.8.1"],
   "ssdp": [
     {
       "manufacturer": "Belkin International Inc."

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any
 
-from pywemo import CoffeeMaker, Insight, Maker, StandbyState
+from pywemo import CoffeeMaker, Insight, Maker, StandbyState, Switch
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -58,6 +58,9 @@ async def async_setup_entry(
 class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
     """Representation of a WeMo switch."""
 
+    # All wemo devices used with WemoSwitch are subclasses of Switch.
+    wemo: Switch
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the device."""
@@ -103,10 +106,9 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
     def detail_state(self) -> str:
         """Return the state of the device."""
         if isinstance(self.wemo, CoffeeMaker):
-            return cast(str, self.wemo.mode_string)
+            return self.wemo.mode_string
         if isinstance(self.wemo, Insight):
-            # Note: wemo.get_standby_state is a @property.
-            standby_state = self.wemo.get_standby_state
+            standby_state = self.wemo.standby_state
             if standby_state == StandbyState.ON:
                 return STATE_ON
             if standby_state == StandbyState.OFF:

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import timedelta
 import logging
 
-from pywemo import Insight, WeMoDevice
+from pywemo import Insight, LongPressMixin, WeMoDevice
 from pywemo.exceptions import ActionException
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
@@ -159,7 +159,7 @@ async def async_register_device(
     registry.on(wemo, None, device.subscription_callback)
     await hass.async_add_executor_job(registry.register, wemo)
 
-    if device.supports_long_press:
+    if isinstance(wemo, LongPressMixin):
         try:
             await hass.async_add_executor_job(wemo.ensure_long_press_virtual_device)
         # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2017,7 +2017,7 @@ pyvolumio==0.1.5
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.7.0
+pywemo==0.8.1
 
 # homeassistant.components.wilight
 pywilight==0.0.70

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1337,7 +1337,7 @@ pyvolumio==0.1.5
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.7.0
+pywemo==0.8.1
 
 # homeassistant.components.wilight
 pywilight==0.0.70

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -69,7 +69,7 @@ def create_pywemo_device(pywemo_registry, pywemo_model):
     device.supports_long_press.return_value = cls.supports_long_press()
 
     if issubclass(cls, pywemo.Insight):
-        device.get_standby_state = pywemo.StandbyState.OFF
+        device.standby_state = pywemo.StandbyState.OFF
         device.current_power_watts = MOCK_INSIGHT_CURRENT_WATTS
         device.today_kwh = MOCK_INSIGHT_TODAY_KWH
         device.threshold_power_watts = MOCK_INSIGHT_STATE_THRESHOLD_POWER

--- a/tests/components/wemo/test_binary_sensor.py
+++ b/tests/components/wemo/test_binary_sensor.py
@@ -117,21 +117,21 @@ class TestInsight(EntityTestHelpers):
         """Verify that the binary_sensor receives state updates from the registry."""
         # On state.
         pywemo_device.get_state.return_value = 1
-        pywemo_device.get_standby_state = StandbyState.ON
+        pywemo_device.standby_state = StandbyState.ON
         pywemo_registry.callbacks[pywemo_device.name](pywemo_device, "", "")
         await hass.async_block_till_done()
         assert hass.states.get(wemo_entity.entity_id).state == STATE_ON
 
         # Standby (Off) state.
         pywemo_device.get_state.return_value = 1
-        pywemo_device.get_standby_state = StandbyState.STANDBY
+        pywemo_device.standby_state = StandbyState.STANDBY
         pywemo_registry.callbacks[pywemo_device.name](pywemo_device, "", "")
         await hass.async_block_till_done()
         assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF
 
         # Off state.
         pywemo_device.get_state.return_value = 0
-        pywemo_device.get_standby_state = StandbyState.OFF
+        pywemo_device.standby_state = StandbyState.OFF
         pywemo_registry.callbacks[pywemo_device.name](pywemo_device, "", "")
         await hass.async_block_till_done()
         assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF

--- a/tests/components/wemo/test_switch.py
+++ b/tests/components/wemo/test_switch.py
@@ -134,19 +134,19 @@ async def test_insight_state_attributes(hass, pywemo_registry):
             )
 
         # Test 'ON' state detail value.
-        insight.get_standby_state = pywemo.StandbyState.ON
+        insight.standby_state = pywemo.StandbyState.ON
         await async_update()
         attributes = hass.states.get(wemo_entity.entity_id).attributes
         assert attributes[ATTR_CURRENT_STATE_DETAIL] == STATE_ON
 
         # Test 'STANDBY' state detail value.
-        insight.get_standby_state = pywemo.StandbyState.STANDBY
+        insight.standby_state = pywemo.StandbyState.STANDBY
         await async_update()
         attributes = hass.states.get(wemo_entity.entity_id).attributes
         assert attributes[ATTR_CURRENT_STATE_DETAIL] == STATE_STANDBY
 
         # Test 'UNKNOWN' state detail value.
-        insight.get_standby_state = None
+        insight.standby_state = None
         await async_update()
         attributes = hass.states.get(wemo_entity.entity_id).attributes
         assert attributes[ATTR_CURRENT_STATE_DETAIL] == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumping `pywemo==0.8.1`.

The main feature of 0.8.0 was the addition of PEP 561 support. This was added based on [feedback in a prior PR](https://github.com/home-assistant/core/pull/62157#issuecomment-997747041). Changes in this PR are in support of PEP 561 and for a deprecated property (`get_standby_state` was replaced with `standby_state`) in pyWeMo.

The list of pyWeMo changes are here:
-  [0.8.0](https://github.com/pywemo/pywemo/releases/tag/0.8.0) release notes.
-  [0.8.1](https://github.com/pywemo/pywemo/releases/tag/0.8.1) release notes.
-  Full Changelog https://github.com/pywemo/pywemo/compare/0.7.0...0.8.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR requires #72378 & #72316 also. I'm intending this to go into a future monthly release, not a bugfix release.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
