### PR TITLE
Vesync air quality

### DIFF
--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -51,30 +51,24 @@ class VeSyncBaseEntity(Entity):
     def __init__(self, device):
         """Initialize the VeSync device."""
         self.device = device
+        self._attr_unique_id = self.base_unique_id
+        self._attr_name = self.base_name
 
     @property
     def base_unique_id(self):
         """Return the ID of this device."""
+        # The unique_id property may be overridden in subclasses, such as in
+        # sensors. Maintaining base_unique_id allows us to group related
+        # entities under a single device.
         if isinstance(self.device.sub_device_no, int):
             return f"{self.device.cid}{str(self.device.sub_device_no)}"
         return self.device.cid
 
     @property
-    def unique_id(self):
-        """Return the ID of this device."""
-        # The unique_id property may be overridden in subclasses, such as in sensors. Maintaining base_unique_id allows
-        # us to group related entities under a single device.
-        return self.base_unique_id
-
-    @property
     def base_name(self):
         """Return the name of the device."""
+        # Same story here as `base_unique_id` above
         return self.device.device_name
-
-    @property
-    def name(self):
-        """Return the name of the entity (may be overridden)."""
-        return self.base_name
 
     @property
     def available(self) -> bool:
@@ -99,6 +93,11 @@ class VeSyncBaseEntity(Entity):
 
 class VeSyncDevice(VeSyncBaseEntity, ToggleEntity):
     """Base class for VeSync Device Representations."""
+
+    @property
+    def details(self):
+        """Provide access to the device details dictionary."""
+        return self.device.details
 
     @property
     def is_on(self):

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -20,6 +20,8 @@ async def async_process_devices(hass, manager):
 
     if manager.fans:
         devices[VS_FANS].extend(manager.fans)
+        # Expose fan sensors separately
+        devices[VS_SENSORS].extend(manager.fans)
         _LOGGER.info("%d VeSync fans found", len(manager.fans))
 
     if manager.bulbs:

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -9,3 +9,31 @@ VS_FANS = "fans"
 VS_LIGHTS = "lights"
 VS_SENSORS = "sensors"
 VS_MANAGER = "manager"
+
+DEV_TYPE_TO_HA = {
+    "wifi-switch-1.3": "outlet",
+    "ESW03-USA": "outlet",
+    "ESW01-EU": "outlet",
+    "ESW15-USA": "outlet",
+    "ESWL01": "switch",
+    "ESWL03": "switch",
+    "ESO15-TB": "outlet",
+}
+
+SKU_TO_BASE_DEVICE = {
+    "LV-PUR131S": "LV-PUR131S",
+    "LV-RH131S": "LV-PUR131S",  # Alt ID Model LV-PUR131S
+    "Core200S": "Core200S",
+    "LAP-C201S-AUSR": "Core200S",  # Alt ID Model Core200S
+    "LAP-C202S-WUSR": "Core200S",  # Alt ID Model Core200S
+    "Core300S": "Core300S",
+    "LAP-C301S-WJP": "Core300S",  # Alt ID Model Core300S
+    "Core400S": "Core400S",
+    "LAP-C401S-WJP": "Core400S",  # Alt ID Model Core400S
+    "LAP-C401S-WUSR": "Core400S",  # Alt ID Model Core400S
+    "LAP-C401S-WAAA": "Core400S",  # Alt ID Model Core400S
+    "Core600S": "Core600S",
+    "LAP-C601S-WUS": "Core600S",  # Alt ID Model Core600S
+    "LAP-C601S-WUSR": "Core600S",  # Alt ID Model Core600S
+    "LAP-C601S-WEU": "Core600S",  # Alt ID Model Core600S
+}

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -14,27 +14,9 @@ from homeassistant.util.percentage import (
 )
 
 from .common import VeSyncDevice
-from .const import DOMAIN, VS_DISCOVERY, VS_FANS
+from .const import DOMAIN, SKU_TO_BASE_DEVICE, VS_DISCOVERY, VS_FANS
 
 _LOGGER = logging.getLogger(__name__)
