### PR TITLE
Revert "Allow non-async functions in device automation (#72147)"

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -189,42 +189,22 @@ def _async_set_entity_device_automation_metadata(
     automation["metadata"]["secondary"] = bool(entry.entity_category or entry.hidden_by)
 
 
-async def _async_get_automation_for_device(
-    hass: HomeAssistant,
-    platform: DeviceAutomationPlatformType,
-    function_name: str,
-    device_id: str,
-) -> list[dict[str, Any]]:
-    """List device automations."""
-    automations = getattr(platform, function_name)(hass, device_id)
-    if asyncio.iscoroutine(automations):
-        # Using a coroutine to get device automations is deprecated
-        # enable warning when core is fully migrated
-        # then remove in Home Assistant Core xxxx.xx
-        return await automations  # type: ignore[no-any-return]
-    return automations  # type: ignore[no-any-return]
-
-
 async def _async_get_device_automations_from_domain(
-    hass: HomeAssistant,
-    domain: str,
-    automation_type: DeviceAutomationType,
-    device_ids: Iterable[str],
-    return_exceptions: bool,
-) -> list[list[dict[str, Any]] | Exception]:
+    hass, domain, automation_type, device_ids, return_exceptions
+):
     """List device automations."""
     try:
         platform = await async_get_device_automation_platform(
             hass, domain, automation_type
         )
     except InvalidDeviceAutomationConfig:
-        return []
+        return {}
 
     function_name = automation_type.value.get_automations_func
 
-    return await asyncio.gather(  # type: ignore[no-any-return]
+    return await asyncio.gather(
         *(
-            _async_get_automation_for_device(hass, platform, function_name, device_id)
+            getattr(platform, function_name)(hass, device_id)
             for device_id in device_ids
         ),
         return_exceptions=return_exceptions,
@@ -310,12 +290,7 @@ async def _async_get_device_automation_capabilities(
         return {}
 
     try:
-        capabilities = getattr(platform, function_name)(hass, automation)
-        if asyncio.iscoroutine(capabilities):
-            # Using a coroutine to get device automation capabitilites is deprecated
-            # enable warning when core is fully migrated
-            # then remove in Home Assistant Core xxxx.xx
-            capabilities = await capabilities
+        capabilities = await getattr(platform, function_name)(hass, automation)
     except InvalidDeviceAutomationConfig:
         return {}
 

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -190,19 +190,23 @@ def _async_set_entity_device_automation_metadata(
 
 
 async def _async_get_device_automations_from_domain(
-    hass, domain, automation_type, device_ids, return_exceptions
-):
+    hass: HomeAssistant,
+    domain: str,
+    automation_type: DeviceAutomationType,
+    device_ids: Iterable[str],
+    return_exceptions: bool,
+) -> list[list[dict[str, Any]] | Exception]:
     """List device automations."""
     try:
         platform = await async_get_device_automation_platform(
             hass, domain, automation_type
         )
     except InvalidDeviceAutomationConfig:
-        return {}
+        return []
 
     function_name = automation_type.value.get_automations_func
 
-    return await asyncio.gather(
+    return await asyncio.gather(  # type: ignore[no-any-return]
         *(
             getattr(platform, function_name)(hass, device_id)
             for device_id in device_ids

--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -1,7 +1,6 @@
 """Device action validator."""
 from __future__ import annotations
 
-from collections.abc import Awaitable
 from typing import Any, Protocol, cast
 
 import voluptuous as vol
@@ -36,14 +35,14 @@ class DeviceAutomationActionProtocol(Protocol):
     ) -> None:
         """Execute a device action."""
 
-    def async_get_action_capabilities(
+    async def async_get_action_capabilities(
         self, hass: HomeAssistant, config: ConfigType
-    ) -> dict[str, vol.Schema] | Awaitable[dict[str, vol.Schema]]:
+    ) -> dict[str, vol.Schema]:
         """List action capabilities."""
 
-    def async_get_actions(
+    async def async_get_actions(
         self, hass: HomeAssistant, device_id: str
-    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
+    ) -> list[dict[str, Any]]:
         """List actions."""
 
 

--- a/homeassistant/components/device_automation/condition.py
+++ b/homeassistant/components/device_automation/condition.py
@@ -1,7 +1,6 @@
 """Validate device conditions."""
 from __future__ import annotations
 
-from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import voluptuous as vol
@@ -36,14 +35,14 @@ class DeviceAutomationConditionProtocol(Protocol):
     ) -> condition.ConditionCheckerType:
         """Evaluate state based on configuration."""
 
-    def async_get_condition_capabilities(
+    async def async_get_condition_capabilities(
         self, hass: HomeAssistant, config: ConfigType
-    ) -> dict[str, vol.Schema] | Awaitable[dict[str, vol.Schema]]:
+    ) -> dict[str, vol.Schema]:
         """List condition capabilities."""
 
-    def async_get_conditions(
+    async def async_get_conditions(
         self, hass: HomeAssistant, device_id: str
-    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
+    ) -> list[dict[str, Any]]:
         """List conditions."""
 
 

--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -1,7 +1,6 @@
 """Offer device oriented automation."""
 from __future__ import annotations
 
-from collections.abc import Awaitable
 from typing import Any, Protocol, cast
 
 import voluptuous as vol
@@ -46,14 +45,14 @@ class DeviceAutomationTriggerProtocol(Protocol):
     ) -> CALLBACK_TYPE:
         """Attach a trigger."""
 
-    def async_get_trigger_capabilities(
+    async def async_get_trigger_capabilities(
         self, hass: HomeAssistant, config: ConfigType
-    ) -> dict[str, vol.Schema] | Awaitable[dict[str, vol.Schema]]:
+    ) -> dict[str, vol.Schema]:
         """List trigger capabilities."""
 
-    def async_get_triggers(
+    async def async_get_triggers(
         self, hass: HomeAssistant, device_id: str
-    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
+    ) -> list[dict[str, Any]]:
         """List triggers."""
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert "Allow non-async functions in device automation (#72147)"

Based on comments: https://github.com/home-assistant/core/pull/72892#discussion_r887679262
> A possible downside of this api change is that we stop integrations from being able to await things inside this function. We don't seem to need that yet, but it is a limitation that we introduce.

and

> I think the benefit from reducing the need of await here while adding another condition for supporting both sync and async content does not worth the change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
