### PR TITLE
Keep track of a context for each listener

### DIFF
--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -131,4 +131,4 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
         # Always update HA states after a button was executed.
         # BMW remote services that change the vehicle's state update the local object
         # when executing the service, so only the HA state machine needs further updates.
-        self.coordinator.notify_listeners()
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -74,8 +74,3 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator):
         if not refresh_token:
             data.pop(CONF_REFRESH_TOKEN)
         self.hass.config_entries.async_update_entry(self._entry, data=data)
-
-    def notify_listeners(self) -> None:
-        """Notify all listeners to refresh HA state machine."""
-        for update_callback in self._listeners:
-            update_callback()

--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -74,12 +74,12 @@ def modernforms_exception_handler(func):
     async def handler(self, *args, **kwargs):
         try:
             await func(self, *args, **kwargs)
-            self.coordinator.update_listeners()
+            self.coordinator.async_update_listeners()
 
         except ModernFormsConnectionError as error:
             _LOGGER.error("Error communicating with API: %s", error)
             self.coordinator.last_update_success = False
-            self.coordinator.update_listeners()
+            self.coordinator.async_update_listeners()
 
         except ModernFormsError as error:
             _LOGGER.error("Invalid response from API: %s", error)
@@ -107,11 +107,6 @@ class ModernFormsDataUpdateCoordinator(DataUpdateCoordinator[ModernFormsDeviceSt
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
         )
-
-    def update_listeners(self) -> None:
-        """Call update on all listeners."""
-        for update_callback in self._listeners:
-            update_callback()
 
     async def _async_update_data(self) -> ModernFormsDevice:
         """Fetch data from Modern Forms."""

--- a/homeassistant/components/moehlenhoff_alpha2/__init__.py
+++ b/homeassistant/components/moehlenhoff_alpha2/__init__.py
@@ -83,8 +83,7 @@ class Alpha2BaseCoordinator(DataUpdateCoordinator[dict[str, dict]]):
     async def async_set_cooling(self, enabled: bool) -> None:
         """Enable or disable cooling mode."""
         await self.base.set_cooling(enabled)
-        for update_callback in self._listeners:
-            update_callback()
+        self.async_update_listeners()
 
     async def async_set_target_temperature(
         self, heat_area_id: str, target_temperature: float
@@ -117,8 +116,7 @@ class Alpha2BaseCoordinator(DataUpdateCoordinator[dict[str, dict]]):
                 "Failed to set target temperature, communication error with alpha2 base"
             ) from http_err
         self.data["heat_areas"][heat_area_id].update(update_data)
-        for update_callback in self._listeners:
-            update_callback()
+        self.async_update_listeners()
 
     async def async_set_heat_area_mode(
         self, heat_area_id: str, heat_area_mode: int
@@ -161,5 +159,5 @@ class Alpha2BaseCoordinator(DataUpdateCoordinator[dict[str, dict]]):
                 self.data["heat_areas"][heat_area_id]["T_TARGET"] = self.data[
                     "heat_areas"
                 ][heat_area_id]["T_HEAT_NIGHT"]
-        for update_callback in self._listeners:
-            update_callback()
+
+        self.async_update_listeners()

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -114,12 +114,7 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self.options = options
         self._notify_future: asyncio.Task | None = None
 
-        @callback
-        def _update_listeners():
-            for update_callback in self._listeners:
-                update_callback()
-
-        self.turn_on = PluggableAction(_update_listeners)
+        self.turn_on = PluggableAction(self.async_update_listeners)
 
         super().__init__(
             hass,

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import Context, Event, HassJob, HomeAssistant, callback
+from homeassistant.core import Context, HassJob, HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -184,11 +184,6 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
     def _unschedule_refresh(self) -> None:
         """Remove data update."""
         super()._unschedule_refresh()
-        self._async_notify_stop()
-
-    @callback
-    def _async_stop_refresh(self, event: Event) -> None:
-        super()._async_stop_refresh(event)
         self._async_notify_stop()
 
     @callback

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -19,14 +19,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    Context,
-    Event,
-    HassJob,
-    HomeAssistant,
-    callback,
-)
+from homeassistant.core import Context, Event, HassJob, HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -193,11 +186,10 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
             self._notify_future = asyncio.create_task(self._notify_task())
 
     @callback
-    def async_remove_listener(self, update_callback: CALLBACK_TYPE) -> None:
+    def _unschedule_refresh(self) -> None:
         """Remove data update."""
-        super().async_remove_listener(update_callback)
-        if not self._listeners:
-            self._async_notify_stop()
+        super()._unschedule_refresh()
+        self._async_notify_stop()
 
     @callback
     def _async_stop_refresh(self, event: Event) -> None:

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -75,11 +75,6 @@ class SystemBridgeDataUpdateCoordinator(
             hass, LOGGER, name=DOMAIN, update_interval=timedelta(seconds=30)
         )
 
-    def update_listeners(self) -> None:
-        """Call update on all listeners."""
-        for update_callback in self._listeners:
-            update_callback()
-
     async def async_get_data(
         self,
         modules: list[str],
@@ -113,7 +108,7 @@ class SystemBridgeDataUpdateCoordinator(
                 self.unsub()
                 self.unsub = None
             self.last_update_success = False
-            self.update_listeners()
+            self.async_update_listeners()
         except (ConnectionClosedException, ConnectionResetError) as exception:
             self.logger.info(
                 "Websocket connection closed for %s. Will retry: %s",
@@ -124,7 +119,7 @@ class SystemBridgeDataUpdateCoordinator(
                 self.unsub()
                 self.unsub = None
             self.last_update_success = False
-            self.update_listeners()
+            self.async_update_listeners()
         except ConnectionErrorException as exception:
             self.logger.warning(
                 "Connection error occurred for %s. Will retry: %s",
@@ -135,7 +130,7 @@ class SystemBridgeDataUpdateCoordinator(
                 self.unsub()
                 self.unsub = None
             self.last_update_success = False
-            self.update_listeners()
+            self.async_update_listeners()
 
     async def _setup_websocket(self) -> None:
         """Use WebSocket for updates."""
@@ -151,7 +146,7 @@ class SystemBridgeDataUpdateCoordinator(
                 self.unsub()
                 self.unsub = None
             self.last_update_success = False
-            self.update_listeners()
+            self.async_update_listeners()
         except ConnectionErrorException as exception:
             self.logger.warning(
                 "Connection error occurred for %s. Will retry: %s",
@@ -159,7 +154,7 @@ class SystemBridgeDataUpdateCoordinator(
                 exception,
             )
             self.last_update_success = False
-            self.update_listeners()
+            self.async_update_listeners()
         except asyncio.TimeoutError as exception:
             self.logger.warning(
                 "Timed out waiting for %s. Will retry: %s",
@@ -167,11 +162,11 @@ class SystemBridgeDataUpdateCoordinator(
                 exception,
             )
             self.last_update_success = False
-            self.update_listeners()
+            self.async_update_listeners()
 
         self.hass.async_create_task(self._listen_for_data())
         self.last_update_success = True
-        self.update_listeners()
+        self.async_update_listeners()
 
         async def close_websocket(_) -> None:
             """Close WebSocket connection."""

--- a/homeassistant/components/toon/coordinator.py
+++ b/homeassistant/components/toon/coordinator.py
@@ -47,11 +47,6 @@ class ToonDataUpdateCoordinator(DataUpdateCoordinator[Status]):
             hass, _LOGGER, name=DOMAIN, update_interval=DEFAULT_SCAN_INTERVAL
         )
 
-    def update_listeners(self) -> None:
-        """Call update on all listeners."""
-        for update_callback in self._listeners:
-            update_callback()
-
     async def register_webhook(self, event: Event | None = None) -> None:
         """Register a webhook with Toon to get live updates."""
         if CONF_WEBHOOK_ID not in self.entry.data:
@@ -128,7 +123,7 @@ class ToonDataUpdateCoordinator(DataUpdateCoordinator[Status]):
 
         try:
             await self.toon.update(data["updateDataSet"])
-            self.update_listeners()
+            self.async_update_listeners()
         except ToonError as err:
             _LOGGER.error("Could not process data received from Toon webhook - %s", err)
 

--- a/homeassistant/components/toon/helpers.py
+++ b/homeassistant/components/toon/helpers.py
@@ -16,12 +16,12 @@ def toon_exception_handler(func):
     async def handler(self, *args, **kwargs):
         try:
             await func(self, *args, **kwargs)
-            self.coordinator.update_listeners()
+            self.coordinator.async_update_listeners()
 
         except ToonConnectionError as error:
             _LOGGER.error("Error communicating with API: %s", error)
             self.coordinator.last_update_success = False
-            self.coordinator.update_listeners()
+            self.coordinator.async_update_listeners()
 
         except ToonError as error:
             _LOGGER.error("Invalid response from API: %s", error)

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -123,12 +123,6 @@ class DeviceCoordinator(DataUpdateCoordinator):
             except ActionException as err:
                 raise UpdateFailed("WeMo update failed") from err
 
-    @callback
-    def async_update_listeners(self) -> None:
-        """Update all listeners."""
-        for update_callback in self._listeners:
-            update_callback()
-
 
 def _device_info(wemo: WeMoDevice) -> DeviceInfo:
     return DeviceInfo(

--- a/homeassistant/components/wled/coordinator.py
+++ b/homeassistant/components/wled/coordinator.py
@@ -54,11 +54,6 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
             self.data is not None and len(self.data.state.segments) > 1
         )
 
-    def update_listeners(self) -> None:
-        """Call update on all listeners."""
-        for update_callback in self._listeners:
-            update_callback()
-
     @callback
     def _use_websocket(self) -> None:
         """Use WebSocket for updates, instead of polling."""
@@ -81,7 +76,7 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
                 self.logger.info(err)
             except WLEDError as err:
                 self.last_update_success = False
-                self.update_listeners()
+                self.async_update_listeners()
                 self.logger.error(err)
 
             # Ensure we are disconnected

--- a/homeassistant/components/wled/helpers.py
+++ b/homeassistant/components/wled/helpers.py
@@ -15,11 +15,11 @@ def wled_exception_handler(func):
     async def handler(self, *args, **kwargs):
         try:
             await func(self, *args, **kwargs)
-            self.coordinator.update_listeners()
+            self.coordinator.async_update_listeners()
 
         except WLEDConnectionError as error:
             self.coordinator.last_update_success = False
-            self.coordinator.update_listeners()
+            self.coordinator.async_update_listeners()
             raise HomeAssistantError("Error communicating with WLED API") from error
 
         except WLEDError as error:

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -106,7 +106,9 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         self.coordinator.musiccast.register_group_update_callback(
             self.update_all_mc_entities
         )
-        self.coordinator.async_add_listener(self.async_schedule_check_client_list)
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_schedule_check_client_list)
+        )
 
     async def async_will_remove_from_hass(self):
         """Entity being removed from hass."""
@@ -116,7 +118,6 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         self.coordinator.musiccast.remove_group_update_callback(
             self.update_all_mc_entities
         )
-        self.coordinator.async_remove_listener(self.async_schedule_check_client_list)
 
     @property
     def should_poll(self):

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -104,6 +104,12 @@ class DataUpdateCoordinator(Generic[_T]):
         return remove_listener
 
     @callback
+    def async_update_listeners(self) -> None:
+        """Update all registered listeners."""
+        for update_callback, _ in list(self._listeners.values()):
+            update_callback()
+
+    @callback
     def _unschedule_refresh(self) -> None:
         """Unschedule any pending refresh since there is no longer any listeners."""
         if self._unsub_refresh:
@@ -274,8 +280,7 @@ class DataUpdateCoordinator(Generic[_T]):
             if not auth_failed and self._listeners and not self.hass.is_stopping:
                 self._schedule_refresh()
 
-        for update_callback, _ in list(self._listeners.values()):
-            update_callback()
+        self.async_update_listeners()
 
     @callback
     def async_set_updated_data(self, data: _T) -> None:
@@ -296,8 +301,7 @@ class DataUpdateCoordinator(Generic[_T]):
         if self._listeners:
             self._schedule_refresh()
 
-        for update_callback, _ in list(self._listeners.values()):
-            update_callback()
+        self.async_update_listeners()
 
     @callback
     def _async_stop_refresh(self, _: Event) -> None:

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -13,7 +13,7 @@ import aiohttp
 import requests
 
 from homeassistant import config_entries
-from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.util.dt import utcnow
 
@@ -302,12 +302,6 @@ class DataUpdateCoordinator(Generic[_T]):
             self._schedule_refresh()
 
         self.async_update_listeners()
-
-    @callback
-    def _async_stop_refresh(self, _: Event) -> None:
-        """Stop refreshing when Home Assistant is stopping."""
-        self.update_interval = None
-        self._unschedule_refresh()
 
 
 class CoordinatorEntity(entity.Entity, Generic[_DataUpdateCoordinatorT]):

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -272,7 +272,7 @@ class DataUpdateCoordinator(Generic[_T]):
             if not auth_failed and self._listeners and not self.hass.is_stopping:
                 self._schedule_refresh()
 
-        for update_callback in list(self._listeners.values()):
+        for update_callback, _ in list(self._listeners.values()):
             update_callback()
 
     @callback
@@ -294,7 +294,7 @@ class DataUpdateCoordinator(Generic[_T]):
         if self._listeners:
             self._schedule_refresh()
 
-        for update_callback in list(self._listeners.values()):
+        for update_callback, _ in list(self._listeners.values()):
             update_callback()
 
     @callback

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -83,7 +83,7 @@ class DataUpdateCoordinator(Generic[_T]):
 
     @callback
     def async_add_listener(
-        self, update_callback: CALLBACK_TYPE, context: object | None = None
+        self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:
         """Listen for data updates."""
         schedule_refresh = not self._listeners
@@ -116,7 +116,7 @@ class DataUpdateCoordinator(Generic[_T]):
             self._unsub_refresh()
             self._unsub_refresh = None
 
-    def async_contexts(self) -> Generator[object, None, None]:
+    def async_contexts(self) -> Generator[Any, None, None]:
         """Return all registered contexts."""
         yield from (
             context for _, context in self._listeners.values() if context is not None
@@ -314,7 +314,7 @@ class CoordinatorEntity(entity.Entity, Generic[_DataUpdateCoordinatorT]):
     """A class for entities using DataUpdateCoordinator."""
 
     def __init__(
-        self, coordinator: _DataUpdateCoordinatorT, context: object | None = None
+        self, coordinator: _DataUpdateCoordinatorT, context: Any = None
     ) -> None:
         """Create the entity with a DataUpdateCoordinator."""
         self.coordinator = coordinator

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -109,12 +109,6 @@ async def test_async_refresh(crd):
     await crd.async_refresh()
     assert updates == [2]
 
-    # Test unsubscribing through method
-    crd.async_add_listener(update_callback)
-    crd.async_remove_listener(update_callback)
-    await crd.async_refresh()
-    assert updates == [2]
-
 
 async def test_request_refresh(crd):
     """Test request refresh for update coordinator."""
@@ -191,7 +185,7 @@ async def test_update_interval(hass, crd):
 
     # Add subscriber
     update_callback = Mock()
-    crd.async_add_listener(update_callback)
+    unsub = crd.async_add_listener(update_callback)
 
     # Test twice we update with subscriber
     async_fire_time_changed(hass, utcnow() + crd.update_interval)
@@ -203,7 +197,7 @@ async def test_update_interval(hass, crd):
     assert crd.data == 2
 
     # Test removing listener
-    crd.async_remove_listener(update_callback)
+    unsub()
 
     async_fire_time_changed(hass, utcnow() + crd.update_interval)
     await hass.async_block_till_done()
@@ -222,7 +216,7 @@ async def test_update_interval_not_present(hass, crd_without_update_interval):
 
     # Add subscriber
     update_callback = Mock()
-    crd.async_add_listener(update_callback)
+    unsub = crd.async_add_listener(update_callback)
 
     # Test twice we don't update with subscriber with no update interval
     async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
@@ -234,7 +228,7 @@ async def test_update_interval_not_present(hass, crd_without_update_interval):
     assert crd.data is None
 
     # Test removing listener
-    crd.async_remove_listener(update_callback)
+    unsub()
 
     async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
     await hass.async_block_till_done()

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -271,9 +271,10 @@ async def test_refresh_recover(crd, caplog):
     assert "Fetching test data recovered" in caplog.text
 
 
-async def test_coordinator_entity(crd):
+async def test_coordinator_entity(crd: update_coordinator.DataUpdateCoordinator[int]):
     """Test the CoordinatorEntity class."""
-    entity = update_coordinator.CoordinatorEntity(crd)
+    context = object()
+    entity = update_coordinator.CoordinatorEntity(crd, context)
 
     assert entity.should_poll is False
 
@@ -295,6 +296,8 @@ async def test_coordinator_entity(crd):
     with patch("homeassistant.helpers.entity.Entity.enabled", False):
         await entity.async_update()
     assert entity.available is False
+
+    assert list(crd.async_contexts()) == [context]
 
 
 async def test_async_set_updated_data(crd):

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -110,6 +110,30 @@ async def test_async_refresh(crd):
     assert updates == [2]
 
 
+async def test_update_context(crd: update_coordinator.DataUpdateCoordinator[int]):
+    """Test update contexts for the update coordinator."""
+    await crd.async_refresh()
+    assert not set(crd.async_contexts())
+
+    def update_callback1():
+        pass
+
+    def update_callback2():
+        pass
+
+    unsub1 = crd.async_add_listener(update_callback1, 1)
+    assert set(crd.async_contexts()) == {1}
+
+    unsub2 = crd.async_add_listener(update_callback2, 2)
+    assert set(crd.async_contexts()) == {1, 2}
+
+    unsub1()
+    assert set(crd.async_contexts()) == {2}
+
+    unsub2()
+    assert not set(crd.async_contexts())
+
+
 async def test_request_refresh(crd):
     """Test request refresh for update coordinator."""
     assert crd.data is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

* Coordinators that rely on internal _listeners and or overload the async_add_listener need to be adapted to take the additional context parameters
* Coordinators that override the async_remove_listener to detect when no listeners are active need to switch to using the _unschedule_refresh
* Coordinators that explicitly call async_remove_listener() should instead call the callback returned from async_add_listener()

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

* Allow a update coordinator to adapt what data to request on update from the backing service based on which entities are enabled.
* Remove async_remove_listener() and instead purely rely on return from async_add_listener(). This allow a better tracking sentinel for the registrations internally and allow for multiple registrations on same callback function.
* Add new overridable _unschedule_refresh() function to allow subclassing coordinators to know when there are no longer any listeners.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Updated developer docs: https://github.com/home-assistant/developers.home-assistant/pull/1355

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
