### PR TITLE
Add support for async_remove_config_entry_device to unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
@@ -35,9 +35,10 @@ from .const import (
     OUTDATED_LOG_MESSAGE,
     PLATFORMS,
 )
-from .data import ProtectData
+from .data import ProtectData, async_ufp_instance_for_config_entry_ids
 from .discovery import async_start_discovery
 from .services import async_cleanup_services, async_setup_services
+from .utils import async_get_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -166,3 +167,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async_cleanup_services(hass)
 
     return bool(unload_ok)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove ufp config entry from a device."""
+    connections = device_entry.connections
+    api = async_ufp_instance_for_config_entry_ids(hass, {config_entry.entry_id})
+    assert api is not None
+    if (dr.CONNECTION_NETWORK_MAC, api.bootstrap.nvr.mac) in connections:
+        return False
+    for device in async_get_devices(api, DEVICES_THAT_ADOPT):
+        if (dr.CONNECTION_NETWORK_MAC, device.mac) in connections:
+            return False
+    return True

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -180,9 +180,7 @@ async def async_remove_config_entry_device(
     }
     api = async_ufp_instance_for_config_entry_ids(hass, {config_entry.entry_id})
     assert api is not None
-    if api.bootstrap.nvr.mac in unifi_macs:
-        return False
-    return not any(
+    return api.bootstrap.nvr.mac not in unifi_macs and not any(
         device.mac in unifi_macs
         for device in async_get_devices(api, DEVICES_THAT_ADOPT)
     )

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -17,10 +17,10 @@ from pyunifiprotect.data import (
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, DOMAIN, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CONF_DISABLE_RTSP, DEVICES_THAT_ADOPT, DEVICES_WITH_ENTITIES
+from .const import CONF_DISABLE_RTSP, DEVICES_THAT_ADOPT, DEVICES_WITH_ENTITIES, DOMAIN
 from .utils import async_get_adoptable_devices_by_type, async_get_devices
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -14,14 +14,14 @@ from pyunifiprotect.data import (
     ModelType,
     WSSubscriptionMessage,
 )
-from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
+from pyunifiprotect.data.base import ProtectDeviceModel
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, DOMAIN, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import CONF_DISABLE_RTSP, DEVICES_THAT_ADOPT, DEVICES_WITH_ENTITIES
-from .utils import async_get_devices
+from .utils import async_get_devices, async_get_devices_by_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,14 +57,10 @@ class ProtectData:
 
     def get_by_types(
         self, device_types: Iterable[ModelType]
-    ) -> Generator[ProtectAdoptableDeviceModel, None, None]:
+    ) -> Generator[ProtectDeviceModel, None, None]:
         """Get all devices matching types."""
         for device_type in device_types:
-            attr = f"{device_type.value}s"
-            devices: dict[str, ProtectAdoptableDeviceModel] = getattr(
-                self.api.bootstrap, attr
-            )
-            yield from devices.values()
+            yield from async_get_devices_by_type(self.api, device_type).values()
 
     async def async_setup(self) -> None:
         """Subscribe and do the refresh."""

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -14,14 +14,14 @@ from pyunifiprotect.data import (
     ModelType,
     WSSubscriptionMessage,
 )
-from pyunifiprotect.data.base import ProtectDeviceModel
+from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, DOMAIN, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import CONF_DISABLE_RTSP, DEVICES_THAT_ADOPT, DEVICES_WITH_ENTITIES
-from .utils import async_get_devices, async_get_devices_by_type
+from .utils import async_get_adoptable_devices_by_type, async_get_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,10 +57,12 @@ class ProtectData:
 
     def get_by_types(
         self, device_types: Iterable[ModelType]
-    ) -> Generator[ProtectDeviceModel, None, None]:
+    ) -> Generator[ProtectAdoptableDeviceModel, None, None]:
         """Get all devices matching types."""
         for device_type in device_types:
-            yield from async_get_devices_by_type(self.api, device_type).values()
+            yield from async_get_adoptable_devices_by_type(
+                self.api, device_type
+            ).values()
 
     async def async_setup(self) -> None:
         """Subscribe and do the refresh."""

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 from .const import ATTR_EVENT_SCORE, DEFAULT_ATTRIBUTION, DEFAULT_BRAND, DOMAIN
 from .data import ProtectData
 from .models import ProtectRequiredKeysMixin
-from .utils import get_nested_attr
+from .utils import async_get_adoptable_devices_by_type, get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,7 +153,9 @@ class ProtectDeviceEntity(Entity):
         """Update Entity object from Protect device."""
         if self.data.last_update_success:
             assert self.device.model
-            devices = getattr(self.data.api.bootstrap, f"{self.device.model.value}s")
+            devices = async_get_adoptable_devices_by_type(
+                self.data.api, self.device.model
+            )
             self.device = devices[self.device.id]
 
         is_connected = (

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.service import async_extract_referenced_entity_ids
 from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import ATTR_MESSAGE, DOMAIN
-from .data import ProtectData
+from .data import async_ufp_instance_for_config_entry_ids
 
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
@@ -59,18 +59,6 @@ CHIME_PAIRED_SCHEMA = vol.All(
 )
 
 
-def _async_ufp_instance_for_config_entry_ids(
-    hass: HomeAssistant, config_entry_ids: set[str]
-) -> ProtectApiClient | None:
-    """Find the UFP instance for the config entry ids."""
-    domain_data = hass.data[DOMAIN]
-    for config_entry_id in config_entry_ids:
-        if config_entry_id in domain_data:
-            protect_data: ProtectData = domain_data[config_entry_id]
-            return protect_data.api
-    return None
-
-
 @callback
 def _async_get_ufp_instance(hass: HomeAssistant, device_id: str) -> ProtectApiClient:
     device_registry = dr.async_get(hass)
@@ -81,7 +69,7 @@ def _async_get_ufp_instance(hass: HomeAssistant, device_id: str) -> ProtectApiCl
         return _async_get_ufp_instance(hass, device_entry.via_device_id)
 
     config_entry_ids = device_entry.config_entries
-    if ufp_instance := _async_ufp_instance_for_config_entry_ids(hass, config_entry_ids):
+    if ufp_instance := async_ufp_instance_for_config_entry_ids(hass, config_entry_ids):
         return ufp_instance
 
     raise HomeAssistantError(f"No device found for device id: {device_id}")

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -1,12 +1,18 @@
 """UniFi Protect Integration utils."""
 from __future__ import annotations
 
+from collections.abc import Generator, Iterable
 import contextlib
 from enum import Enum
 import socket
 from typing import Any
 
+from pyunifiprotect import ProtectApiClient
+from pyunifiprotect.data.base import ProtectDeviceModel
+
 from homeassistant.core import HomeAssistant, callback
+
+from .const import ModelType
 
 
 def get_nested_attr(obj: Any, attr: str) -> Any:
@@ -51,3 +57,15 @@ async def _async_resolve(hass: HomeAssistant, host: str) -> str | None:
             None,
         )
     return None
+
+
+@callback
+def async_get_devices(
+    api: ProtectApiClient, model_type: Iterable[ModelType]
+) -> Generator[ProtectDeviceModel, None, None]:
+    """Return all device by type."""
+    return (
+        device
+        for device_type in model_type
+        for device in getattr(api.bootstrap, f"{device_type.value}s")
+    )

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -8,7 +8,7 @@ import socket
 from typing import Any
 
 from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data.base import ProtectDeviceModel
+from pyunifiprotect.data.base import ProtectAdoptableDeviceModel, ProtectDeviceModel
 
 from homeassistant.core import HomeAssistant, callback
 
@@ -64,6 +64,16 @@ def async_get_devices_by_type(
 ) -> dict[str, ProtectDeviceModel]:
     """Get devices by type."""
     devices: dict[str, ProtectDeviceModel] = getattr(
+        api.bootstrap, f"{device_type.value}s"
+    )
+    return devices
+
+
+def async_get_adoptable_devices_by_type(
+    api: ProtectApiClient, device_type: ModelType
+) -> dict[str, ProtectAdoptableDeviceModel]:
+    """Get adoptable devices by type."""
+    devices: dict[str, ProtectAdoptableDeviceModel] = getattr(
         api.bootstrap, f"{device_type.value}s"
     )
     return devices

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -59,6 +59,16 @@ async def _async_resolve(hass: HomeAssistant, host: str) -> str | None:
     return None
 
 
+def async_get_devices_by_type(
+    api: ProtectApiClient, device_type: ModelType
+) -> dict[str, ProtectDeviceModel]:
+    """Get devices by type."""
+    devices: dict[str, ProtectDeviceModel] = getattr(
+        api.bootstrap, f"{device_type.value}s"
+    )
+    return devices
+
+
 @callback
 def async_get_devices(
     api: ProtectApiClient, model_type: Iterable[ModelType]
@@ -67,5 +77,5 @@ def async_get_devices(
     return (
         device
         for device_type in model_type
-        for device in getattr(api.bootstrap, f"{device_type.value}s")
+        for device in async_get_devices_by_type(api, device_type).values()
     )

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -357,7 +357,7 @@ async def test_device_remove_devices(
     light1._api = mock_entry.api
     light1.name = "Test Light 1"
     light1.id = "lightid1"
-    light1.mac = "aa:bb:cc:dd:ee:ff"
+    light1.mac = "AABBCCDDEEFF"
 
     mock_entry.api.bootstrap.lights = {
         light1.id: light1,

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -362,6 +362,7 @@ async def test_device_remove_devices(
     mock_entry.api.bootstrap.lights = {
         light1.id: light1,
     }
+
     mock_entry.api.get_bootstrap = AsyncMock(return_value=mock_entry.api.bootstrap)
     light_entity_id = "light.test_light_1"
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -2,8 +2,10 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 from pyunifiprotect import NotAuthorized, NvrError
 from pyunifiprotect.data import NVR, Light
 
@@ -11,12 +13,29 @@ from homeassistant.components.unifiprotect.const import CONF_DISABLE_RTSP, DOMAI
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
 
 from . import _patch_discovery
 from .conftest import MockBootstrap, MockEntityFixture
 
 from tests.common import MockConfigEntry
+
+
+async def remove_device(
+    ws_client: aiohttp.ClientWebSocketResponse, device_id: str, config_entry_id: str
+) -> bool:
+    """Remove config entry from a device."""
+    await ws_client.send_json(
+        {
+            "id": 5,
+            "type": "config/device_registry/remove_config_entry",
+            "config_entry_id": config_entry_id,
+            "device_id": device_id,
+        }
+    )
+    response = await ws_client.receive_json()
+    return response["success"]
 
 
 async def test_setup(hass: HomeAssistant, mock_entry: MockEntityFixture):
@@ -321,3 +340,49 @@ async def test_migrate_reboot_button_fail(
     light = registry.async_get(f"{Platform.BUTTON}.test_light_1")
     assert light is not None
     assert light.unique_id == f"{light1.id}"
+
+
+async def test_device_remove_devices(
+    hass: HomeAssistant,
+    mock_entry: MockEntityFixture,
+    mock_light: Light,
+    hass_ws_client: Callable[
+        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
+    ],
+) -> None:
+    """Test we can only remove a device that no longer exists."""
+    assert await async_setup_component(hass, "config", {})
+
+    light1 = mock_light.copy()
+    light1._api = mock_entry.api
+    light1.name = "Test Light 1"
+    light1.id = "lightid1"
+    light1.mac = "aa:bb:cc:dd:ee:ff"
+
+    mock_entry.api.bootstrap.lights = {
+        light1.id: light1,
+    }
+    mock_entry.api.get_bootstrap = AsyncMock(return_value=mock_entry.api.bootstrap)
+    light_entity_id = "light.test_light_1"
+    await hass.config_entries.async_setup(mock_entry.entry.entry_id)
+    await hass.async_block_till_done()
+    entry_id = mock_entry.entry.entry_id
+
+    registry: er.EntityRegistry = er.async_get(hass)
+    entity = registry.entities[light_entity_id]
+    device_registry = dr.async_get(hass)
+
+    live_device_entry = device_registry.async_get(entity.device_id)
+    assert (
+        await remove_device(await hass_ws_client(hass), live_device_entry.id, entry_id)
+        is False
+    )
+
+    dead_device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "e9:88:e7:b8:b4:40")},
+    )
+    assert (
+        await remove_device(await hass_ws_client(hass), dead_device_entry.id, entry_id)
+        is True
+    )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for async_remove_config_entry_device to unifiprotect

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
