### PR TITLE
Fix performance of logbook entity and devices queries with large MySQL databases

### DIFF
--- a/homeassistant/components/logbook/queries/common.py
+++ b/homeassistant/components/logbook/queries/common.py
@@ -12,9 +12,11 @@ from sqlalchemy.sql.selectable import Select
 
 from homeassistant.components.proximity import DOMAIN as PROXIMITY_DOMAIN
 from homeassistant.components.recorder.models import (
+    EVENTS_CONTEXT_ID_INDEX,
     OLD_FORMAT_ATTRS_JSON,
     OLD_STATE,
     SHARED_ATTRS_JSON,
+    STATES_CONTEXT_ID_INDEX,
     EventData,
     Events,
     StateAttributes,
@@ -250,3 +252,17 @@ def _not_uom_attributes_matcher() -> ClauseList:
     return ~StateAttributes.shared_attrs.like(
         UNIT_OF_MEASUREMENT_JSON_LIKE
     ) | ~States.attributes.like(UNIT_OF_MEASUREMENT_JSON_LIKE)
+
+
+def apply_states_context_hints(query: Query) -> Query:
+    """Force mysql to use the right index on large context_id selects."""
+    return query.with_hint(
+        States, f"FORCE INDEX ({STATES_CONTEXT_ID_INDEX})", dialect_name="mysql"
+    )
+
+
+def apply_events_context_hints(query: Query) -> Query:
+    """Force mysql to use the right index on large context_id selects."""
+    return query.with_hint(
+        Events, f"FORCE INDEX ({EVENTS_CONTEXT_ID_INDEX})", dialect_name="mysql"
+    )

--- a/homeassistant/components/logbook/queries/common.py
+++ b/homeassistant/components/logbook/queries/common.py
@@ -121,9 +121,7 @@ def select_events_context_only() -> Select:
     By marking them as context_only we know they are only for
     linking context ids and we can avoid processing them.
     """
-    return select(*EVENT_ROWS_NO_STATES, CONTEXT_ONLY).outerjoin(
-        EventData, (Events.data_id == EventData.data_id)
-    )
+    return select(*EVENT_ROWS_NO_STATES, CONTEXT_ONLY)
 
 
 def select_states_context_only() -> Select:

--- a/homeassistant/components/logbook/queries/devices.py
+++ b/homeassistant/components/logbook/queries/devices.py
@@ -60,14 +60,12 @@ def _apply_devices_context_union(
             select_events_context_only()
             .select_from(devices_cte_select)
             .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
-        )
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
-        .where(Events.context_id.isnot(None)),
+        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
         apply_states_context_hints(
             select_states_context_only()
             .select_from(devices_cte_select)
             .outerjoin(States, devices_cte_select.c.context_id == States.context_id)
-        ).where(States.context_id.isnot(None)),
+        ),
     )
 
 

--- a/homeassistant/components/logbook/queries/devices.py
+++ b/homeassistant/components/logbook/queries/devices.py
@@ -54,17 +54,16 @@ def _apply_devices_context_union(
         event_types,
         json_quotable_device_ids,
     ).cte()
-    devices_cte_select = devices_cte.select()
     return query.union_all(
         apply_events_context_hints(
             select_events_context_only()
-            .select_from(devices_cte_select)
-            .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
+            .select_from(devices_cte)
+            .outerjoin(Events, devices_cte.c.context_id == Events.context_id)
         ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
         apply_states_context_hints(
             select_states_context_only()
-            .select_from(devices_cte_select)
-            .outerjoin(States, devices_cte_select.c.context_id == States.context_id)
+            .select_from(devices_cte)
+            .outerjoin(States, devices_cte.c.context_id == States.context_id)
         ),
     )
 

--- a/homeassistant/components/logbook/queries/devices.py
+++ b/homeassistant/components/logbook/queries/devices.py
@@ -59,10 +59,12 @@ def _apply_devices_context_union(
     return query.union_all(
         select_events_context_only()
         .select_from(devices_cte_select)
+        .group_by(devices_cte_select.c.context_id)
         .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
         .outerjoin(EventData, (Events.data_id == EventData.data_id)),
         select_states_context_only()
         .select_from(devices_cte_select)
+        .group_by(devices_cte_select.c.context_id)
         .outerjoin(States, devices_cte_select.c.context_id == States.context_id),
     )
 

--- a/homeassistant/components/logbook/queries/devices.py
+++ b/homeassistant/components/logbook/queries/devices.py
@@ -10,7 +10,12 @@ from sqlalchemy.sql.elements import ClauseList
 from sqlalchemy.sql.lambdas import StatementLambdaElement
 from sqlalchemy.sql.selectable import CTE, CompoundSelect
 
-from homeassistant.components.recorder.models import DEVICE_ID_IN_EVENT, Events, States
+from homeassistant.components.recorder.models import (
+    DEVICE_ID_IN_EVENT,
+    EventData,
+    Events,
+    States,
+)
 
 from .common import (
     select_events_context_id_subquery,
@@ -50,9 +55,15 @@ def _apply_devices_context_union(
         event_types,
         json_quotable_device_ids,
     ).cte()
+    devices_cte_select = devices_cte.select()
     return query.union_all(
-        select_events_context_only().where(Events.context_id.in_(devices_cte.select())),
-        select_states_context_only().where(States.context_id.in_(devices_cte.select())),
+        select_events_context_only()
+        .select_from(devices_cte_select)
+        .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
+        .outerjoin(EventData, (Events.data_id == EventData.data_id)),
+        select_states_context_only()
+        .select_from(devices_cte_select)
+        .outerjoin(States, devices_cte_select.c.context_id == States.context_id),
     )
 
 

--- a/homeassistant/components/logbook/queries/devices.py
+++ b/homeassistant/components/logbook/queries/devices.py
@@ -60,12 +60,14 @@ def _apply_devices_context_union(
             select_events_context_only()
             .select_from(devices_cte_select)
             .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
-        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
+        )
+        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+        .where(Events.context_id.isnot(None)),
         apply_states_context_hints(
             select_states_context_only()
             .select_from(devices_cte_select)
             .outerjoin(States, devices_cte_select.c.context_id == States.context_id)
-        ),
+        ).where(States.context_id.isnot(None)),
     )
 
 

--- a/homeassistant/components/logbook/queries/devices.py
+++ b/homeassistant/components/logbook/queries/devices.py
@@ -18,6 +18,8 @@ from homeassistant.components.recorder.models import (
 )
 
 from .common import (
+    apply_events_context_hints,
+    apply_states_context_hints,
     select_events_context_id_subquery,
     select_events_context_only,
     select_events_without_states,
@@ -54,13 +56,16 @@ def _apply_devices_context_union(
     ).cte()
     devices_cte_select = devices_cte.select()
     return query.union_all(
-        select_events_context_only()
-        .select_from(devices_cte_select)
-        .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
-        .outerjoin(EventData, (Events.data_id == EventData.data_id)),
-        select_states_context_only()
-        .select_from(devices_cte_select)
-        .outerjoin(States, devices_cte_select.c.context_id == States.context_id),
+        apply_events_context_hints(
+            select_events_context_only()
+            .select_from(devices_cte_select)
+            .outerjoin(Events, devices_cte_select.c.context_id == Events.context_id)
+        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
+        apply_states_context_hints(
+            select_states_context_only()
+            .select_from(devices_cte_select)
+            .outerjoin(States, devices_cte_select.c.context_id == States.context_id)
+        ),
     )
 
 

--- a/homeassistant/components/logbook/queries/entities.py
+++ b/homeassistant/components/logbook/queries/entities.py
@@ -78,12 +78,14 @@ def _apply_entities_context_union(
             select_events_context_only()
             .select_from(entities_cte_select)
             .outerjoin(Events, entities_cte_select.c.context_id == Events.context_id)
-        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
+        )
+        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+        .filter(Events.context_id.isnot(None)),
         apply_states_context_hints(
             select_states_context_only()
             .select_from(entities_cte_select)
             .outerjoin(States, entities_cte_select.c.context_id == States.context_id)
-        ),
+        ).filter(States.context_id.isnot(None)),
     )
 
 

--- a/homeassistant/components/logbook/queries/entities.py
+++ b/homeassistant/components/logbook/queries/entities.py
@@ -78,14 +78,12 @@ def _apply_entities_context_union(
             select_events_context_only()
             .select_from(entities_cte_select)
             .outerjoin(Events, entities_cte_select.c.context_id == Events.context_id)
-        )
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
-        .filter(Events.context_id.isnot(None)),
+        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
         apply_states_context_hints(
             select_states_context_only()
             .select_from(entities_cte_select)
             .outerjoin(States, entities_cte_select.c.context_id == States.context_id)
-        ).filter(States.context_id.isnot(None)),
+        ),
     )
 
 

--- a/homeassistant/components/logbook/queries/entities.py
+++ b/homeassistant/components/logbook/queries/entities.py
@@ -66,7 +66,6 @@ def _apply_entities_context_union(
         entity_ids,
         json_quotable_entity_ids,
     ).cte()
-    entities_cte_select = entities_cte.select()
     # We used to optimize this to exclude rows we already in the union with
     # a States.entity_id.not_in(entity_ids) but that made the
     # query much slower on MySQL, and since we already filter them away
@@ -76,13 +75,13 @@ def _apply_entities_context_union(
         states_query_for_entity_ids(start_day, end_day, entity_ids),
         apply_events_context_hints(
             select_events_context_only()
-            .select_from(entities_cte_select)
-            .outerjoin(Events, entities_cte_select.c.context_id == Events.context_id)
+            .select_from(entities_cte)
+            .outerjoin(Events, entities_cte.c.context_id == Events.context_id)
         ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
         apply_states_context_hints(
             select_states_context_only()
-            .select_from(entities_cte_select)
-            .outerjoin(States, entities_cte_select.c.context_id == States.context_id)
+            .select_from(entities_cte)
+            .outerjoin(States, entities_cte.c.context_id == States.context_id)
         ),
     )
 

--- a/homeassistant/components/logbook/queries/entities.py
+++ b/homeassistant/components/logbook/queries/entities.py
@@ -14,6 +14,7 @@ from homeassistant.components.recorder.models import (
     ENTITY_ID_IN_EVENT,
     ENTITY_ID_LAST_UPDATED_INDEX,
     OLD_ENTITY_ID_IN_EVENT,
+    EventData,
     Events,
     States,
 )
@@ -64,14 +65,17 @@ def _apply_entities_context_union(
         entity_ids,
         json_quotable_entity_ids,
     ).cte()
+    entities_cte_select = entities_cte.select()
     return query.union_all(
         states_query_for_entity_ids(start_day, end_day, entity_ids),
-        select_events_context_only().where(
-            Events.context_id.in_(entities_cte.select())
-        ),
+        select_events_context_only()
+        .select_from(entities_cte_select)
+        .outerjoin(Events, entities_cte_select.c.context_id == Events.context_id)
+        .outerjoin(EventData, (Events.data_id == EventData.data_id)),
         select_states_context_only()
-        .where(States.entity_id.not_in(entity_ids))
-        .where(States.context_id.in_(entities_cte.select())),
+        .select_from(entities_cte_select)
+        .outerjoin(States, entities_cte_select.c.context_id == States.context_id)
+        .where(States.entity_id.not_in(entity_ids)),
     )
 
 

--- a/homeassistant/components/logbook/queries/entities.py
+++ b/homeassistant/components/logbook/queries/entities.py
@@ -70,10 +70,12 @@ def _apply_entities_context_union(
         states_query_for_entity_ids(start_day, end_day, entity_ids),
         select_events_context_only()
         .select_from(entities_cte_select)
+        .group_by(entities_cte_select.c.context_id)
         .outerjoin(Events, entities_cte_select.c.context_id == Events.context_id)
         .outerjoin(EventData, (Events.data_id == EventData.data_id)),
         select_states_context_only()
         .select_from(entities_cte_select)
+        .group_by(entities_cte_select.c.context_id)
         .outerjoin(States, entities_cte_select.c.context_id == States.context_id)
         .where(States.entity_id.not_in(entity_ids)),
     )

--- a/homeassistant/components/logbook/queries/entities_and_devices.py
+++ b/homeassistant/components/logbook/queries/entities_and_devices.py
@@ -67,7 +67,6 @@ def _apply_entities_devices_context_union(
         json_quotable_entity_ids,
         json_quotable_device_ids,
     ).cte()
-    devices_entities_cte_select = devices_entities_cte.select()
     # We used to optimize this to exclude rows we already in the union with
     # a States.entity_id.not_in(entity_ids) but that made the
     # query much slower on MySQL, and since we already filter them away
@@ -77,17 +76,13 @@ def _apply_entities_devices_context_union(
         states_query_for_entity_ids(start_day, end_day, entity_ids),
         apply_events_context_hints(
             select_events_context_only()
-            .select_from(devices_entities_cte_select)
-            .outerjoin(
-                Events, devices_entities_cte_select.c.context_id == Events.context_id
-            )
+            .select_from(devices_entities_cte)
+            .outerjoin(Events, devices_entities_cte.c.context_id == Events.context_id)
         ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
         apply_states_context_hints(
             select_states_context_only()
-            .select_from(devices_entities_cte_select)
-            .outerjoin(
-                States, devices_entities_cte_select.c.context_id == States.context_id
-            )
+            .select_from(devices_entities_cte)
+            .outerjoin(States, devices_entities_cte.c.context_id == States.context_id)
         ),
     )
 

--- a/homeassistant/components/logbook/queries/entities_and_devices.py
+++ b/homeassistant/components/logbook/queries/entities_and_devices.py
@@ -81,16 +81,14 @@ def _apply_entities_devices_context_union(
             .outerjoin(
                 Events, devices_entities_cte_select.c.context_id == Events.context_id
             )
-        )
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
-        .where(Events.context_id.isnot(None)),
+        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
         apply_states_context_hints(
             select_states_context_only()
             .select_from(devices_entities_cte_select)
             .outerjoin(
                 States, devices_entities_cte_select.c.context_id == States.context_id
             )
-        ).where(States.context_id.isnot(None)),
+        ),
     )
 
 

--- a/homeassistant/components/logbook/queries/entities_and_devices.py
+++ b/homeassistant/components/logbook/queries/entities_and_devices.py
@@ -22,6 +22,8 @@ from .devices import apply_event_device_id_matchers
 from .entities import (
     apply_entities_hints,
     apply_event_entity_id_matchers,
+    apply_events_context_hints,
+    apply_states_context_hints,
     states_query_for_entity_ids,
 )
 
@@ -66,20 +68,27 @@ def _apply_entities_devices_context_union(
         json_quotable_device_ids,
     ).cte()
     devices_entities_cte_select = devices_entities_cte.select()
+    # We used to optimize this to exclude rows we already in the union with
+    # a States.entity_id.not_in(entity_ids) but that made the
+    # query much slower on MySQL, and since we already filter them away
+    # in the python code anyways since they will have context_only
+    # set on them the impact is minimal.
     return query.union_all(
         states_query_for_entity_ids(start_day, end_day, entity_ids),
-        select_events_context_only()
-        .select_from(devices_entities_cte_select)
-        .outerjoin(
-            Events, devices_entities_cte_select.c.context_id == Events.context_id
-        )
-        .outerjoin(EventData, (Events.data_id == EventData.data_id)),
-        select_states_context_only()
-        .select_from(devices_entities_cte_select)
-        .outerjoin(
-            States, devices_entities_cte_select.c.context_id == States.context_id
-        )
-        .where(States.entity_id.not_in(entity_ids)),
+        apply_events_context_hints(
+            select_events_context_only()
+            .select_from(devices_entities_cte_select)
+            .outerjoin(
+                Events, devices_entities_cte_select.c.context_id == Events.context_id
+            )
+        ).outerjoin(EventData, (Events.data_id == EventData.data_id)),
+        apply_states_context_hints(
+            select_states_context_only()
+            .select_from(devices_entities_cte_select)
+            .outerjoin(
+                States, devices_entities_cte_select.c.context_id == States.context_id
+            )
+        ),
     )
 
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -93,6 +93,8 @@ TABLES_TO_CHECK = [
 
 LAST_UPDATED_INDEX = "ix_states_last_updated"
 ENTITY_ID_LAST_UPDATED_INDEX = "ix_states_entity_id_last_updated"
+EVENTS_CONTEXT_ID_INDEX = "ix_events_context_id"
+STATES_CONTEXT_ID_INDEX = "ix_states_context_id"
 
 EMPTY_JSON_OBJECT = "{}"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #72882

I got rid of the IN dependent subquery since MySQL does not optimize that well and replaced it with an outerjoin.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72882

- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
