### PR TITLE
Bump `nam` backend library

### DIFF
--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -52,10 +52,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     options = ConnectionOptions(host=host, username=username, password=password)
     try:
         nam = await NettigoAirMonitor.create(websession, options)
-    except AuthFailed as err:
-        raise ConfigEntryAuthFailed from err
     except (ApiError, ClientError, ClientConnectorError, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady from err
+
+    try:
+        await nam.async_check_credentials()
+    except AuthFailed as err:
+        raise ConfigEntryAuthFailed from err
 
     coordinator = NAMDataUpdateCoordinator(hass, nam, entry.unique_id)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -80,7 +80,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize flow."""
         self.host: str
         self.entry: config_entries.ConfigEntry
-        self._auth_enabled: bool = False
+        self._config: NamConfig
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -94,7 +94,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(format_mac(mac))
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
-                if auth_enabled:
+                if auth_enabled is True:
                     return await self.async_step_credentials()
 
                 return self.async_create_entry(
@@ -169,8 +169,10 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 data={CONF_HOST: self.host},
             )
 
-        if not self._auth_enabled:
-            self._set_confirm_only()
+        if self._auth_enabled is True:
+            return await self.async_step_credentials()
+
+        self._set_confirm_only()
 
         return self.async_show_form(
             step_id="confirm_discovery",

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -34,15 +34,31 @@ AUTH_SCHEMA = vol.Schema(
 )
 
 
-async def async_get_mac(hass: HomeAssistant, host: str, data: dict[str, Any]) -> str:
-    """Get device MAC address."""
+async def async_get_config(hass: HomeAssistant, host: str) -> tuple[str, bool]:
+    """Get device MAC address and auth_enabled property."""
     websession = async_get_clientsession(hass)
 
-    options = ConnectionOptions(host, data.get(CONF_USERNAME), data.get(CONF_PASSWORD))
+    options = ConnectionOptions(host)
     nam = await NettigoAirMonitor.create(websession, options)
 
     async with async_timeout.timeout(10):
-        return await nam.async_get_mac_address()
+        mac = await nam.async_get_mac_address()
+
+    return mac, nam.auth_enabled
+
+
+async def async_check_credentials(
+    hass: HomeAssistant, host: str, data: dict[str, Any]
+) -> None:
+    """Check if credentials are valid."""
+    websession = async_get_clientsession(hass)
+
+    options = ConnectionOptions(host, data.get(CONF_USERNAME), data.get(CONF_PASSWORD))
+
+    nam = await NettigoAirMonitor.create(websession, options)
+
+    async with async_timeout.timeout(10):
+        await nam.async_check_credentials()
 
 
 class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -54,6 +70,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize flow."""
         self.host: str
         self.entry: config_entries.ConfigEntry
+        self._auth_enabled: bool = False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -65,9 +82,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.host = user_input[CONF_HOST]
 
             try:
-                mac = await async_get_mac(self.hass, self.host, {})
-            except AuthFailed:
-                return await self.async_step_credentials()
+                mac, auth_enabled = await async_get_config(self.hass, self.host)
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
                 errors["base"] = "cannot_connect"
             except CannotGetMac:
@@ -78,6 +93,9 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 await self.async_set_unique_id(format_mac(mac))
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
+
+                if auth_enabled:
+                    return await self.async_step_credentials()
 
                 return self.async_create_entry(
                     title=self.host,
@@ -98,19 +116,15 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                mac = await async_get_mac(self.hass, self.host, user_input)
+                await async_check_credentials(self.hass, self.host, user_input)
             except AuthFailed:
                 errors["base"] = "invalid_auth"
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
                 errors["base"] = "cannot_connect"
-            except CannotGetMac:
-                return self.async_abort(reason="device_unsupported")
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(format_mac(mac))
-                self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
                 return self.async_create_entry(
                     title=self.host,
@@ -132,9 +146,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: self.host})
 
         try:
-            mac = await async_get_mac(self.hass, self.host, {})
-        except AuthFailed:
-            return await self.async_step_credentials()
+            mac, self._auth_enabled = await async_get_config(self.hass, self.host)
         except (ApiError, ClientConnectorError, asyncio.TimeoutError):
             return self.async_abort(reason="cannot_connect")
         except CannotGetMac:
@@ -157,7 +169,8 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 data={CONF_HOST: self.host},
             )
 
