### PR TITLE
Fix flux_led taking a long time to recover after offline

### DIFF
--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -74,3 +74,5 @@ EFFECT_SPEED_SUPPORT_MODES: Final = {ColorMode.RGB, ColorMode.RGBW, ColorMode.RG
 CONF_CUSTOM_EFFECT_COLORS: Final = "custom_effect_colors"
 CONF_CUSTOM_EFFECT_SPEED_PCT: Final = "custom_effect_speed_pct"
 CONF_CUSTOM_EFFECT_TRANSITION: Final = "custom_effect_transition"
+
+FLUX_LED_DISCOVERY_SIGNAL = "flux_led_discovery_{entry_id}"

--- a/homeassistant/components/flux_led/coordinator.py
+++ b/homeassistant/components/flux_led/coordinator.py
@@ -30,6 +30,7 @@ class FluxLedUpdateCoordinator(DataUpdateCoordinator):
         self.device = device
         self.title = entry.title
         self.entry = entry
+        self.force_next_update = False
         super().__init__(
             hass,
             _LOGGER,
@@ -45,6 +46,8 @@ class FluxLedUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> None:
         """Fetch all device and sensor data from api."""
         try:
-            await self.device.async_update()
+            await self.device.async_update(force=self.force_next_update)
         except FLUX_LED_EXCEPTIONS as ex:
             raise UpdateFailed(ex) from ex
+        finally:
+            self.force_next_update = False

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.28.29"],
+  "requirements": ["flux_led==0.28.30"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch", "@bdraco"],
   "iot_class": "local_push",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -657,7 +657,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.2
 
 # homeassistant.components.flux_led
-flux_led==0.28.29
+flux_led==0.28.30
 
 # homeassistant.components.homekit
 # homeassistant.components.recorder

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -466,7 +466,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.2
 
 # homeassistant.components.flux_led
-flux_led==0.28.29
+flux_led==0.28.30
 
 # homeassistant.components.homekit
 # homeassistant.components.recorder

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from homeassistant import config_entries
 from homeassistant.components import flux_led
 from homeassistant.components.flux_led.const import (
     CONF_REMOTE_ACCESS_ENABLED,
@@ -19,6 +20,8 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
+    STATE_ON,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -27,6 +30,7 @@ from homeassistant.util.dt import utcnow
 
 from . import (
     DEFAULT_ENTRY_TITLE,
+    DHCP_DISCOVERY,
     FLUX_DISCOVERY,
     FLUX_DISCOVERY_PARTIAL,
     IP_ADDRESS,
@@ -111,6 +115,70 @@ async def test_config_entry_retry(hass: HomeAssistant) -> None:
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
         assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_config_entry_retry_right_away_on_discovery(hass: HomeAssistant) -> None:
+    """Test discovery makes the config entry reload if its in a retry state."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS
+    )
+    config_entry.add_to_hass(hass)
+    with _patch_discovery(no_device=True), _patch_wifibulb(no_device=True):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+    with _patch_discovery(), _patch_wifibulb():
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+        await hass.async_block_till_done()
+        assert config_entry.state == ConfigEntryState.LOADED
+
+
+async def test_coordinator_retry_right_away_on_discovery_already_setup(
+    hass: HomeAssistant,
+) -> None:
+    """Test discovery makes the coordinator force poll if its already setup."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    with _patch_discovery(), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    entity_id = "light.bulb_rgbcw_ddeeff"
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    now = utcnow()
+    bulb.async_update = AsyncMock(side_effect=RuntimeError)
+    async_fire_time_changed(hass, now + timedelta(seconds=50))
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    bulb.async_update = AsyncMock()
+
+    with _patch_discovery(), _patch_wifibulb():
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fixes #72432

upstream changelog: https://github.com/Danielhiversen/flux_led/compare/0.28.29...0.28.30 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72432
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
