### PR TITLE
MotionBlinds use device_name helper

### DIFF
--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -1,7 +1,7 @@
 """Support for Motion Blinds using their WLAN API."""
 import logging
 
-from motionblinds import BlindType
+from motionblinds import BlindType, DEVICE_TYPES_WIFI
 import voluptuous as vol
 
 from homeassistant.components.cover import (

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -1,7 +1,7 @@
 """Support for Motion Blinds using their WLAN API."""
 import logging
 
-from motionblinds import DEVICE_TYPES_WIFI, BlindType
+from motionblinds import BlindType
 import voluptuous as vol
 
 from homeassistant.components.cover import (
@@ -34,6 +34,7 @@ from .const import (
     SERVICE_SET_ABSOLUTE_POSITION,
     UPDATE_INTERVAL_MOVING,
 )
+from .gateway import device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -178,13 +179,12 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
         if blind.device_type in DEVICE_TYPES_WIFI:
             via_device = ()
             connections = {(dr.CONNECTION_NETWORK_MAC, blind.mac)}
-            name = blind.blind_type
         else:
             via_device = (DOMAIN, blind._gateway.mac)
             connections = {}
-            name = f"{blind.blind_type} {blind.mac[12:]}"
             sw_version = None
 
+        name = device_name(blind)
         self._attr_device_class = device_class
         self._attr_name = name
         self._attr_unique_id = blind.mac
@@ -364,7 +364,7 @@ class MotionTDBUDevice(MotionPositionDevice):
         super().__init__(coordinator, blind, device_class, sw_version)
         self._motor = motor
         self._motor_key = motor[0]
-        self._attr_name = f"{blind.blind_type} {blind.mac[12:]} {motor}"
+        self._attr_name = f"{device_name(blind)} {motor}"
         self._attr_unique_id = f"{blind.mac}-{motor}"
 
         if self._motor not in ["Bottom", "Top", "Combined"]:

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -1,7 +1,7 @@
 """Support for Motion Blinds using their WLAN API."""
 import logging
 
-from motionblinds import BlindType, DEVICE_TYPES_WIFI
+from motionblinds import DEVICE_TYPES_WIFI, BlindType
 import voluptuous as vol
 
 from homeassistant.components.cover import (

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def device_name(blind):
-    """Construct common name part of a device"""
+    """Construct common name part of a device."""
     if blind.device_type in DEVICE_TYPES_WIFI:
         return blind.blind_type
     return f"{blind.blind_type} {blind.mac[12:]}"

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -12,7 +12,7 @@ from .const import DEFAULT_INTERFACE
 _LOGGER = logging.getLogger(__name__)
 
 
-def device_name(blind)
+def device_name(blind):
     """Construct common name part of a device"""
     if blind.device_type in DEVICE_TYPES_WIFI:
         return blind.blind_type

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -3,7 +3,7 @@ import contextlib
 import logging
 import socket
 
-from motionblinds import AsyncMotionMulticast, DEVICE_TYPES_WIFI, MotionGateway
+from motionblinds import DEVICE_TYPES_WIFI, AsyncMotionMulticast, MotionGateway
 
 from homeassistant.components import network
 

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -3,13 +3,20 @@ import contextlib
 import logging
 import socket
 
-from motionblinds import AsyncMotionMulticast, MotionGateway
+from motionblinds import AsyncMotionMulticast, DEVICE_TYPES_WIFI, MotionGateway
 
 from homeassistant.components import network
 
 from .const import DEFAULT_INTERFACE
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def device_name(blind)
+    """Construct common name part of a device"""
+    if blind.device_type in DEVICE_TYPES_WIFI:
+        return blind.blind_type
+    return f"{blind.blind_type} {blind.mac[12:]}"
 
 
 class ConnectMotionGateway:

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_AVAILABLE, DOMAIN, KEY_COORDINATOR, KEY_GATEWAY
+from .gateway import device_name
 
 ATTR_BATTERY_VOLTAGE = "battery_voltage"
 TYPE_BLIND = "blind"
@@ -54,14 +55,9 @@ class MotionBatterySensor(CoordinatorEntity, SensorEntity):
         """Initialize the Motion Battery Sensor."""
         super().__init__(coordinator)
 
-        if blind.device_type in DEVICE_TYPES_WIFI:
-            name = f"{blind.blind_type} battery"
-        else:
-            name = f"{blind.blind_type} {blind.mac[12:]} battery"
-
         self._blind = blind
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, blind.mac)})
-        self._attr_name = name
+        self._attr_name = f"{device_name(blind)} battery"
         self._attr_unique_id = f"{blind.mac}-battery"
 
     @property
