### PR TITLE
Add option to set a stun server for RTSPtoWebRTC

### DIFF
--- a/homeassistant/components/rtsp_to_webrtc/__init__.py
+++ b/homeassistant/components/rtsp_to_webrtc/__init__.py
@@ -90,7 +90,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    del hass.data[DOMAIN]
+    if DOMAIN in hass.data:
+        del hass.data[DOMAIN]
     return True
 
 

--- a/homeassistant/components/rtsp_to_webrtc/__init__.py
+++ b/homeassistant/components/rtsp_to_webrtc/__init__.py
@@ -82,6 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass, DOMAIN, async_offer_for_stream_source
         )
     )
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     websocket_api.async_register_command(hass, ws_get_settings)
 
@@ -93,6 +94,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if DOMAIN in hass.data:
         del hass.data[DOMAIN]
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload config entry when options change."""
+    if hass.data[DOMAIN][CONF_STUN_SERVER] != entry.options.get(CONF_STUN_SERVER, ""):
+        await hass.config_entries.async_reload(entry.entry_id)
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/rtsp_to_webrtc/config_flow.py
+++ b/homeassistant/components/rtsp_to_webrtc/config_flow.py
@@ -11,10 +11,11 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from . import DATA_SERVER_URL, DOMAIN
+from . import CONF_STUN_SERVER, DATA_SERVER_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,4 +104,39 @@ class RTSPToWebRTCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=self._hassio_discovery["addon"],
             data={DATA_SERVER_URL: url},
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create an options flow."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """RTSPtoWeb Options flow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_STUN_SERVER,
+                        default=self.config_entry.options.get(CONF_STUN_SERVER),
+                    ): str,
+                }
+            ),
         )

--- a/homeassistant/components/rtsp_to_webrtc/config_flow.py
+++ b/homeassistant/components/rtsp_to_webrtc/config_flow.py
@@ -133,9 +133,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
+                    vol.Optional(
                         CONF_STUN_SERVER,
-                        default=self.config_entry.options.get(CONF_STUN_SERVER),
+                        description={
+                            "suggested_value": self.config_entry.options.get(
+                                CONF_STUN_SERVER
+                            ),
+                        },
                     ): str,
                 }
             ),

--- a/homeassistant/components/rtsp_to_webrtc/strings.json
+++ b/homeassistant/components/rtsp_to_webrtc/strings.json
@@ -23,5 +23,14 @@
       "server_failure": "RTSPtoWebRTC server returned an error. Check logs for more information.",
       "server_unreachable": "Unable to communicate with RTSPtoWebRTC server. Check logs for more information."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "stun_server": "Stun server address (host:port)"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/rtsp_to_webrtc/translations/en.json
+++ b/homeassistant/components/rtsp_to_webrtc/translations/en.json
@@ -23,5 +23,14 @@
                 "title": "Configure RTSPtoWebRTC"
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "stun_server": "Stun server address (host:port)"
+                }
+            }
+        }
     }
 }

--- a/tests/components/rtsp_to_webrtc/conftest.py
+++ b/tests/components/rtsp_to_webrtc/conftest.py
@@ -65,9 +65,20 @@ async def config_entry_data() -> dict[str, Any]:
 
 
 @pytest.fixture
-async def config_entry(config_entry_data: dict[str, Any]) -> MockConfigEntry:
+def config_entry_options() -> dict[str, Any] | None:
+    """Fixture to set initial config entry options."""
+    return None
+
+
+@pytest.fixture
+async def config_entry(
+    config_entry_data: dict[str, Any],
+    config_entry_options: dict[str, Any] | None,
+) -> MockConfigEntry:
     """Fixture for MockConfigEntry."""
-    return MockConfigEntry(domain=DOMAIN, data=config_entry_data)
+    return MockConfigEntry(
+        domain=DOMAIN, data=config_entry_data, options=config_entry_options
+    )
 
 
 @pytest.fixture

--- a/tests/components/rtsp_to_webrtc/test_config_flow.py
+++ b/tests/components/rtsp_to_webrtc/test_config_flow.py
@@ -247,3 +247,14 @@ async def test_options_flow(
     assert result["type"] == "create_entry"
     await hass.async_block_till_done()
     assert config_entry.options == {"stun_server": "example.com:1234"}
+
+    # Clear the value
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] == "create_entry"
+    await hass.async_block_till_done()
+    assert config_entry.options == {}

