### PR TITLE
Update mypy to 0.960

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -315,7 +315,7 @@ def _select_unused_attributes_ids(
             seen_ids |= {
                 attrs_id[0]
                 for attrs_id in session.execute(
-                    attributes_ids_exist_in_states(*attr_ids)
+                    attributes_ids_exist_in_states(*attr_ids)  # type: ignore[arg-type]
                 ).all()
                 if attrs_id[0] is not None
             }
@@ -362,7 +362,7 @@ def _select_unused_event_data_ids(
             seen_ids |= {
                 data_id[0]
                 for data_id in session.execute(
-                    data_ids_exist_in_events(*data_ids_group)
+                    data_ids_exist_in_events(*data_ids_group)  # type: ignore[arg-type]
                 ).all()
                 if data_id[0] is not None
             }

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -62,7 +62,7 @@ def soco_error(
 
         def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             """Wrap for all soco UPnP exception."""
-            args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)  # type: ignore[attr-defined]
+            args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)
             try:
                 result = funct(self, *args, **kwargs)
             except (OSError, SoCoException, SoCoUPnPException) as err:

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import colorsys
 import math
-from typing import NamedTuple, cast
+from typing import NamedTuple
 
 import attr
 
@@ -295,9 +295,9 @@ def color_xy_brightness_to_RGB(
 
     # Apply reverse gamma correction.
     r, g, b = map(
-        lambda x: (12.92 * x)
+        lambda x: (12.92 * x)  # type: ignore[no-any-return]
         if (x <= 0.0031308)
-        else ((1.0 + 0.055) * cast(float, pow(x, (1.0 / 2.4))) - 0.055),
+        else ((1.0 + 0.055) * pow(x, (1.0 / 2.4)) - 0.055),
         [r, g, b],
     )
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ codecov==2.1.12
 coverage==6.4
 freezegun==1.2.1
 mock-open==1.4.0
-mypy==0.950
+mypy==0.960
 pre-commit==2.19.0
 pylint==2.13.9
 pipdeptree==2.2.1


### PR DESCRIPTION
## Proposed change
Update mypy to `v0.960`. Mainly small bug fixes and performance improvements.
Blog post: https://mypy-lang.blogspot.com/2022/05/mypy-0960-released.html
Compare view: https://github.com/python/mypy/compare/v0.950...v0.960

**Notable**
* Fix for `Any` constraint with ParamSpec. Unblocks #70973
* `tuple[object, ...]` and `dict[str, object]` as upper bounds for `ParamSpec.args` and `ParamSpec.kwargs`. I.e. `*args: P.args` is now subscriptable -> `args[0]`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