@@ -103,14 +99,9 @@ class MotionTDBUBatterySensor(MotionBatterySensor):
         """Initialize the Motion Battery Sensor."""
         super().__init__(coordinator, blind)
 
-        if blind.device_type in DEVICE_TYPES_WIFI:
-            name = f"{blind.blind_type} {motor} battery"
-        else:
-            name = f"{blind.blind_type} {blind.mac[12:]} {motor} battery"
-
         self._motor = motor
         self._attr_unique_id = f"{blind.mac}-{motor}-battery"
-        self._attr_name = name
+        self._attr_name = f"{device_name(blind)} {motor} battery"
 
     @property
     def native_value(self):
@@ -144,10 +135,8 @@ class MotionSignalStrengthSensor(CoordinatorEntity, SensorEntity):
 
         if device_type == TYPE_GATEWAY:
             name = "Motion gateway signal strength"
-        elif device.device_type in DEVICE_TYPES_WIFI:
-            name = f"{device.blind_type} signal strength"
         else:
-            name = f"{device.blind_type} {device.mac[12:]} signal strength"
+            name = f"{device_name(device)} signal strength"
 
         self._device = device
         self._device_type = device_type

--- a/tests/components/motion_blinds/test_gateway.py
+++ b/tests/components/motion_blinds/test_gateway.py
@@ -1,14 +1,19 @@
 """Test the Motion Blinds config flow."""
 from unittest.mock import Mock
 
-import pytest
-from motionblinds import BlindType
+from motionblinds import DEVICE_TYPES_WIFI, BlindType
 
+from homeassistant.components.motion_blinds.gateway import device_name
+
+TEST_BLIND_MAC = "ab:cd:ef:gh0001"
 
 
 async def test_device_name(hass):
     """test_device_name."""
     blind = Mock()
-    blind.blind_type = BlindType.RollerBlind
-    blind.mac = TEST_MAC
-    assert device_name(blind) == "bla"
+    blind.blind_type = BlindType.RollerBlind.name
+    blind.mac = TEST_BLIND_MAC
+    assert device_name(blind) == "RollerBlind 001"
+
+    blind.device_type = DEVICE_TYPES_WIFI[0]
+    assert device_name(blind) == "RollerBlind"

--- a/tests/components/motion_blinds/test_gateway.py
+++ b/tests/components/motion_blinds/test_gateway.py
@@ -5,7 +5,7 @@ from motionblinds import DEVICE_TYPES_WIFI, BlindType
 
 from homeassistant.components.motion_blinds.gateway import device_name
 
-TEST_BLIND_MAC = "ab:cd:ef:gh0001"
+TEST_BLIND_MAC = "abcdefghujkl0001"
 
 
 async def test_device_name(hass):
@@ -13,7 +13,7 @@ async def test_device_name(hass):
     blind = Mock()
     blind.blind_type = BlindType.RollerBlind.name
     blind.mac = TEST_BLIND_MAC
-    assert device_name(blind) == "RollerBlind 001"
+    assert device_name(blind) == "RollerBlind 0001"
 
     blind.device_type = DEVICE_TYPES_WIFI[0]
     assert device_name(blind) == "RollerBlind"

--- a/tests/components/motion_blinds/test_gateway.py
+++ b/tests/components/motion_blinds/test_gateway.py
@@ -1,0 +1,14 @@
+"""Test the Motion Blinds config flow."""
+from unittest.mock import Mock
+
+import pytest
+from motionblinds import BlindType
+
+
+
+async def test_device_name(hass):
+    """test_device_name."""
+    blind = Mock()
+    blind.blind_type = BlindType.RollerBlind
+    blind.mac = TEST_MAC
+    assert device_name(blind) == "bla"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See revieuw comments in PR: https://github.com/home-assistant/core/pull/72284

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
