### PR TITLE
Attach SSL context to SMTP notify and IMAP sensor

### DIFF
--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util.ssl import client_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +97,9 @@ class EmailReader:
     def connect(self):
         """Login and setup the connection."""
         try:
-            self.connection = imaplib.IMAP4_SSL(self._server, self._port)
+            self.connection = imaplib.IMAP4_SSL(
+                self._server, self._port, ssl_context=client_context()
+            )
             self.connection.login(self._user, self._password)
             return True
         except imaplib.IMAP4.error:

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
+    CONF_VERIFY_SSL,
     CONTENT_TYPE_TEXT_PLAIN,
 )
 from homeassistant.core import HomeAssistant
@@ -47,6 +48,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_FOLDER, default="INBOX"): cv.string,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     }
 )
 
@@ -59,11 +61,12 @@ def setup_platform(
 ) -> None:
     """Set up the Email sensor platform."""
     reader = EmailReader(
-        config.get(CONF_USERNAME),
-        config.get(CONF_PASSWORD),
-        config.get(CONF_SERVER),
-        config.get(CONF_PORT),
-        config.get(CONF_FOLDER),
+        config[CONF_USERNAME],
+        config[CONF_PASSWORD],
+        config[CONF_SERVER],
+        config[CONF_PORT],
+        config[CONF_FOLDER],
+        config[CONF_VERIFY_SSL],
     )
 
     if (value_template := config.get(CONF_VALUE_TEMPLATE)) is not None:
@@ -71,8 +74,8 @@ def setup_platform(
     sensor = EmailContentSensor(
         hass,
         reader,
-        config.get(CONF_NAME) or config.get(CONF_USERNAME),
-        config.get(CONF_SENDERS),
+        config.get(CONF_NAME) or config[CONF_USERNAME],
+        config[CONF_SENDERS],
         value_template,
     )
 
@@ -83,22 +86,24 @@ def setup_platform(
 class EmailReader:
     """A class to read emails from an IMAP server."""
 
-    def __init__(self, user, password, server, port, folder):
+    def __init__(self, user, password, server, port, folder, verify_ssl):
         """Initialize the Email Reader."""
         self._user = user
         self._password = password
         self._server = server
         self._port = port
         self._folder = folder
+        self._verify_ssl = verify_ssl
         self._last_id = None
         self._unread_ids = deque([])
         self.connection = None
 
     def connect(self):
         """Login and setup the connection."""
+        ssl_context = client_context() if self._verify_ssl else None
         try:
             self.connection = imaplib.IMAP4_SSL(
-                self._server, self._port, ssl_context=client_context()
+                self._server, self._port, ssl_context=ssl_context
             )
             self.connection.login(self._user, self._password)
             return True

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import setup_reload_service
 import homeassistant.util.dt as dt_util
+from homeassistant.util.ssl import client_context
 
 from . import DOMAIN, PLATFORMS
 
@@ -123,13 +124,18 @@ class MailNotificationService(BaseNotificationService):
     def connect(self):
         """Connect/authenticate to SMTP Server."""
         if self.encryption == "tls":
-            mail = smtplib.SMTP_SSL(self._server, self._port, timeout=self._timeout)
+            mail = smtplib.SMTP_SSL(
+                self._server,
+                self._port,
+                timeout=self._timeout,
+                context=client_context(),
+            )
         else:
             mail = smtplib.SMTP(self._server, self._port, timeout=self._timeout)
         mail.set_debuglevel(self.debug)
         mail.ehlo_or_helo_if_needed()
         if self.encryption == "starttls":
-            mail.starttls()
+            mail.starttls(context=client_context())
             mail.ehlo()
         if self.username and self.password:
             mail.login(self.username, self.password)

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     CONF_SENDER,
     CONF_TIMEOUT,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import setup_reload_service
@@ -66,6 +67,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_SENDER_NAME): cv.string,
         vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     }
 )
 
@@ -74,16 +76,17 @@ def get_service(hass, config, discovery_info=None):
     """Get the mail notification service."""
     setup_reload_service(hass, DOMAIN, PLATFORMS)
     mail_service = MailNotificationService(
-        config.get(CONF_SERVER),
-        config.get(CONF_PORT),
-        config.get(CONF_TIMEOUT),
-        config.get(CONF_SENDER),
-        config.get(CONF_ENCRYPTION),
+        config[CONF_SERVER],
+        config[CONF_PORT],
+        config[CONF_TIMEOUT],
+        config[CONF_SENDER],
+        config[CONF_ENCRYPTION],
         config.get(CONF_USERNAME),
         config.get(CONF_PASSWORD),
-        config.get(CONF_RECIPIENT),
+        config[CONF_RECIPIENT],
         config.get(CONF_SENDER_NAME),
-        config.get(CONF_DEBUG),
+        config[CONF_DEBUG],
+        config[CONF_VERIFY_SSL],
     )
 
     if mail_service.connection_is_valid():
@@ -107,6 +110,7 @@ class MailNotificationService(BaseNotificationService):
         recipients,
         sender_name,
         debug,
+        verify_ssl,
     ):
         """Initialize the SMTP service."""
         self._server = server
@@ -119,23 +123,25 @@ class MailNotificationService(BaseNotificationService):
         self.recipients = recipients
         self._sender_name = sender_name
         self.debug = debug
+        self._verify_ssl = verify_ssl
         self.tries = 2
 
     def connect(self):
         """Connect/authenticate to SMTP Server."""
+        ssl_context = client_context() if self._verify_ssl else None
         if self.encryption == "tls":
             mail = smtplib.SMTP_SSL(
                 self._server,
                 self._port,
                 timeout=self._timeout,
-                context=client_context(),
+                context=ssl_context,
             )
         else:
             mail = smtplib.SMTP(self._server, self._port, timeout=self._timeout)
         mail.set_debuglevel(self.debug)
         mail.ehlo_or_helo_if_needed()
         if self.encryption == "starttls":
-            mail.starttls(context=client_context())
+            mail.starttls(context=ssl_context)
             mail.ehlo()
         if self.username and self.password:
             mail.login(self.username, self.password)

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -76,6 +76,7 @@ def message():
         ["recip1@example.com", "testrecip@test.com"],
         "Home Assistant",
         0,
+        True,
     )
     yield mailer
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Default SSL contexts in Python standard lib for SMTP and IMAP are set to use an unverified context. This fixes it.

Thanks to @The-Compiler for his research and notifying us.

Background: https://github.com/python/cpython/issues/91826

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
