### PR TITLE
Allow removing a onewire device

### DIFF
--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -40,7 +40,10 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
-    return True
+    onewirehub: OneWireHub = hass.data[DOMAIN][config_entry.entry_id]
+    return not device_entry.identifiers.intersection(
+        (DOMAIN, device.id) for device in onewirehub.devices or []
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -6,6 +6,7 @@ from pyownet import protocol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, PLATFORMS
 from .onewirehub import CannotConnect, OneWireHub
@@ -32,6 +33,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
 
+    return True
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
     return True
 
 

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     ATTR_NAME,
     ATTR_STATE,
     ATTR_VIA_DEVICE,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
@@ -90,7 +91,7 @@ def check_entities(
 
 
 def setup_owproxy_mock_devices(
-    owproxy: MagicMock, platform: str, device_ids: list[str]
+    owproxy: MagicMock, platform: Platform, device_ids: list[str]
 ) -> None:
     """Set up mock for owproxy."""
     main_dir_return_value = []
@@ -125,7 +126,7 @@ def _setup_owproxy_mock_device(
     main_read_side_effect: list,
     sub_read_side_effect: list,
     device_id: str,
-    platform: str,
+    platform: Platform,
 ) -> None:
     """Set up mock for owproxy."""
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
@@ -167,7 +168,7 @@ def _setup_owproxy_mock_device_reads(
     sub_read_side_effect: list,
     mock_device: Any,
     device_id: str,
-    platform: str,
+    platform: Platform,
 ) -> None:
     """Set up mock for owproxy."""
     # Setup device reads

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,12 +1,35 @@
 """Tests for 1-Wire config flow."""
-from unittest.mock import MagicMock
+from collections.abc import Awaitable, Callable
+from unittest.mock import MagicMock, patch
 
+import aiohttp
 from pyownet import protocol
 import pytest
 
 from homeassistant.components.onewire.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from . import setup_owproxy_mock_devices
+
+
+async def remove_device(
+    ws_client: aiohttp.ClientWebSocketResponse, device_id: str, config_entry_id: str
+) -> bool:
+    """Remove config entry from a device."""
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "config/device_registry/remove_config_entry",
+            "config_entry_id": config_entry_id,
+            "device_id": device_id,
+        }
+    )
+    response = await ws_client.receive_json()
+    return response["success"]
 
 
 @pytest.mark.usefixtures("owproxy_with_connerror")
@@ -48,3 +71,46 @@ async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+@patch("homeassistant.components.onewire.PLATFORMS", [Platform.SENSOR])
+async def test_registry_cleanup(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    owproxy: MagicMock,
+    hass_ws_client: Callable[
+        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
+    ],
+):
+    """Test being able to remove a disconnected device."""
+    assert await async_setup_component(hass, "config", {})
+
+    entry_id = config_entry.entry_id
+    device_registry = dr.async_get(hass)
+
+    # Initialise with two components
+    setup_owproxy_mock_devices(
+        owproxy, Platform.SENSOR, ["10.111111111111", "28.111111111111"]
+    )
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    # Reload with a device no longer on bus
+    setup_owproxy_mock_devices(owproxy, Platform.SENSOR, ["10.111111111111"])
+    await hass.config_entries.async_reload(entry_id)
+    await hass.async_block_till_done()
+    assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
+
+    # Try to remove "10.111111111111" - fails
+    identifiers = {(DOMAIN, "10.111111111111")}
+    device = device_registry.async_get_device(identifiers=identifiers)
+    assert await remove_device(await hass_ws_client(hass), device.id, entry_id) is False
+    assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
+    assert device_registry.async_get_device(identifiers=identifiers) is not None
+
+    # Try to remove "28.111111111111" - succeeds
+    identifiers = {(DOMAIN, "28.111111111111")}
+    device = device_registry.async_get_device(identifiers=identifiers)
+    assert await remove_device(await hass_ws_client(hass), device.id, entry_id) is True
+    assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 1
+    assert device_registry.async_get_device(identifiers=identifiers) is None

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -87,30 +87,28 @@ async def test_registry_cleanup(
 
     entry_id = config_entry.entry_id
     device_registry = dr.async_get(hass)
+    live_id = "10.111111111111"
+    dead_id = "28.111111111111"
 
     # Initialise with two components
-    setup_owproxy_mock_devices(
-        owproxy, Platform.SENSOR, ["10.111111111111", "28.111111111111"]
-    )
+    setup_owproxy_mock_devices(owproxy, Platform.SENSOR, [live_id, dead_id])
     await hass.config_entries.async_setup(entry_id)
     await hass.async_block_till_done()
 
     # Reload with a device no longer on bus
-    setup_owproxy_mock_devices(owproxy, Platform.SENSOR, ["10.111111111111"])
+    setup_owproxy_mock_devices(owproxy, Platform.SENSOR, [live_id])
     await hass.config_entries.async_reload(entry_id)
     await hass.async_block_till_done()
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
 
-    # Try to remove "10.111111111111" - fails
-    identifiers = {(DOMAIN, "10.111111111111")}
-    device = device_registry.async_get_device(identifiers=identifiers)
+    # Try to remove "10.111111111111" - fails as it is live
+    device = device_registry.async_get_device(identifiers={(DOMAIN, live_id)})
     assert await remove_device(await hass_ws_client(hass), device.id, entry_id) is False
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
-    assert device_registry.async_get_device(identifiers=identifiers) is not None
+    assert device_registry.async_get_device(identifiers={(DOMAIN, live_id)}) is not None
 
-    # Try to remove "28.111111111111" - succeeds
-    identifiers = {(DOMAIN, "28.111111111111")}
-    device = device_registry.async_get_device(identifiers=identifiers)
+    # Try to remove "28.111111111111" - succeeds as it is dead
+    device = device_registry.async_get_device(identifiers={(DOMAIN, dead_id)})
     assert await remove_device(await hass_ws_client(hass), device.id, entry_id) is True
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 1
-    assert device_registry.async_get_device(identifiers=identifiers) is None
+    assert device_registry.async_get_device(identifiers={(DOMAIN, dead_id)}) is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow removing a onewire device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
