### PR TITLE
Fix bond device state with v3 firmwares

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from aiohttp import ClientError, ClientResponseError, ClientTimeout
-from bond_api import Bond, BPUPSubscriptions, start_bpup
+from bond_async import Bond, BPUPSubscriptions, start_bpup
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
-from bond_api import Action, BPUPSubscriptions
+from bond_async import Action, BPUPSubscriptions
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from aiohttp import ClientConnectionError, ClientResponseError
-from bond_api import Bond
+from bond_async import Bond
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from bond_api import Action, BPUPSubscriptions, DeviceType
+from bond_async import Action, BPUPSubscriptions, DeviceType
 
 from homeassistant.components.cover import (
     ATTR_POSITION,

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -156,9 +156,13 @@ class BondEntity(Entity):
         self._apply_state(state)
 
     @callback
-    def _async_bpup_callback(self, state: dict) -> None:
+    def _async_bpup_callback(self, json_msg: dict) -> None:
         """Process a state change from BPUP."""
-        self._async_state_callback(state)
+        topic = json_msg["t"]
+        if topic != f"devices/{self._device_id}/state":
+            return
+
+        self._async_state_callback(json_msg["b"])
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 from aiohttp import ClientError
-from bond_api import BPUPSubscriptions
+from bond_async import BPUPSubscriptions
 
 from homeassistant.const import (
     ATTR_HW_VERSION,

--- a/homeassistant/components/bond/fan.py
+++ b/homeassistant/components/bond/fan.py
@@ -6,7 +6,7 @@ import math
 from typing import Any
 
 from aiohttp.client_exceptions import ClientResponseError
-from bond_api import Action, BPUPSubscriptions, DeviceType, Direction
+from bond_async import Action, BPUPSubscriptions, DeviceType, Direction
 import voluptuous as vol
 
 from homeassistant.components.fan import (

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from aiohttp.client_exceptions import ClientResponseError
-from bond_api import Action, BPUPSubscriptions, DeviceType
+from bond_async import Action, BPUPSubscriptions, DeviceType
 import voluptuous as vol
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity

--- a/homeassistant/components/bond/manifest.json
+++ b/homeassistant/components/bond/manifest.json
@@ -3,10 +3,10 @@
   "name": "Bond",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bond",
-  "requirements": ["bond-api==0.1.18"],
+  "requirements": ["bond-async==0.1.20"],
   "zeroconf": ["_bond._tcp.local."],
   "codeowners": ["@bdraco", "@prystupa", "@joshs85", "@marciogranzotto"],
   "quality_scale": "platinum",
   "iot_class": "local_push",
-  "loggers": ["bond_api"]
+  "loggers": ["bond_async"]
 }

--- a/homeassistant/components/bond/switch.py
+++ b/homeassistant/components/bond/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from aiohttp.client_exceptions import ClientResponseError
-from bond_api import Action, BPUPSubscriptions, DeviceType
+from bond_async import Action, BPUPSubscriptions, DeviceType
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, cast
 
 from aiohttp import ClientResponseError
-from bond_api import Action, Bond
+from bond_async import Action, Bond
 
 from homeassistant.util.async_ import gather_with_concurrency
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -417,7 +417,7 @@ blockchain==1.4.4
 # bluepy==1.3.0
 
 # homeassistant.components.bond
-bond-api==0.1.18
+bond-async==0.1.20
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.30

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -318,7 +318,7 @@ blebox_uniapi==1.3.3
 blinkpy==0.19.0
 
 # homeassistant.components.bond
-bond-api==0.1.18
+bond-async==0.1.20
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.30

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from aiohttp.client_exceptions import ClientResponseError
-from bond_api import DeviceType
+from bond_async import DeviceType
 
 from homeassistant import core
 from homeassistant.components.bond.const import DOMAIN as BOND_DOMAIN

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -1,6 +1,6 @@
 """Tests for the Bond button device."""
 
-from bond_api import Action, DeviceType
+from bond_async import Action, DeviceType
 
 from homeassistant import core
 from homeassistant.components.bond.button import STEP_SIZE

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -1,7 +1,7 @@
 """Tests for the Bond cover device."""
 from datetime import timedelta
 
-from bond_api import Action, DeviceType
+from bond_async import Action, DeviceType
 
 from homeassistant import core
 from homeassistant.components.cover import (

--- a/tests/components/bond/test_entity.py
+++ b/tests/components/bond/test_entity.py
@@ -44,7 +44,7 @@ async def test_bpup_goes_offline_and_recovers_same_entity(hass: core.HomeAssista
     bpup_subs.notify(
         {
             "s": 200,
-            "t": "bond/test-device-id/update",
+            "t": "devices/test-device-id/state",
             "b": {"power": 1, "speed": 3, "direction": 0},
         }
     )
@@ -54,7 +54,7 @@ async def test_bpup_goes_offline_and_recovers_same_entity(hass: core.HomeAssista
     bpup_subs.notify(
         {
             "s": 200,
-            "t": "bond/test-device-id/update",
+            "t": "devices/test-device-id/state",
             "b": {"power": 1, "speed": 1, "direction": 0},
         }
     )
@@ -75,7 +75,7 @@ async def test_bpup_goes_offline_and_recovers_same_entity(hass: core.HomeAssista
         bpup_subs.notify(
             {
                 "s": 200,
-                "t": "bond/test-device-id/update",
+                "t": "devices/test-device-id/state",
                 "b": {"power": 1, "speed": 2, "direction": 0},
             }
         )
@@ -106,7 +106,7 @@ async def test_bpup_goes_offline_and_recovers_different_entity(
     bpup_subs.notify(
         {
             "s": 200,
-            "t": "bond/test-device-id/update",
+            "t": "devices/test-device-id/state",
             "b": {"power": 1, "speed": 3, "direction": 0},
         }
     )
@@ -116,7 +116,7 @@ async def test_bpup_goes_offline_and_recovers_different_entity(
     bpup_subs.notify(
         {
             "s": 200,
-            "t": "bond/test-device-id/update",
+            "t": "devices/test-device-id/state",
             "b": {"power": 1, "speed": 1, "direction": 0},
         }
     )
@@ -133,7 +133,7 @@ async def test_bpup_goes_offline_and_recovers_different_entity(
     bpup_subs.notify(
         {
             "s": 200,
-            "t": "bond/not-this-device-id/update",
+            "t": "devices/not-this-device-id/state",
             "b": {"power": 1, "speed": 2, "direction": 0},
         }
     )

--- a/tests/components/bond/test_entity.py
+++ b/tests/components/bond/test_entity.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 
-from bond_api import BPUPSubscriptions, DeviceType
+from bond_async import BPUPSubscriptions, DeviceType
 
 from homeassistant import core
 from homeassistant.components import fan

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import call
 
-from bond_api import Action, DeviceType, Direction
+from bond_async import Action, DeviceType, Direction
 import pytest
 
 from homeassistant import core

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -3,7 +3,7 @@ import asyncio
 from unittest.mock import MagicMock, Mock
 
 from aiohttp import ClientConnectionError, ClientResponseError
-from bond_api import DeviceType
+from bond_async import DeviceType
 import pytest
 
 from homeassistant.components.bond.const import DOMAIN

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -1,7 +1,7 @@
 """Tests for the Bond light device."""
 from datetime import timedelta
 
-from bond_api import Action, DeviceType
+from bond_async import Action, DeviceType
 import pytest
 
 from homeassistant import core

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -1,7 +1,7 @@
 """Tests for the Bond switch device."""
 from datetime import timedelta
 
-from bond_api import Action, DeviceType
+from bond_async import Action, DeviceType
 import pytest
 
 from homeassistant import core


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
State updates were not working when receiving messages from BPUP, since it doesn't only return device status messages. It returns all responses to HTTP requests as well.

I.e.:
```bash
    477750:         TS_HTTP:345  : INFO : HTTP PUT /v2/devices/73c3c59b089a795d/actions/Open
    477791: [06000026c8f33dfa HTTP-STA   PUT     0 D   /devices/73c3c59b089a795d/actions/Open] {}
    477805: BBridge_Action_API:1133 : INFO : bbridge_action_handle_put Open() tx via script
    477916: BondScript_RMS35:265  : USER : mfg=1, addr=00685410 chanmap=0001 command=Open, counter=1
    477924: BondScript_Lua_API:102  : INFO : bondscript_tx: freq 433922 BPS 40000 reps 4 len 2946
    477979: [05000038aef5de1d Bond-AWS   GET   200 Ub  /devices/73c3c59b089a795d/state] {"B":"ZPEA77117","d":0,"v":"v3.2.4-alpha","i":"05000038aef5de1d","f":100,"s":200,"m":0,"x":"bond","b":{"open":1,"position":0,"counter1":0,"counter2":0,"_":"109f5bd9","__":"109f5bd9"}}
    477991: [05000038aef5de1d Bond-CLI   GET   200 Ub  /devices/73c3c59b089a795d/state] {"B":"ZPEA77117","d":0,"v":"v3.2.4-alpha","t":"devices/73c3c59b089a795d/state","i":"05000038aef5de1d","f":100,"s":200,"m":0,"x":"bond","b":{"open":1,"position":0,"counter1":0,"counter2":0,"_":"109f5bd9","__":"109f5bd9"}}
    478032: [06000026c8f33dfa HTTP-STA   PUT   200 U   /devices/73c3c59b089a795d/actions/Open] {"_":"00000204","__":"00000204"}
```

This was calling the `notify` function of `bond_api/bpup.py` two times, so it was first returning `{"open":1,"position":0,"counter1":0,"counter2":0,"_":"109f5bd9","__":"109f5bd9"}` and then `{"_":"00000204","__":"00000204"}`

Fixed by updating `bond-api` to the new "official" `BondHome/bond-async` fork and implementing a topic filter on the BPUP callback

lib changes: https://github.com/bondhome/bond-async/compare/v0.1.18...v0.1.20

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
