### PR TITLE
Improve stream playback on high latency cameras

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -454,7 +454,7 @@ class Camera(Entity):
     def __init__(self) -> None:
         """Initialize a camera."""
         self.stream: Stream | None = None
-        self.stream_options: dict[str, str | bool] = {}
+        self.stream_options: dict[str, str | bool | float] = {}
         self.content_type: str = DEFAULT_CONTENT_TYPE
         self.access_tokens: collections.deque = collections.deque([], 2)
         self._warned_old_signature = False

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -209,7 +209,7 @@ async def async_test_stream(hass, info) -> dict[str, str]:
     except TemplateError as err:
         _LOGGER.warning("Problem rendering template %s: %s", stream_source, err)
         return {CONF_STREAM_SOURCE: "template_error"}
-    stream_options: dict[str, bool | str] = {}
+    stream_options: dict[str, str | bool | float] = {}
     if rtsp_transport := info.get(CONF_RTSP_TRANSPORT):
         stream_options[CONF_RTSP_TRANSPORT] = rtsp_transport
     if info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -20,6 +20,7 @@ from google_nest_sdm.exceptions import ApiException
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.camera.const import StreamType
+from homeassistant.components.stream import CONF_EXTRA_PART_WAIT_TIME
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -67,6 +68,7 @@ class NestCamera(Camera):
         self._create_stream_url_lock = asyncio.Lock()
         self._stream_refresh_unsub: Callable[[], None] | None = None
         self._attr_is_streaming = CameraLiveStreamTrait.NAME in self._device.traits
