### PR TITLE
Fix logbook not setting up with an recorder filter that has empty fields

### DIFF
--- a/homeassistant/components/recorder/filters.py
+++ b/homeassistant/components/recorder/filters.py
@@ -36,7 +36,7 @@ def extract_include_exclude_filter_conf(conf: ConfigType) -> dict[str, Any]:
     """
     return {
         filter_type: {
-            matcher: set(conf.get(filter_type, {}).get(matcher, []))
+            matcher: set(conf.get(filter_type, {}).get(matcher) or [])
             for matcher in FITLER_MATCHERS
         }
         for filter_type in FILTER_TYPES

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 import voluptuous as vol
 
-from homeassistant.components import logbook
+from homeassistant.components import logbook, recorder
 from homeassistant.components.alexa.smart_home import EVENT_ALEXA_SMART_HOME
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.logbook.models import LazyEventPartialState
@@ -2796,3 +2796,39 @@ async def test_get_events_with_context_state(hass, hass_ws_client, recorder_mock
     assert results[3]["context_state"] == "off"
     assert results[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
     assert "context_event_type" not in results[3]
+
+
+async def test_logbook_with_empty_config(hass, recorder_mock):
+    """Test we handle a empty configuration."""
+    assert await async_setup_component(
+        hass,
+        logbook.DOMAIN,
+        {
+            logbook.DOMAIN: {},
+            recorder.DOMAIN: {},
+        },
+    )
+    await hass.async_block_till_done()
+
+
+async def test_logbook_with_non_iterable_entity_filter(hass, recorder_mock):
+    """Test we handle a non-iterable entity filter."""
+    assert await async_setup_component(
+        hass,
+        logbook.DOMAIN,
+        {
+            logbook.DOMAIN: {
+                CONF_EXCLUDE: {
+                    CONF_ENTITIES: ["light.additional_excluded"],
+                }
+            },
+            recorder.DOMAIN: {
+                CONF_EXCLUDE: {
+                    CONF_ENTITIES: None,
+                    CONF_DOMAINS: None,
+                    CONF_ENTITY_GLOBS: None,
+                }
+            },
+        },
+    )
+    await hass.async_block_till_done()

--- a/tests/components/recorder/test_filters.py
+++ b/tests/components/recorder/test_filters.py
@@ -12,6 +12,13 @@ from homeassistant.helpers.entityfilter import (
     CONF_INCLUDE,
 )
 
+EMPTY_INCLUDE_FILTER = {
+    CONF_INCLUDE: {
+        CONF_DOMAINS: None,
+        CONF_ENTITIES: None,
+        CONF_ENTITY_GLOBS: None,
+    }
+}
 SIMPLE_INCLUDE_FILTER = {
     CONF_INCLUDE: {
         CONF_DOMAINS: ["homeassistant"],
@@ -86,6 +93,19 @@ def test_extract_include_exclude_filter_conf():
     # verify it really is a copy
     assert SIMPLE_INCLUDE_EXCLUDE_FILTER[CONF_EXCLUDE][CONF_ENTITIES] != {
         "cover.altered"
+    }
+    empty_include_filter = extract_include_exclude_filter_conf(EMPTY_INCLUDE_FILTER)
+    assert empty_include_filter == {
+        CONF_EXCLUDE: {
+            CONF_DOMAINS: set(),
+            CONF_ENTITIES: set(),
+            CONF_ENTITY_GLOBS: set(),
+        },
+        CONF_INCLUDE: {
+            CONF_DOMAINS: set(),
+            CONF_ENTITIES: set(),
+            CONF_ENTITY_GLOBS: set(),
+        },
     }
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the recorder had a filter configured with one or more
of the values being `None`, the logbook could not setup

Reported here https://community.home-assistant.io/t/2022-6-gaining-new-insights/426893/56?u=bdraco


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
