### PR TITLE
Add config entities for the Aqara P1 motion sensor to ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -1,4 +1,6 @@
 """Manufacturer specific channels module for Zigbee Home Automation."""
+import logging
+
 from homeassistant.core import callback
 
 from .. import registries
@@ -13,6 +15,8 @@ from ..const import (
     UNKNOWN,
 )
 from .base import ClientChannel, ZigbeeChannel
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(registries.SMARTTHINGS_HUMIDITY_CLUSTER)
@@ -49,6 +53,14 @@ class OppleRemote(ZigbeeChannel):
     """Opple button channel."""
 
     REPORT_CONFIG = []
+
+    async def async_initialize_channel_specific(self, from_cache: bool) -> None:
+        """Initialize channel specific."""
+        if self.cluster.endpoint.model == "lumi.motion.ac02":
+            interval = self.cluster.get("detection_interval", self.cluster.get(0x0102))
+            self.warning("interval at startup: %s", interval)
+            if interval is not None:
+                self.cluster.endpoint.ias_zone.reset_s = int(interval)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -53,13 +53,18 @@ class OppleRemote(ZigbeeChannel):
     """Opple button channel."""
 
     REPORT_CONFIG = []
+    ZCL_INIT_ATTRS = {
+        "detection_interval": True,
+        "motion_sensitivity": True,
+        "trigger_indicator": True,
+    }
 
     async def async_initialize_channel_specific(self, from_cache: bool) -> None:
         """Initialize channel specific."""
         if self.cluster.endpoint.model == "lumi.motion.ac02":
             interval = self.cluster.get("detection_interval", self.cluster.get(0x0102))
-            self.warning("interval at startup: %s", interval)
             if interval is not None:
+                self.debug("Loaded detection interval at startup: %s", interval)
                 self.cluster.endpoint.ias_zone.reset_s = int(interval)
 
 

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.core import callback
 
-from .. import registries
+from .. import registries, typing as zha_typing
 from ..const import (
     ATTR_ATTRIBUTE_ID,
     ATTR_ATTRIBUTE_NAME,
@@ -53,11 +53,18 @@ class OppleRemote(ZigbeeChannel):
     """Opple button channel."""
 
     REPORT_CONFIG = []
-    ZCL_INIT_ATTRS = {
-        "detection_interval": True,
-        "motion_sensitivity": True,
-        "trigger_indicator": True,
-    }
+
+    def __init__(
+        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
+    ) -> None:
+        """Initialize Opple channel."""
+        super().__init__(cluster, ch_pool)
+        if self.cluster.endpoint.model == "lumi.motion.ac02":
+            self.ZCL_INIT_ATTRS = {  # pylint: disable=C0103
+                "detection_interval": True,
+                "motion_sensitivity": True,
+                "trigger_indicator": True,
+            }
 
     async def async_initialize_channel_specific(self, from_cache: bool) -> None:
         """Initialize channel specific."""

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -433,6 +433,17 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
             _LOGGER.debug("read value=%s", value)
 
 
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.motion.ac02"})
+class AqaraMotionDetectionInterval(
+    ZHANumberConfigurationEntity, id_suffix="detection_interval"
+):
+    """Representation of a ZHA on off transition time configuration entity."""
+
+    _attr_min_value: float = 2
+    _attr_max_value: float = 65535
+    _zcl_attribute: str = "detection_interval"
+
+
 @CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_LEVEL)
 class OnOffTransitionTimeConfigurationEntity(
     ZHANumberConfigurationEntity, id_suffix="on_off_transition_time"

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -5,6 +5,7 @@ from enum import Enum
 import functools
 import logging
 
+from zigpy import types
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd
 
@@ -208,3 +209,19 @@ class ZHAStartupOnOffSelectEntity(
 
     _select_attr = "start_up_on_off"
     _enum: Enum = OnOff.StartUpOnOff
+
+
+class AqaraMotionSensitivities(types.enum8):
+    """Aqara motion sensitivities."""
+
+    Low = 0x01
+    Medium = 0x02
+    High = 0x03
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.motion.ac02"})
+class AqaraMotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"):
+    """Representation of a ZHA on off transition time configuration entity."""
+
+    _select_attr = "motion_sensitivity"
+    _enum: Enum = AqaraMotionSensitivities

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -155,6 +155,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
 class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
     """Representation of a ZHA switch configuration entity."""
 
+    _attr_entity_category = EntityCategory.CONFIG
     _zcl_attribute: str
     _zcl_inverter_attribute: str = ""
 
@@ -260,8 +261,16 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
 class OnOffWindowDetectionFunctionConfigurationEntity(
     ZHASwitchConfigurationEntity, id_suffix="on_off_window_opened_detection"
 ):
-    """Representation of a ZHA on off transition time configuration entity."""
+    """Representation of a ZHA window detection configuration entity."""
 
-    _attr_entity_category = EntityCategory.CONFIG
     _zcl_attribute = "window_detection_function"
     _zcl_inverter_attribute = "window_detection_function_inverter"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.motion.ac02"})
+class P1MotionTriggerIndicatorSwitch(
+    ZHASwitchConfigurationEntity, id_suffix="trigger_indicator"
+):
+    """Representation of a ZHA motion triggering configuration entity."""
+
+    _zcl_attribute = "trigger_indicator"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds config entities for the Aqara P1 motion sensor. The triggering time, Visual feedback and sensitivity are all configurable. 

![image](https://user-images.githubusercontent.com/1335687/170151768-909935d5-b018-47fa-898c-725182f6a5bd.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
