### PR TITLE
Do not swallow WLED errors

### DIFF
--- a/homeassistant/components/wled/helpers.py
+++ b/homeassistant/components/wled/helpers.py
@@ -2,7 +2,7 @@
 
 from wled import WLEDConnectionError, WLEDError
 
-from .const import LOGGER
+from homeassistant.exceptions import HomeAssistantError
 
 
 def wled_exception_handler(func):
@@ -18,11 +18,11 @@ def wled_exception_handler(func):
             self.coordinator.update_listeners()
 
         except WLEDConnectionError as error:
-            LOGGER.error("Error communicating with API: %s", error)
             self.coordinator.last_update_success = False
             self.coordinator.update_listeners()
+            raise HomeAssistantError("Error communicating with WLED API") from error
 
         except WLEDError as error:
-            LOGGER.error("Invalid response from API: %s", error)
+            raise HomeAssistantError("Invalid response from WLED API") from error
 
     return handler

--- a/tests/components/wled/test_number.py
+++ b/tests/components/wled/test_number.py
@@ -14,6 +14,7 @@ from homeassistant.components.number.const import (
 from homeassistant.components.wled.const import SCAN_INTERVAL
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -109,26 +110,25 @@ async def test_speed_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED numbers."""
     mock_wled.segment.side_effect = WLEDError
 
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {
-            ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
-            ATTR_VALUE: 42,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
+                ATTR_VALUE: 42,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("number.wled_rgb_light_segment_1_speed")
     assert state
     assert state.state == "16"
-    assert "Invalid response from API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, speed=42)
 
@@ -137,26 +137,25 @@ async def test_speed_connection_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED numbers."""
     mock_wled.segment.side_effect = WLEDConnectionError
 
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {
-            ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
-            ATTR_VALUE: 42,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
+                ATTR_VALUE: 42,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("number.wled_rgb_light_segment_1_speed")
     assert state
     assert state.state == STATE_UNAVAILABLE
-    assert "Error communicating with API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, speed=42)
 
@@ -250,26 +249,25 @@ async def test_intensity_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED numbers."""
     mock_wled.segment.side_effect = WLEDError
 
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {
-            ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",
-            ATTR_VALUE: 21,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",
+                ATTR_VALUE: 21,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("number.wled_rgb_light_segment_1_intensity")
     assert state
     assert state.state == "64"
-    assert "Invalid response from API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, intensity=21)
 
@@ -278,25 +276,24 @@ async def test_intensity_connection_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED numbers."""
     mock_wled.segment.side_effect = WLEDConnectionError
 
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {
-            ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",
-            ATTR_VALUE: 128,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",
+                ATTR_VALUE: 128,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("number.wled_rgb_light_segment_1_intensity")
     assert state
     assert state.state == STATE_UNAVAILABLE
-    assert "Error communicating with API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, intensity=128)

--- a/tests/components/wled/test_select.py
+++ b/tests/components/wled/test_select.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 import homeassistant.util.dt as dt_util
@@ -161,26 +162,25 @@ async def test_color_palette_select_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.segment.side_effect = WLEDError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
-            ATTR_OPTION: "Icefire",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
+                ATTR_OPTION: "Icefire",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
     assert state
     assert state.state == "Random Cycle"
-    assert "Invalid response from API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, palette="Icefire")
 
@@ -189,26 +189,25 @@ async def test_color_palette_select_connection_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.segment.side_effect = WLEDConnectionError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
-            ATTR_OPTION: "Icefire",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
+                ATTR_OPTION: "Icefire",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
     assert state
     assert state.state == STATE_UNAVAILABLE
-    assert "Error communicating with API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, palette="Icefire")
 
@@ -280,26 +279,25 @@ async def test_preset_select_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.preset.side_effect = WLEDError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
-            ATTR_OPTION: "Preset 2",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
+                ATTR_OPTION: "Preset 2",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgbw_light_preset")
     assert state
     assert state.state == "Preset 1"
-    assert "Invalid response from API" in caplog.text
     assert mock_wled.preset.call_count == 1
     mock_wled.preset.assert_called_with(preset="Preset 2")
 
@@ -309,26 +307,25 @@ async def test_preset_select_connection_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.preset.side_effect = WLEDConnectionError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
-            ATTR_OPTION: "Preset 2",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
+                ATTR_OPTION: "Preset 2",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgbw_light_preset")
     assert state
     assert state.state == STATE_UNAVAILABLE
-    assert "Error communicating with API" in caplog.text
     assert mock_wled.preset.call_count == 1
     mock_wled.preset.assert_called_with(preset="Preset 2")
 
@@ -400,26 +397,25 @@ async def test_playlist_select_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.playlist.side_effect = WLEDError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
-            ATTR_OPTION: "Playlist 2",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
+                ATTR_OPTION: "Playlist 2",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgbw_light_playlist")
     assert state
     assert state.state == "Playlist 1"
-    assert "Invalid response from API" in caplog.text
     assert mock_wled.playlist.call_count == 1
     mock_wled.playlist.assert_called_with(playlist="Playlist 2")
 
@@ -429,26 +425,25 @@ async def test_playlist_select_connection_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.playlist.side_effect = WLEDConnectionError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
-            ATTR_OPTION: "Playlist 2",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
+                ATTR_OPTION: "Playlist 2",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgbw_light_playlist")
     assert state
     assert state.state == STATE_UNAVAILABLE
-    assert "Error communicating with API" in caplog.text
     assert mock_wled.playlist.call_count == 1
     mock_wled.playlist.assert_called_with(playlist="Playlist 2")
 
@@ -489,26 +484,25 @@ async def test_live_select_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.live.side_effect = WLEDError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",
-            ATTR_OPTION: "1",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",
+                ATTR_OPTION: "1",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgb_light_live_override")
     assert state
     assert state.state == "0"
-    assert "Invalid response from API" in caplog.text
     assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live=1)
 
@@ -517,25 +511,24 @@ async def test_live_select_connection_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the WLED selects."""
     mock_wled.live.side_effect = WLEDConnectionError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",
-            ATTR_OPTION: "2",
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",
+                ATTR_OPTION: "2",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     state = hass.states.get("select.wled_rgb_light_live_override")
     assert state
     assert state.state == STATE_UNAVAILABLE
-    assert "Error communicating with API" in caplog.text
     assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live=2)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, the WLED integration swallows every error, causing automation & scripts not to fail when there is an issue.

This is incorrect behavior we "allowed" for in the past, however, automation & script actions can now decide themselves if they want to ignore an error or not.

This PR enables that, by allowing errors to bubble up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
