### PR TITLE
Cleanup nest config flow tests to use common setup fixtures

### DIFF
--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -25,6 +25,9 @@ PlatformSetup = Callable[[], Awaitable[None]]
 _T = TypeVar("_T")
 YieldFixture = Generator[_T, None, None]
 
+WEB_AUTH_DOMAIN = DOMAIN
+APP_AUTH_DOMAIN = f"{DOMAIN}.installed"
+
 PROJECT_ID = "some-project-id"
 CLIENT_ID = "some-client-id"
 CLIENT_SECRET = "some-client-secret"
@@ -81,7 +84,6 @@ TEST_CONFIG_YAML_ONLY = NestTestConfig(
     config=CONFIG,
     config_entry_data={
         "sdm": {},
-        "auth_implementation": "nest",
         "token": create_token_entry(),
     },
 )
@@ -101,7 +103,6 @@ TEST_CONFIG_HYBRID = NestTestConfig(
     },
     config_entry_data={
         "sdm": {},
-        "auth_implementation": "nest",
         "token": create_token_entry(),
         "cloud_project_id": CLOUD_PROJECT_ID,
         "subscriber_id": SUBSCRIBER_ID,

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -28,7 +28,9 @@ YieldFixture = Generator[_T, None, None]
 PROJECT_ID = "some-project-id"
 CLIENT_ID = "some-client-id"
 CLIENT_SECRET = "some-client-secret"
-SUBSCRIBER_ID = "projects/example/subscriptions/subscriber-id-9876"
+CLOUD_PROJECT_ID = "cloud-id-9876"
+SUBSCRIBER_ID = "projects/cloud-id-9876/subscriptions/subscriber-id-9876"
+
 
 CONFIG = {
     "nest": {
@@ -83,6 +85,9 @@ TEST_CONFIG_YAML_ONLY = NestTestConfig(
         "token": create_token_entry(),
     },
 )
+TEST_CONFIGFLOW_YAML_ONLY = NestTestConfig(
+    config=TEST_CONFIG_YAML_ONLY.config, config_entry_data=None
+)
 
 # Exercises mode where subscriber id is created in the config flow, but
 # all authentication is defined in configuration.yaml
@@ -98,8 +103,12 @@ TEST_CONFIG_HYBRID = NestTestConfig(
         "sdm": {},
         "auth_implementation": "nest",
         "token": create_token_entry(),
+        "cloud_project_id": CLOUD_PROJECT_ID,
         "subscriber_id": SUBSCRIBER_ID,
     },
+)
+TEST_CONFIGFLOW_HYBRID = NestTestConfig(
+    TEST_CONFIG_HYBRID.config, config_entry_data=None
 )
 
 TEST_CONFIG_LEGACY = NestTestConfig(

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -24,6 +24,7 @@ from .common import (
     SUBSCRIBER_ID,
     TEST_CONFIG_HYBRID,
     TEST_CONFIG_YAML_ONLY,
+    WEB_AUTH_DOMAIN,
     CreateDevice,
     FakeSubscriber,
     NestTestConfig,
@@ -184,7 +185,7 @@ def subscriber_id() -> str:
 @pytest.fixture
 def auth_implementation() -> str | None:
     """Fixture to let tests override the auth implementation in the config entry."""
-    return None
+    return WEB_AUTH_DOMAIN
 
 
 @pytest.fixture(
@@ -225,8 +226,7 @@ def config_entry(
             data[CONF_SUBSCRIBER_ID] = subscriber_id
         else:
             del data[CONF_SUBSCRIBER_ID]
-    if auth_implementation:
-        data["auth_implementation"] = auth_implementation
+    data["auth_implementation"] = auth_implementation
     return MockConfigEntry(domain=DOMAIN, data=data)
 
 

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -1,7 +1,6 @@
 """Test the Google Nest Device Access config flow."""
 
-import copy
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from google_nest_sdm.exceptions import (
     AuthException,
@@ -11,31 +10,24 @@ from google_nest_sdm.exceptions import (
 from google_nest_sdm.structure import Structure
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.nest.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .common import FakeSubscriber, MockConfigEntry
-
-CLIENT_ID = "1234"
-CLIENT_SECRET = "5678"
-PROJECT_ID = "project-id-4321"
-SUBSCRIBER_ID = "projects/cloud-id-9876/subscriptions/subscriber-id-9876"
-CLOUD_PROJECT_ID = "cloud-id-9876"
-
-CONFIG = {
-    DOMAIN: {
-        "project_id": PROJECT_ID,
-        "subscriber_id": SUBSCRIBER_ID,
-        CONF_CLIENT_ID: CLIENT_ID,
-        CONF_CLIENT_SECRET: CLIENT_SECRET,
-    },
-    "http": {"base_url": "https://example.com"},
-}
+from .common import (
+    CLIENT_ID,
+    CLOUD_PROJECT_ID,
+    FAKE_TOKEN,
+    PROJECT_ID,
+    SUBSCRIBER_ID,
+    TEST_CONFIG_HYBRID,
+    TEST_CONFIG_YAML_ONLY,
+    TEST_CONFIGFLOW_HYBRID,
+    TEST_CONFIGFLOW_YAML_ONLY,
+    MockConfigEntry,
+)
 
 ORIG_AUTH_DOMAIN = DOMAIN
 WEB_AUTH_DOMAIN = DOMAIN
@@ -47,30 +39,6 @@ APP_REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob"
 FAKE_DHCP_DATA = dhcp.DhcpServiceInfo(
     ip="127.0.0.2", macaddress="00:11:22:33:44:55", hostname="fake_hostname"
 )
-
-
-@pytest.fixture
-def subscriber() -> FakeSubscriber:
-    """Create FakeSubscriber."""
-    return FakeSubscriber()
-
-
-def get_config_entry(hass):
-    """Return a single config entry."""
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
-    return entries[0]
-
-
-def create_config_entry(hass: HomeAssistant, data: dict) -> ConfigEntry:
-    """Create the ConfigEntry."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=data,
-        unique_id=DOMAIN,
-    )
-    entry.add_to_hass(hass)
-    return entry
 
 
 class OAuthFixture:
@@ -196,7 +164,9 @@ class OAuthFixture:
 
     def get_config_entry(self) -> ConfigEntry:
         """Get the config entry."""
-        return get_config_entry(self.hass)
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        assert len(entries) == 1
+        return entries[0]
 
 
 @pytest.fixture
@@ -205,16 +175,10 @@ async def oauth(hass, hass_client_no_auth, aioclient_mock, current_request_with_
     return OAuthFixture(hass, hass_client_no_auth, aioclient_mock)
 
 
-async def async_setup_configflow(hass):
-    """Set up component so the pubsub subscriber is managed by config flow."""
-    config = copy.deepcopy(CONFIG)
-    del config[DOMAIN]["subscriber_id"]  # Create in config flow instead
-    return await setup.async_setup_component(hass, DOMAIN, config)
-
-
-async def test_web_full_flow(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_YAML_ONLY])
+async def test_web_full_flow(hass, oauth, setup_platform):
     """Check full flow."""
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -238,29 +202,15 @@ async def test_web_full_flow(hass, oauth):
     assert "subscriber_id" not in entry.data
 
 
-async def test_web_reauth(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIG_YAML_ONLY])
+async def test_web_reauth(hass, oauth, setup_platform, config_entry):
     """Test Nest reauthentication."""
 
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
-    old_entry = create_config_entry(
-        hass,
-        {
-            "auth_implementation": WEB_AUTH_DOMAIN,
-            "token": {
-                # Verify this is replaced at end of the test
-                "access_token": "some-revoked-token",
-            },
-            "sdm": {},
-        },
-    )
+    assert config_entry.data["token"].get("access_token") == FAKE_TOKEN
 
-    entry = get_config_entry(hass)
-    assert entry.data["token"] == {
-        "access_token": "some-revoked-token",
-    }
-
-    result = await oauth.async_reauth(old_entry.data)
+    result = await oauth.async_reauth(config_entry.data)
 
     await oauth.async_oauth_web_flow(result)
     entry = await oauth.async_finish_setup(result)
@@ -277,11 +227,9 @@ async def test_web_reauth(hass, oauth):
     assert "subscriber_id" not in entry.data  # not updated
 
 
-async def test_single_config_entry(hass):
+async def test_single_config_entry(hass, setup_platform):
     """Test that only a single config entry is allowed."""
-    create_config_entry(hass, {"auth_implementation": WEB_AUTH_DOMAIN, "sdm": {}})
-
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -290,18 +238,13 @@ async def test_single_config_entry(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_unexpected_existing_config_entries(hass, oauth):
+async def test_unexpected_existing_config_entries(hass, oauth, setup_platform):
     """Test Nest reauthentication with multiple existing config entries."""
     # Note that this case will not happen in the future since only a single
     # instance is now allowed, but this may have been allowed in the past.
     # On reauth, only one entry is kept and the others are deleted.
 
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
-
-    old_entry = MockConfigEntry(
-        domain=DOMAIN, data={"auth_implementation": WEB_AUTH_DOMAIN, "sdm": {}}
-    )
-    old_entry.add_to_hass(hass)
+    await setup_platform()
 
     old_entry = MockConfigEntry(
         domain=DOMAIN, data={"auth_implementation": WEB_AUTH_DOMAIN, "sdm": {}}
@@ -333,9 +276,9 @@ async def test_unexpected_existing_config_entries(hass, oauth):
     assert "subscriber_id" not in entry.data  # not updated
 
 
-async def test_reauth_missing_config_entry(hass):
+async def test_reauth_missing_config_entry(hass, setup_platform):
     """Test the reauth flow invoked missing existing data."""
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
     # Invoke the reauth flow with no existing data
     result = await hass.config_entries.flow.async_init(
@@ -345,9 +288,10 @@ async def test_reauth_missing_config_entry(hass):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_app_full_flow(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_YAML_ONLY])
+async def test_app_full_flow(hass, oauth, setup_platform):
     """Check full flow."""
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -370,24 +314,15 @@ async def test_app_full_flow(hass, oauth):
     assert "subscriber_id" not in entry.data
 
 
-async def test_app_reauth(hass, oauth):
+@pytest.mark.parametrize(
+    "nest_test_config,auth_implementation", [(TEST_CONFIG_YAML_ONLY, APP_AUTH_DOMAIN)]
+)
+async def test_app_reauth(hass, oauth, setup_platform, config_entry):
     """Test Nest reauthentication for Installed App Auth."""
 
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
-    old_entry = create_config_entry(
-        hass,
-        {
-            "auth_implementation": APP_AUTH_DOMAIN,
-            "token": {
-                # Verify this is replaced at end of the test
-                "access_token": "some-revoked-token",
-            },
-            "sdm": {},
-        },
-    )
-
-    result = await oauth.async_reauth(old_entry.data)
+    result = await oauth.async_reauth(config_entry.data)
     await oauth.async_oauth_app_flow(result)
 
     # Verify existing tokens are replaced
@@ -404,9 +339,10 @@ async def test_app_reauth(hass, oauth):
     assert "subscriber_id" not in entry.data  # not updated
 
 
-async def test_pubsub_subscription(hass, oauth, subscriber):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_pubsub_subscription(hass, oauth, subscriber, setup_platform):
     """Check flow that creates a pub/sub subscription."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -414,16 +350,11 @@ async def test_pubsub_subscription(hass, oauth, subscriber):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
 
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=subscriber,
-    ):
-        result = await oauth.async_configure(result, {"code": "1234"})
-        await oauth.async_pubsub_flow(result)
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+    result = await oauth.async_configure(result, {"code": "1234"})
+    await oauth.async_pubsub_flow(result)
+    entry = await oauth.async_finish_setup(
+        result, {"cloud_project_id": CLOUD_PROJECT_ID}
+    )
 
     assert entry.title == "OAuth for Apps"
     assert "token" in entry.data
@@ -439,9 +370,12 @@ async def test_pubsub_subscription(hass, oauth, subscriber):
     assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID
 
 
-async def test_pubsub_subscription_strip_whitespace(hass, oauth, subscriber):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_pubsub_subscription_strip_whitespace(
+    hass, oauth, subscriber, setup_platform
+):
     """Check that project id has whitespace stripped on entry."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -449,16 +383,11 @@ async def test_pubsub_subscription_strip_whitespace(hass, oauth, subscriber):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
 
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=subscriber,
-    ):
-        result = await oauth.async_configure(result, {"code": "1234"})
-        await oauth.async_pubsub_flow(result)
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": " " + CLOUD_PROJECT_ID + " "}
-        )
-        await hass.async_block_till_done()
+    result = await oauth.async_configure(result, {"code": "1234"})
+    await oauth.async_pubsub_flow(result)
+    entry = await oauth.async_finish_setup(
+        result, {"cloud_project_id": " " + CLOUD_PROJECT_ID + " "}
+    )
 
     assert entry.title == "OAuth for Apps"
     assert "token" in entry.data
@@ -474,9 +403,12 @@ async def test_pubsub_subscription_strip_whitespace(hass, oauth, subscriber):
     assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID
 
 
-async def test_pubsub_subscription_auth_failure(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_pubsub_subscription_auth_failure(
+    hass, oauth, setup_platform, mock_subscriber
+):
     """Check flow that creates a pub/sub subscription."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -484,23 +416,22 @@ async def test_pubsub_subscription_auth_failure(hass, oauth):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
     result = await oauth.async_configure(result, {"code": "1234"})
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber.create_subscription",
-        side_effect=AuthException(),
-    ):
-        await oauth.async_pubsub_flow(result)
-        result = await oauth.async_configure(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+
+    mock_subscriber.create_subscription.side_effect = AuthException()
+
+    await oauth.async_pubsub_flow(result)
+    result = await oauth.async_configure(result, {"cloud_project_id": CLOUD_PROJECT_ID})
 
     assert result["type"] == "abort"
     assert result["reason"] == "invalid_access_token"
 
 
-async def test_pubsub_subscription_failure(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_pubsub_subscription_failure(
+    hass, oauth, setup_platform, mock_subscriber
+):
     """Check flow that creates a pub/sub subscription."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -509,14 +440,10 @@ async def test_pubsub_subscription_failure(hass, oauth):
     await oauth.async_oauth_app_flow(result)
     result = await oauth.async_configure(result, {"code": "1234"})
     await oauth.async_pubsub_flow(result)
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber.create_subscription",
-        side_effect=SubscriberException(),
-    ):
-        result = await oauth.async_configure(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+
+    mock_subscriber.create_subscription.side_effect = SubscriberException()
+
+    result = await oauth.async_configure(result, {"cloud_project_id": CLOUD_PROJECT_ID})
 
     assert result["type"] == "form"
     assert "errors" in result
@@ -524,9 +451,12 @@ async def test_pubsub_subscription_failure(hass, oauth):
     assert result["errors"]["cloud_project_id"] == "subscriber_error"
 
 
-async def test_pubsub_subscription_configuration_failure(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_pubsub_subscription_configuration_failure(
+    hass, oauth, setup_platform, mock_subscriber
+):
     """Check flow that creates a pub/sub subscription."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -535,14 +465,9 @@ async def test_pubsub_subscription_configuration_failure(hass, oauth):
     await oauth.async_oauth_app_flow(result)
     result = await oauth.async_configure(result, {"code": "1234"})
     await oauth.async_pubsub_flow(result)
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber.create_subscription",
-        side_effect=ConfigurationException(),
-    ):
-        result = await oauth.async_configure(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+
+    mock_subscriber.create_subscription.side_effect = ConfigurationException()
+    result = await oauth.async_configure(result, {"cloud_project_id": CLOUD_PROJECT_ID})
 
     assert result["type"] == "form"
     assert "errors" in result
@@ -550,9 +475,10 @@ async def test_pubsub_subscription_configuration_failure(hass, oauth):
     assert result["errors"]["cloud_project_id"] == "bad_project_id"
 
 
-async def test_pubsub_with_wrong_project_id(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_pubsub_with_wrong_project_id(hass, oauth, setup_platform):
     """Test a possible common misconfiguration mixing up project ids."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -572,23 +498,16 @@ async def test_pubsub_with_wrong_project_id(hass, oauth):
     assert result["errors"]["cloud_project_id"] == "wrong_project_id"
 
 
-async def test_pubsub_subscriber_config_entry_reauth(hass, oauth, subscriber):
+@pytest.mark.parametrize(
+    "nest_test_config,auth_implementation", [(TEST_CONFIG_HYBRID, APP_AUTH_DOMAIN)]
+)
+async def test_pubsub_subscriber_config_entry_reauth(
+    hass, oauth, setup_platform, subscriber, config_entry
+):
     """Test the pubsub subscriber id is preserved during reauth."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
-    old_entry = create_config_entry(
-        hass,
-        {
-            "auth_implementation": APP_AUTH_DOMAIN,
-            "subscriber_id": SUBSCRIBER_ID,
-            "cloud_project_id": CLOUD_PROJECT_ID,
-            "token": {
-                "access_token": "some-revoked-token",
-            },
-            "sdm": {},
-        },
-    )
-    result = await oauth.async_reauth(old_entry.data)
+    result = await oauth.async_reauth(config_entry.data)
     await oauth.async_oauth_app_flow(result)
 
     # Entering an updated access token refreshs the config entry.
@@ -606,7 +525,8 @@ async def test_pubsub_subscriber_config_entry_reauth(hass, oauth, subscriber):
     assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID
 
 
-async def test_config_entry_title_from_home(hass, oauth, subscriber):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_config_entry_title_from_home(hass, oauth, setup_platform, subscriber):
     """Test that the Google Home name is used for the config entry title."""
 
     device_manager = await subscriber.async_get_device_manager()
@@ -623,7 +543,7 @@ async def test_config_entry_title_from_home(hass, oauth, subscriber):
         )
     )
 
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -631,16 +551,11 @@ async def test_config_entry_title_from_home(hass, oauth, subscriber):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
 
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=subscriber,
-    ):
-        result = await oauth.async_configure(result, {"code": "1234"})
-        await oauth.async_pubsub_flow(result)
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+    result = await oauth.async_configure(result, {"code": "1234"})
+    await oauth.async_pubsub_flow(result)
+    entry = await oauth.async_finish_setup(
+        result, {"cloud_project_id": CLOUD_PROJECT_ID}
+    )
 
     assert entry.title == "Example Home"
     assert "token" in entry.data
@@ -648,7 +563,10 @@ async def test_config_entry_title_from_home(hass, oauth, subscriber):
     assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID
 
 
-async def test_config_entry_title_multiple_homes(hass, oauth, subscriber):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_config_entry_title_multiple_homes(
+    hass, oauth, setup_platform, subscriber
+):
     """Test handling of multiple Google Homes authorized."""
 
     device_manager = await subscriber.async_get_device_manager()
@@ -677,7 +595,7 @@ async def test_config_entry_title_multiple_homes(hass, oauth, subscriber):
         )
     )
 
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -685,23 +603,18 @@ async def test_config_entry_title_multiple_homes(hass, oauth, subscriber):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
 
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=subscriber,
-    ):
-        result = await oauth.async_configure(result, {"code": "1234"})
-        await oauth.async_pubsub_flow(result)
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
-
+    result = await oauth.async_configure(result, {"code": "1234"})
+    await oauth.async_pubsub_flow(result)
+    entry = await oauth.async_finish_setup(
+        result, {"cloud_project_id": CLOUD_PROJECT_ID}
+    )
     assert entry.title == "Example Home #1, Example Home #2"
 
 
-async def test_title_failure_fallback(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_title_failure_fallback(hass, oauth, setup_platform, mock_subscriber):
     """Test exception handling when determining the structure names."""
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -709,19 +622,13 @@ async def test_title_failure_fallback(hass, oauth):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
 
-    mock_subscriber = AsyncMock(FakeSubscriber)
     mock_subscriber.async_get_device_manager.side_effect = AuthException()
 
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=mock_subscriber,
-    ):
-        result = await oauth.async_configure(result, {"code": "1234"})
-        await oauth.async_pubsub_flow(result)
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+    result = await oauth.async_configure(result, {"code": "1234"})
+    await oauth.async_pubsub_flow(result)
+    entry = await oauth.async_finish_setup(
+        result, {"cloud_project_id": CLOUD_PROJECT_ID}
+    )
 
     assert entry.title == "OAuth for Apps"
     assert "token" in entry.data
@@ -729,7 +636,8 @@ async def test_title_failure_fallback(hass, oauth):
     assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID
 
 
-async def test_structure_missing_trait(hass, oauth, subscriber):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_HYBRID])
+async def test_structure_missing_trait(hass, oauth, setup_platform, subscriber):
     """Test handling the case where a structure has no name set."""
 
     device_manager = await subscriber.async_get_device_manager()
