### PR TITLE
Fix zwave_js custom trigger validation bug

### DIFF
--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -145,7 +145,7 @@ async def async_attach_trigger(
     dev_reg = dr.async_get(hass)
     nodes = async_get_nodes_from_targets(hass, config, dev_reg=dev_reg)
     if config[ATTR_EVENT_SOURCE] == "node" and not nodes:
-        raise vol.Invalid(
+        raise ValueError(
             f"No nodes found for given {ATTR_DEVICE_ID}s or {ATTR_ENTITY_ID}s."
         )
 

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -95,7 +95,7 @@ async def async_attach_trigger(
     """Listen for state changes based on configuration."""
     dev_reg = dr.async_get(hass)
     if not (nodes := async_get_nodes_from_targets(hass, config, dev_reg=dev_reg)):
-        raise vol.Invalid(
+        raise ValueError(
             f"No nodes found for given {ATTR_DEVICE_ID}s or {ATTR_ENTITY_ID}s."
         )
 

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -5,7 +5,6 @@ import functools
 
 import voluptuous as vol
 from zwave_js_server.const import CommandClass
-from zwave_js_server.model.node import Node
 from zwave_js_server.model.value import Value, get_value_id
 
 from homeassistant.components.automation import (
@@ -20,7 +19,6 @@ from homeassistant.components.zwave_js.const import (
     ATTR_CURRENT_VALUE_RAW,
     ATTR_ENDPOINT,
     ATTR_NODE_ID,
-    ATTR_NODES,
     ATTR_PREVIOUS_VALUE,
     ATTR_PREVIOUS_VALUE_RAW,
     ATTR_PROPERTY,
@@ -79,8 +77,7 @@ async def async_validate_trigger_config(
     if async_bypass_dynamic_config_validation(hass, config):
         return config
 
-    config[ATTR_NODES] = async_get_nodes_from_targets(hass, config)
-    if not config[ATTR_NODES]:
+    if not async_get_nodes_from_targets(hass, config):
         raise vol.Invalid(
             f"No nodes found for given {ATTR_DEVICE_ID}s or {ATTR_ENTITY_ID}s."
         )
@@ -96,7 +93,11 @@ async def async_attach_trigger(
     platform_type: str = PLATFORM_TYPE,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
-    nodes: set[Node] = config[ATTR_NODES]
+    dev_reg = dr.async_get(hass)
+    if not (nodes := async_get_nodes_from_targets(hass, config, dev_reg=dev_reg)):
+        raise vol.Invalid(
+            f"No nodes found for given {ATTR_DEVICE_ID}s or {ATTR_ENTITY_ID}s."
+        )
 
     from_value = config[ATTR_FROM]
     to_value = config[ATTR_TO]
@@ -163,7 +164,6 @@ async def async_attach_trigger(
 
         hass.async_run_hass_job(job, {"trigger": payload})
 
-    dev_reg = dr.async_get(hass)
     for node in nodes:
         driver = node.client.driver
         assert driver is not None  # The node comes from the driver.

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -361,7 +361,7 @@ async def test_zwave_js_value_updated_bypass_dynamic_validation_no_nodes(
             },
         )
 
-    # Test that no value filter is triggered
+    # Test that no value filter is NOT triggered because automation failed setup
     event = Event(
         type="value updated",
         data={
@@ -844,7 +844,8 @@ async def test_zwave_js_event_bypass_dynamic_validation_no_nodes(
             },
         )
 
-    # Test that `node no event data filter` is triggered and `node event data filter` is not
+    # Test that `node no event data filter` is NOT triggered because automation failed
+    # setup
     event = Event(
         type="interview stage completed",
         data={


### PR DESCRIPTION
## Proposed change
We attempted to fix issues where automations would fail for these custom triggers during startup and the config entry wasn't ready yet for dynamic validation here: https://github.com/home-assistant/core/pull/72471

The assumption was that we would set a key on the config with the nodes, and during the attach portion, we would use that to grab the nodes. Instead we grab the nodes from all targets for both dynamic config validation and for attaching the trigger. To ensure that someone doesn't craft an improper automation offline, we also validate during the attach phase so it's clear to the user that they did something wrong.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/72647
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
