### PR TITLE
Attempt to fix flaky tomorrowio test

### DIFF
--- a/tests/components/tomorrowio/test_init.py
+++ b/tests/components/tomorrowio/test_init.py
@@ -65,8 +65,8 @@ async def test_update_intervals(
         unique_id=_get_unique_id(hass, data),
         version=1,
     )
+    config_entry.add_to_hass(hass)
     with patch("homeassistant.helpers.update_coordinator.utcnow", return_value=now):
-        config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert len(tomorrowio_config_entry_update.call_args_list) == 1

--- a/tests/components/tomorrowio/test_init.py
+++ b/tests/components/tomorrowio/test_init.py
@@ -70,7 +70,8 @@ async def test_update_intervals(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert len(tomorrowio_config_entry_update.call_args_list) == 1
-        tomorrowio_config_entry_update.reset_mock()
+
+    tomorrowio_config_entry_update.reset_mock()
 
     # Before the update interval, no updates yet
     future = now + timedelta(minutes=30)
@@ -79,12 +80,15 @@ async def test_update_intervals(
         await hass.async_block_till_done()
         assert len(tomorrowio_config_entry_update.call_args_list) == 0
 
+    tomorrowio_config_entry_update.reset_mock()
+
     # On the update interval, we get a new update
     future = now + timedelta(minutes=32)
     with patch("homeassistant.helpers.update_coordinator.utcnow", return_value=future):
         async_fire_time_changed(hass, now + timedelta(minutes=32))
         await hass.async_block_till_done()
         assert len(tomorrowio_config_entry_update.call_args_list) == 1
+
         tomorrowio_config_entry_update.reset_mock()
 
         # Adding a second config entry should cause the update interval to double
@@ -102,7 +106,8 @@ async def test_update_intervals(
         # We should get an immediate call once the new config entry is setup for a
         # partial update
         assert len(tomorrowio_config_entry_update.call_args_list) == 1
-        tomorrowio_config_entry_update.reset_mock()
+
+    tomorrowio_config_entry_update.reset_mock()
 
     # We should get no new calls on our old interval
     future = now + timedelta(minutes=64)
@@ -111,12 +116,16 @@ async def test_update_intervals(
         await hass.async_block_till_done()
         assert len(tomorrowio_config_entry_update.call_args_list) == 0
 
+    tomorrowio_config_entry_update.reset_mock()
+
     # We should get two calls on our new interval, one for each entry
     future = now + timedelta(minutes=96)
     with patch("homeassistant.helpers.update_coordinator.utcnow", return_value=future):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
         assert len(tomorrowio_config_entry_update.call_args_list) == 2
+
+    tomorrowio_config_entry_update.reset_mock()
 
 
 async def test_climacell_migration_logic(


### PR DESCRIPTION
## Proposed change
Attempt to fix flaky `tomorrowio` test.

See https://github.com/home-assistant/core/runs/6703105856?check_suite_focus=true


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