--- a/tests/components/rtsp_to_webrtc/test_config_flow.py
+++ b/tests/components/rtsp_to_webrtc/test_config_flow.py
@@ -9,7 +9,10 @@ import rtsp_to_webrtc
 from homeassistant import config_entries
 from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.rtsp_to_webrtc import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+
+from .conftest import ComponentSetup
 
 from tests.common import MockConfigEntry
 
@@ -212,3 +215,35 @@ async def test_hassio_discovery_server_failure(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result.get("type") == "abort"
         assert result.get("reason") == "server_failure"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    setup_integration: ComponentSetup,
+) -> None:
+    """Test setting stun server in options flow."""
+    with patch(
+        "homeassistant.components.rtsp_to_webrtc.async_setup_entry",
+        return_value=True,
+    ):
+        await setup_integration()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert not config_entry.options
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    data_schema = result["data_schema"].schema
+    assert set(data_schema) == {"stun_server"}
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "stun_server": "example.com:1234",
+        },
+    )
+    assert result["type"] == "create_entry"
+    await hass.async_block_till_done()
+    assert config_entry.options == {"stun_server": "example.com:1234"}

--- a/tests/components/rtsp_to_webrtc/test_init.py
+++ b/tests/components/rtsp_to_webrtc/test_init.py
@@ -11,13 +11,14 @@ import aiohttp
 import pytest
 import rtsp_to_webrtc
 
-from homeassistant.components.rtsp_to_webrtc import DOMAIN
+from homeassistant.components.rtsp_to_webrtc import CONF_STUN_SERVER, DOMAIN
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from .conftest import SERVER_URL, STREAM_SOURCE, ComponentSetup
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 # The webrtc component does not inspect the details of the offer and answer,
@@ -154,3 +155,53 @@ async def test_offer_failure(
     assert response["error"].get("code") == "web_rtc_offer_failed"
     assert "message" in response["error"]
     assert "RTSPtoWebRTC server communication failure" in response["error"]["message"]
+
+
+async def test_no_stun_server(
+    hass: HomeAssistant,
+    rtsp_to_webrtc_client: Any,
+    setup_integration: ComponentSetup,
+    hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
+) -> None:
+    """Test successful setup and unload."""
+    await setup_integration()
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "rtsp_to_webrtc/get_settings",
+        }
+    )
+    response = await client.receive_json()
+    assert response.get("id") == 2
+    assert response.get("type") == TYPE_RESULT
+    assert "result" in response
+    assert response["result"].get("stun_server") == ""
+
+
+@pytest.mark.parametrize(
+    "config_entry_options", [{CONF_STUN_SERVER: "example.com:1234"}]
+)
+async def test_stun_server(
+    hass: HomeAssistant,
+    rtsp_to_webrtc_client: Any,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+    hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
+) -> None:
+    """Test successful setup and unload."""
+    await setup_integration()
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 3,
+            "type": "rtsp_to_webrtc/get_settings",
+        }
+    )
+    response = await client.receive_json()
+    assert response.get("id") == 3
+    assert response.get("type") == TYPE_RESULT
+    assert "result" in response
+    assert response["result"].get("stun_server") == "example.com:1234"

--- a/tests/components/rtsp_to_webrtc/test_init.py
+++ b/tests/components/rtsp_to_webrtc/test_init.py
@@ -205,3 +205,19 @@ async def test_stun_server(
     assert response.get("type") == TYPE_RESULT
     assert "result" in response
     assert response["result"].get("stun_server") == "example.com:1234"
+
+    # Simulate an options flow change, clearing the stun server and verify the change is reflected
+    hass.config_entries.async_update_entry(config_entry, options={})
+    await hass.async_block_till_done()
+
+    await client.send_json(
+        {
+            "id": 4,
+            "type": "rtsp_to_webrtc/get_settings",
+        }
+    )
+    response = await client.receive_json()
+    assert response.get("id") == 4
+    assert response.get("type") == TYPE_RESULT
+    assert "result" in response
+    assert response["result"].get("stun_server") == ""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a configuration option to set a stun server for RTSPtoWebRTC, and a websocket exposed so that the javascript frontend webrtc player can fetch it.

Frontend PR: https://github.com/home-assistant/frontend/pull/13942


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X} There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
