### PR TITLE
Remove YAML configuration from Jandy iAqualink

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -19,9 +19,7 @@ from iaqualink.device import (
 )
 from iaqualink.exception import AqualinkServiceException
 from typing_extensions import Concatenate, ParamSpec
-import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
@@ -32,14 +30,12 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, UPDATE_INTERVAL
 
@@ -52,41 +48,12 @@ ATTR_CONFIG = "config"
 PARALLEL_UPDATES = 0
 
 PLATFORMS = [
-    BINARY_SENSOR_DOMAIN,
-    CLIMATE_DOMAIN,
-    LIGHT_DOMAIN,
-    SENSOR_DOMAIN,
-    SWITCH_DOMAIN,
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
 ]
-
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                }
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Aqualink component."""
-    if (conf := config.get(DOMAIN)) is not None:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data=conf,
-            )
-        )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
@@ -21,7 +22,9 @@ class AqualinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow start."""
         # Supporting a single account.
         entries = self._async_current_entries()
@@ -54,7 +57,3 @@ class AqualinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
-
-    async def async_step_import(self, user_input: dict[str, Any] | None = None):
-        """Occurs when an entry is setup through config."""
-        return await self.async_step_user(user_input)

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -17,9 +17,7 @@ async def test_already_configured(hass, config_entry, config_data):
     flow.hass = hass
     flow.context = {}
 
-    fname = "async_step_user"
-    func = getattr(flow, fname)
-    result = await func(config_data)
+    result = await flow.async_step_user(config_data)
 
     assert result["type"] == "abort"
 
@@ -30,9 +28,7 @@ async def test_without_config(hass):
     flow.hass = hass
     flow.context = {}
 
-    fname = "async_step_user"
-    func = getattr(flow, fname)
-    result = await func()
+    result = await flow.async_step_user()
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
@@ -44,13 +40,11 @@ async def test_with_invalid_credentials(hass, config_data):
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
-    fname = "async_step_user"
-    func = getattr(flow, fname)
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
         side_effect=AqualinkServiceUnauthorizedException,
     ):
-        result = await func(config_data)
+        result = await flow.async_step_user(config_data)
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
@@ -62,13 +56,11 @@ async def test_service_exception(hass, config_data):
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
-    fname = "async_step_user"
-    func = getattr(flow, fname)
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
         side_effect=AqualinkServiceException,
     ):
-        result = await func(config_data)
+        result = await flow.async_step_user(config_data)
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
@@ -81,13 +73,11 @@ async def test_with_existing_config(hass, config_data):
     flow.hass = hass
     flow.context = {}
 
-    fname = "async_step_user"
-    func = getattr(flow, fname)
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
         return_value=None,
     ):
-        result = await func(config_data)
+        result = await flow.async_step_user(config_data)
 
     assert result["type"] == "create_entry"
     assert result["title"] == config_data["username"]

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -5,13 +5,11 @@ from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
 )
-import pytest
 
 from homeassistant.components.iaqualink import config_flow
 
 
-@pytest.mark.parametrize("step", ["import", "user"])
-async def test_already_configured(hass, config_entry, config_data, step):
+async def test_already_configured(hass, config_entry, config_data):
     """Test config flow when iaqualink component is already setup."""
     config_entry.add_to_hass(hass)
 
@@ -19,21 +17,20 @@ async def test_already_configured(hass, config_entry, config_data, step):
     flow.hass = hass
     flow.context = {}
 
-    fname = f"async_step_{step}"
+    fname = "async_step_user"
     func = getattr(flow, fname)
     result = await func(config_data)
 
     assert result["type"] == "abort"
 
 
-@pytest.mark.parametrize("step", ["import", "user"])
-async def test_without_config(hass, step):
+async def test_without_config(hass):
     """Test config flow with no configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
     flow.context = {}
 
-    fname = f"async_step_{step}"
+    fname = "async_step_user"
     func = getattr(flow, fname)
     result = await func()
 
@@ -42,13 +39,12 @@ async def test_without_config(hass, step):
     assert result["errors"] == {}
 
 
-@pytest.mark.parametrize("step", ["import", "user"])
-async def test_with_invalid_credentials(hass, config_data, step):
+async def test_with_invalid_credentials(hass, config_data):
     """Test config flow with invalid username and/or password."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
-    fname = f"async_step_{step}"
+    fname = "async_step_user"
     func = getattr(flow, fname)
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
@@ -61,13 +57,12 @@ async def test_with_invalid_credentials(hass, config_data, step):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-@pytest.mark.parametrize("step", ["import", "user"])
-async def test_service_exception(hass, config_data, step):
+async def test_service_exception(hass, config_data):
     """Test config flow encountering service exception."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
-    fname = f"async_step_{step}"
+    fname = "async_step_user"
     func = getattr(flow, fname)
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
@@ -80,14 +75,13 @@ async def test_service_exception(hass, config_data, step):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-@pytest.mark.parametrize("step", ["import", "user"])
-async def test_with_existing_config(hass, config_data, step):
+async def test_with_existing_config(hass, config_data):
     """Test config flow with existing configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
     flow.context = {}
 
-    fname = f"async_step_{step}"
+    fname = "async_step_user"
     func = getattr(flow, fname)
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration for Jandy iAqualink has been removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #50644

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
