### PR TITLE
Add Overkiz AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -1,6 +1,7 @@
 """Climate entities for the Overkiz (by Somfy) integration."""
 from pyoverkiz.enums.ui import UIWidget
 
+from .atlantic_electrical_heater import AtlanticElectricalHeater
 from .atlantic_electrical_heater_with_adjustable_temperature_setpoint import (
     AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
 )

--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -1,6 +1,10 @@
 """Climate entities for the Overkiz (by Somfy) integration."""
 from pyoverkiz.enums.ui import UIWidget
 
+from .atlantic_electrical_heater_with_adjustable_temperature_setpoint import (
+    AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
+)
+
 from .atlantic_electrical_heater import AtlanticElectricalHeater
 from .atlantic_electrical_towel_dryer import AtlanticElectricalTowelDryer
 from .atlantic_heat_recovery_ventilation import AtlanticHeatRecoveryVentilation
@@ -16,5 +20,6 @@ WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_HEAT_RECOVERY_VENTILATION: AtlanticHeatRecoveryVentilation,
     UIWidget.ATLANTIC_PASS_APC_HEATING_AND_COOLING_ZONE: AtlanticPassAPCHeatingAndCoolingZone,
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
+    UIWidget.ATLANTIC_ELECTRICAL_HEATER_WITH_ADJUSTABLE_TEMPERATURE_SETPOINT: AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
     UIWidget.SOMFY_THERMOSTAT: SomfyThermostat,
 }

--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -5,8 +5,6 @@ from .atlantic_electrical_heater import AtlanticElectricalHeater
 from .atlantic_electrical_heater_with_adjustable_temperature_setpoint import (
     AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
 )
-
-from .atlantic_electrical_heater import AtlanticElectricalHeater
 from .atlantic_electrical_towel_dryer import AtlanticElectricalTowelDryer
 from .atlantic_heat_recovery_ventilation import AtlanticHeatRecoveryVentilation
 from .atlantic_pass_apc_heating_and_cooling_zone import (
@@ -17,10 +15,10 @@ from .somfy_thermostat import SomfyThermostat
 
 WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: AtlanticElectricalHeater,
+    UIWidget.ATLANTIC_ELECTRICAL_HEATER_WITH_ADJUSTABLE_TEMPERATURE_SETPOINT: AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
     UIWidget.ATLANTIC_ELECTRICAL_TOWEL_DRYER: AtlanticElectricalTowelDryer,
     UIWidget.ATLANTIC_HEAT_RECOVERY_VENTILATION: AtlanticHeatRecoveryVentilation,
     UIWidget.ATLANTIC_PASS_APC_HEATING_AND_COOLING_ZONE: AtlanticPassAPCHeatingAndCoolingZone,
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
-    UIWidget.ATLANTIC_ELECTRICAL_HEATER_WITH_ADJUSTABLE_TEMPERATURE_SETPOINT: AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint,
     UIWidget.SOMFY_THERMOSTAT: SomfyThermostat,
 }

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -53,6 +53,8 @@ OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
 
 HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
 
+TEMPERATURE_SENSOR_DEVICE_INDEX = 2
+
 
 class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     OverkizEntity, ClimateEntity
@@ -71,7 +73,9 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     ) -> None:
         """Init method."""
         super().__init__(device_url, coordinator)
