### PR TITLE
Add FlowResultType enum to data entry flow

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -103,7 +103,7 @@ class AuthManagerFlowManager(data_entry_flow.FlowManager):
         """Return a user as result of login flow."""
         flow = cast(LoginFlow, flow)
 
-        if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         # we got final result

--- a/homeassistant/components/almond/config_flow.py
+++ b/homeassistant/components/almond/config_flow.py
@@ -64,7 +64,7 @@ class AlmondFlowHandler(
         """Handle authorize step."""
         result = await super().async_step_auth(user_input)
 
-        if result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP:
+        if result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP:
             self.host = str(URL(result["url"]).with_path("me"))
 
         return result

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -52,7 +52,7 @@ flow for details.
 
 Progress the flow. Most flows will be 1 page, but could optionally add extra
 login challenges, like TFA. Once the flow has finished, the returned step will
-have type RESULT_TYPE_CREATE_ENTRY and "result" key will contain an authorization code.
+have type FlowResultType.CREATE_ENTRY and "result" key will contain an authorization code.
 The authorization code associated with an authorized user by default, it will
 associate with an credential if "type" set to "link_user" in
 "/auth/login_flow"
@@ -123,13 +123,13 @@ class AuthProvidersView(HomeAssistantView):
 
 def _prepare_result_json(result):
     """Convert result to JSON."""
-    if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
         data = result.copy()
         data.pop("result")
         data.pop("data")
         return data
 
-    if result["type"] != data_entry_flow.RESULT_TYPE_FORM:
+    if result["type"] != data_entry_flow.FlowResultType.FORM:
         return result
 
     data = result.copy()
@@ -154,11 +154,11 @@ class LoginFlowBaseView(HomeAssistantView):
 
     async def _async_flow_result_to_response(self, request, client_id, result):
         """Convert the flow result to a response."""
-        if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             # @log_invalid_auth does not work here since it returns HTTP 200.
             # We need to manually log failed login attempts.
             if (
-                result["type"] == data_entry_flow.RESULT_TYPE_FORM
+                result["type"] == data_entry_flow.FlowResultType.FORM
                 and (errors := result.get("errors"))
                 and errors.get("base")
                 in (

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -129,11 +129,11 @@ def websocket_depose_mfa(
 
 def _prepare_result_json(result):
     """Convert result to JSON."""
-    if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
         data = result.copy()
         return data
 
-    if result["type"] != data_entry_flow.RESULT_TYPE_FORM:
+    if result["type"] != data_entry_flow.FlowResultType.FORM:
         return result
 
     data = result.copy()

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -143,7 +143,7 @@ class ConfigManagerEntryResourceReloadView(HomeAssistantView):
 
 def _prepare_config_flow_result_json(result, prepare_result_json):
     """Convert result to JSON."""
-    if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+    if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
         return prepare_result_json(result)
 
     data = result.copy()

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -11,7 +11,7 @@ import time
 
 from homeassistant.const import CONF_DEVICE, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import RESULT_TYPE_ABORT
+from homeassistant.data_entry_flow import FlowResultType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -305,7 +305,7 @@ async def async_start(  # noqa: C901
                 )
                 if (
                     result
-                    and result["type"] == RESULT_TYPE_ABORT
+                    and result["type"] == FlowResultType.ABORT
                     and result["reason"]
                     in ("already_configured", "single_instance_allowed")
                 ):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -676,7 +676,7 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
         if not self._async_has_other_discovery_flows(flow.flow_id):
             persistent_notification.async_dismiss(self.hass, DISCOVERY_NOTIFICATION_ID)
 
-        if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         # Check if config entry exists with unique ID. Unload it.
@@ -1528,7 +1528,7 @@ class OptionsFlowManager(data_entry_flow.FlowManager):
         """
         flow = cast(OptionsFlow, flow)
 
-        if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         entry = self.hass.config_entries.async_get_entry(flow.handler)

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -80,7 +80,7 @@ class FlowResult(TypedDict, total=False):
     """Typed result dict."""
 
     version: int
-    type: str
+    type: FlowResultType
     flow_id: str
     handler: str
     title: str
@@ -223,7 +223,7 @@ class FlowManager(abc.ABC):
             self._initialize_tasks[handler].remove(task)
             self._initializing[handler].remove(init_done)
 
-        if result["type"] != RESULT_TYPE_ABORT:
+        if result["type"] != FlowResultType.ABORT:
             await self.async_post_init(flow, result)
 
         return result
@@ -268,7 +268,7 @@ class FlowManager(abc.ABC):
             user_input = cur_step["data_schema"](user_input)
 
         # Handle a menu navigation choice
-        if cur_step["type"] == RESULT_TYPE_MENU and user_input:
+        if cur_step["type"] == FlowResultType.MENU and user_input:
             result = await self._async_handle_step(
                 flow, user_input["next_step_id"], None
             )
@@ -277,18 +277,25 @@ class FlowManager(abc.ABC):
                 flow, cur_step["step_id"], user_input
             )
 
-        if cur_step["type"] in (RESULT_TYPE_EXTERNAL_STEP, RESULT_TYPE_SHOW_PROGRESS):
-            if cur_step["type"] == RESULT_TYPE_EXTERNAL_STEP and result["type"] not in (
-                RESULT_TYPE_EXTERNAL_STEP,
-                RESULT_TYPE_EXTERNAL_STEP_DONE,
+        if cur_step["type"] in (
+            FlowResultType.EXTERNAL_STEP,
+            FlowResultType.SHOW_PROGRESS,
+        ):
+            if cur_step["type"] == FlowResultType.EXTERNAL_STEP and result[
+                "type"
+            ] not in (
+                FlowResultType.EXTERNAL_STEP,
+                FlowResultType.EXTERNAL_STEP_DONE,
             ):
                 raise ValueError(
                     "External step can only transition to "
                     "external step or external step done."
                 )
-            if cur_step["type"] == RESULT_TYPE_SHOW_PROGRESS and result["type"] not in (
-                RESULT_TYPE_SHOW_PROGRESS,
-                RESULT_TYPE_SHOW_PROGRESS_DONE,
+            if cur_step["type"] == FlowResultType.SHOW_PROGRESS and result[
+                "type"
+            ] not in (
+                FlowResultType.SHOW_PROGRESS,
+                FlowResultType.SHOW_PROGRESS_DONE,
             ):
                 raise ValueError(
                     "Show progress can only transition to show progress or show progress done."
@@ -298,7 +305,7 @@ class FlowManager(abc.ABC):
             # the frontend.
             if (
                 cur_step["step_id"] != result.get("step_id")
-                or result["type"] == RESULT_TYPE_SHOW_PROGRESS
+                or result["type"] == FlowResultType.SHOW_PROGRESS
             ):
                 # Tell frontend to reload the flow state.
                 self.hass.bus.async_fire(
@@ -362,24 +369,24 @@ class FlowManager(abc.ABC):
             step_done.set_result(None)
 
         if result["type"] not in (
-            RESULT_TYPE_FORM,
-            RESULT_TYPE_EXTERNAL_STEP,
-            RESULT_TYPE_CREATE_ENTRY,
-            RESULT_TYPE_ABORT,
-            RESULT_TYPE_EXTERNAL_STEP_DONE,
-            RESULT_TYPE_SHOW_PROGRESS,
-            RESULT_TYPE_SHOW_PROGRESS_DONE,
-            RESULT_TYPE_MENU,
+            FlowResultType.FORM,
+            FlowResultType.EXTERNAL_STEP,
+            FlowResultType.CREATE_ENTRY,
+            FlowResultType.ABORT,
+            FlowResultType.EXTERNAL_STEP_DONE,
+            FlowResultType.SHOW_PROGRESS,
+            FlowResultType.SHOW_PROGRESS_DONE,
+            FlowResultType.MENU,
         ):
             raise ValueError(f"Handler returned incorrect type: {result['type']}")
 
         if result["type"] in (
-            RESULT_TYPE_FORM,
-            RESULT_TYPE_EXTERNAL_STEP,
-            RESULT_TYPE_EXTERNAL_STEP_DONE,
-            RESULT_TYPE_SHOW_PROGRESS,
-            RESULT_TYPE_SHOW_PROGRESS_DONE,
-            RESULT_TYPE_MENU,
+            FlowResultType.FORM,
+            FlowResultType.EXTERNAL_STEP,
+            FlowResultType.EXTERNAL_STEP_DONE,
+            FlowResultType.SHOW_PROGRESS,
+            FlowResultType.SHOW_PROGRESS_DONE,
+            FlowResultType.MENU,
         ):
             flow.cur_step = result
             return result
@@ -388,7 +395,7 @@ class FlowManager(abc.ABC):
         result = await self.async_finish_flow(flow, result.copy())
 
         # _async_finish_flow may change result type, check it again
-        if result["type"] == RESULT_TYPE_FORM:
+        if result["type"] == FlowResultType.FORM:
             flow.cur_step = result
             return result
 
@@ -443,7 +450,7 @@ class FlowHandler:
     ) -> FlowResult:
         """Return the definition of a form to gather user input."""
         return {
-            "type": RESULT_TYPE_FORM,
+            "type": FlowResultType.FORM,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
@@ -465,7 +472,7 @@ class FlowHandler:
         """Finish config flow and create a config entry."""
         return {
             "version": self.VERSION,
-            "type": RESULT_TYPE_CREATE_ENTRY,
+            "type": FlowResultType.CREATE_ENTRY,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "title": title,
@@ -496,7 +503,7 @@ class FlowHandler:
     ) -> FlowResult:
         """Return the definition of an external step for the user to take."""
         return {
-            "type": RESULT_TYPE_EXTERNAL_STEP,
+            "type": FlowResultType.EXTERNAL_STEP,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
@@ -508,7 +515,7 @@ class FlowHandler:
     def async_external_step_done(self, *, next_step_id: str) -> FlowResult:
         """Return the definition of an external step for the user to take."""
         return {
-            "type": RESULT_TYPE_EXTERNAL_STEP_DONE,
+            "type": FlowResultType.EXTERNAL_STEP_DONE,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": next_step_id,
@@ -524,7 +531,7 @@ class FlowHandler:
     ) -> FlowResult:
         """Show a progress message to the user, without user input allowed."""
         return {
-            "type": RESULT_TYPE_SHOW_PROGRESS,
+            "type": FlowResultType.SHOW_PROGRESS,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
@@ -536,7 +543,7 @@ class FlowHandler:
     def async_show_progress_done(self, *, next_step_id: str) -> FlowResult:
         """Mark the progress done."""
         return {
-            "type": RESULT_TYPE_SHOW_PROGRESS_DONE,
+            "type": FlowResultType.SHOW_PROGRESS_DONE,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": next_step_id,
@@ -555,7 +562,7 @@ class FlowHandler:
         Options dict maps step_id => i18n label
         """
         return {
-            "type": RESULT_TYPE_MENU,
+            "type": FlowResultType.MENU,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
@@ -574,7 +581,7 @@ def _create_abort_data(
 ) -> FlowResult:
     """Return the definition of an external step for the user to take."""
     return {
-        "type": RESULT_TYPE_ABORT,
+        "type": FlowResultType.ABORT,
         "flow_id": flow_id,
         "handler": handler,
         "reason": reason,

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -10,10 +10,26 @@ from typing import Any, TypedDict
 
 import voluptuous as vol
 
+from .backports.enum import StrEnum
 from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
 from .util import uuid as uuid_util
 
+
+class FlowResultType(StrEnum):
+    """Result type for a data entry flow."""
+
+    FORM = "form"
+    CREATE_ENTRY = "create_entry"
+    ABORT = "abort"
+    EXTERNAL_STEP = "external"
+    EXTERNAL_STEP_DONE = "external_done"
+    SHOW_PROGRESS = "progress"
+    SHOW_PROGRESS_DONE = "progress_done"
+    MENU = "menu"
+
+
+# RESULT_TYPE_* is deprecated, to be removed in 2022.9
 RESULT_TYPE_FORM = "form"
 RESULT_TYPE_CREATE_ENTRY = "create_entry"
 RESULT_TYPE_ABORT = "abort"

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 from .backports.enum import StrEnum
 from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
+from .helpers.frame import report
 from .util import uuid as uuid_util
 
 
@@ -368,17 +369,13 @@ class FlowManager(abc.ABC):
         if step_done:
             step_done.set_result(None)
 
-        if result["type"] not in (
-            FlowResultType.FORM,
-            FlowResultType.EXTERNAL_STEP,
-            FlowResultType.CREATE_ENTRY,
-            FlowResultType.ABORT,
-            FlowResultType.EXTERNAL_STEP_DONE,
-            FlowResultType.SHOW_PROGRESS,
-            FlowResultType.SHOW_PROGRESS_DONE,
-            FlowResultType.MENU,
-        ):
-            raise ValueError(f"Handler returned incorrect type: {result['type']}")
+        if not isinstance(result["type"], FlowResultType):
+            result["type"] = FlowResultType(result["type"])  # type: ignore[unreachable]
+            report(
+                "does not use FlowResultType enum for data entry flow result type. "
+                "This is deprecated and will stop working in Home Assistant 2022.9",
+                error_if_core=False,
+            )
 
         if result["type"] in (
             FlowResultType.FORM,

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -26,7 +26,7 @@ class _BaseFlowManagerView(HomeAssistantView):
         self, result: data_entry_flow.FlowResult
     ) -> data_entry_flow.FlowResult:
         """Convert result to JSON."""
-        if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+        if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
             data = result.copy()
             data.pop("result")
             data.pop("data")

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -42,7 +42,7 @@ class SchemaFlowFormStep:
     # The next_step function is called if the schema validates successfully or if no
     # schema is defined. The next_step function is passed the union of config entry
     # options and user input from previous steps.
-    # If next_step returns None, the flow is ended with RESULT_TYPE_CREATE_ENTRY.
+    # If next_step returns None, the flow is ended with FlowResultType.CREATE_ENTRY.
     next_step: Callable[[dict[str, Any]], str | None] = lambda _: None
 
     # Optional function to allow amending a form schema.

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -221,6 +221,12 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
             constant=re.compile(r"^SOURCE_(\w*)$"),
         ),
     ],
+    "homeassistant.data_entry_flow": [
+        ObsoleteImportMatch(
+            reason="replaced by FlowResultType enum",
+            constant=re.compile(r"^RESULT_TYPE_(\w*)$"),
+        ),
+    ],
     "homeassistant.helpers.device_registry": [
         ObsoleteImportMatch(
             reason="replaced by DeviceEntryDisabler enum",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
**Developers only:** The use of the following constants has been deprecated:

- `RESULT_TYPE_FORM`
- `RESULT_TYPE_CREATE_ENTRY`
- `RESULT_TYPE_ABORT`
- `RESULT_TYPE_EXTERNAL_STEP`
- `RESULT_TYPE_EXTERNAL_STEP_DONE`
- `RESULT_TYPE_SHOW_PROGRESS`
- `RESULT_TYPE_SHOW_PROGRESS_DONE`
- `RESULT_TYPE_MENU`

Use the new `FlowResultType` StrEnum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces the `FlowResultType`, containing all the supported result types of the data entry flow.

May conflict with:
- [ ] #72884

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1357

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
