### PR TITLE
Fix memory leak when firing state_changed events

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -746,7 +746,7 @@ class LazyState(State):
     def context(self) -> Context:  # type: ignore[override]
         """State context."""
         if self._context is None:
-            self._context = Context(id=None)  # type: ignore[arg-type]
+            self._context = Context(id=None)
         return self._context
 
     @context.setter

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -37,7 +37,6 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-import attr
 import voluptuous as vol
 import yarl
 
@@ -716,14 +715,30 @@ class HomeAssistant:
             self._stopped.set()
 
 
-@attr.s(slots=True, frozen=False)
 class Context:
     """The context that triggered something."""
 
-    user_id: str | None = attr.ib(default=None)
-    parent_id: str | None = attr.ib(default=None)
-    id: str = attr.ib(factory=ulid_util.ulid)
-    origin_event: Event | None = attr.ib(default=None, eq=False)
+    __slots__ = ("user_id", "parent_id", "id", "origin_event")
+
+    def __init__(
+        self,
+        user_id: str | None = None,
+        parent_id: str | None = None,
+        id: str | None = None,  # pylint: disable=redefined-builtin
+    ) -> None:
+        """Init the context."""
+        self.id = id or ulid_util.ulid()
+        self.user_id = user_id
+        self.parent_id = parent_id
+        self.origin_event: Event | None = None
+
+    def __eq__(self, other: Any) -> bool:
+        """Compare contexts."""
+        return bool(self.__class__ == other.__class__ and self.id == other.id)
+
+    def __hash__(self) -> int:
+        """Hash the context."""
+        return hash(self.id)
 
     def as_dict(self) -> dict[str, str | None]:
         """Return a dictionary representation of the context."""
@@ -1163,6 +1178,24 @@ class State:
             context,
         )
 