-        self.temperature_device = self.executor.linked_device(2)
+        self.temperature_device = self.executor.linked_device(
+            TEMPERATURE_SENSOR_DEVICE_INDEX
+        )
 
     @property
     def hvac_mode(self) -> str:

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -1,9 +1,9 @@
 """Support for Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
-from pyoverkiz.enums import OverkizCommand, OverkizState
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -25,37 +25,33 @@ PRESET_COMFORT2 = "comfort-2"
 PRESET_FROST_PROTECTION = "frost_protection"
 PRESET_PROG = "prog"
 
-PRESET_STATE_ECO = "eco"
-PRESET_STATE_BOOST = "boost"
-PRESET_STATE_COMFORT = "comfort"
 
-
-# Map TaHoma presets to Home Assistant presets
+# Map Overkiz presets to Home Assistant presets
 OVERKIZ_TO_PRESET_MODE = {
-    "off": PRESET_NONE,
-    "frostprotection": PRESET_FROST_PROTECTION,
-    "eco": PRESET_ECO,
-    "comfort": PRESET_COMFORT,
-    "comfort-1": PRESET_COMFORT1,
-    "comfort-2": PRESET_COMFORT2,
-    "auto": PRESET_AUTO,
-    "boost": PRESET_BOOST,
-    "internal": PRESET_PROG,
+    OverkizCommandParam.OFF: PRESET_NONE,
+    OverkizCommandParam.FROSTPROTECTION: PRESET_FROST_PROTECTION,
+    OverkizCommandParam.ECO: PRESET_ECO,
+    OverkizCommandParam.COMFORT: PRESET_COMFORT,
+    OverkizCommandParam.COMFORT_1: PRESET_COMFORT1,
+    OverkizCommandParam.COMFORT_2: PRESET_COMFORT2,
+    OverkizCommandParam.AUTO: PRESET_AUTO,
+    OverkizCommandParam.BOOST: PRESET_BOOST,
+    OverkizCommandParam.INTERNAL: PRESET_PROG,
 }
 
-PRESET_MODE_TO_TAHOMA = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
+PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
 
-# Map TaHoma HVAC modes to Home Assistant HVAC modes
+# Map Overkiz HVAC modes to Home Assistant HVAC modes
 OVERKIZ_TO_HVAC_MODE = {
-    "on": HVACMode.HEAT,
-    "off": HVACMode.OFF,
-    "auto": HVACMode.AUTO,
-    "basic": HVACMode.HEAT,
-    "standby": HVACMode.OFF,
-    "internal": HVACMode.AUTO,
+    OverkizCommandParam.ON: HVACMode.HEAT,
+    OverkizCommandParam.OFF: HVACMode.OFF,
+    OverkizCommandParam.AUTO: HVACMode.AUTO,
+    OverkizCommandParam.BASIC: HVACMode.HEAT,
+    OverkizCommandParam.STANDBY: HVACMode.OFF,
+    OverkizCommandParam.INTERNAL: HVACMode.AUTO,
 }
 
-HVAC_MODE_TO_TAHOMA = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
 
 
 class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
@@ -63,8 +59,8 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
 ):
     """Representation of Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
 
-    _attr_hvac_modes = [*HVAC_MODE_TO_TAHOMA]
-    _attr_preset_modes = [*PRESET_MODE_TO_TAHOMA]
+    _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
+    _attr_preset_modes = [*PRESET_MODE_TO_OVERKIZ]
     _attr_temperature_unit = TEMP_CELSIUS
     _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
@@ -78,57 +74,54 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         self.temperature_device = self.executor.linked_device(2)
 
     @property
-    def hvac_mode(self) -> str:
+    def hvac_mode(self) -> str | None:
         """Return hvac operation ie. heat, cool mode."""
-
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
-            return OVERKIZ_TO_HVAC_MODE[
-                self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
-            ]
+            state = self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
+            return OVERKIZ_TO_HVAC_MODE[OverkizCommandParam(state)]
         if OverkizState.CORE_ON_OFF in self.device.states:
-            return OVERKIZ_TO_HVAC_MODE[
-                self.executor.select_state(OverkizState.CORE_ON_OFF)
-            ]
+            state = self.executor.select_state(OverkizState.CORE_ON_OFF)
+            return OVERKIZ_TO_HVAC_MODE[OverkizCommandParam(state)]
 
-    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        return None
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
             await self.executor.async_execute_command(
-                OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_TAHOMA[hvac_mode]
+                OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
             )
         else:
             if hvac_mode == HVACMode.OFF:
