### PR TITLE
Cleanup automation async methods which are not awaiting

### DIFF
--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -31,9 +31,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for Arcam FMJ Receiver control devices."""
     registry = entity_registry.async_get(hass)
     triggers = []

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_UNIQUE_ID,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -697,10 +697,8 @@ async def async_attach_trigger(
     )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant,
-    device_id: str,
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers.
 
     Make sure device is a supported remote model.

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -239,9 +239,8 @@ def async_fire_triggers(conn: HKDevice, events: dict[tuple[int, int], Any]):
                 source.fire(iid, ev)
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for homekit devices."""
 
     if device_id not in hass.data.get(TRIGGERS, {}):

--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -7,7 +7,7 @@ from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.const import CONF_DEVICE_ID
-from homeassistant.core import CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -85,9 +85,8 @@ async def async_attach_trigger(
     )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, Any]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, Any]]:
     """Get device triggers for given (hass) device id."""
     if DOMAIN not in hass.data:
         return []

--- a/homeassistant/components/kodi/device_trigger.py
+++ b/homeassistant/components/kodi/device_trigger.py
@@ -32,9 +32,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for Kodi devices."""
     registry = entity_registry.async_get(hass)
     triggers = []

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -10,7 +10,7 @@ from homeassistant.components.automation import (
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import event
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -49,9 +49,8 @@ TYPE_SCHEMAS = {
 }
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for LCN devices."""
     device_registry = dr.async_get(hass)
     if (device := device_registry.async_get(device_id)) is None:
@@ -99,7 +98,8 @@ async def async_attach_trigger(
     )
 
 