-        self._set_confirm_only()
+        if not self._auth_enabled:
+            self._set_confirm_only()
 
         return self.async_show_form(
             step_id="confirm_discovery",
@@ -181,7 +194,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await async_get_mac(self.hass, self.host, user_input)
+                await async_check_credentials(self.hass, self.host, user_input)
             except (ApiError, AuthFailed, ClientConnectorError, asyncio.TimeoutError):
                 return self.async_abort(reason="reauth_unsuccessful")
             else:

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nettigo Air Monitor",
   "documentation": "https://www.home-assistant.io/integrations/nam",
   "codeowners": ["@bieniu"],
-  "requirements": ["nettigo-air-monitor==1.2.4"],
+  "requirements": ["nettigo-air-monitor==1.3.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1077,7 +1077,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.2.4
+nettigo-air-monitor==1.3.0
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -745,7 +745,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.2.4
+nettigo-air-monitor==1.3.0
 
 # homeassistant.components.nexia
 nexia==1.0.1

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -79,7 +79,6 @@ async def test_form_create_entry_with_auth(hass):
             result["flow_id"],
             VALID_CONFIG,
         )
-        await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "credentials"

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -23,6 +23,8 @@ DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 VALID_CONFIG = {"host": "10.10.2.3"}
 VALID_AUTH = {"username": "fake_username", "password": "fake_password"}
+DEVICE_CONFIG = {"www_basicauth_enabled": False}
+DEVICE_CONFIG_AUTH = {"www_basicauth_enabled": True}
 
 
 async def test_form_create_entry_without_auth(hass):
@@ -34,7 +36,10 @@ async def test_form_create_entry_without_auth(hass):
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {}
 
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG,
+    ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ), patch(
@@ -62,24 +67,23 @@ async def test_form_create_entry_with_auth(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
-        side_effect=AuthFailed("Auth Error"),
-    ):
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG_AUTH,
+    ), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
+    ), patch(
+        "homeassistant.components.nam.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             VALID_CONFIG,
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "credentials"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "credentials"
 
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="aa:bb:cc:dd:ee:ff",
-    ), patch(
-        "homeassistant.components.nam.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             VALID_AUTH,
@@ -104,7 +108,10 @@ async def test_reauth_successful(hass):
     )
     entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG_AUTH,
+    ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ):
@@ -137,7 +144,7 @@ async def test_reauth_unsuccessful(hass):
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
         side_effect=ApiError("API Error"),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -171,8 +178,11 @@ async def test_form_with_auth_errors(hass, error):
     """Test we handle errors when auth is required."""
     exc, base_error = error
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
         side_effect=AuthFailed("Auth Error"),
+    ), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -222,42 +232,17 @@ async def test_form_errors(hass, error):
 
 async def test_form_abort(hass):
     """Test we handle abort after error."""
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        side_effect=CannotGetMac("Cannot get MAC address from device"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-            data=VALID_CONFIG,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "device_unsupported"
-
-
-async def test_form_with_auth_abort(hass):
-    """Test we handle abort after error."""
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
-        side_effect=AuthFailed("Auth Error"),
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG,
+    ), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        side_effect=CannotGetMac("Cannot get MAC address from device"),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
             data=VALID_CONFIG,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "credentials"
-
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        side_effect=CannotGetMac("Cannot get MAC address from device"),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            VALID_AUTH,
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -275,7 +260,10 @@ async def test_form_already_configured(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG,
+    ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ):
@@ -293,7 +281,10 @@ async def test_form_already_configured(hass):
 
 async def test_zeroconf(hass):
     """Test we get the form."""
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG,
+    ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ):
@@ -332,8 +323,11 @@ async def test_zeroconf(hass):
 async def test_zeroconf_with_auth(hass):
     """Test that the zeroconf step with auth works."""
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
         side_effect=AuthFailed("Auth Error"),
+    ), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -351,7 +345,10 @@ async def test_zeroconf_with_auth(hass):
     assert result["errors"] == {}
     assert context["title_placeholders"]["host"] == "10.10.2.3"
 
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        return_value=DEVICE_CONFIG_AUTH,
+    ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ), patch(

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -51,7 +51,7 @@ async def test_config_auth_failed(hass):
     )
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
         side_effect=AuthFailed("Authorization has failed"),
     ):
         entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `nam` backend library version fix the inability to ignore a discovered device with auth enabled.

Changelog: https://github.com/bieniu/nettigo-air-monitor/compare/1.2.4...1.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