-                await self.executor.async_execute_command(
-                    OverkizCommand.OFF,
-                )
+                await self.executor.async_execute_command(OverkizCommand.OFF)
             else:
                 await self.executor.async_execute_command(
-                    OverkizCommand.SET_HEATING_LEVEL, PRESET_STATE_COMFORT
+                    OverkizCommand.SET_HEATING_LEVEL, OverkizCommandParam.COMFORT
                 )
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
-        return OVERKIZ_TO_PRESET_MODE[
-            self.executor.select_state(OverkizState.IO_TARGET_HEATING_LEVEL)
-        ]
+        if state := self.device.states[OverkizState.IO_TARGET_HEATING_LEVEL]:
+            return OVERKIZ_TO_PRESET_MODE[OverkizCommandParam(state.value)]
+        return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode in [PRESET_AUTO, PRESET_PROG]:
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_OPERATING_MODE, PRESET_MODE_TO_TAHOMA[preset_mode]
-            )
+            command = OverkizCommand.SET_OPERATING_MODE
         else:
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_HEATING_LEVEL, PRESET_MODE_TO_TAHOMA[preset_mode]
-            )
+            command = OverkizCommand.SET_HEATING_LEVEL
+        await self.executor.async_execute_command(
+            command, PRESET_MODE_TO_OVERKIZ[preset_mode]
+        )
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature."""
         if OverkizState.CORE_TARGET_TEMPERATURE in self.device.states:
-            return self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+            state = self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+            return cast(float, state)
         return None
 
     @property
@@ -138,7 +131,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             return cast(float, temperature.value)
         return None
 
-    async def async_set_temperature(self, **kwargs) -> None:
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -89,16 +89,9 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if OverkizState.CORE_OPERATING_MODE in self.device.states:
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
-            )
-        elif hvac_mode == HVACMode.OFF:
-            await self.executor.async_execute_command(OverkizCommand.OFF)
-        else:
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_HEATING_LEVEL, OverkizCommandParam.COMFORT
-            )
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
+        )
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -91,13 +91,12 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             await self.executor.async_execute_command(
                 OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
             )
+        elif hvac_mode == HVACMode.OFF:
+            await self.executor.async_execute_command(OverkizCommand.OFF)
         else:
-            if hvac_mode == HVACMode.OFF:
-                await self.executor.async_execute_command(OverkizCommand.OFF)
-            else:
-                await self.executor.async_execute_command(
-                    OverkizCommand.SET_HEATING_LEVEL, OverkizCommandParam.COMFORT
-                )
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_HEATING_LEVEL, OverkizCommandParam.COMFORT
+            )
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -5,12 +5,12 @@ from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
-from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (
+from homeassistant.components.climate import (
     PRESET_BOOST,
     PRESET_COMFORT,
     PRESET_ECO,
     PRESET_NONE,
+    ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
 )

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -55,7 +55,7 @@ OVERKIZ_TO_HVAC_MODE = {
     "internal": HVACMode.AUTO,
 }
 
-_TO_TAHOMA = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+HVAC_MODE_TO_TAHOMA = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
 
 
 class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
@@ -63,7 +63,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
 ):
     """Representation of Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
 
