### PR TITLE
Add test for mikrotik device tracker with numerical device name

### DIFF
--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -32,6 +32,14 @@ DEVICE_2_DHCP = {
     "host-name": "Device_2",
     "comment": "PC",
 }
+DEVICE_3_DHCP_NUMERIC_NAME = {
+    ".id": "*1C",
+    "address": "0.0.0.3",
+    "mac-address": "00:00:00:00:00:03",
+    "active-address": "0.0.0.3",
+    "host-name": 123,
+    "comment": "Mobile",
+}
 DEVICE_1_WIRELESS = {
     ".id": "*264",
     "interface": "wlan1",
@@ -68,38 +76,16 @@ DEVICE_1_WIRELESS = {
 }
 
 DEVICE_2_WIRELESS = {
+    **DEVICE_1_WIRELESS,
     ".id": "*265",
-    "interface": "wlan1",
     "mac-address": "00:00:00:00:00:02",
-    "ap": False,
-    "wds": False,
-    "bridge": False,
-    "rx-rate": "72.2Mbps-20MHz/1S/SGI",
-    "tx-rate": "72.2Mbps-20MHz/1S/SGI",
-    "packets": "59542,17464",
-    "bytes": "17536671,2966351",
-    "frames": "59542,17472",
-    "frame-bytes": "17655785,2862445",
-    "hw-frames": "78935,38395",
-    "hw-frame-bytes": "25636019,4063445",
-    "tx-frames-timed-out": 0,
-    "uptime": "5h49m36s",
-    "last-activity": "170ms",
-    "signal-strength": "-62@1Mbps",
-    "signal-to-noise": 52,
-    "signal-strength-ch0": -63,
-    "signal-strength-ch1": -69,
-    "strength-at-rates": "-62@1Mbps 16s330ms,-64@6Mbps 13s560ms,-65@HT20-3 52m6s30ms,-66@HT20-4 52m4s350ms,-66@HT20-5 51m58s580ms,-65@HT20-6 51m24s780ms,-65@HT20-7 5s680ms",
-    "tx-ccq": 93,
-    "p-throughput": 54928,
     "last-ip": "0.0.0.2",
-    "802.1x-port-enabled": True,
-    "authentication-type": "wpa2-psk",
-    "encryption": "aes-ccm",
-    "group-encryption": "aes-ccm",
-    "management-protection": False,
-    "wmm-enabled": True,
-    "tx-rate-set": "OFDM:6-54 BW:1x SGI:1x HT:0-7",
+}
+DEVICE_3_WIRELESS = {
+    **DEVICE_1_WIRELESS,
+    ".id": "*266",
+    "mac-address": "00:00:00:00:00:03",
+    "last-ip": "0.0.0.3",
 }
 DHCP_DATA = [DEVICE_1_DHCP, DEVICE_2_DHCP]
 

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -9,7 +9,15 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import DEVICE_2_WIRELESS, DHCP_DATA, MOCK_DATA, MOCK_OPTIONS, WIRELESS_DATA
+from . import (
+    DEVICE_2_WIRELESS,
+    DEVICE_3_DHCP_NUMERIC_NAME,
+    DEVICE_3_WIRELESS,
+    DHCP_DATA,
+    MOCK_DATA,
+    MOCK_OPTIONS,
+    WIRELESS_DATA,
+)
 from .test_hub import setup_mikrotik_entry
 
 from tests.common import MockConfigEntry, patch
@@ -27,6 +35,7 @@ def mock_device_registry_devices(hass):
         (
             "00:00:00:00:00:01",
             "00:00:00:00:00:02",
+            "00:00:00:00:00:03",
         )
     ):
         dev_reg.async_get_or_create(
@@ -113,6 +122,24 @@ async def test_device_trackers(hass, mock_device_registry_devices):
 
         device_2 = hass.states.get("device_tracker.device_2")
         assert device_2.state == "not_home"
+
+
+async def test_device_trackers_numerical_name(hass, mock_device_registry_devices):
+    """Test device_trackers created by mikrotik with numerical device name."""
+
+    await setup_mikrotik_entry(
+        hass, dhcp_data=[DEVICE_3_DHCP_NUMERIC_NAME], wireless_data=[DEVICE_3_WIRELESS]
+    )
+
+    device_3 = hass.states.get("device_tracker.123")
+    assert device_3 is not None
+    assert device_3.state == "home"
+    assert device_3.attributes["friendly_name"] == "123"
+    assert device_3.attributes["ip"] == "0.0.0.3"
+    assert "ip_address" not in device_3.attributes
+    assert device_3.attributes["mac"] == "00:00:00:00:00:03"
+    assert device_3.attributes["host_name"] == 123
+    assert "mac_address" not in device_3.attributes
 
 
 async def test_restoring_devices(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add test for mikrotik device tracker with numerical device name

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
