### PR TITLE
Fix hive authentication process

### DIFF
--- a/homeassistant/components/hive/__init__.py
+++ b/homeassistant/components/hive/__init__.py
@@ -76,8 +76,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hive from a config entry."""
 
     websession = aiohttp_client.async_get_clientsession(hass)
-    hive = Hive(websession)
     hive_config = dict(entry.data)
+    hive = Hive(
+        websession,
+        deviceGroupKey=hive_config["device_data"][0],
+        deviceKey=hive_config["device_data"][1],
+        devicePassword=hive_config["device_data"][2],
+    )
 
     hive_config["options"] = {}
     hive_config["options"].update(

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -103,6 +103,7 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Setup the config entry
         self.data["tokens"] = self.tokens
+        self.data["device_data"] = await self.hive_auth.getDeviceData()
         if self.context["source"] == config_entries.SOURCE_REAUTH:
             self.hass.config_entries.async_update_entry(
                 self.entry, title=self.data["username"], data=self.data

--- a/homeassistant/components/hive/manifest.json
+++ b/homeassistant/components/hive/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hive",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/hive",
-  "requirements": ["pyhiveapi==0.4.2"],
+  "requirements": ["pyhiveapi==0.5.4"],
   "codeowners": ["@Rendili", "@KJonline"],
   "iot_class": "cloud_polling",
   "loggers": ["apyhiveapi"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1538,7 +1538,7 @@ pyheos==0.7.2
 pyhik==0.3.0
 
 # homeassistant.components.hive
-pyhiveapi==0.4.2
+pyhiveapi==0.5.4
 
 # homeassistant.components.homematic
 pyhomematic==0.1.77

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1029,7 +1029,7 @@ pyhaversion==22.4.1
 pyheos==0.7.2
 
 # homeassistant.components.hive
-pyhiveapi==0.4.2
+pyhiveapi==0.5.4
 
 # homeassistant.components.homematic
 pyhomematic==0.1.77

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -13,7 +13,7 @@ USERNAME = "username@home-assistant.com"
 UPDATED_USERNAME = "updated_username@home-assistant.com"
 PASSWORD = "test-password"
 UPDATED_PASSWORD = "updated-password"
-INCORRECT_PASSWORD = "incoreect-password"
+INCORRECT_PASSWORD = "incorrect-password"
 SCAN_INTERVAL = 120
 UPDATED_SCAN_INTERVAL = 60
 MFA_CODE = "1234"
@@ -33,6 +33,13 @@ async def test_import_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
+    ), patch(
+        "homeassistant.components.hive.config_flow.Auth.getDeviceData",
+        return_value=[
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
     ), patch(
         "homeassistant.components.hive.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -57,6 +64,11 @@ async def test_import_flow(hass):
             },
             "ChallengeName": "SUCCESS",
         },
+        "device_data": [
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
     }
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1
@@ -82,6 +94,13 @@ async def test_user_flow(hass):
             },
         },
     ), patch(
+        "homeassistant.components.hive.config_flow.Auth.getDeviceData",
+        return_value=[
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
+    ), patch(
         "homeassistant.components.hive.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.hive.async_setup_entry",
@@ -105,6 +124,11 @@ async def test_user_flow(hass):
             },
             "ChallengeName": "SUCCESS",
         },
+        "device_data": [
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
     }
 
     assert len(mock_setup.mock_calls) == 1
@@ -149,6 +173,13 @@ async def test_user_flow_2fa(hass):
             },
         },
     ), patch(
+        "homeassistant.components.hive.config_flow.Auth.getDeviceData",
+        return_value=[
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
+    ), patch(
         "homeassistant.components.hive.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.hive.async_setup_entry",
@@ -171,6 +202,11 @@ async def test_user_flow_2fa(hass):
             },
             "ChallengeName": "SUCCESS",
         },
+        "device_data": [
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
     }
 
     assert len(mock_setup.mock_calls) == 1
@@ -243,7 +279,15 @@ async def test_option_flow(hass):
     entry = MockConfigEntry(
         domain=DOMAIN,
         title=USERNAME,
-        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        data={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            "device_data": [
+                "mock-device-group-key",
+                "mock-device-key",
+                "mock-device-password",
+            ],
+        },
     )
     entry.add_to_hass(hass)
 
@@ -318,6 +362,13 @@ async def test_user_flow_2fa_send_new_code(hass):
             },
         },
     ), patch(
+        "homeassistant.components.hive.config_flow.Auth.getDeviceData",
+        return_value=[
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
+    ), patch(
         "homeassistant.components.hive.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.hive.async_setup_entry",
@@ -340,6 +391,11 @@ async def test_user_flow_2fa_send_new_code(hass):
             },
             "ChallengeName": "SUCCESS",
         },
+        "device_data": [
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

As this change updates the authentication process. All existing Hive users will be required to re-authenticate within the home assistant integration.
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is to fix the issue mentioned below where users can no longer authenticate with Hive from Home Assistant:

Scope of this change:

- Update config flow to export device data and store in the entity config.
- Pass the device data from the entity config to the pyhiveapi library.
-  Bump library to v0.5.4 - https://github.com/Pyhass/Pyhiveapi/compare/v0.4.2...v0.5.4


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #70465
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
