### PR TITLE
Support add/next/play/replace enqueue options in Sonos

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -576,9 +576,14 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 self.set_shuffle(True)
             if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.ADD:
                 plex_plugin.add_to_queue(result.media)
-            elif kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.NEXT:
+            elif kwargs.get(ATTR_MEDIA_ENQUEUE) in (
+                MediaPlayerEnqueue.NEXT,
+                MediaPlayerEnqueue.PLAY,
+            ):
                 pos = (self.media.queue_position or 0) + 1
-                plex_plugin.add_to_queue(result.media, position=pos)
+                new_pos = plex_plugin.add_to_queue(result.media, position=pos)
+                if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.PLAY:
+                    soco.play_from_queue(new_pos - 1)
             else:
                 soco.clear_queue()
                 plex_plugin.add_to_queue(result.media)
@@ -589,9 +594,14 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         if share_link.is_share_link(media_id):
             if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.ADD:
                 share_link.add_share_link_to_queue(media_id)
-            elif kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.NEXT:
+            elif kwargs.get(ATTR_MEDIA_ENQUEUE) in (
+                MediaPlayerEnqueue.NEXT,
+                MediaPlayerEnqueue.PLAY,
+            ):
                 pos = (self.media.queue_position or 0) + 1
-                share_link.add_share_link_to_queue(media_id, position=pos)
+                new_pos = share_link.add_share_link_to_queue(media_id, position=pos)
+                if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.PLAY:
+                    soco.play_from_queue(new_pos - 1)
             else:
                 soco.clear_queue()
                 share_link.add_share_link_to_queue(media_id)
@@ -602,9 +612,14 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
             if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.ADD:
                 soco.add_uri_to_queue(media_id)
-            elif kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.NEXT:
+            elif kwargs.get(ATTR_MEDIA_ENQUEUE) in (
+                MediaPlayerEnqueue.NEXT,
+                MediaPlayerEnqueue.PLAY,
+            ):
                 pos = (self.media.queue_position or 0) + 1
-                soco.add_uri_to_queue(media_id, position=pos)
+                new_pos = soco.add_uri_to_queue(media_id, position=pos)
+                if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.PLAY:
+                    soco.play_from_queue(new_pos - 1)
             else:
                 soco.play_uri(media_id, force_radio=is_radio)
         elif media_type == MEDIA_TYPE_PLAYLIST:

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -576,6 +576,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 self.set_shuffle(True)
             if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.ADD:
                 plex_plugin.add_to_queue(result.media)
+            elif kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.NEXT:
+                pos = (self.media.queue_position or 0) + 1
+                plex_plugin.add_to_queue(result.media, position=pos)
             else:
                 soco.clear_queue()
                 plex_plugin.add_to_queue(result.media)
@@ -586,6 +589,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         if share_link.is_share_link(media_id):
             if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.ADD:
                 share_link.add_share_link_to_queue(media_id)
+            elif kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.NEXT:
+                pos = (self.media.queue_position or 0) + 1
+                share_link.add_share_link_to_queue(media_id, position=pos)
             else:
                 soco.clear_queue()
                 share_link.add_share_link_to_queue(media_id)
@@ -596,6 +602,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
             if kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.ADD:
                 soco.add_uri_to_queue(media_id)
+            elif kwargs.get(ATTR_MEDIA_ENQUEUE) == MediaPlayerEnqueue.NEXT:
+                pos = (self.media.queue_position or 0) + 1
+                soco.add_uri_to_queue(media_id, position=pos)
             else:
                 soco.play_uri(media_id, force_radio=is_radio)
         elif media_type == MEDIA_TYPE_PLAYLIST:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support the new `add`/`next`/`play`/`replace` enqueue options added in #72406 for Sonos.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
