### PR TITLE
Use `pysnmplib` instead of `pysnmp`

### DIFF
--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -42,7 +42,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize."""
-        self.brother: Brother = None
+        self.brother: Brother
         self.host: str | None = None
 
     async def async_step_user(

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brother Printer",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
-  "requirements": ["brother==1.2.2"],
+  "requirements": ["brother==1.2.3"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brother Printer",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
-  "requirements": ["brother==1.2.1"],
+  "requirements": ["brother==1.2.2"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brother Printer",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
-  "requirements": ["brother==1.1.0"],
+  "requirements": ["brother==1.2.1"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "snmp",
   "name": "SNMP",
   "documentation": "https://www.home-assistant.io/integrations/snmp",
-  "requirements": ["pysnmp==4.4.12"],
+  "requirements": ["pysnmplib==5.0.15"],
   "codeowners": [],
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -433,7 +433,7 @@ bravia-tv==1.0.11
 broadlink==0.18.2
 
 # homeassistant.components.brother
-brother==1.2.2
+brother==1.2.3
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -433,7 +433,7 @@ bravia-tv==1.0.11
 broadlink==0.18.2
 
 # homeassistant.components.brother
-brother==1.1.0
+brother==1.2.1
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1
@@ -1838,7 +1838,7 @@ pysmarty==0.8
 pysml==0.0.7
 
 # homeassistant.components.snmp
-pysnmp==4.4.12
+pysnmplib==5.0.15
 
 # homeassistant.components.soma
 pysoma==0.0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -433,7 +433,7 @@ bravia-tv==1.0.11
 broadlink==0.18.2
 
 # homeassistant.components.brother
-brother==1.2.1
+brother==1.2.2
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -330,7 +330,7 @@ bravia-tv==1.0.11
 broadlink==0.18.2
 
 # homeassistant.components.brother
-brother==1.1.0
+brother==1.2.1
 
 # homeassistant.components.brunt
 brunt==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -330,7 +330,7 @@ bravia-tv==1.0.11
 broadlink==0.18.2
 
 # homeassistant.components.brother
-brother==1.2.2
+brother==1.2.3
 
 # homeassistant.components.brunt
 brunt==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -330,7 +330,7 @@ bravia-tv==1.0.11
 broadlink==0.18.2
 
 # homeassistant.components.brother
-brother==1.2.1
+brother==1.2.2
 
 # homeassistant.components.brunt
 brunt==1.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`snmp` and `brother` integrations use `pysnmp` package, which has not been developed in a long time and has a bug preventing it from working with Python 3.10. There is a [community fork](https://github.com/pysnmp/pysnmp) for this package and the bug has been fixed.

This is a second attempt to migrate from `pysnmp` to `pysnmplib` for `snmp` integration and upgrade the version of the `brother` package which also uses `pysnmplib`.

I tested the new version of `pysnmplib` with 10 snmp sensors for a few hours without errors so I think there shouldn't be supprises like this #71368.

pysnmplib changelog: https://github.com/pysnmp/pysnmp/compare/v4.4.12...v5.0.15
brother changelog: https://github.com/bieniu/brother/compare/1.1.0...1.2.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
