### PR TITLE
Remove YAML configuration from vicare

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -7,19 +7,14 @@ import logging
 
 from PyViCare.PyViCare import PyViCare
 from PyViCare.PyViCareDevice import Device
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
-    CONF_CIRCUIT,
     CONF_HEATING_TYPE,
-    DEFAULT_HEATING_TYPE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     HEATING_TYPE_TO_CREATOR_METHOD,
@@ -37,50 +32,6 @@ class ViCareRequiredKeysMixin:
     """Mixin for required keys."""
 
     value_getter: Callable[[Device], bool]
-
-
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.All(
-                cv.deprecated(CONF_CIRCUIT),
-                cv.deprecated(DOMAIN),
-                vol.Schema(
-                    {
-                        vol.Required(CONF_USERNAME): cv.string,
-                        vol.Required(CONF_PASSWORD): cv.string,
-                        vol.Required(CONF_CLIENT_ID): cv.string,
-                        vol.Optional(
-                            CONF_CIRCUIT
-                        ): int,  # Ignored: All circuits are now supported. Will be removed when switching to Setup via UI.
-                        vol.Optional(
-                            CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE.value
-                        ): vol.In([e.value for e in HeatingType]),
-                    }
-                ),
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the ViCare component from yaml."""
-    if DOMAIN not in config:
-        # Setup via UI. No need to continue yaml-based setup
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config[DOMAIN],
-        )
-    )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -32,7 +32,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Invoke when a user initiates a flow via the user interface."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -76,7 +78,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user()
 
-    async def async_step_import(self, import_info):
+    async def async_step_import(self, import_info: dict[str, Any]) -> FlowResult:
         """Handle a flow initiated by a YAML config import."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.device_registry import format_mac
 
 from . import vicare_login
 from .const import (
-    CONF_CIRCUIT,
     CONF_HEATING_TYPE,
     DEFAULT_HEATING_TYPE,
     DOMAIN,
@@ -77,17 +76,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         return await self.async_step_user()
-
-    async def async_step_import(self, import_info: dict[str, Any]) -> FlowResult:
-        """Handle a flow initiated by a YAML config import."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
-        # Remove now unsupported config parameters
-        import_info.pop(CONF_CIRCUIT, None)
-
-        # CONF_HEATING_TYPE is now required but was optional in yaml config. Add if missing.
-        if import_info.get(CONF_HEATING_TYPE) is None:
-            import_info[CONF_HEATING_TYPE] = DEFAULT_HEATING_TYPE.value
-
-        return await self.async_step_user(import_info)

--- a/tests/components/vicare/__init__.py
+++ b/tests/components/vicare/__init__.py
@@ -13,10 +13,4 @@ ENTRY_CONFIG: Final[dict[str, str]] = {
     CONF_HEATING_TYPE: "auto",
 }
 
-ENTRY_CONFIG_NO_HEATING_TYPE: Final[dict[str, str]] = {
-    CONF_USERNAME: "foo@bar.com",
-    CONF_PASSWORD: "1234",
-    CONF_CLIENT_ID: "5678",
-}
-
 MOCK_MAC = "B874241B7B9"

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -5,10 +5,10 @@ from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
-from homeassistant.components.vicare.const import CONF_CIRCUIT, DOMAIN, VICARE_NAME
+from homeassistant.components.vicare.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 
-from . import ENTRY_CONFIG, ENTRY_CONFIG_NO_HEATING_TYPE, MOCK_MAC
+from . import ENTRY_CONFIG, MOCK_MAC
 
 from tests.common import MockConfigEntry
 
@@ -25,8 +25,6 @@ async def test_form(hass):
         "homeassistant.components.vicare.config_flow.vicare_login",
         return_value=None,
     ), patch(
-        "homeassistant.components.vicare.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.vicare.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -43,87 +41,7 @@ async def test_form(hass):
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "ViCare"
     assert result2["data"] == ENTRY_CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import(hass):
-    """Test that the import works."""
-
-    with patch(
-        "homeassistant.components.vicare.config_flow.vicare_login",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.vicare.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.vicare.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=ENTRY_CONFIG,
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == VICARE_NAME
-        assert result["data"] == ENTRY_CONFIG
-
-        await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
-        assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_removes_circuit(hass):
-    """Test that the import works."""
-
-    with patch(
-        "homeassistant.components.vicare.config_flow.vicare_login",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.vicare.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.vicare.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        ENTRY_CONFIG[CONF_CIRCUIT] = 1
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=ENTRY_CONFIG,
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == VICARE_NAME
-        assert result["data"] == ENTRY_CONFIG
-
-        await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
-        assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_adds_heating_type(hass):
-    """Test that the import works."""
-
-    with patch(
-        "homeassistant.components.vicare.config_flow.vicare_login",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.vicare.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.vicare.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=ENTRY_CONFIG_NO_HEATING_TYPE,
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == VICARE_NAME
-        assert result["data"] == ENTRY_CONFIG
-
-        await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
-        assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_invalid_login(hass) -> None:
@@ -171,8 +89,6 @@ async def test_form_dhcp(hass):
         "homeassistant.components.vicare.config_flow.vicare_login",
         return_value=None,
     ), patch(
-        "homeassistant.components.vicare.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.vicare.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -189,25 +105,7 @@ async def test_form_dhcp(hass):
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "ViCare"
     assert result2["data"] == ENTRY_CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_single_instance_allowed(hass):
-    """Test that configuring more than one instance is rejected."""
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=ENTRY_CONFIG,
-    )
-    mock_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=ENTRY_CONFIG,
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_dhcp_single_instance_allowed(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration for vicare has been removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #56691

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
