### PR TITLE
Add digital loggers as a Belkin supported brand

### DIFF
--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -14,5 +14,8 @@
   },
   "codeowners": ["@esev"],
   "iot_class": "local_push",
-  "loggers": ["pywemo"]
+  "loggers": ["pywemo"],
+  "supported_brands": {
+    "digital_loggers": "Digital Loggers"
+  }
 }

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -9,6 +9,8 @@ from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_CONFIGURATION_URL,
+    ATTR_IDENTIFIERS,
     CONF_DEVICE_ID,
     CONF_NAME,
     CONF_PARAMS,
@@ -42,7 +44,7 @@ class DeviceCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.wemo = wemo
         self.device_id = device_id
-        self.device_info = _device_info(wemo)
+        self.device_info = _create_device_info(wemo)
         self.supports_long_press = wemo.supports_long_press()
         self.update_lock = asyncio.Lock()
 
@@ -130,6 +132,15 @@ class DeviceCoordinator(DataUpdateCoordinator):
             update_callback()
 
 
+def _create_device_info(wemo: WeMoDevice) -> DeviceInfo:
+    """Create device information. Modify if special device."""
+    _dev_info = _device_info(wemo)
+    if wemo.model_name == "DLI emulated Belkin Socket":
+        _dev_info[ATTR_CONFIGURATION_URL] = f"http://{wemo.host}"
+        _dev_info[ATTR_IDENTIFIERS] = {(DOMAIN, wemo.serialnumber[:-1])}
+    return _dev_info
+
+
 def _device_info(wemo: WeMoDevice) -> DeviceInfo:
     return DeviceInfo(
         connections={(CONNECTION_UPNP, wemo.udn)},
@@ -150,7 +161,7 @@ async def async_register_device(
 
     device_registry = async_get_device_registry(hass)
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id, **_device_info(wemo)
+        config_entry_id=config_entry.entry_id, **_create_device_info(wemo)
     )
 
     device = DeviceCoordinator(hass, wemo, entry.id)

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -97,6 +97,15 @@ def pywemo_device_fixture(pywemo_registry, pywemo_model):
         yield pywemo_device
 
 
+@pytest.fixture(name="pywemo_dli_device")
+def pywemo_dli_device_fixture(pywemo_registry, pywemo_model):
+    """Fixture for Digital Loggers emulated instances."""
+    with create_pywemo_device(pywemo_registry, pywemo_model) as pywemo_dli_device:
+        pywemo_dli_device.model_name == "DLI emulated Belkin Socket"
+        pywemo_dli_device.serialnumber = "1234567891"
+        yield pywemo_dli_device
+
+
 @pytest.fixture(name="wemo_entity_suffix")
 def wemo_entity_suffix_fixture():
     """Fixture to select a specific entity for wemo_entity."""

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -138,3 +138,9 @@ async def async_create_wemo_entity(hass, pywemo_device, wemo_entity_suffix):
 async def async_wemo_entity_fixture(hass, pywemo_device, wemo_entity_suffix):
     """Fixture for a Wemo entity in hass."""
     return await async_create_wemo_entity(hass, pywemo_device, wemo_entity_suffix)
+
+
+@pytest.fixture(name="wemo_dli_entity")
+async def async_wemo_dli_entity_fixture(hass, pywemo_dli_device, wemo_entity_suffix):
+    """Fixture for a Wemo entity in hass."""
+    return await async_create_wemo_entity(hass, pywemo_dli_device, wemo_entity_suffix)

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -101,7 +101,7 @@ def pywemo_device_fixture(pywemo_registry, pywemo_model):
 def pywemo_dli_device_fixture(pywemo_registry, pywemo_model):
     """Fixture for Digital Loggers emulated instances."""
     with create_pywemo_device(pywemo_registry, pywemo_model) as pywemo_dli_device:
-        pywemo_dli_device.model_name == "DLI emulated Belkin Socket"
+        pywemo_dli_device.model_name = "DLI emulated Belkin Socket"
         pywemo_dli_device.serialnumber = "1234567891"
         yield pywemo_dli_device
 

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -168,7 +168,7 @@ async def test_device_info(hass, wemo_entity):
     assert device_entries[0].sw_version == MOCK_FIRMWARE_VERSION
 
 
-async def test_dli_device_info(hass, wemo_entity, pywemo_dli_device):
+async def test_dli_device_info(hass, wemo_dli_entity):
     """Verify the DeviceInfo data for Digital Loggers emulated wemo device."""
     dr = device_registry.async_get(hass)
     device_entries = list(dr.devices.values())

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -168,6 +168,15 @@ async def test_device_info(hass, wemo_entity):
     assert device_entries[0].sw_version == MOCK_FIRMWARE_VERSION
 
 
+async def test_dli_device_info(hass, wemo_entity, pywemo_dli_device):
+    """Verify the DeviceInfo data for Digital Loggers emulated wemo device."""
+    dr = device_registry.async_get(hass)
+    device_entries = list(dr.devices.values())
+
+    assert device_entries[0].configuration_url == "http://127.0.0.1"
+    assert device_entries[0].identifiers == {(DOMAIN, "123456789")}
+
+
 class TestInsight:
     """Tests specific to the WeMo Insight device."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The digital loggers integration was previously removed for violating ADR0004. Some models of Digital Loggers products support CoAP over WebSockets. This can be enabled in the External APIs section of the device settings. It will be discovered by Home Assistant as Belkin Wemo devices.

The purpose of this is PR is represent a single physical device with the addition of a configuration URL. The one I'm using is the Switch Pro with 8 switches. This is currently presented as 8 different devices in Home Assistant which is not ideal.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
