### PR TITLE
Add logbook entries for zwave_js events

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -297,8 +297,8 @@ async def setup_driver(  # noqa: C901
         if not disc_info.assumed_state:
             return
         value_updates_disc_info[disc_info.primary_value.value_id] = disc_info
-        # If this is the first time we found a value we want to watch for updates,
-        # return early
+        # If this is not the first time we found a value we want to watch for updates,
+        # return early because we only need one listener for all values.
         if len(value_updates_disc_info) != 1:
             return
         # add listener for value updated events

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -503,7 +503,7 @@ async def setup_driver(  # noqa: C901
         elif isinstance(notification, PowerLevelNotification):
             event_data.update(
                 {
-                    ATTR_COMMAND_CLASS_NAME: "Power Level",
+                    ATTR_COMMAND_CLASS_NAME: "Powerlevel",
                     ATTR_TEST_NODE_ID: notification.test_node_id,
                     ATTR_STATUS: notification.status,
                     ATTR_ACKNOWLEDGED_FRAMES: notification.acknowledged_frames,

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -43,7 +43,7 @@ def async_describe_events(
     @callback
     def async_describe_zwave_js_notification_event(
         event: Event,
-    ) -> dict[str, str | int]:
+    ) -> dict[str, str]:
         """Describe Z-Wave JS notification event."""
         device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
         # Z-Wave JS devices always have a name

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -6,11 +6,10 @@ from collections.abc import Callable
 from zwave_js_server.const import CommandClass
 
 from homeassistant.components.logbook.const import (
-    LOGBOOK_ENTRY_ENTITY_ID,
     LOGBOOK_ENTRY_MESSAGE,
     LOGBOOK_ENTRY_NAME,
 )
-from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import Event, HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
 
@@ -26,7 +25,6 @@ from .const import (
     DOMAIN,
     ZWAVE_JS_NOTIFICATION_EVENT,
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
-    ZWAVE_JS_VALUE_UPDATED_EVENT,
 )
 
 
@@ -68,7 +66,8 @@ def async_describe_events(
             return {
                 **data,
                 LOGBOOK_ENTRY_MESSAGE: (
-                    f"{prefix} for event type '{event_type}' with data type '{data_type}'"
+                    f"{prefix} for event type '{event_type}' with data type "
+                    f"'{data_type}'"
                 ),
             }
 
@@ -100,26 +99,10 @@ def async_describe_events(
 
         return {
             LOGBOOK_ENTRY_NAME: device_name,
-            LOGBOOK_ENTRY_MESSAGE: f"fired {command_class} CC 'value notification' event for '{label}': '{value}'",
-        }
-
-    @callback
-    def async_describe_zwave_js_value_updated_event(
-        event: Event,
-    ) -> dict[str, str]:
-        """Describe Z-Wave JS value updated event."""
-        device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
-        # Z-Wave JS devices always have a name
-        device_name = device.name_by_user or device.name
-        assert device_name
-
-        entity_id = event.data[ATTR_ENTITY_ID]
-        value = event.data[ATTR_VALUE]
-
-        return {
-            LOGBOOK_ENTRY_NAME: device_name,
-            LOGBOOK_ENTRY_ENTITY_ID: entity_id,
-            LOGBOOK_ENTRY_MESSAGE: f"fired 'value updated' event: '{value}'",
+            LOGBOOK_ENTRY_MESSAGE: (
+                f"fired {command_class} CC 'value notification' event for '{label}': "
+                f"'{value}'"
+            ),
         }
 
     async_describe_event(
@@ -129,9 +112,4 @@ def async_describe_events(
         DOMAIN,
         ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
         async_describe_zwave_js_value_notification_event,
-    )
-    async_describe_event(
-        DOMAIN,
-        ZWAVE_JS_VALUE_UPDATED_EVENT,
-        async_describe_zwave_js_value_updated_event,
     )

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -34,7 +34,7 @@ from .const import (
 def async_describe_events(
     hass: HomeAssistant,
     async_describe_event: Callable[
-        [str, str, Callable[[Event], dict[str, str | int]]], None
+        [str, str, Callable[[Event], dict[str, str]]], None
     ],
 ) -> None:
     """Describe logbook events."""

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -33,9 +33,7 @@ from .const import (
 @callback
 def async_describe_events(
     hass: HomeAssistant,
-    async_describe_event: Callable[
-        [str, str, Callable[[Event], dict[str, str]]], None
-    ],
+    async_describe_event: Callable[[str, str, Callable[[Event], dict[str, str]]], None],
 ) -> None:
     """Describe logbook events."""
     dev_reg = dr.async_get(hass)

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -1,0 +1,139 @@
+"""Describe Z-Wave JS logbook events."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from zwave_js_server.const import CommandClass
+
+from homeassistant.components.logbook.const import (
+    LOGBOOK_ENTRY_ENTITY_ID,
+    LOGBOOK_ENTRY_MESSAGE,
+    LOGBOOK_ENTRY_NAME,
+)
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.core import Event, HomeAssistant, callback
+import homeassistant.helpers.device_registry as dr
+
+from .const import (
+    ATTR_COMMAND_CLASS,
+    ATTR_COMMAND_CLASS_NAME,
+    ATTR_DATA_TYPE,
+    ATTR_DIRECTION,
+    ATTR_EVENT_LABEL,
+    ATTR_EVENT_TYPE,
+    ATTR_LABEL,
+    ATTR_VALUE,
+    DOMAIN,
+    ZWAVE_JS_NOTIFICATION_EVENT,
+    ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
+    ZWAVE_JS_VALUE_UPDATED_EVENT,
+)
+
+
+@callback
+def async_describe_events(
+    hass: HomeAssistant,
+    async_describe_event: Callable[
+        [str, str, Callable[[Event], dict[str, str | int]]], None
+    ],
+) -> None:
+    """Describe logbook events."""
+    dev_reg = dr.async_get(hass)
+
+    @callback
+    def async_describe_zwave_js_notification_event(
+        event: Event,
+    ) -> dict[str, str | int]:
+        """Describe Z-Wave JS notification event."""
+        device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
+        # Z-Wave JS devices always have a name
+        device_name = device.name_by_user or device.name
+        assert device_name
+
+        command_class = event.data[ATTR_COMMAND_CLASS]
+        command_class_name = event.data[ATTR_COMMAND_CLASS_NAME]
+
+        data: dict[str, str] = {LOGBOOK_ENTRY_NAME: device_name}
+        prefix = f"fired {command_class_name} CC 'notification' event"
+
+        if command_class == CommandClass.NOTIFICATION:
+            label = event.data[ATTR_LABEL]
+            event_label = event.data[ATTR_EVENT_LABEL]
+            return {
+                **data,
+                LOGBOOK_ENTRY_MESSAGE: f"{prefix} '{label}': '{event_label}'",
+            }
+
+        if command_class == CommandClass.ENTRY_CONTROL:
+            event_type = event.data[ATTR_EVENT_TYPE]
+            data_type = event.data[ATTR_DATA_TYPE]
+            return {
+                **data,
+                LOGBOOK_ENTRY_MESSAGE: (
+                    f"{prefix} for event type '{event_type}' with data type '{data_type}'"
+                ),
+            }
+
+        if command_class == CommandClass.SWITCH_MULTILEVEL:
+            event_type = event.data[ATTR_EVENT_TYPE]
+            direction = event.data[ATTR_DIRECTION]
+            return {
+                **data,
+                LOGBOOK_ENTRY_MESSAGE: (
+                    f"{prefix} for event type '{event_type}': '{direction}'"
+                ),
+            }
+
+        return {**data, LOGBOOK_ENTRY_MESSAGE: prefix}
+
+    @callback
+    def async_describe_zwave_js_value_notification_event(
+        event: Event,
+    ) -> dict[str, str | int]:
+        """Describe Z-Wave JS value notification event."""
+        device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
+        # Z-Wave JS devices always have a name
+        device_name = device.name_by_user or device.name
+        assert device_name
+
+        command_class = event.data[ATTR_COMMAND_CLASS_NAME]
+        label = event.data[ATTR_LABEL]
+        value = event.data[ATTR_VALUE]
+
+        return {
+            LOGBOOK_ENTRY_NAME: device_name,
+            LOGBOOK_ENTRY_MESSAGE: f"fired {command_class} CC 'value notification' event for '{label}': '{value}'",
+        }
+
+    @callback
+    def async_describe_zwave_js_value_updated_event(
+        event: Event,
+    ) -> dict[str, str | int]:
+        """Describe Z-Wave JS value updated event."""
+        device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
+        # Z-Wave JS devices always have a name
+        device_name = device.name_by_user or device.name
+        assert device_name
+
+        entity_id = event.data[ATTR_ENTITY_ID]
+        value = event.data[ATTR_VALUE]
+
+        return {
+            LOGBOOK_ENTRY_NAME: device_name,
+            LOGBOOK_ENTRY_ENTITY_ID: entity_id,
+            LOGBOOK_ENTRY_MESSAGE: f"fired 'value updated' event: '{value}'",
+        }
+
+    async_describe_event(
+        DOMAIN, ZWAVE_JS_NOTIFICATION_EVENT, async_describe_zwave_js_notification_event
+    )
+    async_describe_event(
+        DOMAIN,
+        ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
+        async_describe_zwave_js_value_notification_event,
+    )
+    async_describe_event(
+        DOMAIN,
+        ZWAVE_JS_VALUE_UPDATED_EVENT,
+        async_describe_zwave_js_value_updated_event,
+    )

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -108,7 +108,7 @@ def async_describe_events(
     @callback
     def async_describe_zwave_js_value_updated_event(
         event: Event,
-    ) -> dict[str, str | int]:
+    ) -> dict[str, str]:
         """Describe Z-Wave JS value updated event."""
         device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
         # Z-Wave JS devices always have a name

--- a/homeassistant/components/zwave_js/logbook.py
+++ b/homeassistant/components/zwave_js/logbook.py
@@ -89,7 +89,7 @@ def async_describe_events(
     @callback
     def async_describe_zwave_js_value_notification_event(
         event: Event,
-    ) -> dict[str, str | int]:
+    ) -> dict[str, str]:
         """Describe Z-Wave JS value notification event."""
         device = dev_reg.devices[event.data[ATTR_DEVICE_ID]]
         # Z-Wave JS devices always have a name

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -312,7 +312,7 @@ async def test_power_level_notification(hass, hank_binary_switch, integration, c
     node.receive_event(event)
     await hass.async_block_till_done()
     assert len(events) == 1
-    assert events[0].data["command_class_name"] == "Power Level"
+    assert events[0].data["command_class_name"] == "Powerlevel"
     assert events[0].data["command_class"] == 115
     assert events[0].data["test_node_id"] == 1
     assert events[0].data["status"] == 0

--- a/tests/components/zwave_js/test_logbook.py
+++ b/tests/components/zwave_js/test_logbook.py
@@ -1,0 +1,170 @@
+"""The tests for Z-Wave JS logbook."""
+from zwave_js_server.const import CommandClass
+
+from homeassistant.components.zwave_js.const import (
+    ZWAVE_JS_NOTIFICATION_EVENT,
+    ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
+    ZWAVE_JS_VALUE_UPDATED_EVENT,
+)
+from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from .common import SCHLAGE_BE469_LOCK_ENTITY
+
+from tests.components.logbook.common import MockRow, mock_humanify
+
+
+async def test_humanifying_zwave_js_notification_event(
+    hass, client, lock_schlage_be469, integration
+):
+    """Test humanifying Z-Wave JS notification events."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    )
+    assert device
+
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+
+    events = mock_humanify(
+        hass,
+        [
+            MockRow(
+                ZWAVE_JS_NOTIFICATION_EVENT,
+                {
+                    "device_id": device.id,
+                    "command_class": CommandClass.NOTIFICATION.value,
+                    "command_class_name": "Notification",
+                    "label": "label",
+                    "event_label": "event_label",
+                },
+            ),
+            MockRow(
+                ZWAVE_JS_NOTIFICATION_EVENT,
+                {
+                    "device_id": device.id,
+                    "command_class": CommandClass.ENTRY_CONTROL.value,
+                    "command_class_name": "Entry Control",
+                    "event_type": 1,
+                    "data_type": 2,
+                },
+            ),
+            MockRow(
+                ZWAVE_JS_NOTIFICATION_EVENT,
+                {
+                    "device_id": device.id,
+                    "command_class": CommandClass.SWITCH_MULTILEVEL.value,
+                    "command_class_name": "Multilevel Switch",
+                    "event_type": 1,
+                    "direction": "up",
+                },
+            ),
+            MockRow(
+                ZWAVE_JS_NOTIFICATION_EVENT,
+                {
+                    "device_id": device.id,
+                    "command_class": CommandClass.POWERLEVEL.value,
+                    "command_class_name": "Powerlevel",
+                },
+            ),
+        ],
+    )
+
+    assert events[0]["name"] == "Touchscreen Deadbolt"
+    assert events[0]["domain"] == "zwave_js"
+    assert (
+        events[0]["message"]
+        == "fired Notification CC 'notification' event 'label': 'event_label'"
+    )
+
+    assert events[1]["name"] == "Touchscreen Deadbolt"
+    assert events[1]["domain"] == "zwave_js"
+    assert (
+        events[1]["message"]
+        == "fired Entry Control CC 'notification' event for event type '1' with data type '2'"
+    )
+
+    assert events[2]["name"] == "Touchscreen Deadbolt"
+    assert events[2]["domain"] == "zwave_js"
+    assert (
+        events[2]["message"]
+        == "fired Multilevel Switch CC 'notification' event for event type '1': 'up'"
+    )
+
+    assert events[3]["name"] == "Touchscreen Deadbolt"
+    assert events[3]["domain"] == "zwave_js"
+    assert events[3]["message"] == "fired Powerlevel CC 'notification' event"
+
+
+async def test_humanifying_zwave_js_value_notification_event(
+    hass, client, lock_schlage_be469, integration
+):
+    """Test humanifying Z-Wave JS value notification events."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    )
+    assert device
+
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+
+    events = mock_humanify(
+        hass,
+        [
+            MockRow(
+                ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
+                {
+                    "device_id": device.id,
+                    "command_class": CommandClass.SCENE_ACTIVATION.value,
+                    "command_class_name": "Scene Activation",
+                    "label": "Scene ID",
+                    "value": "001",
+                },
+            ),
+        ],
+    )
+
+    assert events[0]["name"] == "Touchscreen Deadbolt"
+    assert events[0]["domain"] == "zwave_js"
+    assert (
+        events[0]["message"]
+        == "fired Scene Activation CC 'value notification' event for 'Scene ID': '001'"
+    )
+
+
+async def test_humanifying_zwave_js_value_updated_event(
+    hass, client, lock_schlage_be469, integration
+):
+    """Test humanifying Z-Wave JS value updated events."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    )
+    assert device
+
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+
+    events = mock_humanify(
+        hass,
+        [
+            MockRow(
+                ZWAVE_JS_VALUE_UPDATED_EVENT,
+                {
+                    "device_id": device.id,
+                    "command_class": CommandClass.SCENE_ACTIVATION.value,
+                    "command_class_name": "Scene Activation",
+                    "entity_id": SCHLAGE_BE469_LOCK_ENTITY,
+                    "value": 1,
+                },
+            ),
+        ],
+    )
+
+    assert events[0]["name"] == "Touchscreen Deadbolt"
+    assert events[0]["domain"] == "zwave_js"
+    assert events[0]["entity_id"] == SCHLAGE_BE469_LOCK_ENTITY
+    assert events[0]["message"] == "fired 'value updated' event: '1'"

--- a/tests/components/zwave_js/test_logbook.py
+++ b/tests/components/zwave_js/test_logbook.py
@@ -4,13 +4,10 @@ from zwave_js_server.const import CommandClass
 from homeassistant.components.zwave_js.const import (
     ZWAVE_JS_NOTIFICATION_EVENT,
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
-    ZWAVE_JS_VALUE_UPDATED_EVENT,
 )
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
-
-from .common import SCHLAGE_BE469_LOCK_ENTITY
 
 from tests.components.logbook.common import MockRow, mock_humanify
 
@@ -133,38 +130,3 @@ async def test_humanifying_zwave_js_value_notification_event(
         events[0]["message"]
         == "fired Scene Activation CC 'value notification' event for 'Scene ID': '001'"
     )
-
-
-async def test_humanifying_zwave_js_value_updated_event(
-    hass, client, lock_schlage_be469, integration
-):
-    """Test humanifying Z-Wave JS value updated events."""
-    dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
-    )
-    assert device
-
-    hass.config.components.add("recorder")
-    assert await async_setup_component(hass, "logbook", {})
-
-    events = mock_humanify(
-        hass,
-        [
-            MockRow(
-                ZWAVE_JS_VALUE_UPDATED_EVENT,
-                {
-                    "device_id": device.id,
-                    "command_class": CommandClass.SCENE_ACTIVATION.value,
-                    "command_class_name": "Scene Activation",
-                    "entity_id": SCHLAGE_BE469_LOCK_ENTITY,
-                    "value": 1,
-                },
-            ),
-        ],
-    )
-
-    assert events[0]["name"] == "Touchscreen Deadbolt"
-    assert events[0]["domain"] == "zwave_js"
-    assert events[0]["entity_id"] == SCHLAGE_BE469_LOCK_ENTITY
-    assert events[0]["message"] == "fired 'value updated' event: '1'"


### PR DESCRIPTION
## Proposed change
Adds new logbook entries for zwave_js specific events:
- zwave_js_notification
- zwave_js_value_notification

`zwave_js_value_updated` is out of scope for now


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