-
-SKU_TO_BASE_DEVICE = {
-    "LV-PUR131S": "LV-PUR131S",
-    "LV-RH131S": "LV-PUR131S",  # Alt ID Model LV-PUR131S
-    "Core200S": "Core200S",
-    "LAP-C201S-AUSR": "Core200S",  # Alt ID Model Core200S
-    "LAP-C202S-WUSR": "Core200S",  # Alt ID Model Core200S
-    "Core300S": "Core300S",
-    "LAP-C301S-WJP": "Core300S",  # Alt ID Model Core300S
-    "Core400S": "Core400S",
-    "LAP-C401S-WJP": "Core400S",  # Alt ID Model Core400S
-    "LAP-C401S-WUSR": "Core400S",  # Alt ID Model Core400S
-    "LAP-C401S-WAAA": "Core400S",  # Alt ID Model Core400S
-    "Core600S": "Core600S",
-    "LAP-C601S-WUS": "Core600S",  # Alt ID Model Core600S
-    "LAP-C601S-WUSR": "Core600S",  # Alt ID Model Core600S
-    "LAP-C601S-WEU": "Core600S",  # Alt ID Model Core600S
-}
 
 DEV_TYPE_TO_HA = {
     "LV-PUR131S": "fan",

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -15,6 +15,7 @@ from homeassistant.util.percentage import (
 
 from .common import VeSyncDevice
 from .const import DOMAIN, VS_DISCOVERY, VS_FANS
+from .sensor import VeSyncAirQualitySensor, VeSyncFilterLifeSensor, VeSyncPm25Sensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,6 +74,35 @@ SPEED_RANGE = {  # off is not included
     "LAP-C601S-WUSR": (1, 4),  # ALt ID Model Core600S
     "LAP-C601S-WEU": (1, 4),  # ALt ID Model Core600S
 }
+SUPPORTED_FEATURES = {
+    "LV-PUR131S": ["air_quality"],
+    "LV-RH131S": ["air_quality"],  # Alt ID Model LV-PUR131S
+    "Core200S": ["night_light", "display_toggle"],
+    "LAP-C201S-AUSR": ["night_light", "display_toggle"],  # Alt ID Model Core200S
+    "LAP-C202S-WUSR": ["night_light", "display_toggle"],  # Alt ID Model Core200S
+    "Core300S": ["display_toggle"],
+    "LAP-C301S-WJP": ["display_toggle"],  # Alt ID Model Core300S
+    "Core400S": ["air_quality", "pm25", "display_toggle"],
+    "LAP-C401S-WJP": ["air_quality", "pm25", "display_toggle"],  # Alt ID Model Core400S
+    "LAP-C401S-WUSR": [
+        "air_quality",
+        "pm25",
+        "display_toggle",
+    ],  # Alt ID Model Core400S
+    "LAP-C401S-WAAA": [
+        "air_quality",
+        "pm25",
+        "display_toggle",
+    ],  # Alt ID Model Core400S
+    "Core600S": ["air_quality", "pm25", "display_toggle"],
+    "LAP-C601S-WUS": ["air_quality", "pm25", "display_toggle"],  # Alt ID Model Core600S
+    "LAP-C601S-WUSR": [
+        "air_quality",
+        "pm25",
+        "display_toggle",
+    ],  # Alt ID Model Core600S
+    "LAP-C601S-WEU": ["air_quality", "pm25", "display_toggle"],  # Alt ID Model Core600S
+}
 
 
 async def async_setup_entry(
@@ -101,6 +131,11 @@ def _setup_entities(devices, async_add_entities):
     for dev in devices:
         if DEV_TYPE_TO_HA.get(dev.device_type) == "fan":
             entities.append(VeSyncFanHA(dev))
+            entities.append(VeSyncFilterLifeSensor(dev))
+            if "pm25" in SUPPORTED_FEATURES.get(dev.device_type):
+                entities.append(VeSyncPm25Sensor(dev))
+            if "air_quality" in SUPPORTED_FEATURES.get(dev.device_type):
+                entities.append(VeSyncAirQualitySensor(dev))
         else:
             _LOGGER.warning(
                 "%s - Unknown device type - %s", dev.device_name, dev.device_type

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -15,7 +15,6 @@ from homeassistant.util.percentage import (
 
 from .common import VeSyncDevice
 from .const import DOMAIN, VS_DISCOVERY, VS_FANS
-from .sensor import VeSyncAirQualitySensor, VeSyncFilterLifeSensor, VeSyncPm25Sensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,35 +73,6 @@ SPEED_RANGE = {  # off is not included
     "LAP-C601S-WUSR": (1, 4),  # ALt ID Model Core600S
     "LAP-C601S-WEU": (1, 4),  # ALt ID Model Core600S
 }
-SUPPORTED_FEATURES = {
-    "LV-PUR131S": ["air_quality"],
-    "LV-RH131S": ["air_quality"],  # Alt ID Model LV-PUR131S
-    "Core200S": ["night_light", "display_toggle"],
-    "LAP-C201S-AUSR": ["night_light", "display_toggle"],  # Alt ID Model Core200S
-    "LAP-C202S-WUSR": ["night_light", "display_toggle"],  # Alt ID Model Core200S
-    "Core300S": ["display_toggle"],
-    "LAP-C301S-WJP": ["display_toggle"],  # Alt ID Model Core300S
-    "Core400S": ["air_quality", "pm25", "display_toggle"],
-    "LAP-C401S-WJP": ["air_quality", "pm25", "display_toggle"],  # Alt ID Model Core400S
-    "LAP-C401S-WUSR": [
-        "air_quality",
-        "pm25",
-        "display_toggle",
-    ],  # Alt ID Model Core400S
-    "LAP-C401S-WAAA": [
-        "air_quality",
-        "pm25",
-        "display_toggle",
-    ],  # Alt ID Model Core400S
-    "Core600S": ["air_quality", "pm25", "display_toggle"],
-    "LAP-C601S-WUS": ["air_quality", "pm25", "display_toggle"],  # Alt ID Model Core600S
-    "LAP-C601S-WUSR": [
-        "air_quality",
-        "pm25",
-        "display_toggle",
-    ],  # Alt ID Model Core600S
-    "LAP-C601S-WEU": ["air_quality", "pm25", "display_toggle"],  # Alt ID Model Core600S
-}
 
 
 async def async_setup_entry(
@@ -131,11 +101,6 @@ def _setup_entities(devices, async_add_entities):
     for dev in devices:
         if DEV_TYPE_TO_HA.get(dev.device_type) == "fan":
             entities.append(VeSyncFanHA(dev))
-            entities.append(VeSyncFilterLifeSensor(dev))
-            if "pm25" in SUPPORTED_FEATURES.get(dev.device_type):
-                entities.append(VeSyncPm25Sensor(dev))
-            if "air_quality" in SUPPORTED_FEATURES.get(dev.device_type):
-                entities.append(VeSyncAirQualitySensor(dev))
         else:
             _LOGGER.warning(
                 "%s - Unknown device type - %s", dev.device_name, dev.device_type

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -206,14 +206,8 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         if hasattr(self.smartfan, "night_light"):
             attr["night_light"] = self.smartfan.night_light
 
-        if self.smartfan.details.get("air_quality_value") is not None:
-            attr["air_quality"] = self.smartfan.details["air_quality_value"]
-
         if hasattr(self.smartfan, "mode"):
             attr["mode"] = self.smartfan.mode
-
-        if hasattr(self.smartfan, "filter_life"):
-            attr["filter_life"] = self.smartfan.filter_life
 
         return attr
 

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -24,6 +24,24 @@ from .switch import DEV_TYPE_TO_HA
 
 _LOGGER = logging.getLogger(__name__)
 
+SUPPORTED_SENSORS = {
+    "LV-PUR131S": ["air_quality", "filter_life"],
+    "LV-RH131S": ["air_quality", "filter_life"],  # Alt ID Model LV-PUR131S
+    "Core200S": ["night_light", "filter_life"],
+    "LAP-C201S-AUSR": ["night_light", "filter_life"],  # Alt ID Model Core200S
+    "LAP-C202S-WUSR": ["night_light", "filter_life"],  # Alt ID Model Core200S
+    "Core300S": ["filter_life"],
+    "LAP-C301S-WJP": ["filter_life"],  # Alt ID Model Core300S
+    "Core400S": ["air_quality", "pm25", "filter_life"],
+    "LAP-C401S-WJP": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core400S
+    "LAP-C401S-WUSR": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core400S
+    "LAP-C401S-WAAA": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core400S
+    "Core600S": ["air_quality", "pm25", "filter_life"],
+    "LAP-C601S-WUS": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core600S
+    "LAP-C601S-WUSR": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core600S
+    "LAP-C601S-WEU": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core600S
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -49,11 +67,15 @@ def _setup_entities(devices, async_add_entities):
     """Check if device is online and add entity."""
     entities = []
     for dev in devices:
-        if DEV_TYPE_TO_HA.get(dev.device_type) != "outlet":
-            # Not an outlet that supports energy/power, so do not create sensor entities
-            continue
-        entities.append(VeSyncPowerSensor(dev))
-        entities.append(VeSyncEnergySensor(dev))
+        if DEV_TYPE_TO_HA.get(dev.device_type) == "outlet":
+            entities.append(VeSyncPowerSensor(dev))
+            entities.append(VeSyncEnergySensor(dev))
+        if "filter_life" in SUPPORTED_SENSORS.get(dev.device_type):
+            entities.append(VeSyncFilterLifeSensor(dev))
+        if "pm25" in SUPPORTED_SENSORS.get(dev.device_type):
+            entities.append(VeSyncPm25Sensor(dev))
+        if "air_quality" in SUPPORTED_SENSORS.get(dev.device_type):
+            entities.append(VeSyncAirQualitySensor(dev))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -158,19 +180,19 @@ class VeSyncEnergySensor(VeSyncSensorEntity):
 class VeSyncPm25Sensor(VeSyncSensorEntity):
     """Sensor for concentration of particulate matter less than 2.5 micrometers."""
 
-    def __init__(self, fan):
-        """Initialize the VeSync fan device."""
-        super().__init__(fan)
-        self.smartfan = fan
+    def __init__(self, device):
+        """Initialize the VeSync device."""
+        super().__init__(device)
+        self.device = device
         self._attr_device_class = SensorDeviceClass.PM25
         self._attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self):
-        """Return an integer representing the concentration of particulate matter less than 2.5 micrometers."""
+        """Return the concentration of particulate matter less than 2.5 micrometers."""
 
-        return self.smartfan.details["air_quality_value"]
+        return self.device.details["air_quality_value"]
 
     @property
     def name(self):
@@ -189,10 +211,10 @@ class VeSyncAirQualitySensor(VeSyncSensorEntity):
     Note: On the LV-PUR131S and derivatives this will be a text string.
     """
 
-    def __init__(self, fan):
-        """Initialize the VeSync fan device."""
-        super().__init__(fan)
-        self.smartfan = fan
+    def __init__(self, device):
+        """Initialize the VeSync device."""
+        super().__init__(device)
+        self.device = device
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
@@ -201,7 +223,7 @@ class VeSyncAirQualitySensor(VeSyncSensorEntity):
 
         Note: On the LV-PUR131S and derivatives this will be a text string.
         """
-        return self.smartfan.details["air_quality"]
+        return self.device.details["air_quality"]
 
     @property
     def name(self):
@@ -217,17 +239,17 @@ class VeSyncAirQualitySensor(VeSyncSensorEntity):
 class VeSyncFilterLifeSensor(VeSyncSensorEntity):
     """Sensor for remaining filter life as a percentage."""
 
-    def __init__(self, fan):
-        """Initialize the VeSync fan device."""
-        super().__init__(fan)
-        self.smartfan = fan
+    def __init__(self, device):
+        """Initialize the VeSync device."""
+        super().__init__(device)
+        self.device = device
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self):
         """Return the remaining filter life as a percentage."""
-        return self.smartfan.details["filter_life"]
+        return self.device.details["filter_life"]
 
     @property
     def name(self):

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -1,9 +1,12 @@
 """Support for power & energy sensors for VeSync outlets."""
+from collections.abc import Callable
+from dataclasses import dataclass
 import logging
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -17,30 +20,104 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
-from .common import VeSyncBaseEntity
+from .common import VeSyncBaseEntity, VeSyncDevice
 from .const import DOMAIN, VS_DISCOVERY, VS_SENSORS
+from .fan import SKU_TO_BASE_DEVICE
 from .switch import DEV_TYPE_TO_HA
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_SENSORS = {
-    "LV-PUR131S": ["air_quality", "filter_life"],
-    "LV-RH131S": ["air_quality", "filter_life"],  # Alt ID Model LV-PUR131S
-    "Core200S": ["night_light", "filter_life"],
-    "LAP-C201S-AUSR": ["night_light", "filter_life"],  # Alt ID Model Core200S
-    "LAP-C202S-WUSR": ["night_light", "filter_life"],  # Alt ID Model Core200S
-    "Core300S": ["filter_life"],
-    "LAP-C301S-WJP": ["filter_life"],  # Alt ID Model Core300S
-    "Core400S": ["air_quality", "pm25", "filter_life"],
-    "LAP-C401S-WJP": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core400S
-    "LAP-C401S-WUSR": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core400S
-    "LAP-C401S-WAAA": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core400S
-    "Core600S": ["air_quality", "pm25", "filter_life"],
-    "LAP-C601S-WUS": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core600S
-    "LAP-C601S-WUSR": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core600S
-    "LAP-C601S-WEU": ["air_quality", "pm25", "filter_life"],  # Alt ID Model Core600S
-}
+
+@dataclass
+class VeSyncSensorEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[VeSyncDevice], StateType]
+
+
+@dataclass
+class VeSyncSensorEntityDescription(
+    SensorEntityDescription, VeSyncSensorEntityDescriptionMixin
+):
+    """Describe VeSync sensor entity."""
+
+    exists_fn: Callable[[VeSyncDevice], bool] = lambda _: True
+    update_fn: Callable[[VeSyncDevice], None] = lambda _: None
+
+
+def update_energy(device):
+    """Update outlet details and energy usage."""
+    device.update()
+    device.update_energy()
+
+
+def sku_from_device(device):
+    """Get the base device of which a device is an instance."""
+    return SKU_TO_BASE_DEVICE.get(device.device_type)
+
+
+def ha_dev_type(device):
+    """Get the homeassistant device_type for a given device."""
+    return DEV_TYPE_TO_HA.get(device.device_type)
+
+
+SENSORS: tuple[VeSyncSensorEntityDescription, ...] = (
+    VeSyncSensorEntityDescription(
+        key="filter-life",
+        name="Filter Life",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.details["filter_life"],
+        exists_fn=lambda device: sku_from_device(device)
+        in [
+            "LV-PUR131S",
+            "Core200S",
+            "Core300S",
+            "Core400S",
+            "Core600S",
+        ],
+    ),
+    VeSyncSensorEntityDescription(
+        key="air-quality",
+        name="Air Quality",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda device: device.details["air_quality"],
+        exists_fn=lambda device: sku_from_device(device)
+        in ["LV-PUR131S", "Core400S", "Core600S"],
+    ),
+    VeSyncSensorEntityDescription(
+        key="pm25",
+        name="PM2.5",
+        device_class=SensorDeviceClass.PM25,
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda device: device.details["air_quality_value"],
+        exists_fn=lambda device: sku_from_device(device) in ["Core400S", "Core600S"],
+    ),
+    VeSyncSensorEntityDescription(
+        key="power",
+        name="current power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=POWER_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda device: device.details["power"],
+        update_fn=update_energy,
+        exists_fn=lambda device: ha_dev_type(device) == "outlet",
+    ),
+    VeSyncSensorEntityDescription(
+        key="energy",
+        name="energy use today",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda device: device.details["energy"],
+        update_fn=update_energy,
+        exists_fn=lambda device: ha_dev_type(device) == "outlet",
+    ),
+)
 
 
 async def async_setup_entry(
@@ -67,196 +144,33 @@ def _setup_entities(devices, async_add_entities):
     """Check if device is online and add entity."""
     entities = []
     for dev in devices:
-        if DEV_TYPE_TO_HA.get(dev.device_type) == "outlet":
-            entities.append(VeSyncPowerSensor(dev))
-            entities.append(VeSyncEnergySensor(dev))
-        if "filter_life" in SUPPORTED_SENSORS.get(dev.device_type):
-            entities.append(VeSyncFilterLifeSensor(dev))
-        if "pm25" in SUPPORTED_SENSORS.get(dev.device_type):
-            entities.append(VeSyncPm25Sensor(dev))
-        if "air_quality" in SUPPORTED_SENSORS.get(dev.device_type):
-            entities.append(VeSyncAirQualitySensor(dev))
-
+        for description in SENSORS:
+            if description.exists_fn(dev):
+                entities.append(VeSyncSensorEntity(dev, description))
     async_add_entities(entities, update_before_add=True)
 
 
 class VeSyncSensorEntity(VeSyncBaseEntity, SensorEntity):
-    """Representation of a sensor describing diagnostics of a VeSync outlet."""
+    """Representation of a sensor describing a VeSync device."""
 
-    def __init__(self, plug):
+    entity_description: VeSyncSensorEntityDescription
+
+    def __init__(
+        self,
+        device: VeSyncDevice,
+        description: VeSyncSensorEntityDescription,
+    ) -> None:
         """Initialize the VeSync outlet device."""
-        super().__init__(plug)
-        self.smartplug = plug
-
-    @property
-    def entity_category(self):
-        """Return the diagnostic entity category."""
-        return EntityCategory.DIAGNOSTIC
-
-
-class VeSyncPowerSensor(VeSyncSensorEntity):
-    """Representation of current power use for a VeSync outlet."""
-
-    @property
-    def unique_id(self):
-        """Return unique ID for power sensor on device."""
-        return f"{super().unique_id}-power"
-
-    @property
-    def name(self):
-        """Return sensor name."""
-        return f"{super().name} current power"
-
-    @property
-    def device_class(self):
-        """Return the power device class."""
-        return SensorDeviceClass.POWER
-
-    @property
-    def native_value(self):
-        """Return the current power usage in W."""
-        return self.smartplug.power
-
-    @property
-    def native_unit_of_measurement(self):
-        """Return the Watt unit of measurement."""
-        return POWER_WATT
-
-    @property
-    def state_class(self):
-        """Return the measurement state class."""
-        return SensorStateClass.MEASUREMENT
-
-    def update(self):
-        """Update outlet details and energy usage."""
-        self.smartplug.update()
-        self.smartplug.update_energy()
-
-
-class VeSyncEnergySensor(VeSyncSensorEntity):
-    """Representation of current day's energy use for a VeSync outlet."""
-
-    def __init__(self, plug):
-        """Initialize the VeSync outlet device."""
-        super().__init__(plug)
-        self.smartplug = plug
-
-    @property
-    def unique_id(self):
-        """Return unique ID for power sensor on device."""
-        return f"{super().unique_id}-energy"
-
-    @property
-    def name(self):
-        """Return sensor name."""
-        return f"{super().name} energy use today"
-
-    @property
-    def device_class(self):
-        """Return the energy device class."""
-        return SensorDeviceClass.ENERGY
-
-    @property
-    def native_value(self):
-        """Return the today total energy usage in kWh."""
-        return self.smartplug.energy_today
-
-    @property
-    def native_unit_of_measurement(self):
-        """Return the kWh unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
-
-    @property
-    def state_class(self):
-        """Return the total_increasing state class."""
-        return SensorStateClass.TOTAL_INCREASING
-
-    def update(self):
-        """Update outlet details and energy usage."""
-        self.smartplug.update()
-        self.smartplug.update_energy()
-
-
-class VeSyncPm25Sensor(VeSyncSensorEntity):
-    """Sensor for concentration of particulate matter less than 2.5 micrometers."""
-
-    def __init__(self, device):
-        """Initialize the VeSync device."""
         super().__init__(device)
-        self.device = device
-        self._attr_device_class = SensorDeviceClass.PM25
-        self._attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self.entity_description = description
+        self._attr_name = f"{super().name} {description.name}"
+        self._attr_unique_id = f"{super().unique_id}-{description.key}"
 
     @property
-    def native_value(self):
-        """Return the concentration of particulate matter less than 2.5 micrometers."""
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return self.entity_description.value_fn(self.device)
 
-        return self.device.details["air_quality_value"]
-
-    @property
-    def name(self):
-        """Return sensor name."""
-        return f"{super().name} PM2.5"
-
-    @property
-    def unique_id(self):
-        """Return unique ID for power sensor on device."""
-        return f"{super().unique_id}-pm25"
-
-
-class VeSyncAirQualitySensor(VeSyncSensorEntity):
-    """Sensor for air quality levels.
-
-    Note: On the LV-PUR131S and derivatives this will be a text string.
-    """
-
-    def __init__(self, device):
-        """Initialize the VeSync device."""
-        super().__init__(device)
-        self.device = device
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def native_value(self):
-        """Return the air quality level.
-
-        Note: On the LV-PUR131S and derivatives this will be a text string.
-        """
-        return self.device.details["air_quality"]
-
-    @property
-    def name(self):
-        """Return sensor name."""
-        return f"{super().name} Air Quality"
-
-    @property
-    def unique_id(self):
-        """Return unique ID for power sensor on device."""
-        return f"{super().unique_id}-air-quality"
-
-
-class VeSyncFilterLifeSensor(VeSyncSensorEntity):
-    """Sensor for remaining filter life as a percentage."""
-
-    def __init__(self, device):
-        """Initialize the VeSync device."""
-        super().__init__(device)
-        self.device = device
-        self._attr_native_unit_of_measurement = PERCENTAGE
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def native_value(self):
-        """Return the remaining filter life as a percentage."""
-        return self.device.details["filter_life"]
-
-    @property
-    def name(self):
-        """Return sensor name."""
-        return f"{super().name} Filter Life"
-
-    @property
-    def unique_id(self):
-        """Return unique ID for power sensor on device."""
-        return f"{super().unique_id}-filter-life"
+    def update(self) -> None:
+        """Run the update function defined for the sensor."""
+        return self.entity_description.update_fn(self.device)

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -7,7 +7,12 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_WATT
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    POWER_WATT,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
@@ -148,3 +153,88 @@ class VeSyncEnergySensor(VeSyncSensorEntity):
         """Update outlet details and energy usage."""
         self.smartplug.update()
         self.smartplug.update_energy()
+
+
+class VeSyncPm25Sensor(VeSyncSensorEntity):
+    """Sensor for concentration of particulate matter less than 2.5 micrometers."""
+
+    def __init__(self, fan):
+        """Initialize the VeSync fan device."""
+        super().__init__(fan)
+        self.smartfan = fan
+        self._attr_device_class = SensorDeviceClass.PM25
+        self._attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        """Return an integer representing the concentration of particulate matter less than 2.5 micrometers."""
+
+        return self.smartfan.details["air_quality_value"]
+
+    @property
+    def name(self):
+        """Return sensor name."""
+        return f"{super().name} PM2.5"
+
+    @property
+    def unique_id(self):
+        """Return unique ID for power sensor on device."""
+        return f"{super().unique_id}-pm25"
+
+
+class VeSyncAirQualitySensor(VeSyncSensorEntity):
+    """Sensor for air quality levels.
+
+    Note: On the LV-PUR131S and derivatives this will be a text string.
+    """
+
+    def __init__(self, fan):
+        """Initialize the VeSync fan device."""
+        super().__init__(fan)
+        self.smartfan = fan
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        """Return the air quality level.
+
+        Note: On the LV-PUR131S and derivatives this will be a text string.
+        """
+        return self.smartfan.details["air_quality"]
+
+    @property
+    def name(self):
+        """Return sensor name."""
+        return f"{super().name} Air Quality"
+
+    @property
+    def unique_id(self):
+        """Return unique ID for power sensor on device."""
+        return f"{super().unique_id}-air-quality"
+
+
+class VeSyncFilterLifeSensor(VeSyncSensorEntity):
+    """Sensor for remaining filter life as a percentage."""
+
+    def __init__(self, fan):
+        """Initialize the VeSync fan device."""
+        super().__init__(fan)
+        self.smartfan = fan
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        """Return the remaining filter life as a percentage."""
+        return self.smartfan.details["filter_life"]
+
+    @property
+    def name(self):
+        """Return sensor name."""
+        return f"{super().name} Filter Life"
+
+    @property
+    def unique_id(self):
+        """Return unique ID for power sensor on device."""
+        return f"{super().unique_id}-filter-life"

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -8,19 +8,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .common import VeSyncDevice
-from .const import DOMAIN, VS_DISCOVERY, VS_SWITCHES
+from .const import DEV_TYPE_TO_HA, DOMAIN, VS_DISCOVERY, VS_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)
-
-DEV_TYPE_TO_HA = {
-    "wifi-switch-1.3": "outlet",
-    "ESW03-USA": "outlet",
-    "ESW01-EU": "outlet",
-    "ESW15-USA": "outlet",
-    "ESWL01": "switch",
-    "ESWL03": "switch",
-    "ESO15-TB": "outlet",
-}
 
 
 async def async_setup_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Remove `air_quality` and `filter_life` attributes for VeSync fans. These are now present as sensor entities instead.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-up to #71771, breaking out both `air_quality` and `air_quality_value` as dedicated sensor entities instead of stuffing them into `extra_state_attributes`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #71427 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
