### PR TITLE
Only create auto comfort entities for BAF devices that support them

### DIFF
--- a/homeassistant/components/baf/climate.py
+++ b/homeassistant/components/baf/climate.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up BAF fan auto comfort."""
     data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    if data.device.has_fan:
+    if data.device.has_fan and data.device.has_auto_comfort:
         async_add_entities(
             [BAFAutoComfort(data.device, f"{data.device.name} Auto Comfort")]
         )

--- a/homeassistant/components/baf/manifest.json
+++ b/homeassistant/components/baf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Big Ass Fans",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/baf",
-  "requirements": ["aiobafi6==0.3.0"],
+  "requirements": ["aiobafi6==0.5.0"],
   "codeowners": ["@bdraco", "@jfroy"],
   "iot_class": "local_push",
   "zeroconf": [

--- a/homeassistant/components/baf/number.py
+++ b/homeassistant/components/baf/number.py
@@ -36,27 +36,7 @@ class BAFNumberDescription(NumberEntityDescription, BAFNumberDescriptionMixin):
     """Class describing BAF sensor entities."""
 
 
-FAN_NUMBER_DESCRIPTIONS = (
-    BAFNumberDescription(
-        key="return_to_auto_timeout",
-        name="Return to Auto Timeout",
-        min_value=ONE_MIN_SECS,
-        max_value=HALF_DAY_SECS,
-        entity_category=EntityCategory.CONFIG,
-        unit_of_measurement=TIME_SECONDS,
-        value_fn=lambda device: cast(Optional[int], device.return_to_auto_timeout),
-        mode=NumberMode.SLIDER,
-    ),
-    BAFNumberDescription(
-        key="motion_sense_timeout",
-        name="Motion Sense Timeout",
-        min_value=ONE_MIN_SECS,
-        max_value=ONE_DAY_SECS,
-        entity_category=EntityCategory.CONFIG,
-        unit_of_measurement=TIME_SECONDS,
-        value_fn=lambda device: cast(Optional[int], device.motion_sense_timeout),
-        mode=NumberMode.SLIDER,
-    ),
+AUTO_COMFORT_NUMBER_DESCRIPTIONS = (
     BAFNumberDescription(
         key="comfort_min_speed",
         name="Auto Comfort Minimum Speed",
@@ -83,6 +63,29 @@ FAN_NUMBER_DESCRIPTIONS = (
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda device: cast(Optional[int], device.comfort_heat_assist_speed),
         mode=NumberMode.BOX,
+    ),
+)
+
+FAN_NUMBER_DESCRIPTIONS = (
+    BAFNumberDescription(
+        key="return_to_auto_timeout",
+        name="Return to Auto Timeout",
+        min_value=ONE_MIN_SECS,
+        max_value=HALF_DAY_SECS,
+        entity_category=EntityCategory.CONFIG,
+        unit_of_measurement=TIME_SECONDS,
+        value_fn=lambda device: cast(Optional[int], device.return_to_auto_timeout),
+        mode=NumberMode.SLIDER,
+    ),
+    BAFNumberDescription(
+        key="motion_sense_timeout",
+        name="Motion Sense Timeout",
+        min_value=ONE_MIN_SECS,
+        max_value=ONE_DAY_SECS,
+        entity_category=EntityCategory.CONFIG,
+        unit_of_measurement=TIME_SECONDS,
+        value_fn=lambda device: cast(Optional[int], device.motion_sense_timeout),
+        mode=NumberMode.SLIDER,
     ),
 )
 
@@ -125,6 +128,8 @@ async def async_setup_entry(
         descriptions.extend(FAN_NUMBER_DESCRIPTIONS)
     if device.has_light:
         descriptions.extend(LIGHT_NUMBER_DESCRIPTIONS)
+    if device.has_auto_comfort:
+        descriptions.extend(AUTO_COMFORT_NUMBER_DESCRIPTIONS)
     async_add_entities(BAFNumber(device, description) for description in descriptions)
 
 

--- a/homeassistant/components/baf/sensor.py
+++ b/homeassistant/components/baf/sensor.py
@@ -39,7 +39,7 @@ class BAFSensorDescription(
     """Class describing BAF sensor entities."""
 
 
-BASE_SENSORS = (
+AUTO_COMFORT_SENSORS = (
     BAFSensorDescription(
         key="temperature",
         name="Temperature",
@@ -103,10 +103,12 @@ async def async_setup_entry(
     """Set up BAF fan sensors."""
     data: BAFData = hass.data[DOMAIN][entry.entry_id]
     device = data.device
-    sensors_descriptions = list(BASE_SENSORS)
+    sensors_descriptions: list[BAFSensorDescription] = []
     for description in DEFINED_ONLY_SENSORS:
         if getattr(device, description.key):
             sensors_descriptions.append(description)
+    if device.has_auto_comfort:
+        sensors_descriptions.extend(AUTO_COMFORT_SENSORS)
     if device.has_fan:
         sensors_descriptions.extend(FAN_SENSORS)
     async_add_entities(

--- a/homeassistant/components/baf/switch.py
+++ b/homeassistant/components/baf/switch.py
@@ -48,13 +48,16 @@ BASE_SWITCHES = [
     ),
 ]
 
-FAN_SWITCHES = [
+AUTO_COMFORT_SWITCHES = [
     BAFSwitchDescription(
         key="comfort_heat_assist_enable",
         name="Auto Comfort Heat Assist",
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda device: cast(Optional[bool], device.comfort_heat_assist_enable),
     ),
+]
+
+FAN_SWITCHES = [
     BAFSwitchDescription(
         key="fan_beep_enable",
         name="Beep",
@@ -120,6 +123,8 @@ async def async_setup_entry(
         descriptions.extend(FAN_SWITCHES)
     if device.has_light:
         descriptions.extend(LIGHT_SWITCHES)
+    if device.has_auto_comfort:
+        descriptions.extend(AUTO_COMFORT_SWITCHES)
     async_add_entities(BAFSwitch(device, description) for description in descriptions)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -122,7 +122,7 @@ aioasuswrt==1.4.0
 aioazuredevops==1.3.5
 
 # homeassistant.components.baf
-aiobafi6==0.3.0
+aiobafi6==0.5.0
 
 # homeassistant.components.aws
 aiobotocore==2.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -109,7 +109,7 @@ aioasuswrt==1.4.0
 aioazuredevops==1.3.5
 
 # homeassistant.components.baf
-aiobafi6==0.3.0
+aiobafi6==0.5.0
 
 # homeassistant.components.aws
 aiobotocore==2.1.0


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #72934

Dep changelog: https://github.com/jfroy/aiobafi6/compare/0.4.0...0.5.0



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
