### PR TITLE
Deprecate google calendar add_event service, replaced with entity service

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -43,6 +43,18 @@ from .const import (
     DATA_SERVICE,
     DEVICE_AUTH_IMPL,
     DOMAIN,
+    EVENT_DESCRIPTION,
+    EVENT_END_CONF,
+    EVENT_END_DATE,
+    EVENT_END_DATETIME,
+    EVENT_IN,
+    EVENT_IN_DAYS,
+    EVENT_IN_WEEKS,
+    EVENT_START_CONF,
+    EVENT_START_DATE,
+    EVENT_START_DATETIME,
+    EVENT_SUMMARY,
+    EVENT_TYPES_CONF,
     FeatureAccess,
 )
 
@@ -61,18 +73,6 @@ CONF_MAX_RESULTS = "max_results"
 DEFAULT_CONF_OFFSET = "!!"
 
 EVENT_CALENDAR_ID = "calendar_id"
-EVENT_DESCRIPTION = "description"
-EVENT_END_CONF = "end"
-EVENT_END_DATE = "end_date"
-EVENT_END_DATETIME = "end_date_time"
-EVENT_IN = "in"
-EVENT_IN_DAYS = "days"
-EVENT_IN_WEEKS = "weeks"
-EVENT_START_CONF = "start"
-EVENT_START_DATE = "start_date"
-EVENT_START_DATETIME = "start_date_time"
-EVENT_SUMMARY = "summary"
-EVENT_TYPES_CONF = "event_types"
 
 NOTIFICATION_ID = "google_calendar_notification"
 NOTIFICATION_TITLE = "Google Calendar Setup"
@@ -276,6 +276,12 @@ async def async_setup_add_event_service(
 
     async def _add_event(call: ServiceCall) -> None:
         """Add a new event to calendar."""
+        _LOGGER.warning(
+            "The Google Calendar add_event service has been deprecated, and "
+            "will be removed in a future Home Assistant release. Please move "
+            "calls to the create_event service"
+        )
+
         start: DateOrDatetime | None = None
         end: DateOrDatetime | None = None
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -147,7 +147,7 @@ ADD_EVENT_SERVICE_SCHEMA = vol.Schema(
         vol.Exclusive(EVENT_END_DATE, EVENT_END_CONF): cv.date,
         vol.Exclusive(EVENT_START_DATETIME, EVENT_START_CONF): cv.datetime,
         vol.Exclusive(EVENT_END_DATETIME, EVENT_END_CONF): cv.datetime,
-        vol.Exclusive(EVENT_IN, EVENT_START_CONF, EVENT_END_CONF): _EVENT_IN_TYPES,
+        vol.Exclusive(EVENT_IN, EVENT_START_CONF): _EVENT_IN_TYPES,
     }
 )
 