+        self.stream_options[CONF_EXTRA_PART_WAIT_TIME] = 3
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -64,6 +64,7 @@ from .diagnostics import Diagnostics
 from .hls import HlsStreamOutput, async_setup_hls
 
 __all__ = [
+    "CONF_EXTRA_PART_WAIT_TIME",
     "CONF_RTSP_TRANSPORT",
     "CONF_USE_WALLCLOCK_AS_TIMESTAMPS",
     "FORMAT_CONTENT_TYPE",

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping
+import copy
 import logging
 import re
 import secrets
@@ -38,6 +39,7 @@ from .const import (
     ATTR_ENDPOINTS,
     ATTR_SETTINGS,
     ATTR_STREAMS,
+    CONF_EXTRA_PART_WAIT_TIME,
     CONF_LL_HLS,
     CONF_PART_DURATION,
     CONF_RTSP_TRANSPORT,
@@ -91,7 +93,7 @@ def redact_credentials(data: str) -> str:
 def create_stream(
     hass: HomeAssistant,
     stream_source: str,
-    options: dict[str, str | bool],
+    options: dict[str, str | bool | float],
     stream_label: str | None = None,
 ) -> Stream:
     """Create a stream with the specified identfier based on the source url.
@@ -105,7 +107,7 @@ def create_stream(
         raise HomeAssistantError("Stream integration is not set up.")
 
     # Convert extra stream options into PyAV options
-    pyav_options = convert_stream_options(options)
+    pyav_options, stream_settings = convert_stream_options(hass, options)
     # For RTSP streams, prefer TCP
     if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
         pyav_options = {
@@ -115,7 +117,11 @@ def create_stream(
         }
 
     stream = Stream(
-        hass, stream_source, options=pyav_options, stream_label=stream_label
+        hass,
+        stream_source,
+        pyav_options=pyav_options,
+        stream_settings=stream_settings,
+        stream_label=stream_label,
     )
     hass.data[DOMAIN][ATTR_STREAMS].append(stream)
     return stream
@@ -230,13 +236,15 @@ class Stream:
         self,
         hass: HomeAssistant,
         source: str,
-        options: dict[str, str],
+        pyav_options: dict[str, str],
+        stream_settings: StreamSettings,
         stream_label: str | None = None,
     ) -> None:
         """Initialize a stream."""
         self.hass = hass
         self.source = source
-        self.options = options
+        self.pyav_options = pyav_options
+        self._stream_settings = stream_settings
         self._stream_label = stream_label
         self.keepalive = False
         self.access_token: str | None = None
@@ -284,7 +292,9 @@ class Stream:
                 self.check_idle()
 
             provider = PROVIDERS[fmt](
-                self.hass, IdleTimer(self.hass, timeout, idle_callback)
+                self.hass,
+                IdleTimer(self.hass, timeout, idle_callback),
+                self._stream_settings,
             )
             self._outputs[fmt] = provider
 
@@ -368,7 +378,8 @@ class Stream:
             try:
                 stream_worker(
                     self.source,
-                    self.options,
+                    self.pyav_options,
+                    self._stream_settings,
                     stream_state,
                     self._keyframe_converter,
                     self._thread_quit,
@@ -507,22 +518,28 @@ STREAM_OPTIONS_SCHEMA: Final = vol.Schema(
     {
         vol.Optional(CONF_RTSP_TRANSPORT): vol.In(RTSP_TRANSPORTS),
         vol.Optional(CONF_USE_WALLCLOCK_AS_TIMESTAMPS): bool,
+        vol.Optional(CONF_EXTRA_PART_WAIT_TIME): cv.positive_float,
     }
 )
 
 
-def convert_stream_options(stream_options: dict[str, str | bool]) -> dict[str, str]:
+def convert_stream_options(
+    hass: HomeAssistant, stream_options: dict[str, str | bool | float]
+) -> tuple[dict[str, str], StreamSettings]:
     """Convert options from stream options into PyAV options."""
+    stream_settings = copy.copy(hass.data[DOMAIN][ATTR_SETTINGS])
     pyav_options: dict[str, str] = {}
     try:
         STREAM_OPTIONS_SCHEMA(stream_options)
     except vol.Invalid as exc:
         raise HomeAssistantError("Invalid stream options") from exc
 
+    if extra_wait_time := stream_options.get(CONF_EXTRA_PART_WAIT_TIME):
+        stream_settings.hls_part_timeout += extra_wait_time
     if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
         assert isinstance(rtsp_transport, str)
         pyav_options["rtsp_transport"] = rtsp_transport
     if stream_options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
         pyav_options["use_wallclock_as_timestamps"] = "1"
 
-    return pyav_options
+    return pyav_options, stream_settings

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -64,9 +64,11 @@ from .diagnostics import Diagnostics
 from .hls import HlsStreamOutput, async_setup_hls
 
 __all__ = [
+    "ATTR_SETTINGS",
     "CONF_EXTRA_PART_WAIT_TIME",
     "CONF_RTSP_TRANSPORT",
     "CONF_USE_WALLCLOCK_AS_TIMESTAMPS",
+    "DOMAIN",
     "FORMAT_CONTENT_TYPE",
     "HLS_PROVIDER",
     "OUTPUT_FORMATS",
@@ -525,7 +527,7 @@ STREAM_OPTIONS_SCHEMA: Final = vol.Schema(
 
 
 def convert_stream_options(
-    hass: HomeAssistant, stream_options: dict[str, str | bool | float]
+    hass: HomeAssistant, stream_options: Mapping[str, str | bool | float]
 ) -> tuple[dict[str, str], StreamSettings]:
     """Convert options from stream options into PyAV options."""
     stream_settings = copy.copy(hass.data[DOMAIN][ATTR_SETTINGS])

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -106,10 +106,34 @@ def create_stream(
 
     The stream_label is a string used as an additional message in logging.
     """
+
+    def convert_stream_options(
+        hass: HomeAssistant, stream_options: Mapping[str, str | bool | float]
+    ) -> tuple[dict[str, str], StreamSettings]:
+        """Convert options from stream options into PyAV options and stream settings."""
+        stream_settings = copy.copy(hass.data[DOMAIN][ATTR_SETTINGS])
+        pyav_options: dict[str, str] = {}
+        try:
+            STREAM_OPTIONS_SCHEMA(stream_options)
+        except vol.Invalid as exc:
+            raise HomeAssistantError("Invalid stream options") from exc
+
+        if extra_wait_time := stream_options.get(CONF_EXTRA_PART_WAIT_TIME):
+            stream_settings.hls_part_timeout += extra_wait_time
+        if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
+            assert isinstance(rtsp_transport, str)
+            # The PyAV options currently match the stream CONF constants, but this
+            # will not necessarily always be the case, so they are hard coded here
+            pyav_options["rtsp_transport"] = rtsp_transport
+        if stream_options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
+            pyav_options["use_wallclock_as_timestamps"] = "1"
+
+        return pyav_options, stream_settings
+
     if DOMAIN not in hass.config.components:
         raise HomeAssistantError("Stream integration is not set up.")
 
-    # Convert extra stream options into PyAV options
+    # Convert extra stream options into PyAV options and stream settings
     pyav_options, stream_settings = convert_stream_options(hass, options)
     # For RTSP streams, prefer TCP
     if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
@@ -524,25 +548,3 @@ STREAM_OPTIONS_SCHEMA: Final = vol.Schema(
         vol.Optional(CONF_EXTRA_PART_WAIT_TIME): cv.positive_float,
     }
 )
-
-
-def convert_stream_options(
-    hass: HomeAssistant, stream_options: Mapping[str, str | bool | float]
-) -> tuple[dict[str, str], StreamSettings]:
-    """Convert options from stream options into PyAV options."""
-    stream_settings = copy.copy(hass.data[DOMAIN][ATTR_SETTINGS])
-    pyav_options: dict[str, str] = {}
-    try:
-        STREAM_OPTIONS_SCHEMA(stream_options)
-    except vol.Invalid as exc:
-        raise HomeAssistantError("Invalid stream options") from exc
-
-    if extra_wait_time := stream_options.get(CONF_EXTRA_PART_WAIT_TIME):
-        stream_settings.hls_part_timeout += extra_wait_time
-    if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
-        assert isinstance(rtsp_transport, str)
-        pyav_options["rtsp_transport"] = rtsp_transport
-    if stream_options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
-        pyav_options["use_wallclock_as_timestamps"] = "1"
-
-    return pyav_options, stream_settings

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -96,7 +96,7 @@ def redact_credentials(data: str) -> str:
 def create_stream(
     hass: HomeAssistant,
     stream_source: str,
-    options: dict[str, str | bool | float],
+    options: Mapping[str, str | bool | float],
     stream_label: str | None = None,
 ) -> Stream:
     """Create a stream with the specified identfier based on the source url.

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -53,3 +53,4 @@ RTSP_TRANSPORTS = {
     "http": "HTTP",
 }
 CONF_USE_WALLCLOCK_AS_TIMESTAMPS = "use_wallclock_as_timestamps"
+CONF_EXTRA_PART_WAIT_TIME = "extra_part_wait_time"

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -237,11 +237,13 @@ class StreamOutput:
         self,
         hass: HomeAssistant,
         idle_timer: IdleTimer,
+        stream_settings: StreamSettings,
         deque_maxlen: int | None = None,
     ) -> None:
         """Initialize a stream output."""
         self._hass = hass
         self.idle_timer = idle_timer
+        self.stream_settings = stream_settings
         self._event = asyncio.Event()
         self._part_event = asyncio.Event()
         self._segments: deque[Segment] = deque(maxlen=deque_maxlen)

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -118,6 +118,10 @@ class Segment:
         if self.hls_playlist_complete:
             return self.hls_playlist_template[0]
         if not self.hls_playlist_template:
+            # Logically EXT-X-DISCONTINUITY makes sense above the parts, but Apple's
+            # media stream validator seems to only want it before the segment
+            if last_stream_id != self.stream_id:
+                self.hls_playlist_template.append("#EXT-X-DISCONTINUITY")
             # This is a placeholder where the rendered parts will be inserted
             self.hls_playlist_template.append("{}")
         if render_parts:
@@ -133,22 +137,19 @@ class Segment:
             # the first element to avoid an extra newline when we don't render any parts.
             # Append an empty string to create a trailing newline when we do render parts
             self.hls_playlist_parts.append("")
-            self.hls_playlist_template = []
-            # Logically EXT-X-DISCONTINUITY would make sense above the parts, but Apple's
-            # media stream validator seems to only want it before the segment
-            if last_stream_id != self.stream_id:
-                self.hls_playlist_template.append("#EXT-X-DISCONTINUITY")
+            self.hls_playlist_template = (
+                [] if last_stream_id == self.stream_id else ["#EXT-X-DISCONTINUITY"]
+            )
             # Add the remaining segment metadata
+            # The placeholder goes on the same line as the next element
             self.hls_playlist_template.extend(
                 [
-                    "#EXT-X-PROGRAM-DATE-TIME:"
+                    "{}#EXT-X-PROGRAM-DATE-TIME:"
                     + self.start_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
                     + "Z",
                     f"#EXTINF:{self.duration:.3f},\n./segment/{self.sequence}.m4s",
                 ]
             )
-            # The placeholder now goes on the same line as the first element
-            self.hls_playlist_template[0] = "{}" + self.hls_playlist_template[0]
 
         # Store intermediate playlist data in member variables for reuse
         self.hls_playlist_template = ["\n".join(self.hls_playlist_template)]

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -9,8 +9,6 @@ from aiohttp import web
 from homeassistant.core import HomeAssistant, callback
 
 from .const import (
-    ATTR_SETTINGS,
-    DOMAIN,
     EXT_X_START_LL_HLS,
     EXT_X_START_NON_LL_HLS,
     FORMAT_CONTENT_TYPE,
@@ -47,11 +45,15 @@ def async_setup_hls(hass: HomeAssistant) -> str:
 class HlsStreamOutput(StreamOutput):
     """Represents HLS Output formats."""
 
-    def __init__(self, hass: HomeAssistant, idle_timer: IdleTimer) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        idle_timer: IdleTimer,
+        stream_settings: StreamSettings,
+    ) -> None:
         """Initialize HLS output."""
-        super().__init__(hass, idle_timer, deque_maxlen=MAX_SEGMENTS)
-        self.stream_settings: StreamSettings = hass.data[DOMAIN][ATTR_SETTINGS]
-        self._target_duration = self.stream_settings.min_segment_duration
+        super().__init__(hass, idle_timer, stream_settings, deque_maxlen=MAX_SEGMENTS)
+        self._target_duration = stream_settings.min_segment_duration
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -17,7 +17,7 @@ from .const import (
     RECORDER_PROVIDER,
     SEGMENT_CONTAINER_FORMAT,
 )
-from .core import PROVIDERS, IdleTimer, Segment, StreamOutput
+from .core import PROVIDERS, IdleTimer, Segment, StreamOutput, StreamSettings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,9 +121,14 @@ def recorder_save_worker(file_out: str, segments: deque[Segment]) -> None:
 class RecorderOutput(StreamOutput):
     """Represents HLS Output formats."""
 
-    def __init__(self, hass: HomeAssistant, idle_timer: IdleTimer) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        idle_timer: IdleTimer,
+        stream_settings: StreamSettings,
+    ) -> None:
         """Initialize recorder output."""
-        super().__init__(hass, idle_timer)
+        super().__init__(hass, idle_timer, stream_settings)
         self.video_path: str
 
     @property

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -16,9 +16,7 @@ from homeassistant.core import HomeAssistant
 
 from . import redact_credentials
 from .const import (
-    ATTR_SETTINGS,
     AUDIO_CODECS,
-    DOMAIN,
     HLS_PROVIDER,
     MAX_MISSING_DTS,
     MAX_TIMESTAMP_GAP,
@@ -111,6 +109,7 @@ class StreamMuxer:
         video_stream: av.video.VideoStream,
         audio_stream: av.audio.stream.AudioStream | None,
         stream_state: StreamState,
+        stream_settings: StreamSettings,
     ) -> None:
         """Initialize StreamMuxer."""
         self._hass = hass
@@ -126,7 +125,7 @@ class StreamMuxer:
         self._memory_file_pos: int = cast(int, None)
         self._part_start_dts: int = cast(int, None)
         self._part_has_keyframe = False
-        self._stream_settings: StreamSettings = hass.data[DOMAIN][ATTR_SETTINGS]
+        self._stream_settings = stream_settings
         self._stream_state = stream_state
         self._start_time = datetime.datetime.utcnow()
 
@@ -445,19 +444,20 @@ def unsupported_audio(packets: Iterator[av.Packet], audio_stream: Any) -> bool:
 
 def stream_worker(
     source: str,
-    options: dict[str, str],
+    pyav_options: dict[str, str],
+    stream_settings: StreamSettings,
     stream_state: StreamState,
     keyframe_converter: KeyFrameConverter,
     quit_event: Event,
 ) -> None:
     """Handle consuming streams."""
 
-    if av.library_versions["libavformat"][0] >= 59 and "stimeout" in options:
+    if av.library_versions["libavformat"][0] >= 59 and "stimeout" in pyav_options:
         # the stimeout option was renamed to timeout as of ffmpeg 5.0
-        options["timeout"] = options["stimeout"]
-        del options["stimeout"]
+        pyav_options["timeout"] = pyav_options["stimeout"]
+        del pyav_options["stimeout"]
     try:
-        container = av.open(source, options=options, timeout=SOURCE_TIMEOUT)
+        container = av.open(source, options=pyav_options, timeout=SOURCE_TIMEOUT)
     except av.AVError as err:
         raise StreamWorkerError(
             f"Error opening stream ({err.type}, {err.strerror}) {redact_credentials(str(source))}"
@@ -480,6 +480,9 @@ def stream_worker(
     # Some audio streams do not have a profile and throw errors when remuxing
     if audio_stream and audio_stream.profile is None:
         audio_stream = None
+    # Disable ll-hls for hls inputs
+    if container.format.name in {"hls"}:
+        stream_settings.ll_hls = False
     stream_state.diagnostics.set_value("container_format", container.format.name)
     stream_state.diagnostics.set_value("video_codec", video_stream.name)
     if audio_stream:
@@ -535,7 +538,9 @@ def stream_worker(
             "Error demuxing stream while finding first packet: %s" % str(ex)
         ) from ex
 
-    muxer = StreamMuxer(stream_state.hass, video_stream, audio_stream, stream_state)
+    muxer = StreamMuxer(
+        stream_state.hass, video_stream, audio_stream, stream_state, stream_settings
+    )
     muxer.reset(start_dts)
 
     # Mux the first keyframe, then proceed through the rest of the packets

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -481,7 +481,7 @@ def stream_worker(
     if audio_stream and audio_stream.profile is None:
         audio_stream = None
     # Disable ll-hls for hls inputs
-    if container.format.name in {"hls"}:
+    if container.format.name == "hls":
         stream_settings.ll_hls = False
     stream_state.diagnostics.set_value("container_format", container.format.name)
     stream_state.diagnostics.set_value("video_codec", video_stream.name)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -85,7 +85,7 @@ class StreamState:
         # simple to check for discontinuity at output time, and to determine
         # the discontinuity sequence number.
         self._stream_id += 1
-        # Call discontinuity to remove incomplete segment from the HLS output
+        # Call discontinuity to fix incomplete segment in HLS output
         if hls_output := self._outputs_callback().get(HLS_PROVIDER):
             cast(HlsStreamOutput, hls_output).discontinuity()
 

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -9,6 +9,7 @@ import respx
 
 from homeassistant import config_entries, setup
 from homeassistant.components.generic.const import DOMAIN
+from homeassistant.components.stream import ATTR_SETTINGS, DOMAIN as STREAM_DOMAIN
 
 from tests.common import MockConfigEntry
 
@@ -120,3 +121,10 @@ async def setup_entry(hass, config_entry):
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     return config_entry
+
+
+@pytest.fixture(autouse=True)
+async def setup_stream(hass):
+    """Put an entry in stream settings so convert_stream_options works."""
+    hass.data[STREAM_DOMAIN] = {}
+    hass.data[STREAM_DOMAIN][ATTR_SETTINGS] = {}

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -9,7 +9,6 @@ import respx
 
 from homeassistant import config_entries, setup
 from homeassistant.components.generic.const import DOMAIN
-from homeassistant.components.stream import ATTR_SETTINGS, DOMAIN as STREAM_DOMAIN
 
 from tests.common import MockConfigEntry
 
@@ -121,10 +120,3 @@ async def setup_entry(hass, config_entry):
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     return config_entry
-
-
-@pytest.fixture(autouse=True)
-async def setup_stream(hass):
-    """Put an entry in stream settings so convert_stream_options works."""
-    hass.data[STREAM_DOMAIN] = {}
-    hass.data[STREAM_DOMAIN][ATTR_SETTINGS] = {}

--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -91,12 +91,12 @@ def make_segment_with_parts(
 ):
     """Create a playlist response for a segment including part segments."""
     response = []
+    if discontinuity:
+        response.append("#EXT-X-DISCONTINUITY")
     for i in range(num_parts):
         response.append(
             f'#EXT-X-PART:DURATION={TEST_PART_DURATION:.3f},URI="./segment/{segment}.{i}.m4s"{",INDEPENDENT=YES" if i%independent_period==0 else ""}'
         )
-    if discontinuity:
-        response.append("#EXT-X-DISCONTINUITY")
     response.extend(
         [
             "#EXT-X-PROGRAM-DATE-TIME:"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Input cameras with high latencies can cause playback issues when using stream. This PR:
1) Copies the global stream settings into each stream, so they can be modified on a per stream basis by setting stream_options. They can also be modified by the stream worker.
2) Adds the option to increase the timeout when waiting for the stream worker to get the next part and uses this timeout in the Nest integration.
3) Disables ll-hls when an hls input is detected. This should fix issues with Netatmo cameras.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72089
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
