### PR TITLE
Defer google calendar integration reload to a task to avoid races of reload during setup

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -239,7 +239,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err
 
-    if not _async_entry_has_scopes(hass, entry):
+    if not async_entry_has_scopes(hass, entry):
         raise ConfigEntryAuthFailed(
             "Required scopes are not available, reauth required"
         )
@@ -260,7 +260,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def _async_entry_has_scopes(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+def async_entry_has_scopes(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Verify that the config entry desired scope is present in the oauth token."""
     access = get_feature_access(hass, entry)
     token_scopes = entry.data.get("token", {}).get("scope", [])
     return access.scope in token_scopes
@@ -273,7 +274,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry if the access options change."""
-    if not _async_entry_has_scopes(hass, entry):
+    if not async_entry_has_scopes(hass, entry):
         await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -284,7 +284,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the config entry when it changed."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    # Avoid race if reload happens while integration is still setting up
+    hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
 
 async def async_setup_services(

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -19,6 +19,7 @@ from oauth2client.client import (
 )
 
 from homeassistant.components.application_credentials import AuthImplementation
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.event import async_track_time_interval
@@ -127,8 +128,17 @@ class DeviceFlow:
         )
 
 
-def get_feature_access(hass: HomeAssistant) -> FeatureAccess:
+def get_feature_access(
+    hass: HomeAssistant, config_entry: ConfigEntry | None = None
+) -> FeatureAccess:
     """Return the desired calendar feature access."""
+    if (
+        config_entry
+        and config_entry.options
+        and CONF_CALENDAR_ACCESS in config_entry.options
+    ):
+        return FeatureAccess[config_entry.options[CONF_CALENDAR_ACCESS]]
+
     # This may be called during config entry setup without integration setup running when there
     # is no google entry in configuration.yaml
     return cast(

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -540,9 +540,15 @@ async def test_options_flow_triggers_reauth(
 ) -> None:
     """Test load and unload of a ConfigEntry."""
     config_entry.add_to_hass(hass)
-    await component_setup()
+
+    with patch(
+        "homeassistant.components.google.async_setup_entry", return_value=True
+    ) as mock_setup:
+        await component_setup()
+        mock_setup.assert_called_once()
+
     assert config_entry.state is ConfigEntryState.LOADED
-    assert config_entry.options == {"calendar_access": "read_write"}
+    assert config_entry.options == {}  # Default is read_write
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == "form"
@@ -557,14 +563,7 @@ async def test_options_flow_triggers_reauth(
         },
     )
     assert result["type"] == "create_entry"
-
-    await hass.async_block_till_done()
     assert config_entry.options == {"calendar_access": "read_only"}
-    # Re-auth flow was initiated because access level changed
-    assert config_entry.state is ConfigEntryState.SETUP_ERROR
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["step_id"] == "reauth_confirm"
 
 
 async def test_options_flow_no_changes(
@@ -574,9 +573,15 @@ async def test_options_flow_no_changes(
 ) -> None:
     """Test load and unload of a ConfigEntry."""
     config_entry.add_to_hass(hass)
-    await component_setup()
+
+    with patch(
+        "homeassistant.components.google.async_setup_entry", return_value=True
+    ) as mock_setup:
+        await component_setup()
+        mock_setup.assert_called_once()
+
     assert config_entry.state is ConfigEntryState.LOADED
-    assert config_entry.options == {"calendar_access": "read_write"}
+    assert config_entry.options == {}  # Default is read_write
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == "form"
@@ -589,8 +594,4 @@ async def test_options_flow_no_changes(
         },
     )
     assert result["type"] == "create_entry"
-
-    await hass.async_block_till_done()
     assert config_entry.options == {"calendar_access": "read_write"}
-    # Re-auth flow was initiated because access level changed
-    assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -652,19 +652,47 @@ async def test_calendar_yaml_update(
 async def test_update_will_reload(
     hass: HomeAssistant,
     component_setup: ComponentSetup,
+    setup_config_entry: Any,
+    mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test updating config entry options will trigger a reload."""
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
     await component_setup()
     assert config_entry.state is ConfigEntryState.LOADED
-    assert config_entry.options == {}
+    assert config_entry.options == {}  # read_write is default
 
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_reload",
         return_value=None,
     ) as mock_reload:
+        # No-op does not reload
+        hass.config_entries.async_update_entry(
+            config_entry, options={CONF_CALENDAR_ACCESS: "read_write"}
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        mock_reload.assert_not_called()
+
+        # Data change does not trigger reload
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={
+                **config_entry.data,
+                "example": "field",
+            },
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        mock_reload.assert_not_called()
+
+        # Reload when options changed
         hass.config_entries.async_update_entry(
             config_entry, options={CONF_CALENDAR_ACCESS: "read_only"}
         )
+        await hass.async_block_till_done()
         await hass.async_block_till_done()
         mock_reload.assert_called_once()

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -674,7 +674,6 @@ async def test_update_will_reload(
             config_entry, options={CONF_CALENDAR_ACCESS: "read_write"}
         )
         await hass.async_block_till_done()
-        await hass.async_block_till_done()
         mock_reload.assert_not_called()
 
         # Data change does not trigger reload
@@ -686,13 +685,11 @@ async def test_update_will_reload(
             },
         )
         await hass.async_block_till_done()
-        await hass.async_block_till_done()
         mock_reload.assert_not_called()
 
         # Reload when options changed
         hass.config_entries.async_update_entry(
             config_entry, options={CONF_CALENDAR_ACCESS: "read_only"}
         )
-        await hass.async_block_till_done()
         await hass.async_block_till_done()
         mock_reload.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Defer google calendar integration reload to a task to avoid races of updating the configuration while the integration is still being setup.

I considered running the update itself as a task instead, but that felt like a larger change since it requires some rewriting of the config entry. The reload itself it the actual problem, so deferring that only seemed fine.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
    - fixes #72592 
    - fixed #72555
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
