### PR TITLE
Add support for async_remove_config_entry_device to august

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .activity import ActivityStream
 from .const import DOMAIN, MIN_TIME_BETWEEN_DETAIL_UPDATES, PLATFORMS
@@ -283,12 +284,15 @@ class AugustData(AugustSubscriberMixin):
             device.device_id,
         )
 
-    def _get_device_name(self, device_id):
+    def get_device(self, device_id: str) -> Doorbell | Lock | None:
+        """Get a device by id."""
+        return self._locks_by_id.get(device_id) or self._doorbells_by_id.get(device_id)
+
+    def _get_device_name(self, device_id: str) -> str | None:
         """Return doorbell or lock name as August has it stored."""
-        if device_id in self._locks_by_id:
-            return self._locks_by_id[device_id].device_name
-        if device_id in self._doorbells_by_id:
-            return self._doorbells_by_id[device_id].device_name
+        if device := self.get_device(device_id):
+            return device.device_name
+        return None
 
     async def async_lock(self, device_id):
         """Lock the device."""
@@ -403,3 +407,15 @@ def _restore_live_attrs(lock_detail, attrs):
     """Restore the non-cache attributes after a cached update."""
     for attr, value in attrs.items():
         setattr(lock_detail, attr, value)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove august config entry from a device if its no longer present."""
+    data: AugustData = hass.data[DOMAIN][config_entry.entry_id]
+    return any(
+        identifier
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN and not data.get_device(identifier[1])
+    )

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -414,8 +414,8 @@ async def async_remove_config_entry_device(
 ) -> bool:
     """Remove august config entry from a device if its no longer present."""
     data: AugustData = hass.data[DOMAIN][config_entry.entry_id]
-    return any(
+    return not any(
         identifier
         for identifier in device_entry.identifiers
-        if identifier[0] == DOMAIN and not data.get_device(identifier[1])
+        if identifier[0] == DOMAIN and data.get_device(identifier[1])
     )

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -1,7 +1,10 @@
 """Mocks for the august component."""
+from __future__ import annotations
+
 import json
 import os
 import time
+from typing import Any, Iterable
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from yalexs.activity import (
@@ -26,7 +29,9 @@ from yalexs.lock import Lock, LockDetail
 from yalexs.pubnub_async import AugustPubNub
 
 from homeassistant.components.august.const import CONF_LOGIN_METHOD, DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -76,9 +81,13 @@ async def _mock_setup_august(
 
 
 async def _create_august_with_devices(
-    hass, devices, api_call_side_effects=None, activities=None, pubnub=None
-):
-    entry, api_instance = await _create_august_api_with_devices(
+    hass: HomeAssistant,
+    devices: Iterable[LockDetail | DoorbellDetail],
+    api_call_side_effects: dict[str, Any] | None = None,
+    activities: list[Any] | None = None,
+    pubnub: AugustPubNub | None = None,
+) -> ConfigEntry:
+    entry, _ = await _create_august_api_with_devices(
         hass, devices, api_call_side_effects, activities, pubnub
     )
     return entry


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for async_remove_config_entry_device to august

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