+    def expire(self) -> None:
+        """Mark the state as old.
+
+        We give up the original reference to the context to ensure
+        the context can be garbage collected by replacing it with
+        a new one with the same id to ensure the old state
+        can still be examined for comparison against the new state.
+
+        Since we are always going to fire a EVENT_STATE_CHANGED event
+        after we remove a state from the state machine we need to make
+        sure we don't end up holding a reference to the original context
+        since it can never be garbage collected as each event would
+        reference the previous one.
+        """
+        self.context = Context(
+            self.context.user_id, self.context.parent_id, self.context.id
+        )
+
     def __eq__(self, other: Any) -> bool:
         """Return the comparison of the state."""
         return (  # type: ignore[no-any-return]
@@ -1303,6 +1336,7 @@ class StateMachine:
         if old_state is None:
             return False
 
+        old_state.expire()
         self._bus.async_fire(
             EVENT_STATE_CHANGED,
             {"entity_id": entity_id, "old_state": old_state, "new_state": None},
@@ -1396,7 +1430,6 @@ class StateMachine:
 
         if context is None:
             context = Context(id=ulid_util.ulid(dt_util.utc_to_timestamp(now)))
-
         state = State(
             entity_id,
             new_state,
@@ -1406,6 +1439,8 @@ class StateMachine:
             context,
             old_state is None,
         )
+        if old_state is not None:
+            old_state.expire()
         self._states[entity_id] = state
         self._bus.async_fire(
             EVENT_STATE_CHANGED,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -736,10 +736,6 @@ class Context:
         """Compare contexts."""
         return bool(self.__class__ == other.__class__ and self.id == other.id)
 
-    def __hash__(self) -> int:
-        """Hash the context."""
-        return hash(self.id)
-
     def as_dict(self) -> dict[str, str | None]:
         """Return a dictionary representation of the context."""
         return {"id": self.id, "parent_id": self.parent_id, "user_id": self.user_id}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1854,16 +1854,20 @@ async def test_state_changed_events_to_not_leak_contexts(hass):
     """Test state changed events do not leak contexts."""
     gc.collect()
 
-    assert len(_get_by_type("homeassistant.core.Context")) == 0
+    # Other tests can log context which keep them in memory
+    # so we need to look at how many exist at the start
+    init_count = len(_get_by_type("homeassistant.core.Context"))
+
+    assert len(_get_by_type("homeassistant.core.Context")) == init_count
     for i in range(20):
         hass.states.async_set("light.switch", str(i))
     await hass.async_block_till_done()
     gc.collect()
 
-    assert len(_get_by_type("homeassistant.core.Context")) == 2
+    assert len(_get_by_type("homeassistant.core.Context")) == init_count + 2
 
     hass.states.async_remove("light.switch")
     await hass.async_block_till_done()
     gc.collect()
 
-    assert len(_get_by_type("homeassistant.core.Context")) == 0
+    assert len(_get_by_type("homeassistant.core.Context")) == init_count

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1852,6 +1852,9 @@ def _get_by_type(full_name: str) -> list[Any]:
 @patch.object(ha._LOGGER, "debug", lambda *args: None)
 async def test_state_changed_events_to_not_leak_contexts(hass):
     """Test state changed events do not leak contexts."""
+    gc.collect()
+
+    assert len(_get_by_type("homeassistant.core.Context")) == 0
     for i in range(20):
         hass.states.async_set("light.switch", str(i))
     await hass.async_block_till_done()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1849,11 +1849,14 @@ def _get_by_type(full_name: str) -> list[Any]:
 
 # The logger will hold a strong reference to the event for the life of the tests
 # so we must patch it out
+@pytest.mark.skipif(
+    not os.environ.get("DEBUG_MEMORY"),
+    reason="Takes too long on the CI",
+)
 @patch.object(ha._LOGGER, "debug", lambda *args: None)
 async def test_state_changed_events_to_not_leak_contexts(hass):
     """Test state changed events do not leak contexts."""
     gc.collect()
-
     # Other tests can log Contexts which keep them in memory
     # so we need to look at how many exist at the start
     init_count = len(_get_by_type("homeassistant.core.Context"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,9 +6,11 @@ import array
 import asyncio
 from datetime import datetime, timedelta
 import functools
+import gc
 import logging
 import os
 from tempfile import TemporaryDirectory
+from typing import Any
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
@@ -1829,3 +1831,36 @@ async def test_event_context(hass):
     cancel2()
 
     assert dummy_event2.context.origin_event == dummy_event
+
+
+def _get_full_name(obj) -> str:
+    """Get the full name of an object in memory."""
+    objtype = type(obj)
+    name = objtype.__name__
+    if module := getattr(objtype, "__module__", None):
+        return f"{module}.{name}"
+    return name
+
+
+def _get_by_type(full_name: str) -> list[Any]:
+    """Get all objects in memory with a specific type."""
+    return [obj for obj in gc.get_objects() if _get_full_name(obj) == full_name]
+
+
+# The logger will hold a strong reference to the event for the life of the tests
+# so we must patch it out
+@patch.object(ha._LOGGER, "debug", lambda *args: None)
+async def test_state_changed_events_to_not_leak_contexts(hass):
+    """Test state changed events do not leak contexts."""
+    for i in range(20):
+        hass.states.async_set("light.switch", str(i))
+    await hass.async_block_till_done()
+    gc.collect()
+
+    assert len(_get_by_type("homeassistant.core.Context")) == 2
+
+    hass.states.async_remove("light.switch")
+    await hass.async_block_till_done()
+    gc.collect()
+
+    assert len(_get_by_type("homeassistant.core.Context")) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1854,7 +1854,7 @@ async def test_state_changed_events_to_not_leak_contexts(hass):
     """Test state changed events do not leak contexts."""
     gc.collect()
 
-    # Other tests can log context which keep them in memory
+    # Other tests can log Contexts which keep them in memory
     # so we need to look at how many exist at the start
     init_count = len(_get_by_type("homeassistant.core.Context"))
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Ensures that each successive state changed event never
  holds a reference to the old state's Context.

  We hold a reference to the origin event on the Context
  to prevent it from going away until all references to the
  original event are no longer present.

  State changed events are a special case
  as they contain State objects that share the Context, and
  that hold a reference to both the new and old Context via
  these State objects. Because of this, state_changed events
  can hold a reference to the previous Context in a chain which
  prevented garbage collection.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72528
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
