### PR TITLE
Don't import google calendar user pref for disabling new entities

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -199,11 +199,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     _LOGGER.warning(
         "Configuration of Google Calendar in YAML in configuration.yaml is "
         "is deprecated and will be removed in a future release; Your existing "
-        "OAuth Application Credentials and other settings have been imported "
+        "OAuth Application Credentials and access settings have been imported "
         "into the UI automatically and can be safely removed from your "
         "configuration.yaml file"
     )
-
+    if conf.get(CONF_TRACK_NEW) is False:
+        # The track_new as False would previously result in new entries
+        # in google_calendars.yaml with track set to Fasle which is
+        # handled at calendar entity creation time.
+        _LOGGER.warning(
+            "You must manually set the integration System Options in the "
+            "UI to disable newly discovered entities going forward"
+        )
     return True
 
 
@@ -260,23 +267,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 def async_upgrade_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Upgrade the config entry if needed."""
-    if DATA_CONFIG not in hass.data[DOMAIN] and entry.options:
+    if entry.options:
         return
-
-    options = (
-        entry.options
-        if entry.options
-        else {
-            CONF_CALENDAR_ACCESS: get_feature_access(hass).name,
-        }
-    )
-    disable_new_entities = (
-        not hass.data[DOMAIN].get(DATA_CONFIG, {}).get(CONF_TRACK_NEW, True)
-    )
     hass.config_entries.async_update_entry(
         entry,
-        options=options,
-        pref_disable_new_entities=disable_new_entities,
+        options={
+            CONF_CALENDAR_ACCESS: get_feature_access(hass).name,
+        },
     )
 
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -154,57 +154,6 @@ async def test_calendar_yaml_error(
     assert hass.states.get(TEST_API_ENTITY)
 
 
-@pytest.mark.parametrize(
-    "google_config_track_new,calendars_config,expected_state",
-    [
-        (
-            None,
-            [],
-            State(
-                TEST_API_ENTITY,
-                STATE_OFF,
-                attributes={
-                    "offset_reached": False,
-                    "friendly_name": TEST_API_ENTITY_NAME,
-                },
-            ),
-        ),
-        (
-            True,
-            [],
-            State(
-                TEST_API_ENTITY,
-                STATE_OFF,
-                attributes={
-                    "offset_reached": False,
-                    "friendly_name": TEST_API_ENTITY_NAME,
-                },
-            ),
-        ),
-        (False, [], None),
-    ],
-    ids=["default", "True", "False"],
-)
-async def test_track_new(
-    hass: HomeAssistant,
-    component_setup: ComponentSetup,
-    mock_calendars_list: ApiResult,
-    test_api_calendar: dict[str, Any],
-    mock_events_list: ApiResult,
-    mock_calendars_yaml: None,
-    expected_state: State,
-    setup_config_entry: MockConfigEntry,
-) -> None:
-    """Test behavior of configuration.yaml settings for tracking new calendars not in the config."""
-
-    mock_calendars_list({"items": [test_api_calendar]})
-    mock_events_list({})
-    assert await component_setup()
-
-    state = hass.states.get(TEST_API_ENTITY)
-    assert_state(state, expected_state)
-
-
 @pytest.mark.parametrize("calendars_config", [[]])
 async def test_found_calendar_from_api(
     hass: HomeAssistant,
@@ -263,7 +212,7 @@ async def test_load_application_credentials(
 
 
 @pytest.mark.parametrize(
-    "calendars_config_track,expected_state",
+    "calendars_config_track,expected_state,google_config_track_new",
     [
         (
             True,
@@ -275,8 +224,35 @@ async def test_load_application_credentials(
                     "friendly_name": TEST_YAML_ENTITY_NAME,
                 },
             ),
+            None,
         ),
-        (False, None),
+        (
+            True,
+            State(
+                TEST_YAML_ENTITY,
+                STATE_OFF,
+                attributes={
+                    "offset_reached": False,
+                    "friendly_name": TEST_YAML_ENTITY_NAME,
+                },
+            ),
+            True,
+        ),
+        (
+            True,
+            State(
+                TEST_YAML_ENTITY,
+                STATE_OFF,
+                attributes={
+                    "offset_reached": False,
+                    "friendly_name": TEST_YAML_ENTITY_NAME,
+                },
+            ),
+            False,  # Has no effect
+        ),
+        (False, None, None),
+        (False, None, True),
+        (False, None, False),
     ],
 )
 async def test_calendar_config_track_new(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
*Note for Release Notes: This supersedes the breaking change in https://github.com/home-assistant/core/pull/72288 and the updated note is summarized here*

Google Calendars integration configuration.yaml has been migrated to configuration via the UI, and
has been deprecated and will be removed in a future Home Assistant release.

Your existing OAuth application credentials in the YAML configuration are automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

All entity tracking state (`track` setting) has been migrated to use the standard Home Assistant entity enable/disable features in the user interface and system options. However, the `track_new` setting was not imported and you need to manually use the integration *System Options* if you wish disable additional entities in the future.

Note that `google_calendars.yaml` is still supported.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not import google calendar `track_new` as a partial rollback of https://github.com/home-assistant/core/pull/72288 

The result of importing this is *all* entities are disabled, requiring a manual enable by the user which was not intended.  As a compromise instead, we already preserve any existing `track: False` from `google_calendars.yaml` so existing discovered entities are handled, but now the user has to manually set a `track_new: False` equivalent  in the integration *System Options* going forward.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72600
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
