### PR TITLE
Use modern WS API for auth integration + add auth provider type to refresh token info

### DIFF
--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -193,7 +193,7 @@ async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
     user = refresh_token.user
     client = await hass_ws_client(hass, hass_access_token)
 
-    await client.send_json({"id": 5, "type": auth.WS_TYPE_CURRENT_USER})
+    await client.send_json({"id": 5, "type": "auth/current_user"})
 
     result = await client.receive_json()
     assert result["success"], result
@@ -410,7 +410,7 @@ async def test_ws_long_lived_access_token(hass, hass_ws_client, hass_access_toke
     await ws_client.send_json(
         {
             "id": 5,
-            "type": auth.WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
+            "type": "auth/long_lived_access_token",
             "client_name": "GPS Logger",
             "lifespan": 365,
         }
@@ -434,7 +434,7 @@ async def test_ws_refresh_tokens(hass, hass_ws_client, hass_access_token):
 
     ws_client = await hass_ws_client(hass, hass_access_token)
 
-    await ws_client.send_json({"id": 5, "type": auth.WS_TYPE_REFRESH_TOKENS})
+    await ws_client.send_json({"id": 5, "type": "auth/refresh_tokens"})
 
     result = await ws_client.receive_json()
     assert result["success"], result
@@ -468,7 +468,7 @@ async def test_ws_delete_refresh_token(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": auth.WS_TYPE_DELETE_REFRESH_TOKEN,
+            "type": "auth/delete_refresh_token",
             "refresh_token_id": refresh_token.id,
         }
     )
@@ -490,7 +490,7 @@ async def test_ws_sign_path(hass, hass_ws_client, hass_access_token):
         await ws_client.send_json(
             {
                 "id": 5,
-                "type": auth.WS_TYPE_SIGN_PATH,
+                "type": "auth/sign_path",
                 "path": "/api/hello",
                 "expires": 20,
             }

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -450,6 +450,7 @@ async def test_ws_refresh_tokens(hass, hass_ws_client, hass_access_token):
     assert token["is_current"] is True
     assert token["last_used_at"] == refresh_token.last_used_at.isoformat()
     assert token["last_used_ip"] == refresh_token.last_used_ip
+    assert token["auth_provider_type"] == "homeassistant"
 
 
 async def test_ws_delete_refresh_token(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Clean up the auth integration to use modern WS register API.
- Include the `auth_provider_type` that created the refresh token



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
