### PR TITLE
Ensure netgear devices are tracked with one enabled config entry

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -18,7 +18,6 @@ from .const import (
     KEY_COORDINATOR_SPEED,
     KEY_COORDINATOR_TRAFFIC,
     KEY_ROUTER,
-    MODE_ROUTER,
     PLATFORMS,
 )
 from .errors import CannotLoginException
@@ -72,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_devices() -> bool:
         """Fetch data from the router."""
-        if router.mode == MODE_ROUTER:
+        if router.track_devices:
             return await router.async_update_device_trackers()
         return False
 
@@ -107,7 +106,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=SPEED_TEST_INTERVAL,
     )
 
-    if router.mode == MODE_ROUTER:
+    if router.track_devices:
         await coordinator.async_config_entry_first_refresh()
     await coordinator_traffic_meter.async_config_entry_first_refresh()
 
@@ -134,7 +133,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
 
-    if router.mode != MODE_ROUTER:
+    if not router.track_devices:
         router_id = None
         # Remove devices that are no longer tracked
         device_registry = dr.async_get(hass)

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -113,7 +113,7 @@ class NetgearRouter:
         self.serial_number = self._info["SerialNumber"]
         self.mode = self._info.get("DeviceMode", MODE_ROUTER)
 
-        loaded_entries = list(self.hass.config_entries.async_entries(DOMAIN))
+        loaded_entries = self.hass.config_entries.async_entries(DOMAIN)
         self.track_devices = self.mode == MODE_ROUTER or len(loaded_entries) == 1
         _LOGGER.debug(
             "Netgear track_devices = '%s', device mode '%s'",

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -80,6 +80,7 @@ class NetgearRouter:
         self.hardware_version = ""
         self.serial_number = ""
 
+        self.track_devices = True
         self.method_version = 1
         consider_home_int = entry.options.get(
             CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME.total_seconds()
@@ -112,11 +113,19 @@ class NetgearRouter:
         self.serial_number = self._info["SerialNumber"]
         self.mode = self._info.get("DeviceMode", MODE_ROUTER)
 
+        loaded_entries = [
+            entry
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
+        ]
+        self.track_devices = self.mode == MODE_ROUTER or len(loaded_entries) == 1
+        _LOGGER.debug("Netgear track_devices = '%s', device mode '%s'", self.track_devices, self.mode)
+ 
+
         for model in MODELS_V2:
             if self.model.startswith(model):
                 self.method_version = 2
 
-        if self.method_version == 2 and self.mode == MODE_ROUTER:
+        if self.method_version == 2 and self.track_devices:
             if not self._api.get_attached_devices_2():
                 _LOGGER.error(
                     "Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2",
@@ -133,7 +142,7 @@ class NetgearRouter:
                 return False
 
         # set already known devices to away instead of unavailable
-        if self.mode == MODE_ROUTER:
+        if self.track_devices:
             device_registry = dr.async_get(self.hass)
             devices = dr.async_entries_for_config_entry(device_registry, self.entry_id)
             for device_entry in devices:

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -113,13 +113,13 @@ class NetgearRouter:
         self.serial_number = self._info["SerialNumber"]
         self.mode = self._info.get("DeviceMode", MODE_ROUTER)
 
-        loaded_entries = [
-            entry
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
-        ]
+        loaded_entries = list(self.hass.config_entries.async_entries(DOMAIN))
         self.track_devices = self.mode == MODE_ROUTER or len(loaded_entries) == 1
-        _LOGGER.debug("Netgear track_devices = '%s', device mode '%s'", self.track_devices, self.mode)
- 
+        _LOGGER.debug(
+            "Netgear track_devices = '%s', device mode '%s'",
+            self.track_devices,
+            self.mode,
+        )
 
         for model in MODELS_V2:
             if self.model.startswith(model):

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -116,7 +116,7 @@ class NetgearRouter:
         loaded_entries = [
             entry
             for entry in self.hass.config_entries.async_entries(DOMAIN)
-            if entry.disabled_by is not None
+            if entry.disabled_by is None
         ]
         self.track_devices = self.mode == MODE_ROUTER or len(loaded_entries) == 1
         _LOGGER.debug(

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -113,7 +113,11 @@ class NetgearRouter:
         self.serial_number = self._info["SerialNumber"]
         self.mode = self._info.get("DeviceMode", MODE_ROUTER)
 
-        loaded_entries = self.hass.config_entries.async_entries(DOMAIN)
+        loaded_entries = [
+            entry
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
+            if entry.disabled_by is not None
+        ]
         self.track_devices = self.mode == MODE_ROUTER or len(loaded_entries) == 1
         _LOGGER.debug(
             "Netgear track_devices = '%s', device mode '%s'",

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -113,12 +113,12 @@ class NetgearRouter:
         self.serial_number = self._info["SerialNumber"]
         self.mode = self._info.get("DeviceMode", MODE_ROUTER)
 
-        loaded_entries = [
+        enabled_entries = [
             entry
             for entry in self.hass.config_entries.async_entries(DOMAIN)
             if entry.disabled_by is None
         ]
-        self.track_devices = self.mode == MODE_ROUTER or len(loaded_entries) == 1
+        self.track_devices = self.mode == MODE_ROUTER or len(enabled_entries) == 1
         _LOGGER.debug(
             "Netgear track_devices = '%s', device mode '%s'",
             self.track_devices,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a Netgear router is set to acces point mode it will not track devices anymore since HomeAssistant version 2022.06.
This is to prevent duplicate entities when there is a main Netgear device in router mode and multiple Netgear devices in AP mode.
However some user have a setup like this:
```
 FritzBox (no DNS or DHCP, just DSL connection)
    |                           |
PiHole (DNS & DHCP)            Orbi (AP Mode)
```
In which the main router (the Orbi) is basically the main router to which all devices connect, but is still in AP mode due to restrictions of the router supplied by the internet service supplier (FritzBox) that do not always support Bridge mode.

This PR will ensure devices are tracked if the Netgear device is in router mode or it is the only Netgear HomeAssistant integration setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/72885
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
