### PR TITLE
Alter RainMachine to not create entities if the underlying data is missing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -969,6 +969,7 @@ omit =
     homeassistant/components/rainmachine/model.py
     homeassistant/components/rainmachine/sensor.py
     homeassistant/components/rainmachine/switch.py
+    homeassistant/components/rainmachine/util.py
     homeassistant/components/raspyrfm/*
     homeassistant/components/recollect_waste/__init__.py
     homeassistant/components/recollect_waste/sensor.py

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -50,10 +50,7 @@ from .const import (
     LOGGER,
 )
 
-DEFAULT_ATTRIBUTION = "Data provided by Green Electronics LLC"
-DEFAULT_ICON = "mdi:water"
 DEFAULT_SSL = True
-DEFAULT_UPDATE_INTERVAL = timedelta(seconds=15)
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -139,7 +139,7 @@ async def async_setup_entry(
                 entry, coordinator, controller, description
             )
             for description in BINARY_SENSOR_DESCRIPTIONS
-            if (coordinator := coordinators[description.api_category])
+            if (coordinator := coordinators[description.api_category]) is not None
             and key_exists(coordinator.data, description.data_key)
         ]
     )

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -1,6 +1,5 @@
 """This platform provides binary sensors for key RainMachine data."""
 from dataclasses import dataclass
-from functools import partial
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -21,6 +20,7 @@ from .const import (
     DOMAIN,
 )
 from .model import RainMachineDescriptionMixinApiCategory
+from .util import key_exists
 
 TYPE_FLOW_SENSOR = "flow_sensor"
 TYPE_FREEZE = "freeze"
@@ -46,6 +46,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         name="Flow Sensor",
         icon="mdi:water-pump",
         api_category=DATA_PROVISION_SETTINGS,
+        data_key="useFlowSensor",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_FREEZE,
@@ -53,6 +54,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         icon="mdi:cancel",
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
+        data_key="freeze",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_FREEZE_PROTECTION,
@@ -60,6 +62,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         icon="mdi:weather-snowy",
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="freezeProtectEnabled",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_HOT_DAYS,
@@ -67,6 +70,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         icon="mdi:thermometer-lines",
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="hotDaysExtraWatering",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_HOURLY,
@@ -75,6 +79,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         api_category=DATA_RESTRICTIONS_CURRENT,
+        data_key="hourly",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_MONTH,
@@ -83,6 +88,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         api_category=DATA_RESTRICTIONS_CURRENT,
+        data_key="month",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_RAINDELAY,
@@ -91,6 +97,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         api_category=DATA_RESTRICTIONS_CURRENT,
+        data_key="rainDelay",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_RAINSENSOR,
@@ -99,6 +106,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         api_category=DATA_RESTRICTIONS_CURRENT,
+        data_key="rainSensor",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_WEEKDAY,
@@ -107,6 +115,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         api_category=DATA_RESTRICTIONS_CURRENT,
+        data_key="weekDay",
     ),
 )
 
@@ -118,35 +127,20 @@ async def async_setup_entry(
     controller = hass.data[DOMAIN][entry.entry_id][DATA_CONTROLLER]
     coordinators = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
 
-    @callback
-    def async_get_sensor_by_api_category(api_category: str) -> partial:
-        """Generate the appropriate sensor object for an API category."""
-        if api_category == DATA_PROVISION_SETTINGS:
-            return partial(
-                ProvisionSettingsBinarySensor,
-                entry,
-                coordinators[DATA_PROVISION_SETTINGS],
-            )
-
-        if api_category == DATA_RESTRICTIONS_CURRENT:
-            return partial(
-                CurrentRestrictionsBinarySensor,
-                entry,
-                coordinators[DATA_RESTRICTIONS_CURRENT],
-            )
-
-        return partial(
-            UniversalRestrictionsBinarySensor,
-            entry,
-            coordinators[DATA_RESTRICTIONS_UNIVERSAL],
-        )
+    api_category_sensor_map = {
+        DATA_PROVISION_SETTINGS: ProvisionSettingsBinarySensor,
+        DATA_RESTRICTIONS_CURRENT: CurrentRestrictionsBinarySensor,
+        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsBinarySensor,
+    }
 
     async_add_entities(
         [
-            async_get_sensor_by_api_category(description.api_category)(
-                controller, description
+            api_category_sensor_map[description.api_category](
+                entry, coordinator, controller, description
             )
             for description in BINARY_SENSOR_DESCRIPTIONS
+            if (coordinator := coordinators[description.api_category])
+            and key_exists(coordinator.data, description.data_key)
         ]
     )
 

--- a/homeassistant/components/rainmachine/model.py
+++ b/homeassistant/components/rainmachine/model.py
@@ -7,6 +7,7 @@ class RainMachineDescriptionMixinApiCategory:
     """Define an entity description mixin for binary and regular sensors."""
 
     api_category: str
+    data_key: str
 
 
 @dataclass

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -133,7 +133,7 @@ async def async_setup_entry(
             entry, coordinator, controller, description
         )
         for description in SENSOR_DESCRIPTIONS
-        if (coordinator := coordinators[description.api_category])
+        if (coordinator := coordinators[description.api_category]) is not None
         and key_exists(coordinator.data, description.data_key)
     ]
 

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from functools import partial
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -33,6 +32,7 @@ from .model import (
     RainMachineDescriptionMixinApiCategory,
     RainMachineDescriptionMixinUid,
 )
+from .util import key_exists
 
 DEFAULT_ZONE_COMPLETION_TIME_WOBBLE_TOLERANCE = timedelta(seconds=5)
 
@@ -68,6 +68,7 @@ SENSOR_DESCRIPTIONS = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         api_category=DATA_PROVISION_SETTINGS,
+        data_key="flowSensorClicksPerCubicMeter",
     ),
     RainMachineSensorDescriptionApiCategory(
         key=TYPE_FLOW_SENSOR_CONSUMED_LITERS,
@@ -78,6 +79,7 @@ SENSOR_DESCRIPTIONS = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
         api_category=DATA_PROVISION_SETTINGS,
+        data_key="flowSensorWateringClicks",
     ),
     RainMachineSensorDescriptionApiCategory(
         key=TYPE_FLOW_SENSOR_START_INDEX,
@@ -87,6 +89,7 @@ SENSOR_DESCRIPTIONS = (
         native_unit_of_measurement="index",
         entity_registry_enabled_default=False,
         api_category=DATA_PROVISION_SETTINGS,
+        data_key="flowSensorStartIndex",
     ),
     RainMachineSensorDescriptionApiCategory(
         key=TYPE_FLOW_SENSOR_WATERING_CLICKS,
@@ -97,6 +100,7 @@ SENSOR_DESCRIPTIONS = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         api_category=DATA_PROVISION_SETTINGS,
+        data_key="flowSensorWateringClicks",
     ),
     RainMachineSensorDescriptionApiCategory(
         key=TYPE_FREEZE_TEMP,
@@ -107,6 +111,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="freezeProtectTemp",
     ),
 )
 
@@ -118,27 +123,18 @@ async def async_setup_entry(
     controller = hass.data[DOMAIN][entry.entry_id][DATA_CONTROLLER]
     coordinators = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
 
-    @callback
-    def async_get_sensor_by_api_category(api_category: str) -> partial:
-        """Generate the appropriate sensor object for an API category."""
-        if api_category == DATA_PROVISION_SETTINGS:
-            return partial(
-                ProvisionSettingsSensor,
-                entry,
-                coordinators[DATA_PROVISION_SETTINGS],
-            )
-
-        return partial(
-            UniversalRestrictionsSensor,
-            entry,
-            coordinators[DATA_RESTRICTIONS_UNIVERSAL],
-        )
+    api_category_sensor_map = {
+        DATA_PROVISION_SETTINGS: ProvisionSettingsSensor,
+        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsSensor,
+    }
 
     sensors = [
-        async_get_sensor_by_api_category(description.api_category)(
-            controller, description
+        api_category_sensor_map[description.api_category](
+            entry, coordinator, controller, description
         )
         for description in SENSOR_DESCRIPTIONS
+        if (coordinator := coordinators[description.api_category])
+        and key_exists(coordinator.data, description.data_key)
     ]
 
     zone_coordinator = coordinators[DATA_ZONES]

--- a/homeassistant/components/rainmachine/util.py
+++ b/homeassistant/components/rainmachine/util.py
@@ -1,0 +1,14 @@
+"""Define RainMachine utilities."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def key_exists(data: dict[str, Any], search_key: str) -> bool:
+    """Return whether a key exists in a nested dict."""
+    for key, value in data.items():
+        if key == search_key:
+            return True
+        if isinstance(value, dict):
+            return key_exists(value, search_key)
+    return False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/72632, this PR alters RainMachine to not create entities for which the underlying API data doesn't exist.

The PR does _not_ attempt to remove any of these invalid entities that might already exist (and instead leans on the user to manually delete them from the entity registry if they wish).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/issues/68022
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
