### PR TITLE
Manage stations via integrations configuration in Tankerkoenig

### DIFF
--- a/homeassistant/components/tankerkoenig/strings.json
+++ b/homeassistant/components/tankerkoenig/strings.json
@@ -32,7 +32,7 @@
       "init": {
         "title": "Tankerkoenig options",
         "data": {
-          "scan_interval": "Update Interval",
+          "stations": "Stations",
           "show_on_map": "Show stations on map"
         }
       }

--- a/homeassistant/components/tankerkoenig/translations/en.json
+++ b/homeassistant/components/tankerkoenig/translations/en.json
@@ -31,8 +31,8 @@
         "step": {
             "init": {
                 "data": {
-                    "scan_interval": "Update Interval",
-                    "show_on_map": "Show stations on map"
+                    "show_on_map": "Show stations on map",
+                    "stations": "Stations"
                 },
                 "title": "Tankerkoenig options"
             }

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -42,6 +42,15 @@ MOCK_STATIONS_DATA = {
     ],
 }
 
+MOCK_OPTIONS_DATA = {
+    **MOCK_USER_DATA,
+    CONF_STATIONS: [
+        "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+        "36b4b812-xxxx-xxxx-xxxx-c51735325858",
+        "54e2b642-xxxx-xxxx-xxxx-87cd4e9867f1",
+    ],
+}
+
 MOCK_IMPORT_DATA = {
     CONF_API_KEY: "269534f6-xxxx-xxxx-xxxx-yyyyzzzzxxxx",
     CONF_FUEL_TYPES: ["e5"],
@@ -217,7 +226,7 @@ async def test_options_flow(hass: HomeAssistant):
 
     mock_config = MockConfigEntry(
         domain=DOMAIN,
-        data=MOCK_USER_DATA,
+        data=MOCK_OPTIONS_DATA,
         options={CONF_SHOW_ON_MAP: True},
         unique_id=f"{DOMAIN}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
     )
@@ -225,17 +234,23 @@ async def test_options_flow(hass: HomeAssistant):
 
     with patch(
         "homeassistant.components.tankerkoenig.async_setup_entry"
-    ) as mock_setup_entry:
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.tankerkoenig.config_flow.getNearbyStations",
+        return_value=MOCK_NEARVY_STATIONS_OK,
+    ):
         await mock_config.async_setup(hass)
         await hass.async_block_till_done()
         assert mock_setup_entry.called
 
-    result = await hass.config_entries.options.async_init(mock_config.entry_id)
+        result = await hass.config_entries.options.async_init(mock_config.entry_id)
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "init"
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_SHOW_ON_MAP: False},
+        user_input={
+            CONF_SHOW_ON_MAP: False,
+            CONF_STATIONS: MOCK_OPTIONS_DATA[CONF_STATIONS],
+        },
     )
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert not mock_config.options[CONF_SHOW_ON_MAP]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes possible to enable and disable stations via integrations configuration.
Former manually added stations (_outside of defined radius, but imported from yaml config_) are shown with it's id

![image](https://user-images.githubusercontent.com/35783820/170836842-5e2807b1-07b0-4293-aea4-d2834967caa3.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69693
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
