### PR TITLE
Bump google-nest-sdm to `2.0.0` and cleanup nest auth implementation in config flow

### DIFF
--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -43,7 +43,6 @@ from google_nest_sdm.exceptions import (
 from google_nest_sdm.structure import InfoTrait, Structure
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
@@ -319,12 +318,11 @@ class NestFlowHandler(
             if not (subscriber_id := data.get(CONF_SUBSCRIBER_ID, "")):
                 subscriber_id = _generate_subscription_id(cloud_project_id)
             _LOGGER.debug("Creating subscriber id '%s'", subscriber_id)
-            # Create a placeholder ConfigEntry to use since with the auth we've already created.
-            entry = ConfigEntry(
-                version=1, domain=DOMAIN, title="", data=self._data, source=""
-            )
-            subscriber = await api.new_subscriber_with_impl(
-                self.hass, entry, subscriber_id, self.flow_impl
+            subscriber = api.new_subscriber_with_token(
+                self.hass,
+                self._data["token"]["access_token"],
+                config[CONF_PROJECT_ID],
+                subscriber_id,
             )
             try:
                 await subscriber.create_subscription()

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": ["ffmpeg", "http", "auth"],
   "after_dependencies": ["media_source"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
-  "requirements": ["python-nest==4.2.0", "google-nest-sdm==1.8.0"],
+  "requirements": ["python-nest==4.2.0", "google-nest-sdm==2.0.0"],
   "codeowners": ["@allenporter"],
   "quality_scale": "platinum",
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ google-cloud-pubsub==2.11.0
 google-cloud-texttospeech==2.11.0
 
 # homeassistant.components.nest
-google-nest-sdm==1.8.0
+google-nest-sdm==2.0.0
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -535,7 +535,7 @@ goodwe==0.2.15
 google-cloud-pubsub==2.11.0
 
 # homeassistant.components.nest
-google-nest-sdm==1.8.0
+google-nest-sdm==2.0.0
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup nest auth implementation in config flow by using a dedicated auth implementation that does not support refresh.  This is a similar change as made to `google` in https://github.com/home-assistant/core/pull/72243 to avoid creating a synthetic ConfigEntry.

This upgrades `google-nest-sdm` to 2.0.0 which includes a change to not refresh tokens when creating subscriptions which is usually done only after new credentials are created and no refresh is needed.

Release notes: [2.0.0](https://github.com/allenporter/python-google-nest-sdm/releases/tag/2.0.0)
Release notes: [1.9.0](https://github.com/allenporter/python-google-nest-sdm/releases/tag/1.9.0)
Changes: https://github.com/allenporter/python-google-nest-sdm/compare/1.8.0...2.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
