### PR TITLE
Move power and energy attributes to sensors for SmartThings Air conditioner

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -106,7 +106,6 @@ def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:
         Capability.air_conditioner_mode,
         Capability.demand_response_load_control,
         Capability.air_conditioner_fan_mode,
-        Capability.power_consumption_report,
         Capability.relative_humidity_measurement,
         Capability.switch,
         Capability.temperature_measurement,
@@ -422,10 +421,6 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
             "drlc_status_level",
             "drlc_status_start",
             "drlc_status_override",
-            "power_consumption_start",
-            "power_consumption_power",
-            "power_consumption_energy",
-            "power_consumption_end",
         ]
         state_attributes = {}
         for attribute in attributes:

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -553,7 +553,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add binary sensors for a config entry."""
+    """Add sensors for a config entry."""
     broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
     entities: list[SensorEntity] = []
     for device in broker.devices.values():
@@ -641,7 +641,7 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
 
     @property
     def name(self) -> str:
-        """Return the name of the binary sensor."""
+        """Return the name of the sensor."""
         return f"{self._device.label} {self._name}"
 
     @property
@@ -681,7 +681,7 @@ class SmartThingsThreeAxisSensor(SmartThingsEntity, SensorEntity):
 
     @property
     def name(self) -> str:
-        """Return the name of the binary sensor."""
+        """Return the name of the sensor."""
         return f"{self._device.label} {THREE_AXIS_NAMES[self._index]}"
 
     @property
@@ -716,7 +716,7 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
 
     @property
     def name(self) -> str:
-        """Return the name of the binary sensor."""
+        """Return the name of the sensor."""
         return f"{self._device.label} {self.report_name}"
 
     @property
@@ -747,3 +747,19 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
         if self.report_name == "power":
             return POWER_WATT
         return ENERGY_KILO_WATT_HOUR
+
+    @property
+    def extra_state_attributes(self):
+        """Return specific state attributes."""
+        if self.report_name == "power":
+            attributes = [
+                "power_consumption_start",
+                "power_consumption_end",
+            ]
+            state_attributes = {}
+            for attribute in attributes:
+                value = getattr(self._device.status, attribute)
+                if value is not None:
+                    state_attributes[attribute] = value
+            return state_attributes
+        return None

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -148,7 +148,6 @@ def air_conditioner_fixture(device_factory):
             Capability.air_conditioner_mode,
             Capability.demand_response_load_control,
             Capability.air_conditioner_fan_mode,
-            Capability.power_consumption_report,
             Capability.switch,
             Capability.temperature_measurement,
             Capability.thermostat_cooling_setpoint,
@@ -177,12 +176,6 @@ def air_conditioner_fixture(device_factory):
                 "high",
                 "turbo",
             ],
-            Attribute.power_consumption: {
-                "start": "2019-02-24T21:03:04Z",
-                "power": 0,
-                "energy": 500,
-                "end": "2019-02-26T02:05:55Z",
-            },
             Attribute.switch: "on",
             Attribute.cooling_setpoint: 23,
         },
@@ -320,10 +313,6 @@ async def test_air_conditioner_entity_state(hass, air_conditioner):
     assert state.attributes["drlc_status_level"] == -1
     assert state.attributes["drlc_status_start"] == "1970-01-01T00:00:00Z"
     assert state.attributes["drlc_status_override"] is False
-    assert state.attributes["power_consumption_start"] == "2019-02-24T21:03:04Z"
-    assert state.attributes["power_consumption_power"] == 0
-    assert state.attributes["power_consumption_energy"] == 500
-    assert state.attributes["power_consumption_end"] == "2019-02-26T02:05:55Z"
 
 
 async def test_set_fan_mode(hass, thermostat, air_conditioner):

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -190,6 +190,8 @@ async def test_power_consumption_sensor(hass, device_factory):
     state = hass.states.get("sensor.refrigerator_power")
     assert state
     assert state.state == "109"
+    assert state.attributes["power_consumption_start"] == "2021-07-30T16:45:25Z"
+    assert state.attributes["power_consumption_end"] == "2021-07-30T16:58:33Z"
     entry = entity_registry.async_get("sensor.refrigerator_power")
     assert entry
     assert entry.unique_id == f"{device.device_id}.power_meter"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The following power attributes:
```
power_consumption_start
power_consumption_end
power_consumption_power
power_consumption_energy
```
from the climate entity for Smartthings Air Conditioner have been removed and added as separate sensors. Please update your templates, automation and any other configuration accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move power and energy attributes from the climate entity for Smarttings Air Conditioner to separate sensors like it is done for other Smartthings devices (refrigerator for example)
These sensors can now be used directly in the Energy dashboard without the need for templates sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22903

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
