### PR TITLE
Require passing target player when resolving media

### DIFF
--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -18,10 +18,11 @@ from homeassistant.components.media_player.browse_media import (
 )
 from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.frame import report
 from homeassistant.helpers.integration_platform import (
     async_process_integration_platforms,
 )
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import UNDEFINED, ConfigType
 from homeassistant.loader import bind_hass
 
 from . import local_source
@@ -80,15 +81,15 @@ async def _process_media_source_platform(
 
 @callback
 def _get_media_item(
-    hass: HomeAssistant, media_content_id: str | None
+    hass: HomeAssistant, media_content_id: str | None, target_media_player: str | None
 ) -> MediaSourceItem:
     """Return media item."""
     if media_content_id:
-        item = MediaSourceItem.from_uri(hass, media_content_id)
+        item = MediaSourceItem.from_uri(hass, media_content_id, target_media_player)
     else:
         # We default to our own domain if its only one registered
         domain = None if len(hass.data[DOMAIN]) > 1 else DOMAIN
-        return MediaSourceItem(hass, domain, "")
+        return MediaSourceItem(hass, domain, "", target_media_player)
 
     if item.domain is not None and item.domain not in hass.data[DOMAIN]:
         raise ValueError("Unknown media source")
@@ -108,7 +109,7 @@ async def async_browse_media(
         raise BrowseError("Media Source not loaded")
 
     try:
-        item = await _get_media_item(hass, media_content_id).async_browse()
+        item = await _get_media_item(hass, media_content_id, None).async_browse()
     except ValueError as err:
         raise BrowseError(str(err)) from err
 
@@ -124,13 +125,21 @@ async def async_browse_media(
 
 
 @bind_hass
-async def async_resolve_media(hass: HomeAssistant, media_content_id: str) -> PlayMedia:
+async def async_resolve_media(
+    hass: HomeAssistant,
+    media_content_id: str,
+    target_media_player: str | None = UNDEFINED,
+) -> PlayMedia:
     """Get info to play media."""
     if DOMAIN not in hass.data:
         raise Unresolvable("Media Source not loaded")
 
+    if target_media_player is UNDEFINED:
+        report("calls media_source.async_resolve_media without passing an entity_id")
+        target_media_player = None
+
     try:
-        item = _get_media_item(hass, media_content_id)
+        item = _get_media_item(hass, media_content_id, target_media_player)
     except ValueError as err:
         raise Unresolvable(str(err)) from err
 

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.frame import report
 from homeassistant.helpers.integration_platform import (
     async_process_integration_platforms,
 )
-from homeassistant.helpers.typing import UNDEFINED, ConfigType
+from homeassistant.helpers.typing import UNDEFINED, ConfigType, UndefinedType
 from homeassistant.loader import bind_hass
 
 from . import local_source
@@ -128,7 +128,7 @@ async def async_browse_media(
 async def async_resolve_media(
     hass: HomeAssistant,
     media_content_id: str,
-    target_media_player: str | None = UNDEFINED,
+    target_media_player: str | None | UndefinedType = UNDEFINED,
 ) -> PlayMedia:
     """Get info to play media."""
     if DOMAIN not in hass.data:

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -264,7 +264,7 @@ class UploadMediaView(http.HomeAssistantView):
             raise web.HTTPBadRequest() from err
 
         try:
-            item = MediaSourceItem.from_uri(self.hass, data["media_content_id"])
+            item = MediaSourceItem.from_uri(self.hass, data["media_content_id"], None)
         except ValueError as err:
             LOGGER.error("Received invalid upload data: %s", err)
             raise web.HTTPBadRequest() from err
@@ -328,7 +328,7 @@ async def websocket_remove_media(
 ) -> None:
     """Remove media."""
     try:
-        item = MediaSourceItem.from_uri(hass, msg["media_content_id"])
+        item = MediaSourceItem.from_uri(hass, msg["media_content_id"], None)
     except ValueError as err:
         connection.send_error(msg["id"], websocket_api.ERR_INVALID_FORMAT, str(err))
         return

--- a/homeassistant/components/media_source/models.py
+++ b/homeassistant/components/media_source/models.py
@@ -50,6 +50,7 @@ class MediaSourceItem:
     hass: HomeAssistant
     domain: str | None
     identifier: str
+    target_media_player: str | None
 
     async def async_browse(self) -> BrowseMediaSource:
         """Browse this item."""
@@ -94,7 +95,9 @@ class MediaSourceItem:
         return cast(MediaSource, self.hass.data[DOMAIN][self.domain])
 
     @classmethod
-    def from_uri(cls, hass: HomeAssistant, uri: str) -> MediaSourceItem:
+    def from_uri(
+        cls, hass: HomeAssistant, uri: str, target_media_player: str | None
+    ) -> MediaSourceItem:
         """Create an item from a uri."""
         if not (match := URI_SCHEME_REGEX.match(uri)):
             raise ValueError("Invalid media source URI")
@@ -102,7 +105,7 @@ class MediaSourceItem:
         domain = match.group("domain")
         identifier = match.group("identifier")
 
-        return cls(hass, domain, identifier)
+        return cls(hass, domain, identifier, target_media_player)
 
 
 class MediaSource(ABC):

--- a/tests/components/dlna_dms/test_media_source.py
+++ b/tests/components/dlna_dms/test_media_source.py
@@ -49,7 +49,7 @@ async def test_get_media_source(hass: HomeAssistant) -> None:
 async def test_resolve_media_unconfigured(hass: HomeAssistant) -> None:
     """Test resolve_media without any devices being configured."""
     source = DmsMediaSource(hass)
-    item = MediaSourceItem(hass, DOMAIN, "source_id/media_id")
+    item = MediaSourceItem(hass, DOMAIN, "source_id/media_id", None)
     with pytest.raises(Unresolvable, match="No sources have been configured"):
         await source.async_resolve_media(item)
 
@@ -116,11 +116,11 @@ async def test_resolve_media_success(
 async def test_browse_media_unconfigured(hass: HomeAssistant) -> None:
     """Test browse_media without any devices being configured."""
     source = DmsMediaSource(hass)
-    item = MediaSourceItem(hass, DOMAIN, "source_id/media_id")
+    item = MediaSourceItem(hass, DOMAIN, "source_id/media_id", None)
     with pytest.raises(BrowseError, match="No sources have been configured"):
         await source.async_browse_media(item)
 
-    item = MediaSourceItem(hass, DOMAIN, "")
+    item = MediaSourceItem(hass, DOMAIN, "", None)
     with pytest.raises(BrowseError, match="No sources have been configured"):
         await source.async_browse_media(item)
 
@@ -239,7 +239,7 @@ async def test_browse_media_source_id(
     dms_device_mock.async_browse_metadata.side_effect = UpnpError
 
     # Browse by source_id
-    item = MediaSourceItem(hass, DOMAIN, f"{MOCK_SOURCE_ID}/:media-item-id")
+    item = MediaSourceItem(hass, DOMAIN, f"{MOCK_SOURCE_ID}/:media-item-id", None)
     dms_source = DmsMediaSource(hass)
     with pytest.raises(BrowseError):
         await dms_source.async_browse_media(item)

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -109,6 +109,24 @@ async def test_async_resolve_media(hass):
     assert media.mime_type == "audio/mpeg"
 
 
+async def test_async_resolve_media_no_entity(hass, caplog):
+    """Test browse media."""
+    assert await async_setup_component(hass, media_source.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    media = await media_source.async_resolve_media(
+        hass,
+        media_source.generate_media_source_id(media_source.DOMAIN, "local/test.mp3"),
+    )
+    assert isinstance(media, media_source.models.PlayMedia)
+    assert media.url == "/media/local/test.mp3"
+    assert media.mime_type == "audio/mpeg"
+    assert (
+        "calls media_source.async_resolve_media without passing an entity_id"
+        in caplog.text
+    )
+
+
 async def test_async_unresolve_media(hass):
     """Test browse media."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -109,6 +109,7 @@ async def test_async_resolve_media(hass):
     assert media.mime_type == "audio/mpeg"
 
 
+@patch("homeassistant.helpers.frame._REPORTED_INTEGRATIONS", set())
 async def test_async_resolve_media_no_entity(hass, caplog):
     """Test browse media."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Require passing entity_id of the target media player when resolving media
If an entity_id is not passed, a warning is logged.

Integrations will be migrated in a follow-up

The `entity_id` is stored in the `MediaSourceItem` and media sources can use it to customize the result depending on the targetted `entity_id`

This is intended to solve a use case for the media browser in @marcelveldt's music_assistant. The music_assistant integration maintains a queue per media player, and if a song is picked in the media browser from his integration's media source he wants to add it to the queue of the entity for which it was picked.

This is a more targeted approach than https://github.com/home-assistant/core/pull/71558

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
