### PR TITLE
Fix wind speed SMHI

### DIFF
--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -154,13 +154,11 @@ class SmhiWeather(WeatherEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return additional attributes."""
         if self._forecasts:
-            wind_gust = self._forecasts[0].wind_gust
-            if (wind_speed_unit := self._weather_option_wind_speed_unit) is not None:
-                wind_gust = speed_util.convert(
-                    self._forecasts[0].wind_gust,
-                    SPEED_METERS_PER_SECOND,
-                    wind_speed_unit,
-                )
+            wind_gust = speed_util.convert(
+                self._forecasts[0].wind_gust,
+                SPEED_METERS_PER_SECOND,
+                self._wind_speed_unit,
+            )
             return {
                 ATTR_SMHI_CLOUDINESS: self._forecasts[0].cloudiness,
                 ATTR_SMHI_WIND_GUST_SPEED: round(wind_gust, ROUNDING_PRECISION),

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -28,9 +28,12 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_WINDY_VARIANT,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_PRECIPITATION,
+    ATTR_FORECAST_PRESSURE,
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
+    ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_SPEED,
     Forecast,
     WeatherEntity,
 )
@@ -160,7 +163,7 @@ class SmhiWeather(WeatherEntity):
         if self._forecasts:
             self._attr_temperature = self._forecasts[0].temperature
             self._attr_humidity = self._forecasts[0].humidity
-            self._attr_wind_speed = round(self._forecasts[0].wind_speed)
+            self._attr_wind_speed = self._forecasts[0].wind_speed
             self._attr_wind_bearing = self._forecasts[0].wind_direction
             self._attr_visibility = self._forecasts[0].horizontal_visibility
             self._attr_pressure = self._forecasts[0].pressure
@@ -175,7 +178,7 @@ class SmhiWeather(WeatherEntity):
             self._attr_extra_state_attributes = {
                 ATTR_SMHI_CLOUDINESS: self._forecasts[0].cloudiness,
                 # Convert from m/s to km/h
-                ATTR_SMHI_WIND_GUST_SPEED: round(self._forecasts[0].wind_gust * 18 / 5),
+                ATTR_SMHI_WIND_GUST_SPEED: self._forecasts[0].wind_gust,
                 ATTR_SMHI_THUNDER_PROBABILITY: self._forecasts[0].thunder,
             }
 
@@ -205,6 +208,9 @@ class SmhiWeather(WeatherEntity):
                     ATTR_FORECAST_TEMP_LOW: forecast.temperature_min,
                     ATTR_FORECAST_PRECIPITATION: round(forecast.total_precipitation, 1),
                     ATTR_FORECAST_CONDITION: condition,
+                    ATTR_FORECAST_PRESSURE: forecast.pressure,
+                    ATTR_FORECAST_WIND_BEARING: forecast.wind_direction,
+                    ATTR_FORECAST_WIND_SPEED: forecast.wind_speed,
                 }
             )
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -41,6 +41,7 @@ from homeassistant.const import (
     CONF_NAME,
     LENGTH_KILOMETERS,
     LENGTH_MILLIMETERS,
+    SPEED_METERS_PER_SECOND,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
@@ -115,6 +116,7 @@ class SmhiWeather(WeatherEntity):
     _attr_temperature_unit = TEMP_CELSIUS
     _attr_visibility_unit = LENGTH_KILOMETERS
     _attr_precipitation_unit = LENGTH_MILLIMETERS
+    _attr_wind_speed_unit = SPEED_METERS_PER_SECOND
 
     def __init__(
         self,
@@ -159,7 +161,7 @@ class SmhiWeather(WeatherEntity):
             self._attr_temperature = self._forecasts[0].temperature
             self._attr_humidity = self._forecasts[0].humidity
             # Convert from m/s to km/h
-            self._attr_wind_speed = round(self._forecasts[0].wind_speed * 18 / 5)
+            self._attr_wind_speed = round(self._forecasts[0].wind_speed)
             self._attr_wind_bearing = self._forecasts[0].wind_direction
             self._attr_visibility = self._forecasts[0].horizontal_visibility
             self._attr_pressure = self._forecasts[0].pressure

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -160,7 +160,6 @@ class SmhiWeather(WeatherEntity):
         if self._forecasts:
             self._attr_temperature = self._forecasts[0].temperature
             self._attr_humidity = self._forecasts[0].humidity
-            # Convert from m/s to km/h
             self._attr_wind_speed = round(self._forecasts[0].wind_speed)
             self._attr_wind_bearing = self._forecasts[0].wind_direction
             self._attr_visibility = self._forecasts[0].horizontal_visibility

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 import logging
-from typing import Final
+from typing import Any, Final
 
 import aiohttp
 import async_timeout
@@ -27,13 +28,14 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_WINDY,
     ATTR_CONDITION_WINDY_VARIANT,
     ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_PRECIPITATION,
-    ATTR_FORECAST_PRESSURE,
-    ATTR_FORECAST_TEMP,
-    ATTR_FORECAST_TEMP_LOW,
+    ATTR_FORECAST_NATIVE_PRECIPITATION,
+    ATTR_FORECAST_NATIVE_PRESSURE,
+    ATTR_FORECAST_NATIVE_TEMP,
+    ATTR_FORECAST_NATIVE_TEMP_LOW,
+    ATTR_FORECAST_NATIVE_WIND_SPEED,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
-    ATTR_FORECAST_WIND_SPEED,
+    ROUNDING_PRECISION,
     Forecast,
     WeatherEntity,
 )
@@ -44,6 +46,7 @@ from homeassistant.const import (
     CONF_NAME,
     LENGTH_KILOMETERS,
     LENGTH_MILLIMETERS,
+    PRESSURE_HPA,
     SPEED_METERS_PER_SECOND,
     TEMP_CELSIUS,
 )
@@ -53,7 +56,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util import Throttle, slugify
+from homeassistant.util import Throttle, slugify, speed as speed_util
 
 from .const import (
     ATTR_SMHI_CLOUDINESS,
@@ -116,10 +119,11 @@ class SmhiWeather(WeatherEntity):
     """Representation of a weather entity."""
 
     _attr_attribution = "Swedish weather institute (SMHI)"
-    _attr_temperature_unit = TEMP_CELSIUS
-    _attr_visibility_unit = LENGTH_KILOMETERS
-    _attr_precipitation_unit = LENGTH_MILLIMETERS
-    _attr_wind_speed_unit = SPEED_METERS_PER_SECOND
+    _attr_native_temperature_unit = TEMP_CELSIUS
+    _attr_native_visibility_unit = LENGTH_KILOMETERS
+    _attr_native_precipitation_unit = LENGTH_MILLIMETERS
+    _attr_native_wind_speed_unit = SPEED_METERS_PER_SECOND
+    _attr_native_pressure_unit = PRESSURE_HPA
 
     def __init__(
         self,
@@ -144,7 +148,25 @@ class SmhiWeather(WeatherEntity):
             configuration_url="http://opendata.smhi.se/apidocs/metfcst/parameters.html",
         )
         self._attr_condition = None
-        self._attr_temperature = None
+        self._attr_native_temperature = None
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return additional attributes."""
+        if self._forecasts:
+            wind_gust = self._forecasts[0].wind_gust
+            if (wind_speed_unit := self._weather_option_wind_speed_unit) is not None:
+                wind_gust = speed_util.convert(
+                    self._forecasts[0].wind_gust,
+                    SPEED_METERS_PER_SECOND,
+                    wind_speed_unit,
+                )
+            return {
+                ATTR_SMHI_CLOUDINESS: self._forecasts[0].cloudiness,
+                ATTR_SMHI_WIND_GUST_SPEED: round(wind_gust, ROUNDING_PRECISION),
+                ATTR_SMHI_THUNDER_PROBABILITY: self._forecasts[0].thunder,
+            }
+        return None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:
@@ -161,12 +183,12 @@ class SmhiWeather(WeatherEntity):
                 return
 
         if self._forecasts:
-            self._attr_temperature = self._forecasts[0].temperature
+            self._attr_native_temperature = self._forecasts[0].temperature
             self._attr_humidity = self._forecasts[0].humidity
-            self._attr_wind_speed = self._forecasts[0].wind_speed
+            self._attr_native_wind_speed = self._forecasts[0].wind_speed
             self._attr_wind_bearing = self._forecasts[0].wind_direction
-            self._attr_visibility = self._forecasts[0].horizontal_visibility
-            self._attr_pressure = self._forecasts[0].pressure
+            self._attr_native_visibility = self._forecasts[0].horizontal_visibility
+            self._attr_native_pressure = self._forecasts[0].pressure
             self._attr_condition = next(
                 (
                     k
@@ -175,12 +197,6 @@ class SmhiWeather(WeatherEntity):
                 ),
                 None,
             )
-            self._attr_extra_state_attributes = {
-                ATTR_SMHI_CLOUDINESS: self._forecasts[0].cloudiness,
-                # Convert from m/s to km/h
-                ATTR_SMHI_WIND_GUST_SPEED: self._forecasts[0].wind_gust,
-                ATTR_SMHI_THUNDER_PROBABILITY: self._forecasts[0].thunder,
-            }
 
     async def retry_update(self, _: datetime) -> None:
         """Retry refresh weather forecast."""
@@ -204,13 +220,13 @@ class SmhiWeather(WeatherEntity):
             data.append(
                 {
                     ATTR_FORECAST_TIME: forecast.valid_time.isoformat(),
-                    ATTR_FORECAST_TEMP: forecast.temperature_max,
-                    ATTR_FORECAST_TEMP_LOW: forecast.temperature_min,
-                    ATTR_FORECAST_PRECIPITATION: round(forecast.total_precipitation, 1),
+                    ATTR_FORECAST_NATIVE_TEMP: forecast.temperature_max,
+                    ATTR_FORECAST_NATIVE_TEMP_LOW: forecast.temperature_min,
+                    ATTR_FORECAST_NATIVE_PRECIPITATION: forecast.total_precipitation,
                     ATTR_FORECAST_CONDITION: condition,
-                    ATTR_FORECAST_PRESSURE: forecast.pressure,
+                    ATTR_FORECAST_NATIVE_PRESSURE: forecast.pressure,
                     ATTR_FORECAST_WIND_BEARING: forecast.wind_direction,
-                    ATTR_FORECAST_WIND_SPEED: forecast.wind_speed,
+                    ATTR_FORECAST_NATIVE_WIND_SPEED: forecast.wind_speed,
                 }
             )
 

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -346,7 +346,7 @@ async def test_custom_speed_unit(
         {ATTR_WEATHER_WIND_SPEED_UNIT: SPEED_KILOMETERS_PER_HOUR},
     )
 
-    await asyncio.sleep(2)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 16.92

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -16,9 +16,12 @@ from homeassistant.components.weather import (
     ATTR_FORECAST,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_PRECIPITATION,
+    ATTR_FORECAST_PRESSURE,
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
+    ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_SPEED,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
@@ -58,13 +61,13 @@ async def test_setup_hass(
     assert state.state == "sunny"
     assert state.attributes[ATTR_SMHI_CLOUDINESS] == 50
     assert state.attributes[ATTR_SMHI_THUNDER_PROBABILITY] == 33
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 17
+    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 4.7
     assert state.attributes[ATTR_ATTRIBUTION].find("SMHI") >= 0
     assert state.attributes[ATTR_WEATHER_HUMIDITY] == 55
     assert state.attributes[ATTR_WEATHER_PRESSURE] == 1024
     assert state.attributes[ATTR_WEATHER_TEMPERATURE] == 17
     assert state.attributes[ATTR_WEATHER_VISIBILITY] == 50
-    assert state.attributes[ATTR_WEATHER_WIND_SPEED] == 2
+    assert state.attributes[ATTR_WEATHER_WIND_SPEED] == 1.9
     assert state.attributes[ATTR_WEATHER_WIND_BEARING] == 134
     assert len(state.attributes["forecast"]) == 4
 
@@ -74,6 +77,9 @@ async def test_setup_hass(
     assert forecast[ATTR_FORECAST_TEMP_LOW] == 6
     assert forecast[ATTR_FORECAST_PRECIPITATION] == 0
     assert forecast[ATTR_FORECAST_CONDITION] == "partlycloudy"
+    assert forecast[ATTR_FORECAST_PRESSURE] == 1026
+    assert forecast[ATTR_FORECAST_WIND_BEARING] == 203
+    assert forecast[ATTR_FORECAST_WIND_SPEED] == 1.7
 
 
 async def test_properties_no_data(hass: HomeAssistant) -> None:

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -31,11 +31,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED_UNIT,
     DOMAIN as WEATHER_DOMAIN,
 )
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    SPEED_KILOMETERS_PER_HOUR,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import ATTR_ATTRIBUTION, SPEED_METERS_PER_SECOND, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
@@ -68,7 +64,7 @@ async def test_setup_hass(
     assert state.state == "sunny"
     assert state.attributes[ATTR_SMHI_CLOUDINESS] == 50
     assert state.attributes[ATTR_SMHI_THUNDER_PROBABILITY] == 33
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 4.7
+    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 16.92
     assert state.attributes[ATTR_ATTRIBUTION].find("SMHI") >= 0
     assert state.attributes[ATTR_WEATHER_HUMIDITY] == 55
     assert state.attributes[ATTR_WEATHER_PRESSURE] == 1024
@@ -337,16 +333,16 @@ async def test_custom_speed_unit(
 
     assert state
     assert state.name == "test"
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 4.7
+    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 16.92
 
     entity_reg = er.async_get(hass)
     entity_reg.async_update_entity_options(
         state.entity_id,
         WEATHER_DOMAIN,
-        {ATTR_WEATHER_WIND_SPEED_UNIT: SPEED_KILOMETERS_PER_HOUR},
+        {ATTR_WEATHER_WIND_SPEED_UNIT: SPEED_METERS_PER_SECOND},
     )
 
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_ID)
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 16.92
+    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 4.7

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -64,7 +64,7 @@ async def test_setup_hass(
     assert state.attributes[ATTR_WEATHER_PRESSURE] == 1024
     assert state.attributes[ATTR_WEATHER_TEMPERATURE] == 17
     assert state.attributes[ATTR_WEATHER_VISIBILITY] == 50
-    assert state.attributes[ATTR_WEATHER_WIND_SPEED] == 7
+    assert state.attributes[ATTR_WEATHER_WIND_SPEED] == 2
     assert state.attributes[ATTR_WEATHER_WIND_BEARING] == 134
     assert len(state.attributes["forecast"]) == 4
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Wind speed and Wind gust speed are now correctly provided in m/s instead of previously km/h (falsely shown as m/s).
Any templates or automations based on these two attributes needs to be updated.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Align SMHI integration with the new native values and units

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72673
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
