### PR TITLE
Bypass dynamic validation for zwave_js custom triggers

### DIFF
--- a/homeassistant/components/zwave_js/triggers/helpers.py
+++ b/homeassistant/components/zwave_js/triggers/helpers.py
@@ -1,0 +1,35 @@
+"""Helpers for Z-Wave JS custom triggers."""
+from homeassistant.components.zwave_js.const import ATTR_CONFIG_ENTRY_ID, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.typing import ConfigType
+
+
+@callback
+def async_bypass_dynamic_config_validation(
+    hass: HomeAssistant, config: ConfigType
+) -> bool:
+    """Return whether target zwave_js config entry is not loaded."""
+    # If the config entry is not loaded for a zwave_js device, entity, or the
+    # config entry ID provided, we can't perform dynamic validation
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    trigger_devices = config.get(ATTR_DEVICE_ID, [])
+    trigger_entities = config.get(ATTR_ENTITY_ID, [])
+    return any(
+        entry.state != ConfigEntryState.LOADED
+        and (
+            entry.entry_id == config.get(ATTR_CONFIG_ENTRY_ID)
+            or any(
+                device.id in trigger_devices
+                for device in dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+            )
+            or (
+                entity.entity_id in trigger_entities
+                for entity in er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+            )
+        )
+        for entry in hass.config_entries.async_entries(DOMAIN)
+    )

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -13,6 +13,7 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
+from homeassistant.components.zwave_js.config_validation import VALUE_SCHEMA
 from homeassistant.components.zwave_js.const import (
     ATTR_COMMAND_CLASS,
     ATTR_COMMAND_CLASS_NAME,
@@ -38,7 +39,7 @@ from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
-from ..config_validation import VALUE_SCHEMA
+from .helpers import async_bypass_dynamic_config_validation
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
 PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
@@ -75,6 +76,9 @@ async def async_validate_trigger_config(
 ) -> ConfigType:
     """Validate config."""
     config = TRIGGER_SCHEMA(config)
+
+    if async_bypass_dynamic_config_validation(hass, config):
+        return config
 
     config[ATTR_NODES] = async_get_nodes_from_targets(hass, config)
     if not config[ATTR_NODES]:

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -671,35 +671,6 @@ async def test_zwave_js_event_invalid_config_entry_id(
     caplog.clear()
 
 
-# async def test_zwave_js_event_unloaded_config_entry(hass, client, integration, caplog):
-#     """Test zwave_js.event automation trigger fails when config entry is unloaded."""
-#     trigger_type = f"{DOMAIN}.event"
-
-#     await hass.config_entries.async_unload(integration.entry_id)
-
-#     assert await async_setup_component(
-#         hass,
-#         automation.DOMAIN,
-#         {
-#             automation.DOMAIN: [
-#                 {
-#                     "trigger": {
-#                         "platform": trigger_type,
-#                         "config_entry_id": integration.entry_id,
-#                         "event_source": "controller",
-#                         "event": "inclusion started",
-#                     },
-#                     "action": {
-#                         "event": "node_no_event_data_filter",
-#                     },
-#                 }
-#             ]
-#         },
-#     )
-
-#     assert f"Config entry '{integration.entry_id}' not loaded" in caplog.text
-
-
 async def test_async_validate_trigger_config(hass):
     """Test async_validate_trigger_config."""
     mock_platform = AsyncMock()

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -718,7 +718,7 @@ async def test_zwave_js_trigger_config_entry_unloaded(
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
 
-    # Test bypass check passes
+    # Test bypass check is False
     assert not async_bypass_dynamic_config_validation(
         hass,
         {

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -718,6 +718,17 @@ async def test_zwave_js_trigger_config_entry_unloaded(
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
 
+    # Test bypass check passes
+    assert not async_bypass_dynamic_config_validation(
+        hass,
+        {
+            "platform": f"{DOMAIN}.value_updated",
+            "entity_id": SCHLAGE_BE469_LOCK_ENTITY,
+            "command_class": CommandClass.DOOR_LOCK.value,
+            "property": "latchStatus",
+        },
+    )
+
     await hass.config_entries.async_unload(integration.entry_id)
 
     # Test full validation for both events


### PR DESCRIPTION
## Proposed change
Like we discussed here for device automations: https://github.com/home-assistant/core/pull/71715 we need a mechanism to check if we can do dynamic validation for our custom triggers. This is a similar check we use in the device automations but slightly modified because our custom triggers accept both entity ID and device ID and one trigger also accepts a config entry ID, all of which we need to check.

Fixes https://github.com/home-assistant/core/issues/72046


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
