### PR TITLE
Avoid swallowing Roku errors

### DIFF
--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -9,6 +9,8 @@ from typing import Any, TypeVar
 from rokuecp import RokuConnectionError, RokuConnectionTimeoutError, RokuError
 from typing_extensions import Concatenate, ParamSpec
 
+from homeassistant.exceptions import HomeAssistantError
+
 from .entity import RokuEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,13 +46,13 @@ def roku_exception_handler(
                 await func(self, *args, **kwargs)
             except RokuConnectionTimeoutError as error:
                 if not ignore_timeout and self.available:
-                    _LOGGER.error("Error communicating with API: %s", error)
+                    raise HomeAssistantError("Error communicating with Roku API: %s", error)
             except RokuConnectionError as error:
                 if self.available:
-                    _LOGGER.error("Error communicating with API: %s", error)
+                    raise HomeAssistantError("Error communicating with Roku API: %s", error)
             except RokuError as error:
                 if self.available:
-                    _LOGGER.error("Invalid response from API: %s", error)
+                    raise HomeAssistantError("Invalid response from Roku API: %s", error)
 
         return wrapper
 

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-import logging
 from typing import Any, TypeVar
 
 from rokuecp import RokuConnectionError, RokuConnectionTimeoutError, RokuError
@@ -12,8 +11,6 @@ from typing_extensions import Concatenate, ParamSpec
 from homeassistant.exceptions import HomeAssistantError
 
 from .entity import RokuEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 _RokuEntityT = TypeVar("_RokuEntityT", bound=RokuEntity)
 _P = ParamSpec("_P")

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -43,7 +43,9 @@ def roku_exception_handler(
                 await func(self, *args, **kwargs)
             except RokuConnectionTimeoutError as error:
                 if not ignore_timeout:
-                    raise HomeAssistantError("Timeout communicating with Roku API") from error
+                    raise HomeAssistantError(
+                        "Timeout communicating with Roku API"
+                    ) from error
             except RokuConnectionError as error:
                 raise HomeAssistantError("Error communicating with Roku API") from error
             except RokuError as error:

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -45,14 +45,12 @@ def roku_exception_handler(
             try:
                 await func(self, *args, **kwargs)
             except RokuConnectionTimeoutError as error:
-                if not ignore_timeout and self.available:
-                    raise HomeAssistantError("Error communicating with Roku API: %s", error)
+                if not ignore_timeout:
+                    raise HomeAssistantError("Timeout communicating with Roku API") from error
             except RokuConnectionError as error:
-                if self.available:
-                    raise HomeAssistantError("Error communicating with Roku API: %s", error)
+                raise HomeAssistantError("Error communicating with Roku API") from error
             except RokuError as error:
-                if self.available:
-                    raise HomeAssistantError("Invalid response from Roku API: %s", error)
+                raise HomeAssistantError("Invalid response from Roku API") from error
 
         return wrapper
 

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -106,7 +106,6 @@ async def test_application_select_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_roku: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the Roku selects."""
     entity_registry = er.async_get(hass)
@@ -125,20 +124,20 @@ async def test_application_select_error(
 
     mock_roku.launch.side_effect = RokuError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.my_roku_3_application",
-            ATTR_OPTION: "Netflix",
-        },
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError, match="Invalid response from Roku API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.my_roku_3_application",
+                ATTR_OPTION: "Netflix",
+            },
+            blocking=True,
+        )
 
     state = hass.states.get("select.my_roku_3_application")
     assert state
     assert state.state == "Home"
-    assert "Invalid response from API" in caplog.text
     assert mock_roku.launch.call_count == 1
     mock_roku.launch.assert_called_with("12")
 
@@ -218,24 +217,23 @@ async def test_channel_select_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_roku: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the Roku selects."""
     mock_roku.tune.side_effect = RokuError
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: "select.58_onn_roku_tv_channel",
-            ATTR_OPTION: "99.1",
-        },
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError, match="Invalid response from Roku API"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.58_onn_roku_tv_channel",
+                ATTR_OPTION: "99.1",
+            },
+            blocking=True,
+        )
 
     state = hass.states.get("select.58_onn_roku_tv_channel")
     assert state
     assert state.state == "getTV (14.3)"
-    assert "Invalid response from API" in caplog.text
     assert mock_roku.tune.call_count == 1
     mock_roku.tune.assert_called_with("99.1")

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -2,7 +2,13 @@
 from unittest.mock import MagicMock
 
 import pytest
-from rokuecp import Application, Device as RokuDevice, RokuError
+from rokuecp import (
+    Application,
+    Device as RokuDevice,
+    RokuConnectionError,
+    RokuConnectionTimeoutError,
+    RokuError,
+)
 
 from homeassistant.components.roku.const import DOMAIN
 from homeassistant.components.roku.coordinator import SCAN_INTERVAL

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -10,6 +10,7 @@ from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.select.const import ATTR_OPTION, ATTR_OPTIONS
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, SERVICE_SELECT_OPTION
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