@@ -304,11 +304,11 @@ async def async_setup_add_event_service(
                 start = DateOrDatetime(date=start_in)
                 end = DateOrDatetime(date=end_in)
 
-        elif EVENT_START_DATE in call.data:
+        elif EVENT_START_DATE in call.data and EVENT_END_DATE in call.data:
             start = DateOrDatetime(date=call.data[EVENT_START_DATE])
             end = DateOrDatetime(date=call.data[EVENT_END_DATE])
 
-        elif EVENT_START_DATETIME in call.data:
+        elif EVENT_START_DATETIME in call.data and EVENT_END_DATETIME in call.data:
             start_dt = call.data[EVENT_START_DATETIME]
             end_dt = call.data[EVENT_END_DATETIME]
             start = DateOrDatetime(

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -44,13 +44,11 @@ from .const import (
     DEVICE_AUTH_IMPL,
     DOMAIN,
     EVENT_DESCRIPTION,
-    EVENT_END_CONF,
     EVENT_END_DATE,
     EVENT_END_DATETIME,
     EVENT_IN,
     EVENT_IN_DAYS,
     EVENT_IN_WEEKS,
-    EVENT_START_CONF,
     EVENT_START_DATE,
     EVENT_START_DATETIME,
     EVENT_SUMMARY,
@@ -138,17 +136,31 @@ _EVENT_IN_TYPES = vol.Schema(
     }
 )
 
-ADD_EVENT_SERVICE_SCHEMA = vol.Schema(
+ADD_EVENT_SERVICE_SCHEMA = vol.All(
+    cv.has_at_least_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
+    cv.has_at_most_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
     {
         vol.Required(EVENT_CALENDAR_ID): cv.string,
         vol.Required(EVENT_SUMMARY): cv.string,
         vol.Optional(EVENT_DESCRIPTION, default=""): cv.string,
-        vol.Exclusive(EVENT_START_DATE, EVENT_START_CONF): cv.date,
-        vol.Exclusive(EVENT_END_DATE, EVENT_END_CONF): cv.date,
-        vol.Exclusive(EVENT_START_DATETIME, EVENT_START_CONF): cv.datetime,
-        vol.Exclusive(EVENT_END_DATETIME, EVENT_END_CONF): cv.datetime,
-        vol.Exclusive(EVENT_IN, EVENT_START_CONF): _EVENT_IN_TYPES,
-    }
+        vol.Inclusive(
+            EVENT_START_DATE, "dates", "Start and end dates must both be specified"
+        ): cv.date,
+        vol.Inclusive(
+            EVENT_END_DATE, "dates", "Start and end dates must both be specified"
+        ): cv.date,
+        vol.Inclusive(
+            EVENT_START_DATETIME,
+            "datetimes",
+            "Start and end datetimes must both be specified",
+        ): cv.datetime,
+        vol.Inclusive(
+            EVENT_END_DATETIME,
+            "datetimes",
+            "Start and end datetimes must both be specified",
+        ): cv.datetime,
+        vol.Optional(EVENT_IN): _EVENT_IN_TYPES,
+    },
 )
 
 

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -9,7 +9,8 @@ from typing import Any
 
 from gcal_sync.api import GoogleCalendarService, ListEventsRequest
 from gcal_sync.exceptions import ApiException
-from gcal_sync.model import Event
+from gcal_sync.model import DateOrDatetime, Event
+import voluptuous as vol
 
 from homeassistant.components.calendar import (
     ENTITY_ID_FORMAT,
@@ -22,6 +23,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID, CONF_ENTITIES, CONF_NAME, CONF_OFFSET
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import Throttle
@@ -38,21 +40,49 @@ from . import (
     load_config,
     update_config,
 )
+from .const import (
+    CONF_CALENDAR_ACCESS,
+    EVENT_DESCRIPTION,
+    EVENT_END_CONF,
+    EVENT_END_DATE,
+    EVENT_END_DATETIME,
+    EVENT_IN,
+    EVENT_IN_DAYS,
+    EVENT_IN_WEEKS,
+    EVENT_START_CONF,
+    EVENT_START_DATE,
+    EVENT_START_DATETIME,
+    EVENT_SUMMARY,
+    EVENT_TYPES_CONF,
+    FeatureAccess,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-DEFAULT_GOOGLE_SEARCH_PARAMS = {
-    "orderBy": "startTime",
-    "singleEvents": True,
-}
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
 
 # Events have a transparency that determine whether or not they block time on calendar.
 # When an event is opaque, it means "Show me as busy" which is the default.  Events that
 # are not opaque are ignored by default.
-TRANSPARENCY = "transparency"
 OPAQUE = "opaque"
+
+_EVENT_IN_TYPES = vol.Schema(
+    {
+        vol.Exclusive(EVENT_IN_DAYS, EVENT_TYPES_CONF): cv.positive_int,
+        vol.Exclusive(EVENT_IN_WEEKS, EVENT_TYPES_CONF): cv.positive_int,
+    }
+)
+
+SERVICE_CREATE_EVENT = "create_event"
+CREATE_EVENT_SCHEMA = {
+    vol.Required(EVENT_SUMMARY): cv.string,
+    vol.Optional(EVENT_DESCRIPTION, default=""): cv.string,
+    vol.Exclusive(EVENT_START_DATE, EVENT_START_CONF): cv.date,
+    vol.Exclusive(EVENT_END_DATE, EVENT_END_CONF): cv.date,
+    vol.Exclusive(EVENT_START_DATETIME, EVENT_START_CONF): cv.datetime,
+    vol.Exclusive(EVENT_END_DATETIME, EVENT_END_CONF): cv.datetime,
+    vol.Exclusive(EVENT_IN, EVENT_START_CONF, EVENT_END_CONF): _EVENT_IN_TYPES,
+}
 
 
 async def async_setup_entry(
@@ -116,6 +146,14 @@ async def async_setup_entry(
 
         await hass.async_add_executor_job(append_calendars_to_config)
 
+    platform = entity_platform.async_get_current_platform()
+    if FeatureAccess[entry.options[CONF_CALENDAR_ACCESS]] is FeatureAccess.read_write:
+        platform.async_register_entity_service(
+            SERVICE_CREATE_EVENT,
+            CREATE_EVENT_SCHEMA,
+            async_create_event,
+        )
+
 
 class GoogleCalendarEntity(CalendarEntity):
     """A calendar event device."""
@@ -130,8 +168,8 @@ class GoogleCalendarEntity(CalendarEntity):
         entity_enabled: bool,
     ) -> None:
         """Create the Calendar event device."""
-        self._calendar_service = calendar_service
-        self._calendar_id = calendar_id
+        self.calendar_service = calendar_service
+        self.calendar_id = calendar_id
         self._search: str | None = data.get(CONF_SEARCH)
         self._ignore_availability: bool = data.get(CONF_IGNORE_AVAILABILITY, False)
         self._event: CalendarEvent | None = None
@@ -178,14 +216,14 @@ class GoogleCalendarEntity(CalendarEntity):
         """Get all events in a specific time frame."""
 
         request = ListEventsRequest(
-            calendar_id=self._calendar_id,
+            calendar_id=self.calendar_id,
             start_time=start_date,
             end_time=end_date,
             search=self._search,
         )
         result_items = []
         try:
-            result = await self._calendar_service.async_list_events(request)
+            result = await self.calendar_service.async_list_events(request)
             async for result_page in result:
                 result_items.extend(result_page.items)
         except ApiException as err:
@@ -199,9 +237,9 @@ class GoogleCalendarEntity(CalendarEntity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:
         """Get the latest data."""
-        request = ListEventsRequest(calendar_id=self._calendar_id, search=self._search)
+        request = ListEventsRequest(calendar_id=self.calendar_id, search=self._search)
         try:
-            result = await self._calendar_service.async_list_events(request)
+            result = await self.calendar_service.async_list_events(request)
         except ApiException as err:
             _LOGGER.error("Unable to connect to Google: %s", err)
             return
@@ -225,4 +263,53 @@ def _get_calendar_event(event: Event) -> CalendarEvent:
         end=event.end.value,
         description=event.description,
         location=event.location,
+    )
+
+
+async def async_create_event(entity: GoogleCalendarEntity, call: ServiceCall) -> None:
+    """Add a new event to calendar."""
+    start: DateOrDatetime | None = None
+    end: DateOrDatetime | None = None
+    hass = entity.hass
+
+    if EVENT_IN in call.data:
+        if EVENT_IN_DAYS in call.data[EVENT_IN]:
+            now = datetime.now()
+
+            start_in = now + timedelta(days=call.data[EVENT_IN][EVENT_IN_DAYS])
+            end_in = start_in + timedelta(days=1)
+
+            start = DateOrDatetime(date=start_in)
+            end = DateOrDatetime(date=end_in)
+
+        elif EVENT_IN_WEEKS in call.data[EVENT_IN]:
+            now = datetime.now()
+
+            start_in = now + timedelta(weeks=call.data[EVENT_IN][EVENT_IN_WEEKS])
+            end_in = start_in + timedelta(days=1)
+
+            start = DateOrDatetime(date=start_in)
+            end = DateOrDatetime(date=end_in)
+
+    elif EVENT_START_DATE in call.data:
+        start = DateOrDatetime(date=call.data[EVENT_START_DATE])
+        end = DateOrDatetime(date=call.data[EVENT_END_DATE])
+
+    elif EVENT_START_DATETIME in call.data:
+        start_dt = call.data[EVENT_START_DATETIME]
+        end_dt = call.data[EVENT_END_DATETIME]
+        start = DateOrDatetime(date_time=start_dt, timezone=str(hass.config.time_zone))
+        end = DateOrDatetime(date_time=end_dt, timezone=str(hass.config.time_zone))
+
+    if start is None or end is None:
+        raise ValueError("Missing required fields to set start or end date/datetime")
+
+    await entity.calendar_service.async_create_event(
+        entity.calendar_id,
+        Event(
+            summary=call.data[EVENT_SUMMARY],
+            description=call.data[EVENT_DESCRIPTION],
+            start=start,
+            end=end,
+        ),
     )

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -81,7 +81,7 @@ CREATE_EVENT_SCHEMA = {
     vol.Exclusive(EVENT_END_DATE, EVENT_END_CONF): cv.date,
     vol.Exclusive(EVENT_START_DATETIME, EVENT_START_CONF): cv.datetime,
     vol.Exclusive(EVENT_END_DATETIME, EVENT_END_CONF): cv.datetime,
-    vol.Exclusive(EVENT_IN, EVENT_START_CONF, EVENT_END_CONF): _EVENT_IN_TYPES,
+    vol.Exclusive(EVENT_IN, EVENT_START_CONF): _EVENT_IN_TYPES,
 }
 
 
@@ -291,11 +291,11 @@ async def async_create_event(entity: GoogleCalendarEntity, call: ServiceCall) ->
             start = DateOrDatetime(date=start_in)
             end = DateOrDatetime(date=end_in)
 
-    elif EVENT_START_DATE in call.data:
+    elif EVENT_START_DATE in call.data and EVENT_END_DATE in call.data:
         start = DateOrDatetime(date=call.data[EVENT_START_DATE])
         end = DateOrDatetime(date=call.data[EVENT_END_DATE])
 
-    elif EVENT_START_DATETIME in call.data:
+    elif EVENT_START_DATETIME in call.data and EVENT_END_DATETIME in call.data:
         start_dt = call.data[EVENT_START_DATETIME]
         end_dt = call.data[EVENT_END_DATETIME]
         start = DateOrDatetime(date_time=start_dt, timezone=str(hass.config.time_zone))

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -43,13 +43,11 @@ from . import (
 from .const import (
     CONF_CALENDAR_ACCESS,
     EVENT_DESCRIPTION,
-    EVENT_END_CONF,
     EVENT_END_DATE,
     EVENT_END_DATETIME,
     EVENT_IN,
     EVENT_IN_DAYS,
     EVENT_IN_WEEKS,
-    EVENT_START_CONF,
     EVENT_START_DATE,
     EVENT_START_DATETIME,
     EVENT_SUMMARY,
@@ -74,15 +72,33 @@ _EVENT_IN_TYPES = vol.Schema(
 )
 
 SERVICE_CREATE_EVENT = "create_event"
-CREATE_EVENT_SCHEMA = {
-    vol.Required(EVENT_SUMMARY): cv.string,
-    vol.Optional(EVENT_DESCRIPTION, default=""): cv.string,
-    vol.Exclusive(EVENT_START_DATE, EVENT_START_CONF): cv.date,
-    vol.Exclusive(EVENT_END_DATE, EVENT_END_CONF): cv.date,
-    vol.Exclusive(EVENT_START_DATETIME, EVENT_START_CONF): cv.datetime,
-    vol.Exclusive(EVENT_END_DATETIME, EVENT_END_CONF): cv.datetime,
-    vol.Exclusive(EVENT_IN, EVENT_START_CONF): _EVENT_IN_TYPES,
-}
+CREATE_EVENT_SCHEMA = vol.All(
+    cv.has_at_least_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
+    cv.has_at_most_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
+    cv.make_entity_service_schema(
+        {
+            vol.Required(EVENT_SUMMARY): cv.string,
+            vol.Optional(EVENT_DESCRIPTION, default=""): cv.string,
+            vol.Inclusive(
+                EVENT_START_DATE, "dates", "Start and end dates must both be specified"
+            ): cv.date,
+            vol.Inclusive(
+                EVENT_END_DATE, "dates", "Start and end dates must both be specified"
+            ): cv.date,
+            vol.Inclusive(
+                EVENT_START_DATETIME,
+                "datetimes",
+                "Start and end datetimes must both be specified",
+            ): cv.datetime,
+            vol.Inclusive(
+                EVENT_END_DATETIME,
+                "datetimes",
+                "Start and end datetimes must both be specified",
+            ): cv.datetime,
+            vol.Optional(EVENT_IN): _EVENT_IN_TYPES,
+        }
+    ),
+)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -21,7 +21,7 @@ from homeassistant.components.calendar import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID, CONF_ENTITIES, CONF_NAME, CONF_OFFSET
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import generate_entity_id
@@ -40,8 +40,8 @@ from . import (
     load_config,
     update_config,
 )
+from .api import get_feature_access
 from .const import (
-    CONF_CALENDAR_ACCESS,
     EVENT_DESCRIPTION,
     EVENT_END_DATE,
     EVENT_END_DATETIME,
@@ -163,7 +163,7 @@ async def async_setup_entry(
         await hass.async_add_executor_job(append_calendars_to_config)
 
     platform = entity_platform.async_get_current_platform()
-    if FeatureAccess[entry.options[CONF_CALENDAR_ACCESS]] is FeatureAccess.read_write:
+    if get_feature_access(hass, entry) is FeatureAccess.read_write:
         platform.async_register_entity_service(
             SERVICE_CREATE_EVENT,
             CREATE_EVENT_SCHEMA,

--- a/homeassistant/components/google/const.py
+++ b/homeassistant/components/google/const.py
@@ -29,3 +29,17 @@ class FeatureAccess(Enum):
 
 
 DEFAULT_FEATURE_ACCESS = FeatureAccess.read_write
+
+
+EVENT_DESCRIPTION = "description"
+EVENT_END_CONF = "end"
+EVENT_END_DATE = "end_date"
+EVENT_END_DATETIME = "end_date_time"
+EVENT_IN = "in"
+EVENT_IN_DAYS = "days"
+EVENT_IN_WEEKS = "weeks"
+EVENT_START_CONF = "start"
+EVENT_START_DATE = "start_date"
+EVENT_START_DATETIME = "start_date_time"
+EVENT_SUMMARY = "summary"
+EVENT_TYPES_CONF = "event_types"

--- a/homeassistant/components/google/const.py
+++ b/homeassistant/components/google/const.py
@@ -32,13 +32,11 @@ DEFAULT_FEATURE_ACCESS = FeatureAccess.read_write
 
 
 EVENT_DESCRIPTION = "description"
-EVENT_END_CONF = "end"
 EVENT_END_DATE = "end_date"
 EVENT_END_DATETIME = "end_date_time"
 EVENT_IN = "in"
 EVENT_IN_DAYS = "days"
 EVENT_IN_WEEKS = "weeks"
-EVENT_START_CONF = "start"
 EVENT_START_DATE = "start_date"
 EVENT_START_DATETIME = "start_date_time"
 EVENT_SUMMARY = "summary"

--- a/homeassistant/components/google/services.yaml
+++ b/homeassistant/components/google/services.yaml
@@ -52,3 +52,54 @@ add_event:
       example: '"days": 2 or "weeks": 2'
       selector:
         object:
+create_event:
+  name: Create event
+  description: Add a new calendar event.
+  target:
+    entity:
+      integration: google
+      domain: calendar
+  fields:
+    summary:
+      name: Summary
+      description: Acts as the title of the event.
+      required: true
+      example: "Bowling"
+      selector:
+        text:
+    description:
+      name: Description
+      description: The description of the event. Optional.
+      example: "Birthday bowling"
+      selector:
+        text:
+    start_date_time:
+      name: Start time
+      description: The date and time the event should start.
+      example: "2022-03-22 20:00:00"
+      selector:
+        text:
+    end_date_time:
+      name: End time
+      description: The date and time the event should end.
+      example: "2022-03-22 22:00:00"
+      selector:
+        text:
+    start_date:
+      name: Start date
+      description: The date the whole day event should start.
+      example: "2022-03-10"
+      selector:
+        text:
+    end_date:
+      name: End date
+      description: The date the whole day event should end.
+      example: "2022-03-11"
+      selector:
+        text:
+    in:
+      name: In
+      description: Days or weeks that you want to create the event in.
+      example: '"days": 2 or "weeks": 2'
+      selector:
+        object:

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -346,36 +346,36 @@ async def test_calendar_config_track_new(
     [
         (
             {},
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "must contain at least one of start_date, start_date_time, in",
         ),
         (
             {
                 "start_date": "2022-04-01",
             },
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
         ),
         (
             {
                 "end_date": "2022-04-02",
             },
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "must contain at least one of start_date, start_date_time, in.",
         ),
         (
             {
                 "start_date_time": "2022-04-01T06:00:00",
             },
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "Start and end datetimes must both be specified",
         ),
         (
             {
                 "end_date_time": "2022-04-02T07:00:00",
             },
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "must contain at least one of start_date, start_date_time, in.",
         ),
         (
             {
@@ -384,7 +384,7 @@ async def test_calendar_config_track_new(
                 "end_date_time": "2022-04-02T07:00:00",
             },
             vol.error.MultipleInvalid,
-            "two or more values in the same group of exclusion 'start'",
+            "must contain at most one of start_date, start_date_time, in.",
         ),
         (
             {
@@ -393,23 +393,23 @@ async def test_calendar_config_track_new(
                 "end_date": "2022-04-02",
             },
             vol.error.MultipleInvalid,
-            "two or more values in the same group of exclusion 'end'",
+            "Start and end dates must both be specified",
         ),
         (
             {
                 "start_date": "2022-04-01",
                 "end_date_time": "2022-04-02T07:00:00",
             },
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
         ),
         (
             {
                 "start_date_time": "2022-04-01T07:00:00",
                 "end_date": "2022-04-02",
             },
-            ValueError,
-            "Missing required fields",
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
         ),
         (
             {
@@ -430,7 +430,7 @@ async def test_calendar_config_track_new(
                 },
             },
             vol.error.MultipleInvalid,
-            "two or more values in the same group of exclusion 'start'",
+            "must contain at most one of start_date, start_date_time, in.",
         ),
         (
             {
@@ -441,7 +441,7 @@ async def test_calendar_config_track_new(
                 },
             },
             vol.error.MultipleInvalid,
-            "two or more values in the same group of exclusion 'start'",
+            "must contain at most one of start_date, start_date_time, in.",
         ),
     ],
     ids=[

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.google import DOMAIN, SERVICE_ADD_EVENT
+from homeassistant.components.google.calendar import SERVICE_CREATE_EVENT
 from homeassistant.components.google.const import CONF_CALENDAR_ACCESS
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF
@@ -57,6 +58,42 @@ def setup_config_entry(
 ) -> MockConfigEntry:
     """Fixture to initialize the config entry."""
     config_entry.add_to_hass(hass)
+
+
+@pytest.fixture(
+    params=[
+        (
+            SERVICE_ADD_EVENT,
+            {"calendar_id": CALENDAR_ID},
+            None,
+        ),
+        (
+            SERVICE_CREATE_EVENT,
+            {},
+            {"entity_id": TEST_YAML_ENTITY},
+        ),
+    ],
+)
+def add_event_call_service(
+    hass: HomeAssistant,
+    request: Any,
+) -> Callable[dict[str, Any], Awaitable[None]]:
+    """Fixture for calling the add or create event service."""
+    (service_call, data, target) = request.param
+
+    async def call_service(params: dict[str, Any]) -> None:
+        await hass.services.async_call(
+            DOMAIN,
+            service_call,
+            {
+                **data,
+                **params,
+            },
+            target=target,
+            blocking=True,
+        )
+
+    return call_service
 
 
 async def test_unload_entry(
@@ -302,22 +339,23 @@ async def test_add_event_missing_required_fields(
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
     test_api_calendar: dict[str, Any],
+    mock_calendars_yaml: None,
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
+    add_event_call_service: Callable[dict[str, Any], Awaitable[None]],
 ) -> None:
     """Test service call that adds an event missing required fields."""
 
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     with pytest.raises(ValueError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_ADD_EVENT,
+        await add_event_call_service(
             {
-                "calendar_id": CALENDAR_ID,
                 "summary": "Summary",
                 "description": "Description",
             },
-            blocking=True,
         )
 
 
@@ -343,38 +381,39 @@ async def test_add_event_date_in_x(
     mock_calendars_list: ApiResult,
     mock_insert_event: Callable[[..., dict[str, Any]], None],
     test_api_calendar: dict[str, Any],
+    mock_calendars_yaml: None,
+    mock_events_list: ApiResult,
     date_fields: dict[str, Any],
     start_timedelta: datetime.timedelta,
     end_timedelta: datetime.timedelta,
     setup_config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
+    add_event_call_service: Callable[dict[str, Any], Awaitable[None]],
 ) -> None:
     """Test service call that adds an event with various time ranges."""
 
-    mock_calendars_list({})
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     now = datetime.datetime.now()
     start_date = now + start_timedelta
     end_date = now + end_timedelta
 
+    aioclient_mock.clear_requests()
     mock_insert_event(
         calendar_id=CALENDAR_ID,
     )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_ADD_EVENT,
+    await add_event_call_service(
         {
-            "calendar_id": CALENDAR_ID,
             "summary": "Summary",
             "description": "Description",
             **date_fields,
         },
-        blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 2
-    assert aioclient_mock.mock_calls[1][2] == {
+    assert len(aioclient_mock.mock_calls) == 1
+    assert aioclient_mock.mock_calls[0][2] == {
         "summary": "Summary",
         "description": "Description",
         "start": {"date": start_date.date().isoformat()},
@@ -386,37 +425,39 @@ async def test_add_event_date(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
     mock_insert_event: Callable[[str, dict[str, Any]], None],
+    mock_calendars_yaml: None,
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
+    add_event_call_service: Callable[dict[str, Any], Awaitable[None]],
 ) -> None:
     """Test service call that sets a date range."""
 
-    mock_calendars_list({})
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     now = utcnow()
     today = now.date()
     end_date = today + datetime.timedelta(days=2)
 
+    aioclient_mock.clear_requests()
     mock_insert_event(
         calendar_id=CALENDAR_ID,
     )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_ADD_EVENT,
+    await add_event_call_service(
         {
-            "calendar_id": CALENDAR_ID,
             "summary": "Summary",
             "description": "Description",
             "start_date": today.isoformat(),
             "end_date": end_date.isoformat(),
         },
-        blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 2
-    assert aioclient_mock.mock_calls[1][2] == {
+    assert len(aioclient_mock.mock_calls) == 1
+    assert aioclient_mock.mock_calls[0][2] == {
         "summary": "Summary",
         "description": "Description",
         "start": {"date": today.isoformat()},
@@ -430,36 +471,37 @@ async def test_add_event_date_time(
     mock_calendars_list: ApiResult,
     mock_insert_event: Callable[[str, dict[str, Any]], None],
     test_api_calendar: dict[str, Any],
+    mock_calendars_yaml: None,
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
+    add_event_call_service: Callable[dict[str, Any], Awaitable[None]],
 ) -> None:
     """Test service call that adds an event with a date time range."""
 
-    mock_calendars_list({})
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     assert await component_setup()
 
     start_datetime = datetime.datetime.now()
     delta = datetime.timedelta(days=3, hours=3)
     end_datetime = start_datetime + delta
 
+    aioclient_mock.clear_requests()
     mock_insert_event(
         calendar_id=CALENDAR_ID,
     )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_ADD_EVENT,
+    await add_event_call_service(
         {
-            "calendar_id": CALENDAR_ID,
             "summary": "Summary",
             "description": "Description",
             "start_date_time": start_datetime.isoformat(),
             "end_date_time": end_datetime.isoformat(),
         },
-        blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 2
-    assert aioclient_mock.mock_calls[1][2] == {
+    assert len(aioclient_mock.mock_calls) == 1
+    assert aioclient_mock.mock_calls[0][2] == {
         "summary": "Summary",
         "description": "Description",
         "start": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Google Calendar `add_event` service is deprecated, and will be removed in a future Home Assistant release.  A new service `create_event` with equivalent functionality is its replacement, which is an entity based service that takes an entity as a target (rather than a Google Calendar ID).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a `create_event` entity service, and deprecate `add_event`. The existing add event service takes a google calendar entity id, which does not follow typical home assistant pattern of taking an entity id.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22883

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
