### PR TITLE
Remove google scan_for_calendars service and simplify platform setup

### DIFF
--- a/homeassistant/components/google/const.py
+++ b/homeassistant/components/google/const.py
@@ -11,8 +11,6 @@ DATA_CALENDARS = "calendars"
 DATA_SERVICE = "service"
 DATA_CONFIG = "config"
 
-DISCOVER_CALENDAR = "google_discover_calendar"
-
 
 class FeatureAccess(Enum):
     """Class to represent different access scopes."""

--- a/homeassistant/components/google/services.yaml
+++ b/homeassistant/components/google/services.yaml
@@ -1,6 +1,3 @@
-scan_for_calendars:
-  name: Scan for calendars
-  description: Scan for new calendars.
 add_event:
   name: Add event
   description: Add a new calendar event.

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -136,17 +136,24 @@ async def test_invalid_calendar_yaml(
     component_setup: ComponentSetup,
     calendars_config: list[dict[str, Any]],
     mock_calendars_yaml: None,
+    mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
+    mock_events_list: ApiResult,
     setup_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup with missing entity id fields fails to setup the config entry."""
+    """Test setup with missing entity id fields fails to load the platform."""
+    mock_calendars_list({"items": [test_api_calendar]})
+    mock_events_list({})
+
     assert await component_setup()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     entry = entries[0]
-    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.LOADED
 
     assert not hass.states.get(TEST_YAML_ENTITY)
+    assert not hass.states.get(TEST_API_ENTITY)
 
 
 async def test_calendar_yaml_error(

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -14,11 +14,7 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.components.google import (
-    DOMAIN,
-    SERVICE_ADD_EVENT,
-    SERVICE_SCAN_CALENDARS,
-)
+from homeassistant.components.google import DOMAIN, SERVICE_ADD_EVENT
 from homeassistant.components.google.const import CONF_CALENDAR_ACCESS
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF
@@ -468,57 +464,6 @@ async def test_add_event_date_time(
             "timeZone": "America/Regina",
         },
     }
-
-
-async def test_scan_calendars(
-    hass: HomeAssistant,
-    component_setup: ComponentSetup,
-    mock_calendars_list: ApiResult,
-    mock_events_list: ApiResult,
-    setup_config_entry: MockConfigEntry,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Test finding a calendar from the API."""
-
-    mock_calendars_list({"items": []})
-    assert await component_setup()
-
-    calendar_1 = {
-        "id": "calendar-id-1",
-        "summary": "Calendar 1",
-    }
-    calendar_2 = {
-        "id": "calendar-id-2",
-        "summary": "Calendar 2",
-    }
-
-    aioclient_mock.clear_requests()
-    mock_calendars_list({"items": [calendar_1]})
-    mock_events_list({}, calendar_id="calendar-id-1")
-    await hass.services.async_call(DOMAIN, SERVICE_SCAN_CALENDARS, {}, blocking=True)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("calendar.calendar_1")
-    assert state
-    assert state.name == "Calendar 1"
-    assert state.state == STATE_OFF
-    assert not hass.states.get("calendar.calendar_2")
-
-    aioclient_mock.clear_requests()
-    mock_calendars_list({"items": [calendar_1, calendar_2]})
-    mock_events_list({}, calendar_id="calendar-id-1")
-    mock_events_list({}, calendar_id="calendar-id-2")
-    await hass.services.async_call(DOMAIN, SERVICE_SCAN_CALENDARS, {}, blocking=True)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("calendar.calendar_1")
-    assert state
-    assert state.name == "Calendar 1"
-    assert state.state == STATE_OFF
-    state = hass.states.get("calendar.calendar_2")
-    assert state
-    assert state.name == "Calendar 2"
-    assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Google Calendar `google.scan_for_calendars` service has been removed. Similar functionality can be achieved with the service `homeassistant.reload_config_entry` which will reload the integration and load all new calendars from the API.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove google scan_for_calendars service and simplify platform setup, inlining all the code into a single function. This removes all the back and forth which includes loading the platform, calling a service, running callbacks, invoking an event dispatcher, and adding the entity. The locking for updating the yaml file has been replaced so it just runs in a single function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
