### PR TITLE
Clean zwave_js entity driver access

### DIFF
--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node as ZwaveNode
 
 from homeassistant.components.button import ButtonEntity
@@ -28,7 +29,9 @@ async def async_setup_entry(
     @callback
     def async_add_ping_button_entity(node: ZwaveNode) -> None:
         """Add ping button entity."""
-        async_add_entities([ZWaveNodePingButton(client, node)])
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
+        async_add_entities([ZWaveNodePingButton(driver, node)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
@@ -45,7 +48,7 @@ class ZWaveNodePingButton(ButtonEntity):
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, client: ZwaveClient, node: ZwaveNode) -> None:
+    def __init__(self, driver: Driver, node: ZwaveNode) -> None:
         """Initialize a ping Z-Wave device button entity."""
         self.node = node
         name: str = (
@@ -53,11 +56,11 @@ class ZWaveNodePingButton(ButtonEntity):
         )
         # Entity class attributes
         self._attr_name = f"{name}: Ping"
-        self._base_unique_id = get_valueless_base_unique_id(client, node)
+        self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.ping"
         # device is precreated in main handler
         self._attr_device_info = DeviceInfo(
-            identifiers={get_device_id(client, node)},
+            identifiers={get_device_id(driver, node)},
         )
 
     async def async_poll_value(self, _: bool) -> None:

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import logging
 
-from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import NodeStatus
+from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
 
 from homeassistant.config_entries import ConfigEntry
@@ -30,11 +30,11 @@ class ZWaveBaseEntity(Entity):
     _attr_should_poll = False
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize a generic Z-Wave device entity."""
         self.config_entry = config_entry
-        self.client = client
+        self.driver = driver
         self.info = info
         # entities requiring additional values, can add extra ids to this list
         self.watched_value_ids = {self.info.primary_value.value_id}
@@ -46,16 +46,14 @@ class ZWaveBaseEntity(Entity):
 
         # Entity class attributes
         self._attr_name = self.generate_name()
-        self._attr_unique_id = get_unique_id(
-            self.client, self.info.primary_value.value_id
-        )
+        self._attr_unique_id = get_unique_id(driver, self.info.primary_value.value_id)
         self._attr_entity_registry_enabled_default = (
             self.info.entity_registry_enabled_default
         )
         self._attr_assumed_state = self.info.assumed_state
         # device is precreated in main handler
         self._attr_device_info = DeviceInfo(
-            identifiers={get_device_id(self.client, self.info.node)},
+            identifiers={get_device_id(driver, self.info.node)},
         )
 
     @callback
@@ -145,7 +143,10 @@ class ZWaveBaseEntity(Entity):
             if item:
                 name += f" - {item}"
         # append endpoint if > 1
-        if self.info.primary_value.endpoint > 1:
+        if (
+            self.info.primary_value.endpoint is not None
+            and self.info.primary_value.endpoint > 1
+        ):
             name += f" ({self.info.primary_value.endpoint})"
 
         return name
@@ -154,7 +155,7 @@ class ZWaveBaseEntity(Entity):
     def available(self) -> bool:
         """Return entity availability."""
         return (
-            self.client.connected
+            self.driver.client.connected
             and bool(self.info.node.ready)
             and self.info.node.status != NodeStatus.DEAD
         )

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -110,29 +110,29 @@ def update_data_collection_preference(
 
 
 @callback
-def get_valueless_base_unique_id(client: ZwaveClient, node: ZwaveNode) -> str:
+def get_valueless_base_unique_id(driver: Driver, node: ZwaveNode) -> str:
     """Return the base unique ID for an entity that is not based on a value."""
-    return f"{client.driver.controller.home_id}.{node.node_id}"
+    return f"{driver.controller.home_id}.{node.node_id}"
 
 
-def get_unique_id(client: ZwaveClient, value_id: str) -> str:
+def get_unique_id(driver: Driver, value_id: str) -> str:
     """Get unique ID from client and value ID."""
-    return f"{client.driver.controller.home_id}.{value_id}"
+    return f"{driver.controller.home_id}.{value_id}"
 
 
 @callback
-def get_device_id(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str]:
+def get_device_id(driver: Driver, node: ZwaveNode) -> tuple[str, str]:
     """Get device registry identifier for Z-Wave node."""
-    return (DOMAIN, f"{client.driver.controller.home_id}-{node.node_id}")
+    return (DOMAIN, f"{driver.controller.home_id}-{node.node_id}")
 
 
 @callback
-def get_device_id_ext(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str] | None:
+def get_device_id_ext(driver: Driver, node: ZwaveNode) -> tuple[str, str] | None:
     """Get extended device registry identifier for Z-Wave node."""
     if None in (node.manufacturer_id, node.product_type, node.product_id):
         return None
 
-    domain, dev_id = get_device_id(client, node)
+    domain, dev_id = get_device_id(driver, node)
     return (
         domain,
         f"{dev_id}-{node.manufacturer_id}:{node.product_type}:{node.product_id}",

--- a/homeassistant/components/zwave_js/humidifier.py
+++ b/homeassistant/components/zwave_js/humidifier.py
@@ -11,6 +11,7 @@ from zwave_js_server.const.command_class.humidity_control import (
     HumidityControlMode,
     HumidityControlSetpointType,
 )
+from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.components.humidifier import (
@@ -85,6 +86,8 @@ async def async_setup_entry(
     @callback
     def async_add_humidifier(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Humidifier."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
         entities: list[ZWaveBaseEntity] = []
 
         if (
@@ -93,7 +96,7 @@ async def async_setup_entry(
         ):
             entities.append(
                 ZWaveHumidifier(
-                    config_entry, client, info, HUMIDIFIER_ENTITY_DESCRIPTION
+                    config_entry, driver, info, HUMIDIFIER_ENTITY_DESCRIPTION
                 )
             )
 
@@ -103,7 +106,7 @@ async def async_setup_entry(
         ):
             entities.append(
                 ZWaveHumidifier(
-                    config_entry, client, info, DEHUMIDIFIER_ENTITY_DESCRIPTION
+                    config_entry, driver, info, DEHUMIDIFIER_ENTITY_DESCRIPTION
                 )
             )
 
@@ -128,12 +131,12 @@ class ZWaveHumidifier(ZWaveBaseEntity, HumidifierEntity):
     def __init__(
         self,
         config_entry: ConfigEntry,
-        client: ZwaveClient,
+        driver: Driver,
         info: ZwaveDiscoveryInfo,
         description: ZwaveHumidifierEntityDescription,
     ) -> None:
         """Initialize humidifier."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
 
         self.entity_description = description
 

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -23,6 +23,7 @@ from zwave_js_server.const.command_class.color_switch import (
     TARGET_COLOR_PROPERTY,
     ColorComponent,
 )
+from zwave_js_server.model.driver import Driver
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -72,11 +73,13 @@ async def async_setup_entry(
     @callback
     def async_add_light(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Light."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
 
         if info.platform_hint == "black_is_off":
-            async_add_entities([ZwaveBlackIsOffLight(config_entry, client, info)])
+            async_add_entities([ZwaveBlackIsOffLight(config_entry, driver, info)])
         else:
-            async_add_entities([ZwaveLight(config_entry, client, info)])
+            async_add_entities([ZwaveLight(config_entry, driver, info)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
@@ -101,10 +104,10 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
     """Representation of a Z-Wave light."""
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize the light."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
         self._supports_color = False
         self._supports_rgbw = False
         self._supports_color_temp = False
@@ -445,10 +448,10 @@ class ZwaveBlackIsOffLight(ZwaveLight):
     """
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize the light."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
 
         self._last_color: dict[str, int] | None = None
         self._supported_color_modes.discard(ColorMode.BRIGHTNESS)

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -61,8 +61,10 @@ async def async_setup_entry(
     @callback
     def async_add_lock(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Lock."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
         entities: list[ZWaveBaseEntity] = []
-        entities.append(ZWaveLock(config_entry, client, info))
+        entities.append(ZWaveLock(config_entry, driver, info))
 
         async_add_entities(entities)
 

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 
-from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.const import STATE_UNAVAILABLE
@@ -138,12 +138,12 @@ def async_migrate_discovered_value(
     ent_reg: EntityRegistry,
     registered_unique_ids: set[str],
     device: DeviceEntry,
-    client: ZwaveClient,
+    driver: Driver,
     disc_info: ZwaveDiscoveryInfo,
 ) -> None:
     """Migrate unique ID for entity/entities tied to discovered value."""
 
-    new_unique_id = get_unique_id(client, disc_info.primary_value.value_id)
+    new_unique_id = get_unique_id(driver, disc_info.primary_value.value_id)
 
     # On reinterviews, there is no point in going through this logic again for already
     # discovered values
@@ -155,7 +155,7 @@ def async_migrate_discovered_value(
 
     # 2021.2.*, 2021.3.0b0, and 2021.3.0 formats
     old_unique_ids = [
-        get_unique_id(client, value_id)
+        get_unique_id(driver, value_id)
         for value_id in get_old_value_ids(disc_info.primary_value)
     ]
 

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -6,6 +6,7 @@ from typing import cast
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import TARGET_VALUE_PROPERTY, CommandClass
 from zwave_js_server.const.command_class.sound_switch import ToneID
+from zwave_js_server.model.driver import Driver
 
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN, SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -32,15 +33,17 @@ async def async_setup_entry(
     @callback
     def async_add_select(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave select entity."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
         entities: list[ZWaveBaseEntity] = []
         if info.platform_hint == "Default tone":
-            entities.append(ZwaveDefaultToneSelectEntity(config_entry, client, info))
+            entities.append(ZwaveDefaultToneSelectEntity(config_entry, driver, info))
         elif info.platform_hint == "multilevel_switch":
             entities.append(
-                ZwaveMultilevelSwitchSelectEntity(config_entry, client, info)
+                ZwaveMultilevelSwitchSelectEntity(config_entry, driver, info)
             )
         else:
-            entities.append(ZwaveSelectEntity(config_entry, client, info))
+            entities.append(ZwaveSelectEntity(config_entry, driver, info))
         async_add_entities(entities)
 
     config_entry.async_on_unload(
@@ -58,10 +61,10 @@ class ZwaveSelectEntity(ZWaveBaseEntity, SelectEntity):
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize a ZwaveSelectEntity entity."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
 
         # Entity class attributes
         self._attr_name = self.generate_name(include_value_name=True)
@@ -94,10 +97,10 @@ class ZwaveDefaultToneSelectEntity(ZWaveBaseEntity, SelectEntity):
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize a ZwaveDefaultToneSelectEntity entity."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
         self._tones_value = self.get_zwave_value(
             "toneId", command_class=CommandClass.SOUND_SWITCH
         )
@@ -145,10 +148,10 @@ class ZwaveMultilevelSwitchSelectEntity(ZWaveBaseEntity, SelectEntity):
     """Representation of a Z-Wave Multilevel Switch CC select entity."""
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize a ZwaveSelectEntity entity."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
         self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         assert self.info.platform_data_template
         self._lookup_map = cast(

--- a/homeassistant/components/zwave_js/siren.py
+++ b/homeassistant/components/zwave_js/siren.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const.command_class.sound_switch import ToneID
+from zwave_js_server.model.driver import Driver
 
 from homeassistant.components.siren import (
     DOMAIN as SIREN_DOMAIN,
@@ -35,8 +36,10 @@ async def async_setup_entry(
     @callback
     def async_add_siren(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave siren entity."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
         entities: list[ZWaveBaseEntity] = []
-        entities.append(ZwaveSirenEntity(config_entry, client, info))
+        entities.append(ZwaveSirenEntity(config_entry, driver, info))
         async_add_entities(entities)
 
     config_entry.async_on_unload(
@@ -52,10 +55,10 @@ class ZwaveSirenEntity(ZWaveBaseEntity, SirenEntity):
     """Representation of a Z-Wave siren entity."""
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize a ZwaveSirenEntity entity."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
         # Entity class attributes
         self._attr_available_tones = {
             int(id): val for id, val in self.info.primary_value.metadata.states.items()

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -9,6 +9,7 @@ from zwave_js_server.const import TARGET_VALUE_PROPERTY
 from zwave_js_server.const.command_class.barrier_operator import (
     BarrierEventSignalingSubsystemState,
 )
+from zwave_js_server.model.driver import Driver
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -36,13 +37,15 @@ async def async_setup_entry(
     @callback
     def async_add_switch(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Switch."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
         entities: list[ZWaveBaseEntity] = []
         if info.platform_hint == "barrier_event_signaling_state":
             entities.append(
-                ZWaveBarrierEventSignalingSwitch(config_entry, client, info)
+                ZWaveBarrierEventSignalingSwitch(config_entry, driver, info)
             )
         else:
-            entities.append(ZWaveSwitch(config_entry, client, info))
+            entities.append(ZWaveSwitch(config_entry, driver, info))
 
         async_add_entities(entities)
 
@@ -59,10 +62,10 @@ class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
     """Representation of a Z-Wave switch."""
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
         """Initialize the switch."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
 
         self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
 
@@ -91,11 +94,11 @@ class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):
     def __init__(
         self,
         config_entry: ConfigEntry,
-        client: ZwaveClient,
+        driver: Driver,
         info: ZwaveDiscoveryInfo,
     ) -> None:
         """Initialize a ZWaveBarrierEventSignalingSwitch entity."""
-        super().__init__(config_entry, client, info)
+        super().__init__(config_entry, driver, info)
         self._state: bool | None = None
 
         self._update_state()

--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -207,7 +207,9 @@ async def async_attach_trigger(
         unsubs.append(source.on(event_name, async_on_event))
 
     for node in nodes:
-        device_identifier = get_device_id(node.client, node)
+        driver = node.client.driver
+        assert driver is not None  # The node comes from the driver.
+        device_identifier = get_device_id(driver, node)
         device = dev_reg.async_get_device({device_identifier})
         assert device
         # We need to store the device for the callback

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -162,7 +162,9 @@ async def async_attach_trigger(
 
     dev_reg = dr.async_get(hass)
     for node in nodes:
-        device_identifier = get_device_id(node.client, node)
+        driver = node.client.driver
+        assert driver is not None  # The node comes from the driver.
+        device_identifier = get_device_id(driver, node)
         device = dev_reg.async_get_device({device_identifier})
         assert device
         value_id = get_value_id(node, command_class, property_, endpoint, property_key)

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -78,7 +78,7 @@ from homeassistant.helpers import device_registry as dr
 def get_device(hass, node):
     """Get device ID for a node."""
     dev_reg = dr.async_get(hass)
-    device_id = get_device_id(node.client, node)
+    device_id = get_device_id(node.client.driver, node)
     return dev_reg.async_get_device({device_id})
 
 
@@ -124,11 +124,12 @@ async def test_node_ready(
     node_data = deepcopy(multisensor_6_state)  # Copy to allow modification in tests.
     node = Node(client, node_data)
     node.data["ready"] = False
-    client.driver.controller.nodes[node.node_id] = node
+    driver = client.driver
+    driver.controller.nodes[node.node_id] = node
 
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
-        config_entry_id=entry.entry_id, identifiers={get_device_id(client, node)}
+        config_entry_id=entry.entry_id, identifiers={get_device_id(driver, node)}
     )
 
     await ws_client.send_json(

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -49,11 +49,12 @@ async def test_ping_entity(
     assert "There is no value to refresh for this entity" in caplog.text
 
     # Assert a node ping button entity is not created for the controller
-    node = client.driver.controller.nodes[1]
+    driver = client.driver
+    node = driver.controller.nodes[1]
     assert node.is_controller_node
     assert (
         async_get(hass).async_get_entity_id(
-            DOMAIN, "sensor", f"{get_valueless_base_unique_id(client, node)}.ping"
+            DOMAIN, "sensor", f"{get_valueless_base_unique_id(driver, node)}.ping"
         )
         is None
     )

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -30,7 +30,9 @@ async def test_get_actions(
     """Test we get the expected actions from a zwave_js node."""
     node = lock_schlage_be469
     dev_reg = device_registry.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client, node)})
+    driver = client.driver
+    assert driver
+    device = dev_reg.async_get_device({get_device_id(driver, node)})
     assert device
     expected_actions = [
         {
@@ -99,7 +101,9 @@ async def test_get_actions_meter(
     """Test we get the expected meter actions from a zwave_js node."""
     node = aeon_smart_switch_6
     dev_reg = device_registry.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client, node)})
+    driver = client.driver
+    assert driver
+    device = dev_reg.async_get_device({get_device_id(driver, node)})
     assert device
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device.id
@@ -116,7 +120,9 @@ async def test_actions(
 ) -> None:
     """Test actions."""
     node = climate_radio_thermostat_ct100_plus
-    device_id = get_device_id(client, node)
+    driver = client.driver
+    assert driver
+    device_id = get_device_id(driver, node)
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device({device_id})
     assert device
@@ -236,7 +242,9 @@ async def test_actions_multiple_calls(
 ) -> None:
     """Test actions can be called multiple times and still work."""
     node = climate_radio_thermostat_ct100_plus
-    device_id = get_device_id(client, node)
+    driver = client.driver
+    assert driver
+    device_id = get_device_id(driver, node)
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device({device_id})
     assert device
@@ -281,7 +289,9 @@ async def test_lock_actions(
 ) -> None:
     """Test actions for locks."""
     node = lock_schlage_be469
-    device_id = get_device_id(client, node)
+    driver = client.driver
+    assert driver
+    device_id = get_device_id(driver, node)
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device({device_id})
     assert device
@@ -350,7 +360,9 @@ async def test_reset_meter_action(
 ) -> None:
     """Test reset_meter action."""
     node = aeon_smart_switch_6
-    device_id = get_device_id(client, node)
+    driver = client.driver
+    assert driver
+    device_id = get_device_id(driver, node)
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device({device_id})
     assert device
@@ -613,7 +625,9 @@ async def test_get_action_capabilities_meter_triggers(
     """Test we get the expected action capabilities for meter triggers."""
     node = aeon_smart_switch_6
     dev_reg = device_registry.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client, node)})
+    driver = client.driver
+    assert driver
+    device = dev_reg.async_get_device({get_device_id(driver, node)})
     assert device
     capabilities = await device_action.async_get_action_capabilities(
         hass,
@@ -669,7 +683,9 @@ async def test_unavailable_entity_actions(
     await hass.async_block_till_done()
     node = lock_schlage_be469
     dev_reg = device_registry.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client, node)})
+    driver = client.driver
+    assert driver
+    device = dev_reg.async_get_device({get_device_id(driver, node)})
     assert device
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device.id

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -51,7 +51,7 @@ async def test_device_diagnostics(
 ):
     """Test the device level diagnostics data dump."""
     dev_reg = async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client, multisensor_6)})
+    device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
     assert device
 
     # Update a value and ensure it is reflected in the node state

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -800,8 +800,10 @@ async def test_removed_device(
     hass, client, climate_radio_thermostat_ct100_plus, lock_schlage_be469, integration
 ):
     """Test that the device registry gets updated when a device gets removed."""
+    driver = client.driver
+    assert driver
     # Verify how many nodes are available
-    assert len(client.driver.controller.nodes) == 2
+    assert len(driver.controller.nodes) == 2
 
     # Make sure there are the same number of devices
     dev_reg = dr.async_get(hass)
@@ -814,7 +816,7 @@ async def test_removed_device(
     assert len(entity_entries) == 29
 
     # Remove a node and reload the entry
-    old_node = client.driver.controller.nodes.pop(13)
+    old_node = driver.controller.nodes.pop(13)
     await hass.config_entries.async_reload(integration.entry_id)
     await hass.async_block_till_done()
 
@@ -824,7 +826,7 @@ async def test_removed_device(
     assert len(device_entries) == 1
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
     assert len(entity_entries) == 17
-    assert dev_reg.async_get_device({get_device_id(client, old_node)}) is None
+    assert dev_reg.async_get_device({get_device_id(driver, old_node)}) is None
 
 
 async def test_suggested_area(hass, client, eaton_rf9640_dimmer):

--- a/tests/components/zwave_js/test_migrate.py
+++ b/tests/components/zwave_js/test_migrate.py
@@ -190,12 +190,14 @@ async def test_old_entity_migration(
 ):
     """Test old entity on a different endpoint is migrated to a new one."""
     node = Node(client, copy.deepcopy(hank_binary_switch_state))
+    driver = client.driver
+    assert driver
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
         config_entry_id=integration.entry_id,
-        identifiers={get_device_id(client, node)},
+        identifiers={get_device_id(driver, node)},
         manufacturer=hank_binary_switch_state["deviceConfig"]["manufacturer"],
         model=hank_binary_switch_state["deviceConfig"]["label"],
     )
@@ -204,7 +206,7 @@ async def test_old_entity_migration(
     entity_name = SENSOR_NAME.split(".")[1]
 
     # Create entity RegistryEntry using fake endpoint
-    old_unique_id = f"{client.driver.controller.home_id}.32-50-1-value-66049"
+    old_unique_id = f"{driver.controller.home_id}.32-50-1-value-66049"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -221,7 +223,7 @@ async def test_old_entity_migration(
     for i in range(0, 2):
         # Add a ready node, unique ID should be migrated
         event = {"node": node}
-        client.driver.controller.emit("node added", event)
+        driver.controller.emit("node added", event)
         await hass.async_block_till_done()
 
         # Check that new RegistryEntry is using new unique ID format
@@ -236,12 +238,14 @@ async def test_different_endpoint_migration_status_sensor(
 ):
     """Test that the different endpoint migration logic skips over the status sensor."""
     node = Node(client, copy.deepcopy(hank_binary_switch_state))
+    driver = client.driver
+    assert driver
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
         config_entry_id=integration.entry_id,
-        identifiers={get_device_id(client, node)},
+        identifiers={get_device_id(driver, node)},
         manufacturer=hank_binary_switch_state["deviceConfig"]["manufacturer"],
         model=hank_binary_switch_state["deviceConfig"]["label"],
     )
@@ -250,7 +254,7 @@ async def test_different_endpoint_migration_status_sensor(
     entity_name = SENSOR_NAME.split(".")[1]
 
     # Create entity RegistryEntry using fake endpoint
-    old_unique_id = f"{client.driver.controller.home_id}.32.node_status"
+    old_unique_id = f"{driver.controller.home_id}.32.node_status"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -267,7 +271,7 @@ async def test_different_endpoint_migration_status_sensor(
     for i in range(0, 2):
         # Add a ready node, unique ID should be migrated
         event = {"node": node}
-        client.driver.controller.emit("node added", event)
+        driver.controller.emit("node added", event)
         await hass.async_block_till_done()
 
         # Check that the RegistryEntry is using the same unique ID
@@ -280,12 +284,14 @@ async def test_skip_old_entity_migration_for_multiple(
 ):
     """Test that multiple entities of the same value but on a different endpoint get skipped."""
     node = Node(client, copy.deepcopy(hank_binary_switch_state))
+    driver = client.driver
+    assert driver
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
         config_entry_id=integration.entry_id,
-        identifiers={get_device_id(client, node)},
+        identifiers={get_device_id(driver, node)},
         manufacturer=hank_binary_switch_state["deviceConfig"]["manufacturer"],
         model=hank_binary_switch_state["deviceConfig"]["label"],
     )
@@ -294,7 +300,7 @@ async def test_skip_old_entity_migration_for_multiple(
     entity_name = SENSOR_NAME.split(".")[1]
 
     # Create two entity entrrys using different endpoints
-    old_unique_id_1 = f"{client.driver.controller.home_id}.32-50-1-value-66049"
+    old_unique_id_1 = f"{driver.controller.home_id}.32-50-1-value-66049"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -308,7 +314,7 @@ async def test_skip_old_entity_migration_for_multiple(
     assert entity_entry.unique_id == old_unique_id_1
 
     # Create two entity entrrys using different endpoints
-    old_unique_id_2 = f"{client.driver.controller.home_id}.32-50-2-value-66049"
+    old_unique_id_2 = f"{driver.controller.home_id}.32-50-2-value-66049"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -322,12 +328,12 @@ async def test_skip_old_entity_migration_for_multiple(
     assert entity_entry.unique_id == old_unique_id_2
     # Add a ready node, unique ID should be migrated
     event = {"node": node}
-    client.driver.controller.emit("node added", event)
+    driver.controller.emit("node added", event)
     await hass.async_block_till_done()
 
     # Check that new RegistryEntry is created using new unique ID format
     entity_entry = ent_reg.async_get(SENSOR_NAME)
-    new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
+    new_unique_id = f"{driver.controller.home_id}.32-50-0-value-66049"
     assert entity_entry.unique_id == new_unique_id
 
     # Check that the old entities stuck around because we skipped the migration step
@@ -340,12 +346,14 @@ async def test_old_entity_migration_notification_binary_sensor(
 ):
     """Test old entity on a different endpoint is migrated to a new one for a notification binary sensor."""
     node = Node(client, copy.deepcopy(multisensor_6_state))
+    driver = client.driver
+    assert driver
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
         config_entry_id=integration.entry_id,
-        identifiers={get_device_id(client, node)},
+        identifiers={get_device_id(driver, node)},
         manufacturer=multisensor_6_state["deviceConfig"]["manufacturer"],
         model=multisensor_6_state["deviceConfig"]["label"],
     )
@@ -353,7 +361,9 @@ async def test_old_entity_migration_notification_binary_sensor(
     entity_name = NOTIFICATION_MOTION_BINARY_SENSOR.split(".")[1]
 
     # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.52-113-1-Home Security-Motion sensor status.8"
+    old_unique_id = (
+        f"{driver.controller.home_id}.52-113-1-Home Security-Motion sensor status.8"
+    )
     entity_entry = ent_reg.async_get_or_create(
         "binary_sensor",
         DOMAIN,
@@ -370,12 +380,14 @@ async def test_old_entity_migration_notification_binary_sensor(
     for _ in range(0, 2):
         # Add a ready node, unique ID should be migrated
         event = {"node": node}
-        client.driver.controller.emit("node added", event)
+        driver.controller.emit("node added", event)
         await hass.async_block_till_done()
 
         # Check that new RegistryEntry is using new unique ID format
         entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_BINARY_SENSOR)
-        new_unique_id = f"{client.driver.controller.home_id}.52-113-0-Home Security-Motion sensor status.8"
+        new_unique_id = (
+            f"{driver.controller.home_id}.52-113-0-Home Security-Motion sensor status.8"
+        )
         assert entity_entry.unique_id == new_unique_id
         assert (
             ent_reg.async_get_entity_id("binary_sensor", DOMAIN, old_unique_id) is None

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -205,13 +205,14 @@ async def test_node_status_sensor(
     assert hass.states.get(NODE_STATUS_ENTITY).state != STATE_UNAVAILABLE
 
     # Assert a node status sensor entity is not created for the controller
-    node = client.driver.controller.nodes[1]
+    driver = client.driver
+    node = driver.controller.nodes[1]
     assert node.is_controller_node
     assert (
         ent_reg.async_get_entity_id(
             DOMAIN,
             "sensor",
-            f"{get_valueless_base_unique_id(client, node)}.node_status",
+            f"{get_valueless_base_unique_id(driver, node)}.node_status",
         )
         is None
     )

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -1367,11 +1367,11 @@ async def test_multicast_set_value(
     # Test using area ID
     dev_reg = async_get_dev_reg(hass)
     device_eurotronic = dev_reg.async_get_device(
-        {get_device_id(client, climate_eurotronic_spirit_z)}
+        {get_device_id(client.driver, climate_eurotronic_spirit_z)}
     )
     assert device_eurotronic
     device_danfoss = dev_reg.async_get_device(
-        {get_device_id(client, climate_danfoss_lc_13)}
+        {get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device_danfoss
     area_reg = async_get_area_reg(hass)
@@ -1655,11 +1655,15 @@ async def test_ping(
     """Test ping service."""
     dev_reg = async_get_dev_reg(hass)
     device_radio_thermostat = dev_reg.async_get_device(
-        {get_device_id(client, climate_radio_thermostat_ct100_plus_different_endpoints)}
+        {
+            get_device_id(
+                client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
+            )
+        }
     )
     assert device_radio_thermostat
     device_danfoss = dev_reg.async_get_device(
-        {get_device_id(client, climate_danfoss_lc_13)}
+        {get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device_danfoss
 
@@ -1789,11 +1793,15 @@ async def test_invoke_cc_api(
     """Test invoke_cc_api service."""
     dev_reg = async_get_dev_reg(hass)
     device_radio_thermostat = dev_reg.async_get_device(
-        {get_device_id(client, climate_radio_thermostat_ct100_plus_different_endpoints)}
+        {
+            get_device_id(
+                client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
+            )
+        }
     )
     assert device_radio_thermostat
     device_danfoss = dev_reg.async_get_device(
-        {get_device_id(client, climate_danfoss_lc_13)}
+        {get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device_danfoss
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Pass the driver instance to the entity instead of the client instance. This eases typing.
- Depends on https://github.com/home-assistant/core/pull/72419

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
