### PR TITLE
Sync empty entities when Google is disabled in cloud

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -210,10 +210,10 @@ class CloudClient(Interface):
 
     async def async_google_message(self, payload: dict[Any, Any]) -> dict[Any, Any]:
         """Process cloud google message to client."""
-        if not self._prefs.google_enabled:
-            return ga.turned_off_response(payload)
-
         gconf = await self.get_google_config()
+
+        if not self._prefs.google_enabled:
+            return ga.api_disabled_response(payload, gconf.agent_user_id)
 
         return await ga.async_handle_message(
             self._hass, gconf, gconf.cloud_user, payload, gc.SOURCE_CLOUD

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -219,6 +219,7 @@ class CloudGoogleConfig(AbstractConfig):
             sync_entities = True
         elif not self.enabled and self.is_local_sdk_active:
             self.async_disable_local_sdk()
+            sync_entities = True
 
         self._cur_entity_prefs = prefs.google_entity_configs
         self._cur_default_expose = prefs.google_default_expose

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -356,9 +356,6 @@ class AbstractConfig(ABC):
                 pprint.pformat(payload),
             )
 
-        if not self.enabled:
-            return json_response(smart_home.turned_off_response(payload))
-
         if (agent_user_id := self.get_local_agent_user_id(webhook_id)) is None:
             # No agent user linked to this webhook, means that the user has somehow unregistered
             # removing webhook and stopping processing of this request.
@@ -369,6 +366,11 @@ class AbstractConfig(ABC):
             )
             webhook.async_unregister(self.hass, webhook_id)
             return None
+
+        if not self.enabled:
+            return json_response(
+                smart_home.api_disabled_response(payload, agent_user_id)
+            )
 
         result = await smart_home.async_handle_message(
             self.hass,

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -134,7 +134,16 @@ async def test_handler_google_actions(hass):
     assert device["roomHint"] == "living room"
 
 
-async def test_handler_google_actions_disabled(hass, mock_cloud_fixture):
+@pytest.mark.parametrize(
+    "intent,response_payload",
+    [
+        ("action.devices.SYNC", {"agentUserId": "myUserName", "devices": []}),
+        ("action.devices.QUERY", {"errorCode": "deviceTurnedOff"}),
+    ],
+)
+async def test_handler_google_actions_disabled(
+    hass, mock_cloud_fixture, intent, response_payload
+):
     """Test handler Google Actions when user has disabled it."""
     mock_cloud_fixture._prefs[PREF_ENABLE_GOOGLE] = False
 
@@ -142,13 +151,17 @@ async def test_handler_google_actions_disabled(hass, mock_cloud_fixture):
         assert await async_setup_component(hass, "cloud", {})
 
     reqid = "5711642932632160983"
-    data = {"requestId": reqid, "inputs": [{"intent": "action.devices.SYNC"}]}
+    data = {"requestId": reqid, "inputs": [{"intent": intent}]}
 
     cloud = hass.data["cloud"]
-    resp = await cloud.client.async_google_message(data)
+    with patch(
+        "hass_nabucasa.Cloud._decode_claims",
+        return_value={"cognito:username": "myUserName"},
+    ):
+        resp = await cloud.client.async_google_message(data)
 
     assert resp["requestId"] == reqid
-    assert resp["payload"]["errorCode"] == "deviceTurnedOff"
+    assert resp["payload"] == response_payload
 
 
 async def test_webhook_msg(hass, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alternative to #72805.

If we merge #72805, should be reverted to make this PR work.

When Google API is disabled in cloud and Google triggers a sync, sync empty devices back so Google forgets the devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
