### PR TITLE
Fix regression for logarithm template

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1370,18 +1370,18 @@ def multiply(value, amount, default=_SENTINEL):
 def logarithm(value, base=math.e, default=_SENTINEL):
     """Filter and function to get logarithm of the value with a specific base."""
     try:
-        value_float = float(value)
-    except (ValueError, TypeError):
-        if default is _SENTINEL:
-            raise_no_default("log", value)
-        return default
-    try:
         base_float = float(base)
     except (ValueError, TypeError):
         if default is _SENTINEL:
             raise_no_default("log", base)
         return default
-    return math.log(value_float, base_float)
+    try:
+        value_float = float(value)
+        return math.log(value_float, base_float)
+    except (ValueError, TypeError):
+        if default is _SENTINEL:
+            raise_no_default("log", value)
+        return default
 
 
 def sine(value, default=_SENTINEL):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -447,6 +447,8 @@ def test_logarithm(hass):
     assert render(hass, "{{ 'no_number' | log(10, default=1) }}") == 1
     assert render(hass, "{{ log('no_number', 10, 1) }}") == 1
     assert render(hass, "{{ log('no_number', 10, default=1) }}") == 1
+    assert render(hass, "{{ log(0, 10, 1) }}") == 1
+    assert render(hass, "{{ log(0, 10, default=1) }}") == 1
 
 
 def test_sine(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--## Breaking change -->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Commit https://github.com/home-assistant/core/commit/4885331509eeffe50f42d76b234996467b06170f (cc @emontnemery) introduced a change that broke the use of the default value when calling the logarithm function in templates (https://github.com/home-assistant/core/commit/4885331509eeffe50f42d76b234996467b06170f#diff-45e24c5d3515b969f85f0523fac26ae43bfc97d55e436266d95115f3fb56f204R1372-R1384): the `math.log` function was called in a `try..except` block, and was moved outside of it, thus ignoring all exceptions that can be caused by the call to the `math.log` function itself.
This PR makes a small change to fix that breaking change and restore the previous behavior, allowing to have a default value for the logarithm function when the value used is leading to a logarithm error (e.g. `0` as value)

Note I made the PR against master as bugfix for the currently live version of Home Assistant.

As recommended by epenet below, I also made a PR against `dev` for this: https://github.com/home-assistant/core/pull/72960 - If one of the two is not useful, please don't hesitate to close it :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

<!-- - This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: -->
- This PR fixes issue introduced by https://github.com/home-assistant/core/commit/4885331509eeffe50f42d76b234996467b06170f

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
