### PR TITLE
Download multiple packages in parallel when building images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,22 @@ WORKDIR /usr/src
 ## Setup Home Assistant Core dependencies
 COPY requirements.txt homeassistant/
 COPY homeassistant/package_constraints.txt homeassistant/homeassistant/
+RUN \ 
+   cat homeassistant/requirements.txt | grep -v ^# | grep -v ^- | xargs -P 6 -n 4 -- \
+   pip3 download --no-index --only-binary=:all: \
+   --find-links "${WHEELS_LINKS}" --use-deprecated=legacy-resolver \
+   --cache-dir "/tmp/pip_cache"
 RUN \
-    pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -r homeassistant/requirements.txt --use-deprecated=legacy-resolver
+    pip3 install --cache-dir "/tmp/pip_cache" --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
+    -r homeassistant/requirements.txt --use-deprecated=legacy-resolver ; exit 0
 COPY requirements_all.txt homeassistant/
+RUN \ 
+   cat homeassistant/requirements_all.txt | grep -v ^# | grep -v ^- | xargs -P 8 -n 120 -- \
+   pip3 download --no-index --only-binary=:all: \
+   --find-links "${WHEELS_LINKS}" --use-deprecated=legacy-resolver \
+   --cache-dir "/tmp/pip_cache" ; exit 0
 RUN \
-    pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
+    pip3 install --cache-dir "/tmp/pip_cache" --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
     -r homeassistant/requirements_all.txt --use-deprecated=legacy-resolver
 
 ## Setup Home Assistant Core

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ RUN \
    grep -v '^[#-]' < homeassistant/requirements.txt | xargs -P 6 -n 4 -- \
    pip3 download --no-index --only-binary=:all: \
    --find-links "${WHEELS_LINKS}" --use-deprecated=legacy-resolver \
-   --cache-dir "/tmp/pip_cache"
+   --cache-dir "/tmp/pip_cache" ; exit 0
 RUN \
     pip3 install --cache-dir "/tmp/pip_cache" --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -r homeassistant/requirements.txt --use-deprecated=legacy-resolver ; exit 0
+    -r homeassistant/requirements.txt --use-deprecated=legacy-resolver
 COPY requirements_all.txt homeassistant/
 # hadolint ignore=DL4006
 RUN \ 
@@ -29,6 +29,8 @@ RUN \
 RUN \
     pip3 install --cache-dir "/tmp/pip_cache" --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
     -r homeassistant/requirements_all.txt --use-deprecated=legacy-resolver
+
+RUN rm -rf /tmp/pip_cache
 
 ## Setup Home Assistant Core
 COPY . homeassistant/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /usr/src
 ## Setup Home Assistant Core dependencies
 COPY requirements.txt homeassistant/
 COPY homeassistant/package_constraints.txt homeassistant/homeassistant/
+# hadolint ignore=DL4006
 RUN \ 
    cat homeassistant/requirements.txt | grep -v ^# | grep -v ^- | xargs -P 6 -n 4 -- \
    pip3 download --no-index --only-binary=:all: \
@@ -19,6 +20,7 @@ RUN \
     pip3 install --cache-dir "/tmp/pip_cache" --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
     -r homeassistant/requirements.txt --use-deprecated=legacy-resolver ; exit 0
 COPY requirements_all.txt homeassistant/
+# hadolint ignore=DL4006
 RUN \ 
    cat homeassistant/requirements_all.txt | grep -v ^# | grep -v ^- | xargs -P 8 -n 120 -- \
    pip3 download --no-index --only-binary=:all: \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt homeassistant/
 COPY homeassistant/package_constraints.txt homeassistant/homeassistant/
 # hadolint ignore=DL4006
 RUN \ 
-   cat homeassistant/requirements.txt | grep -v ^# | grep -v ^- | xargs -P 6 -n 4 -- \
+   grep -v '^[#-]' < homeassistant/requirements.txt | xargs -P 6 -n 4 -- \
    pip3 download --no-index --only-binary=:all: \
    --find-links "${WHEELS_LINKS}" --use-deprecated=legacy-resolver \
    --cache-dir "/tmp/pip_cache"
@@ -22,7 +22,7 @@ RUN \
 COPY requirements_all.txt homeassistant/
 # hadolint ignore=DL4006
 RUN \ 
-   cat homeassistant/requirements_all.txt | grep -v ^# | grep -v ^- | xargs -P 8 -n 120 -- \
+   grep -v '^[#-]' < homeassistant/requirements_all.txt | xargs -P 8 -n 120 -- \
    pip3 download --no-index --only-binary=:all: \
    --find-links "${WHEELS_LINKS}" --use-deprecated=legacy-resolver \
    --cache-dir "/tmp/pip_cache" ; exit 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- I adapted this from my dev env build script since I have
  a higher latency connection parts of the year, and I got a bit
  annoyed at how long it took to make a dev env.

Opening this for feedback since I figure it could be useful
here as well.

While its much faster for me for building dev envs I'm not sure how this will
actually perform in this context, but I figure its worth a shot
if we get faster images.

Tested with `docker build -t hass/test1 --build-arg BUILD_FROM='ghcr.io/home-assistant/amd64-homeassistant-base:2022.02.0' --build-arg BUILD_ARCH=amd64 .`

This one is hard to know what the outcome will be since the local test performance vs how it runs on github is likely to be quite different

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