-async def async_get_trigger_capabilities(
+@callback
+def async_get_trigger_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List trigger capabilities."""

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -345,9 +345,8 @@ async def async_validate_trigger_config(
     return schema(config)
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for lutron caseta devices."""
     triggers = []
 

--- a/homeassistant/components/mobile_app/device_action.py
+++ b/homeassistant/components/mobile_app/device_action.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.components import notify
 from homeassistant.components.device_automation import InvalidDeviceAutomationConfig
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
@@ -24,9 +24,8 @@ ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_actions(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device actions for Mobile App devices."""
     webhook_id = webhook_id_from_device_id(hass, device_id)
 
@@ -77,7 +76,8 @@ async def async_call_action_from_config(
     )
 
 
-async def async_get_action_capabilities(
+@callback
+def async_get_action_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List action capabilities."""

--- a/homeassistant/components/nanoleaf/device_trigger.py
+++ b/homeassistant/components/nanoleaf/device_trigger.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -34,9 +34,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for Nanoleaf devices."""
     device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get(device_id)

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -61,9 +61,8 @@ def async_get_device_trigger_types(
     return trigger_types
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for a Nest device."""
     nest_device_id = async_get_nest_device_id(hass, device_id)
     if not nest_device_id:

--- a/homeassistant/components/philips_js/device_trigger.py
+++ b/homeassistant/components/philips_js/device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components.automation import (
 )
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
@@ -27,9 +27,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for device."""
     triggers = []
     triggers.append(

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -7,7 +7,7 @@ from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
@@ -38,9 +38,8 @@ ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_actions(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device actions for RFXCOM RFXtrx devices."""
 
     try:

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN
@@ -47,9 +47,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for RFXCOM RFXtrx devices."""
     device = async_get_device_object(hass, device_id)
 

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.typing import ConfigType
 
 from . import get_block_device_wrapper, get_rpc_device_wrapper
@@ -106,9 +106,8 @@ async def async_validate_trigger_config(
     )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for Shelly devices."""
     triggers: list[dict[str, str]] = []
 

--- a/homeassistant/components/tasmota/device_trigger.py
+++ b/homeassistant/components/tasmota/device_trigger.py
@@ -255,7 +255,7 @@ async def async_setup_trigger(
 
 async def async_remove_triggers(hass: HomeAssistant, device_id: str) -> None:
     """Cleanup any device triggers for a Tasmota device."""
-    triggers = await async_get_triggers(hass, device_id)
+    triggers = async_get_triggers(hass, device_id)
 
     if not triggers:
         return
@@ -273,9 +273,8 @@ async def async_remove_triggers(hass: HomeAssistant, device_id: str) -> None:
             device_trigger.remove_update_signal()
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for a Tasmota device."""
     triggers: list[dict[str, str]] = []
 

--- a/homeassistant/components/webostv/device_trigger.py
+++ b/homeassistant/components/webostv/device_trigger.py
@@ -12,7 +12,7 @@ from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
 
@@ -56,9 +56,8 @@ async def async_validate_trigger_config(
     return config
 
 
-async def async_get_triggers(
-    _hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(_hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers for device."""
     triggers = []
     base_trigger = {

--- a/homeassistant/components/wemo/device_trigger.py
+++ b/homeassistant/components/wemo/device_trigger.py
@@ -11,7 +11,7 @@ from homeassistant.components.automation import (
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN as WEMO_DOMAIN, WEMO_SUBSCRIPTION_EVENT
@@ -26,9 +26,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """Return a list of triggers."""
 
     wemo_trigger = {

--- a/homeassistant/components/zha/device_action.py
+++ b/homeassistant/components/zha/device_action.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
@@ -56,9 +56,8 @@ async def async_call_action_from_config(
     )
 
 
-async def async_get_actions(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device actions."""
     try:
         zha_device = async_get_zha_device(hass, device_id)

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
 
@@ -81,9 +81,8 @@ async def async_attach_trigger(
     )
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device triggers.
 
     Make sure the device supports device automations and

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     CONF_TYPE,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
@@ -141,9 +141,8 @@ ACTION_SCHEMA = vol.Any(
 )
 
 
-async def async_get_actions(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, Any]]:
+@callback
+def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict[str, Any]]:
     """List device actions for Z-Wave JS devices."""
     registry = entity_registry.async_get(hass)
     actions: list[dict] = []
@@ -274,7 +273,8 @@ async def async_call_action_from_config(
     )
 
 
-async def async_get_action_capabilities(
+@callback
+def async_get_action_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List action capabilities."""

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -122,9 +122,8 @@ async def async_validate_condition_config(
     return config
 
 
-async def async_get_conditions(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, str]]:
+@callback
+def async_get_conditions(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
     """List device conditions for Z-Wave JS devices."""
     conditions = []
     base_condition = {
@@ -197,7 +196,7 @@ def async_condition_from_config(
 
 
 @callback
-async def async_get_condition_capabilities(
+def async_get_condition_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List condition capabilities."""

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
@@ -247,9 +247,8 @@ def get_trigger_platform_from_type(trigger_type: str) -> str:
     return trigger_platform
 
 
-async def async_get_triggers(
-    hass: HomeAssistant, device_id: str
-) -> list[dict[str, Any]]:
+@callback
+def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, Any]]:
     """List device triggers for Z-Wave JS devices."""
     dev_reg = device_registry.async_get(hass)
     node = async_get_node_from_device_id(hass, device_id, dev_reg)
@@ -457,7 +456,8 @@ async def async_attach_trigger(
     raise HomeAssistantError(f"Unhandled trigger type {trigger_type}")
 
 
-async def async_get_trigger_capabilities(
+@callback
+def async_get_trigger_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List trigger capabilities."""

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -253,7 +253,7 @@ async def test_get_transponder_trigger_capabilities(hass, entry, lcn_connection)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             CONF_PLATFORM: "device",
@@ -274,7 +274,7 @@ async def test_get_fingerprint_trigger_capabilities(hass, entry, lcn_connection)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             CONF_PLATFORM: "device",
@@ -295,7 +295,7 @@ async def test_get_transmitter_trigger_capabilities(hass, entry, lcn_connection)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             CONF_PLATFORM: "device",
@@ -326,7 +326,7 @@ async def test_get_send_keys_trigger_capabilities(hass, entry, lcn_connection):
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             CONF_PLATFORM: "device",
@@ -362,7 +362,7 @@ async def test_unknown_trigger_capabilities(hass, entry, lcn_connection):
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             CONF_PLATFORM: "device",

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -413,7 +413,7 @@ async def test_get_action_capabilities(
     )[0]
 
     # Test refresh_value
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -429,7 +429,7 @@ async def test_get_action_capabilities(
     ) == [{"type": "boolean", "name": "refresh_all_values", "optional": True}]
 
     # Test ping
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -441,7 +441,7 @@ async def test_get_action_capabilities(
     assert not capabilities
 
     # Test set_value
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -492,7 +492,7 @@ async def test_get_action_capabilities(
     ]
 
     # Test enumerated type param
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -524,7 +524,7 @@ async def test_get_action_capabilities(
     ]
 
     # Test range type param
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -551,7 +551,7 @@ async def test_get_action_capabilities(
     ]
 
     # Test undefined type param
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -579,7 +579,7 @@ async def test_get_action_capabilities_lock_triggers(
     )[0]
 
     # Test clear_lock_usercode
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -596,7 +596,7 @@ async def test_get_action_capabilities_lock_triggers(
     ) == [{"type": "string", "name": "code_slot", "required": True}]
 
     # Test set_lock_usercode
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -629,7 +629,7 @@ async def test_get_action_capabilities_meter_triggers(
     assert driver
     device = dev_reg.async_get_device({get_device_id(driver, node)})
     assert device
-    capabilities = await device_action.async_get_action_capabilities(
+    capabilities = device_action.async_get_action_capabilities(
         hass,
         {
             "platform": "device",
@@ -664,7 +664,7 @@ async def test_failure_scenarios(
         )
 
     assert (
-        await device_action.async_get_action_capabilities(
+        device_action.async_get_action_capabilities(
             hass, {"type": "failed.test", "device_id": device.id}
         )
         == {}

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -381,7 +381,7 @@ async def test_get_condition_capabilities_node_status(
         dev_reg, integration.entry_id
     )[0]
 
-    capabilities = await device_condition.async_get_condition_capabilities(
+    capabilities = device_condition.async_get_condition_capabilities(
         hass,
         {
             "platform": "device",
@@ -417,7 +417,7 @@ async def test_get_condition_capabilities_value(
         dev_reg, integration.entry_id
     )[0]
 
-    capabilities = await device_condition.async_get_condition_capabilities(
+    capabilities = device_condition.async_get_condition_capabilities(
         hass,
         {
             "platform": "device",
@@ -467,7 +467,7 @@ async def test_get_condition_capabilities_config_parameter(
     )[0]
 
     # Test enumerated type param
-    capabilities = await device_condition.async_get_condition_capabilities(
+    capabilities = device_condition.async_get_condition_capabilities(
         hass,
         {
             "platform": "device",
@@ -498,7 +498,7 @@ async def test_get_condition_capabilities_config_parameter(
     ]
 
     # Test range type param
-    capabilities = await device_condition.async_get_condition_capabilities(
+    capabilities = device_condition.async_get_condition_capabilities(
         hass,
         {
             "platform": "device",
@@ -524,7 +524,7 @@ async def test_get_condition_capabilities_config_parameter(
     ]
 
     # Test undefined type param
-    capabilities = await device_condition.async_get_condition_capabilities(
+    capabilities = device_condition.async_get_condition_capabilities(
         hass,
         {
             "platform": "device",
@@ -558,7 +558,7 @@ async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
         return_value=None,
     ):
         assert (
-            await device_condition.async_get_condition_capabilities(
+            device_condition.async_get_condition_capabilities(
                 hass, {"type": "failed.test", "device_id": device.id}
             )
             == {}

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -158,7 +158,7 @@ async def test_get_trigger_capabilities_notification_notification(
     """Test we get the expected capabilities from a notification.notification trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -276,7 +276,7 @@ async def test_get_trigger_capabilities_entry_control_notification(
     """Test we get the expected capabilities from a notification.entry_control trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -415,7 +415,7 @@ async def test_get_trigger_capabilities_node_status(
     await hass.config_entries.async_reload(integration.entry_id)
     await hass.async_block_till_done()
 
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -595,7 +595,7 @@ async def test_get_trigger_capabilities_basic_value_notification(
     """Test we get the expected capabilities from a value_notification.basic trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -770,7 +770,7 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
     """Test we get the expected capabilities from a value_notification.central_scene trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -937,7 +937,7 @@ async def test_get_trigger_capabilities_scene_activation_value_notification(
     """Test we get the expected capabilities from a value_notification.scene_activation trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -1080,7 +1080,7 @@ async def test_get_trigger_capabilities_value_updated_value(
     """Test we get the expected capabilities from a zwave_js.value_updated.value trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -1220,7 +1220,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
     """Test we get the expected capabilities from a range zwave_js.value_updated.config_parameter trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -1262,7 +1262,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
     """Test we get the expected capabilities from an enumerated zwave_js.value_updated.config_parameter trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
-    capabilities = await device_trigger.async_get_trigger_capabilities(
+    capabilities = device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
@@ -1343,7 +1343,7 @@ async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
         return_value=None,
     ):
         assert (
-            await device_trigger.async_get_trigger_capabilities(
+            device_trigger.async_get_trigger_capabilities(
                 hass, {"type": "failed.test", "device_id": "invalid_device_id"}
             )
             == {}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup automation async methods which are not awaiting (components)

As follow-up to #72147

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
