### PR TITLE
Ensure description_placeholders is always typed

### DIFF
--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -272,7 +272,7 @@ class LoginFlow(data_entry_flow.FlowHandler):
             if not errors:
                 return await self.async_finish(self.credential)
 
-        description_placeholders: dict[str, str | None] = {
+        description_placeholders: dict[str, str] = {
             "mfa_module_name": auth_module.name,
             "mfa_module_id": auth_module.id,
         }

--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import aiohwenergy
 from aiohwenergy.hwenergy import SUPPORTED_DEVICES
@@ -161,9 +161,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="discovery_confirm",
             description_placeholders={
-                CONF_PRODUCT_TYPE: self.config[CONF_PRODUCT_TYPE],
-                CONF_SERIAL: self.config[CONF_SERIAL],
-                CONF_IP_ADDRESS: self.config[CONF_IP_ADDRESS],
+                CONF_PRODUCT_TYPE: cast(str, self.config[CONF_PRODUCT_TYPE]),
+                CONF_SERIAL: cast(str, self.config[CONF_SERIAL]),
+                CONF_IP_ADDRESS: cast(str, self.config[CONF_IP_ADDRESS]),
             },
         )
 

--- a/homeassistant/components/tankerkoenig/config_flow.py
+++ b/homeassistant/components/tankerkoenig/config_flow.py
@@ -116,7 +116,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             return self.async_show_form(
                 step_id="select_station",
-                description_placeholders={"stations_count": len(self._stations)},
+                description_placeholders={"stations_count": str(len(self._stations))},
                 data_schema=vol.Schema(
                     {vol.Required(CONF_STATIONS): cv.multi_select(self._stations)}
                 ),

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1386,7 +1386,10 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     @callback
     def async_abort(
-        self, *, reason: str, description_placeholders: dict[str, Any] | None = None
+        self,
+        *,
+        reason: str,
+        description_placeholders: dict[str, str | None] | None = None,
     ) -> data_entry_flow.FlowResult:
         """Abort the config flow."""
         # Remove reauth notification if no reauth flows are in progress
@@ -1460,7 +1463,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         title: str,
         data: Mapping[str, Any],
         description: str | None = None,
-        description_placeholders: dict[str, Any] | None = None,
+        description_placeholders: dict[str, str | None] | None = None,
         options: Mapping[str, Any] | None = None,
     ) -> data_entry_flow.FlowResult:
         """Finish config flow and create a config entry."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1386,7 +1386,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     @callback
     def async_abort(
-        self, *, reason: str, description_placeholders: dict | None = None
+        self, *, reason: str, description_placeholders: dict[str, Any] | None = None
     ) -> data_entry_flow.FlowResult:
         """Abort the config flow."""
         # Remove reauth notification if no reauth flows are in progress
@@ -1460,7 +1460,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         title: str,
         data: Mapping[str, Any],
         description: str | None = None,
-        description_placeholders: dict | None = None,
+        description_placeholders: dict[str, Any] | None = None,
         options: Mapping[str, Any] | None = None,
     ) -> data_entry_flow.FlowResult:
         """Finish config flow and create a config entry."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1389,7 +1389,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self,
         *,
         reason: str,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> data_entry_flow.FlowResult:
         """Abort the config flow."""
         # Remove reauth notification if no reauth flows are in progress
@@ -1463,7 +1463,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         title: str,
         data: Mapping[str, Any],
         description: str | None = None,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
         options: Mapping[str, Any] | None = None,
     ) -> data_entry_flow.FlowResult:
         """Finish config flow and create a config entry."""

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -52,7 +52,7 @@ class AbortFlow(FlowError):
     """Exception to indicate a flow needs to be aborted."""
 
     def __init__(
-        self, reason: str, description_placeholders: dict[str, str | None] | None = None
+        self, reason: str, description_placeholders: Mapping[str, str] | None = None
     ) -> None:
         """Initialize an abort flow exception."""
         super().__init__(f"Flow aborted: {reason}")
@@ -75,7 +75,7 @@ class FlowResult(TypedDict, total=False):
     required: bool
     errors: dict[str, str] | None
     description: str | None
-    description_placeholders: dict[str, str | None] | None
+    description_placeholders: Mapping[str, str | None] | None
     progress_action: str
     url: str
     reason: str
@@ -422,7 +422,7 @@ class FlowHandler:
         step_id: str,
         data_schema: vol.Schema | None = None,
         errors: dict[str, str] | None = None,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str | None] | None = None,
         last_step: bool | None = None,
     ) -> FlowResult:
         """Return the definition of a form to gather user input."""