-    _attr_hvac_modes = [*_TO_TAHOMA]
+    _attr_hvac_modes = [*HVAC_MODE_TO_TAHOMA]
     _attr_preset_modes = [*PRESET_MODE_TO_TAHOMA]
     _attr_temperature_unit = TEMP_CELSIUS
     _attr_supported_features = (
@@ -94,7 +94,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         """Set new target hvac mode."""
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
             await self.executor.async_execute_command(
-                OverkizCommand.SET_OPERATING_MODE, _TO_TAHOMA[hvac_mode]
+                OverkizCommand.SET_OPERATING_MODE, HVAC_MODE_TO_TAHOMA[hvac_mode]
             )
         else:
             if hvac_mode == HVACMode.OFF:

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -1,0 +1,146 @@
+"""Support for Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
+from __future__ import annotations
+
+from typing import cast
+
+from pyoverkiz.enums import OverkizCommand, OverkizState
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_NONE,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+from ..coordinator import OverkizDataUpdateCoordinator
+from ..entity import OverkizEntity
+
+PRESET_AUTO = "auto"
+PRESET_COMFORT1 = "comfort-1"
+PRESET_COMFORT2 = "comfort-2"
+PRESET_FROST_PROTECTION = "frost_protection"
+PRESET_PROG = "prog"
+
+PRESET_STATE_ECO = "eco"
+PRESET_STATE_BOOST = "boost"
+PRESET_STATE_COMFORT = "comfort"
+
+
+# Map TaHoma presets to Home Assistant presets
+OVERKIZ_TO_PRESET_MODE = {
+    "off": PRESET_NONE,
+    "frostprotection": PRESET_FROST_PROTECTION,
+    "eco": PRESET_ECO,
+    "comfort": PRESET_COMFORT,
+    "comfort-1": PRESET_COMFORT1,
+    "comfort-2": PRESET_COMFORT2,
+    "auto": PRESET_AUTO,
+    "boost": PRESET_BOOST,
+    "internal": PRESET_PROG,
+}
+
+PRESET_MODE_TO_TAHOMA = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
+
+# Map TaHoma HVAC modes to Home Assistant HVAC modes
+OVERKIZ_TO_HVAC_MODE = {
+    "on": HVACMode.HEAT,
+    "off": HVACMode.OFF,
+    "auto": HVACMode.AUTO,
+    "basic": HVACMode.HEAT,
+    "standby": HVACMode.OFF,
+    "internal": HVACMode.AUTO,
+}
+
+_TO_TAHOMA = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+
+
+class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
+    OverkizEntity, ClimateEntity
+):
+    """Representation of Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
+
+    _attr_hvac_modes = [*_TO_TAHOMA]
+    _attr_preset_modes = [*PRESET_MODE_TO_TAHOMA]
+    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_supported_features = (
+        ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
+    )
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Init method."""
+        super().__init__(device_url, coordinator)
+        self.temperature_device = self.executor.linked_device(2)
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+
+        if OverkizState.CORE_OPERATING_MODE in self.device.states:
+            return OVERKIZ_TO_HVAC_MODE[
+                self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
+            ]
+        if OverkizState.CORE_ON_OFF in self.device.states:
+            return OVERKIZ_TO_HVAC_MODE[
+                self.executor.select_state(OverkizState.CORE_ON_OFF)
+            ]
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        if OverkizState.CORE_OPERATING_MODE in self.device.states:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_OPERATING_MODE, _TO_TAHOMA[hvac_mode]
+            )
+        else:
+            if hvac_mode == HVACMode.OFF:
+                await self.executor.async_execute_command(
+                    OverkizCommand.OFF,
+                )
+            else:
+                await self.executor.async_execute_command(
+                    OverkizCommand.SET_HEATING_LEVEL, PRESET_STATE_COMFORT
+                )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return OVERKIZ_TO_PRESET_MODE[
+            self.executor.select_state(OverkizState.IO_TARGET_HEATING_LEVEL)
+        ]
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode in [PRESET_AUTO, PRESET_PROG]:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_OPERATING_MODE, PRESET_MODE_TO_TAHOMA[preset_mode]
+            )
+        else:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_HEATING_LEVEL, PRESET_MODE_TO_TAHOMA[preset_mode]
+            )
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the temperature."""
+        if OverkizState.CORE_TARGET_TEMPERATURE in self.device.states:
+            return self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+        return None
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+            return cast(float, temperature.value)
+        return None
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new temperature."""
+        temperature = kwargs[ATTR_TEMPERATURE]
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_TARGET_TEMPERATURE, temperature
+        )

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -74,7 +74,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         self.temperature_device = self.executor.linked_device(2)
 
     @property
-    def hvac_mode(self) -> str | None:
+    def hvac_mode(self) -> str:
         """Return hvac operation ie. heat, cool mode."""
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
             state = self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
@@ -83,7 +83,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             state = self.executor.select_state(OverkizState.CORE_ON_OFF)
             return OVERKIZ_TO_HVAC_MODE[OverkizCommandParam(state)]
 
-        return None
+        return HVACMode.OFF
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -1,7 +1,7 @@
 """Support for Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -77,10 +77,10 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     def hvac_mode(self) -> str:
         """Return hvac operation ie. heat, cool mode."""
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
-            state = self.executor.select_state(OverkizState.CORE_OPERATING_MODE)
+            state = self.device.states[OverkizState.CORE_OPERATING_MODE]
             return OVERKIZ_TO_HVAC_MODE[OverkizCommandParam(state)]
         if OverkizState.CORE_ON_OFF in self.device.states:
-            state = self.executor.select_state(OverkizState.CORE_ON_OFF)
+            state = self.device.states[OverkizState.CORE_ON_OFF]
             return OVERKIZ_TO_HVAC_MODE[OverkizCommandParam(state)]
 
         return HVACMode.OFF
@@ -118,16 +118,15 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature."""
-        if OverkizState.CORE_TARGET_TEMPERATURE in self.device.states:
-            state = self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
-            return cast(float, state)
+        if state := self.device.states[OverkizState.CORE_TARGET_TEMPERATURE]:
+            return state.value_as_float
         return None
 
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
-            return cast(float, temperature.value)
+            return temperature.value_as_float
         return None
 
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -63,6 +63,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIClass.WINDOW: Platform.COVER,
     UIWidget.ALARM_PANEL_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
+    UIWidget.ATLANTIC_ELECTRICAL_HEATER_WITH_ADJUSTABLE_TEMPERATURE_SETPOINT: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.ATLANTIC_ELECTRICAL_TOWEL_DRYER: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.ATLANTIC_HEAT_RECOVERY_VENTILATION: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.ATLANTIC_PASS_APC_DHW: Platform.WATER_HEATER,  # widgetName, uiClass is WaterHeatingSystem (not supported)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As explained in #67045, we continue to add one by one all the climate devices we support. Here, AEH with adjustable temperature.
Sauter Ipala Electrical Heater is an example of such device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65427
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
