### PR TITLE
Add support for async_remove_config_entry_device to bond

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -119,3 +119,22 @@ def _async_remove_old_device_identifiers(
             continue
         if config_entry_id in dev.config_entries:
             device_registry.async_remove_device(dev.id)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove bond config entry from a device."""
+    hub: BondHub = hass.data[DOMAIN][config_entry.entry_id][HUB]
+    for identifier in device_entry.identifiers:
+        if identifier[0] != DOMAIN or len(identifier) != 3:
+            continue
+        bond_id: str = identifier[1]
+        device_id: str = identifier[2]  # type: ignore[misc]
+        # If device_id is no longer present on
+        # the hub, we allow removal.
+        if hub.bond_id == bond_id and not all(
+            device_id == device.device_id for device in hub.devices
+        ):
+            return True
+    return False

--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -135,7 +135,7 @@ async def async_remove_config_entry_device(
         device_id: str = identifier[2]  # type: ignore[misc]
         # If device_id is no longer present on
         # the hub, we allow removal.
-        if hub.bond_id == bond_id and not any(
+        if hub.bond_id != bond_id or not any(
             device_id == device.device_id for device in hub.devices
         ):
             return True

--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -135,7 +135,7 @@ async def async_remove_config_entry_device(
         device_id: str = identifier[2]  # type: ignore[misc]
         # If device_id is no longer present on
         # the hub, we allow removal.
-        if hub.bond_id == bond_id and not all(
+        if hub.bond_id == bond_id and not any(
             device_id == device.device_id for device in hub.devices
         ):
             return True

--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -130,6 +130,8 @@ async def async_remove_config_entry_device(
         if identifier[0] != DOMAIN or len(identifier) != 3:
             continue
         bond_id: str = identifier[1]
+        # Bond still uses the 3 arg tuple before
+        # the identifiers were typed
         device_id: str = identifier[2]  # type: ignore[misc]
         # If device_id is no longer present on
         # the hub, we allow removal.

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -19,6 +19,20 @@ from homeassistant.util import utcnow
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+async def remove_device(ws_client, device_id, config_entry_id):
+    """Remove config entry from a device."""
+    await ws_client.send_json(
+        {
+            "id": 5,
+            "type": "config/device_registry/remove_config_entry",
+            "config_entry_id": config_entry_id,
+            "device_id": device_id,
+        }
+    )
+    response = await ws_client.receive_json()
+    return response["success"]
+
+
 def ceiling_fan_with_breeze(name: str):
     """Create a ceiling fan with given name with breeze support."""
     return {
@@ -246,3 +260,12 @@ async def help_test_entity_available(
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
     assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+
+def ceiling_fan(name: str):
+    """Create a ceiling fan with given name."""
+    return {
+        "name": name,
+        "type": DeviceType.CEILING_FAN,
+        "actions": ["SetSpeed", "SetDirection"],
+    }

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -33,6 +33,7 @@ from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
 from .common import (
+    ceiling_fan,
     help_test_entity_available,
     patch_bond_action,
     patch_bond_action_returns_clientresponseerror,
@@ -41,15 +42,6 @@ from .common import (
 )
 
 from tests.common import async_fire_time_changed
-
-
-def ceiling_fan(name: str):
-    """Create a ceiling fan with given name."""
-    return {
-        "name": name,
-        "type": DeviceType.CEILING_FAN,
-        "actions": ["SetSpeed", "SetDirection"],
-    }
 
 
 def ceiling_fan_with_breeze(name: str):

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -332,3 +332,14 @@ async def test_device_remove_devices(hass, hass_ws_client):
         )
         is True
     )
+
+    hub_device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "test-hub-id")},
+    )
+    assert (
+        await remove_device(
+            await hass_ws_client(hass), hub_device_entry.id, config_entry.entry_id
+        )
+        is False
+    )

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -321,3 +321,14 @@ async def test_device_remove_devices(hass, hass_ws_client):
         )
         is True
     )
+
+    dead_device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "wrong-hub-id", "test-device-id")},
+    )
+    assert (
+        await remove_device(
+            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
+        )
+        is True
+    )

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -7,13 +7,16 @@ from bond_api import DeviceType
 import pytest
 
 from homeassistant.components.bond.const import DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 
 from .common import (
+    ceiling_fan,
     patch_bond_bridge,
     patch_bond_device,
     patch_bond_device_ids,
@@ -22,7 +25,9 @@ from .common import (
     patch_bond_version,
     patch_setup_entry,
     patch_start_bpup,
+    remove_device,
     setup_bond_entity,
+    setup_platform,
 )
 
 from tests.common import MockConfigEntry
@@ -279,3 +284,40 @@ async def test_bridge_device_suggested_area(hass: HomeAssistant):
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert device is not None
     assert device.suggested_area == "Office"
+
+
+async def test_device_remove_devices(hass, hass_ws_client):
+    """Test we can only remove a device that no longer exists."""
+    assert await async_setup_component(hass, "config", {})
+
+    config_entry = await setup_platform(
+        hass,
+        FAN_DOMAIN,
+        ceiling_fan("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_device_id="test-device-id",
+    )
+
+    registry: EntityRegistry = er.async_get(hass)
+    entity = registry.entities["fan.name_1"]
+    assert entity.unique_id == "test-hub-id_test-device-id"
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get(entity.device_id)
+    assert (
+        await remove_device(
+            await hass_ws_client(hass), device_entry.id, config_entry.entry_id
+        )
+        is False
+    )
+
+    dead_device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "test-hub-id", "remove-device-id")},
+    )
+    assert (
+        await remove_device(
+            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
+        )
+        is True
+    )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for async_remove_config_entry_device to bond

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