@@ -743,7 +651,7 @@ async def test_structure_missing_trait(hass, oauth, subscriber):
         )
     )
 
-    assert await async_setup_configflow(hass)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -751,16 +659,11 @@ async def test_structure_missing_trait(hass, oauth, subscriber):
     result = await oauth.async_pick_flow(result, APP_AUTH_DOMAIN)
     await oauth.async_oauth_app_flow(result)
 
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=subscriber,
-    ):
-        result = await oauth.async_configure(result, {"code": "1234"})
-        await oauth.async_pubsub_flow(result)
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": CLOUD_PROJECT_ID}
-        )
-        await hass.async_block_till_done()
+    result = await oauth.async_configure(result, {"code": "1234"})
+    await oauth.async_pubsub_flow(result)
+    entry = await oauth.async_finish_setup(
+        result, {"cloud_project_id": CLOUD_PROJECT_ID}
+    )
 
     # Fallback to default name
     assert entry.title == "OAuth for Apps"
@@ -778,9 +681,10 @@ async def test_dhcp_discovery_without_config(hass, oauth):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_dhcp_discovery(hass, oauth):
+@pytest.mark.parametrize("nest_test_config", [TEST_CONFIGFLOW_YAML_ONLY])
+async def test_dhcp_discovery(hass, oauth, setup_platform):
     """Discover via dhcp when config is present."""
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    await setup_platform()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .common import (
+    APP_AUTH_DOMAIN,
     CLIENT_ID,
     CLOUD_PROJECT_ID,
     FAKE_TOKEN,
@@ -26,12 +27,10 @@ from .common import (
     TEST_CONFIG_YAML_ONLY,
     TEST_CONFIGFLOW_HYBRID,
     TEST_CONFIGFLOW_YAML_ONLY,
+    WEB_AUTH_DOMAIN,
     MockConfigEntry,
 )
 
-ORIG_AUTH_DOMAIN = DOMAIN
-WEB_AUTH_DOMAIN = DOMAIN
-APP_AUTH_DOMAIN = f"{DOMAIN}.installed"
 WEB_REDIRECT_URL = "https://example.com/auth/external/callback"
 APP_REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move nest config flow tests to use the same test fixtures as the rest of the nest tests, in order to more systematically exercise various steps. This is in preparation for OOB auth deprecation and app credentials which will add even more variations and stats that need to be exercised.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