@@ -444,7 +444,7 @@ class FlowHandler:
         title: str,
         data: Mapping[str, Any],
         description: str | None = None,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
         """Finish config flow and create a config entry."""
         return {
@@ -463,7 +463,7 @@ class FlowHandler:
         self,
         *,
         reason: str,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
         """Abort the config flow."""
         return _create_abort_data(
@@ -476,7 +476,7 @@ class FlowHandler:
         *,
         step_id: str,
         url: str,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
         """Return the definition of an external step for the user to take."""
         return {
@@ -504,7 +504,7 @@ class FlowHandler:
         *,
         step_id: str,
         progress_action: str,
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
         """Show a progress message to the user, without user input allowed."""
         return {
@@ -532,7 +532,7 @@ class FlowHandler:
         *,
         step_id: str,
         menu_options: list[str] | dict[str, str],
-        description_placeholders: dict[str, str | None] | None = None,
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> FlowResult:
         """Show a navigation menu to the user.
 
@@ -554,7 +554,7 @@ def _create_abort_data(
     flow_id: str,
     handler: str,
     reason: str,
-    description_placeholders: dict[str, str | None] | None = None,
+    description_placeholders: Mapping[str, str] | None = None,
 ) -> FlowResult:
     """Return the definition of an external step for the user to take."""
     return {

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -52,7 +52,7 @@ class AbortFlow(FlowError):
     """Exception to indicate a flow needs to be aborted."""
 
     def __init__(
-        self, reason: str, description_placeholders: dict[str, Any] | None = None
+        self, reason: str, description_placeholders: dict[str, str | None] | None = None
     ) -> None:
         """Initialize an abort flow exception."""
         super().__init__(f"Flow aborted: {reason}")
@@ -75,7 +75,7 @@ class FlowResult(TypedDict, total=False):
     required: bool
     errors: dict[str, str] | None
     description: str | None
-    description_placeholders: dict[str, Any] | None
+    description_placeholders: dict[str, str | None] | None
     progress_action: str
     url: str
     reason: str
@@ -422,7 +422,7 @@ class FlowHandler:
         step_id: str,
         data_schema: vol.Schema | None = None,
         errors: dict[str, str] | None = None,
-        description_placeholders: dict[str, Any] | None = None,
+        description_placeholders: dict[str, str | None] | None = None,
         last_step: bool | None = None,
     ) -> FlowResult:
         """Return the definition of a form to gather user input."""
@@ -444,7 +444,7 @@ class FlowHandler:
         title: str,
         data: Mapping[str, Any],
         description: str | None = None,
-        description_placeholders: dict[str, Any] | None = None,
+        description_placeholders: dict[str, str | None] | None = None,
     ) -> FlowResult:
         """Finish config flow and create a config entry."""
         return {
@@ -460,7 +460,10 @@ class FlowHandler:
 
     @callback
     def async_abort(
-        self, *, reason: str, description_placeholders: dict[str, Any] | None = None
+        self,
+        *,
+        reason: str,
+        description_placeholders: dict[str, str | None] | None = None,
     ) -> FlowResult:
         """Abort the config flow."""
         return _create_abort_data(
@@ -473,7 +476,7 @@ class FlowHandler:
         *,
         step_id: str,
         url: str,
-        description_placeholders: dict[str, Any] | None = None,
+        description_placeholders: dict[str, str | None] | None = None,
     ) -> FlowResult:
         """Return the definition of an external step for the user to take."""
         return {
@@ -501,7 +504,7 @@ class FlowHandler:
         *,
         step_id: str,
         progress_action: str,
-        description_placeholders: dict[str, Any] | None = None,
+        description_placeholders: dict[str, str | None] | None = None,
     ) -> FlowResult:
         """Show a progress message to the user, without user input allowed."""
         return {
@@ -529,7 +532,7 @@ class FlowHandler:
         *,
         step_id: str,
         menu_options: list[str] | dict[str, str],
-        description_placeholders: dict[str, Any] | None = None,
+        description_placeholders: dict[str, str | None] | None = None,
     ) -> FlowResult:
         """Show a navigation menu to the user.
 
@@ -551,7 +554,7 @@ def _create_abort_data(
     flow_id: str,
     handler: str,
     reason: str,
-    description_placeholders: dict[str, Any] | None = None,
+    description_placeholders: dict[str, str | None] | None = None,
 ) -> FlowResult:
     """Return the definition of an external step for the user to take."""
     return {

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -52,7 +52,7 @@ class AbortFlow(FlowError):
     """Exception to indicate a flow needs to be aborted."""
 
     def __init__(
-        self, reason: str, description_placeholders: dict | None = None
+        self, reason: str, description_placeholders: dict[str, Any] | None = None
     ) -> None:
         """Initialize an abort flow exception."""
         super().__init__(f"Flow aborted: {reason}")
@@ -444,7 +444,7 @@ class FlowHandler:
         title: str,
         data: Mapping[str, Any],
         description: str | None = None,
-        description_placeholders: dict | None = None,
+        description_placeholders: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Finish config flow and create a config entry."""
         return {
@@ -460,7 +460,7 @@ class FlowHandler:
 
     @callback
     def async_abort(
-        self, *, reason: str, description_placeholders: dict | None = None
+        self, *, reason: str, description_placeholders: dict[str, Any] | None = None
     ) -> FlowResult:
         """Abort the config flow."""
         return _create_abort_data(
@@ -469,7 +469,11 @@ class FlowHandler:
 
     @callback
     def async_external_step(
-        self, *, step_id: str, url: str, description_placeholders: dict | None = None
+        self,
+        *,
+        step_id: str,
+        url: str,
+        description_placeholders: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Return the definition of an external step for the user to take."""
         return {
@@ -497,7 +501,7 @@ class FlowHandler:
         *,
         step_id: str,
         progress_action: str,
-        description_placeholders: dict | None = None,
+        description_placeholders: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Show a progress message to the user, without user input allowed."""
         return {
@@ -525,7 +529,7 @@ class FlowHandler:
         *,
         step_id: str,
         menu_options: list[str] | dict[str, str],
-        description_placeholders: dict | None = None,
+        description_placeholders: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Show a navigation menu to the user.
 
@@ -547,7 +551,7 @@ def _create_abort_data(
     flow_id: str,
     handler: str,
     reason: str,
-    description_placeholders: dict | None = None,
+    description_placeholders: dict[str, Any] | None = None,
 ) -> FlowResult:
     """Return the definition of an external step for the user to take."""
     return {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When looking at #72680, I spotted that `description_placeholders` was not always typed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
