### PR TITLE
Ensure metoffice daily are returned once daily

### DIFF
--- a/homeassistant/components/metoffice/helpers.py
+++ b/homeassistant/components/metoffice/helpers.py
@@ -7,6 +7,7 @@ import datapoint
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util.dt import utcnow
 
+from .const import MODE_3HOURLY
 from .data import MetOfficeData
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,7 +39,10 @@ def fetch_data(connection: datapoint.Manager, site, mode) -> MetOfficeData:
                 timestep
                 for day in forecast.days
                 for timestep in day.timesteps
-                if timestep.date > time_now and timestep.date.hour > 6
+                if timestep.date > time_now
+                and (
+                    mode == MODE_3HOURLY or timestep.date.hour > 6
+                )  # ensures only one result per day in MODE_DAILY
             ],
             site,
         )

--- a/homeassistant/components/metoffice/helpers.py
+++ b/homeassistant/components/metoffice/helpers.py
@@ -38,7 +38,7 @@ def fetch_data(connection: datapoint.Manager, site, mode) -> MetOfficeData:
                 timestep
                 for day in forecast.days
                 for timestep in day.timesteps
-                if timestep.date > time_now
+                if timestep.date > time_now and timestep.date.hour > 6
             ],
             site,
         )

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -163,16 +163,17 @@ async def test_one_weather_site_running(hass, requests_mock):
     assert weather.attributes.get("humidity") == 50
 
     # Also has Forecasts added - again, just pick out 1 entry to check
-    assert len(weather.attributes.get("forecast")) == 8
+    # ensures that daily filters out multiple results per day
+    assert len(weather.attributes.get("forecast")) == 4
 
     assert (
-        weather.attributes.get("forecast")[7]["datetime"] == "2020-04-29T12:00:00+00:00"
+        weather.attributes.get("forecast")[3]["datetime"] == "2020-04-29T12:00:00+00:00"
     )
-    assert weather.attributes.get("forecast")[7]["condition"] == "rainy"
-    assert weather.attributes.get("forecast")[7]["precipitation_probability"] == 59
-    assert weather.attributes.get("forecast")[7]["temperature"] == 13
-    assert weather.attributes.get("forecast")[7]["wind_speed"] == 13
-    assert weather.attributes.get("forecast")[7]["wind_bearing"] == "SE"
+    assert weather.attributes.get("forecast")[3]["condition"] == "rainy"
+    assert weather.attributes.get("forecast")[3]["precipitation_probability"] == 59
+    assert weather.attributes.get("forecast")[3]["temperature"] == 13
+    assert weather.attributes.get("forecast")[3]["wind_speed"] == 13
+    assert weather.attributes.get("forecast")[3]["wind_bearing"] == "SE"
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
@@ -258,16 +259,17 @@ async def test_two_weather_sites_running(hass, requests_mock):
     assert weather.attributes.get("humidity") == 50
 
     # Also has Forecasts added - again, just pick out 1 entry to check
-    assert len(weather.attributes.get("forecast")) == 8
+    # ensures that daily filters out multiple results per day
+    assert len(weather.attributes.get("forecast")) == 4
 
     assert (
-        weather.attributes.get("forecast")[7]["datetime"] == "2020-04-29T12:00:00+00:00"
+        weather.attributes.get("forecast")[3]["datetime"] == "2020-04-29T12:00:00+00:00"
     )
-    assert weather.attributes.get("forecast")[7]["condition"] == "rainy"
-    assert weather.attributes.get("forecast")[7]["precipitation_probability"] == 59
-    assert weather.attributes.get("forecast")[7]["temperature"] == 13
-    assert weather.attributes.get("forecast")[7]["wind_speed"] == 13
-    assert weather.attributes.get("forecast")[7]["wind_bearing"] == "SE"
+    assert weather.attributes.get("forecast")[3]["condition"] == "rainy"
+    assert weather.attributes.get("forecast")[3]["precipitation_probability"] == 59
+    assert weather.attributes.get("forecast")[3]["temperature"] == 13
+    assert weather.attributes.get("forecast")[3]["wind_speed"] == 13
+    assert weather.attributes.get("forecast")[3]["wind_bearing"] == "SE"
 
     # King's Lynn 3-hourly weather platform expected results
     weather = hass.states.get("weather.met_office_king_s_lynn_3_hourly")
@@ -305,13 +307,14 @@ async def test_two_weather_sites_running(hass, requests_mock):
     assert weather.attributes.get("humidity") == 75
 
     # All should have Forecast added - again, just picking out 1 entry to check
-    assert len(weather.attributes.get("forecast")) == 8
+    # ensures daily filters out multiple results per day
+    assert len(weather.attributes.get("forecast")) == 4
 
     assert (
-        weather.attributes.get("forecast")[5]["datetime"] == "2020-04-28T12:00:00+00:00"
+        weather.attributes.get("forecast")[2]["datetime"] == "2020-04-28T12:00:00+00:00"
     )
-    assert weather.attributes.get("forecast")[5]["condition"] == "cloudy"
-    assert weather.attributes.get("forecast")[5]["precipitation_probability"] == 14
-    assert weather.attributes.get("forecast")[5]["temperature"] == 11
-    assert weather.attributes.get("forecast")[5]["wind_speed"] == 7
-    assert weather.attributes.get("forecast")[5]["wind_bearing"] == "ESE"
+    assert weather.attributes.get("forecast")[2]["condition"] == "cloudy"
+    assert weather.attributes.get("forecast")[2]["precipitation_probability"] == 14
+    assert weather.attributes.get("forecast")[2]["temperature"] == 11
+    assert weather.attributes.get("forecast")[2]["wind_speed"] == 7
+    assert weather.attributes.get("forecast")[2]["wind_bearing"] == "ESE"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

the metoffice (weather) integration returns two forecasts per day instead of one. This is because the library it uses chooses to return a "day" and "night" forecast for every day: https://github.com/EJEP/datapoint-python/blob/master/datapoint/Manager.py#L322

This change restricts the integration into only providing one forecast per day, choosing the "day" forecast. This brings the integration in-line with other weather integrations and makes the daily forecasts work better with frontend elements

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72007
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
