### PR TITLE
Add battery status attribute to lcn transmitter event

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -203,7 +203,12 @@ def _async_fire_access_control_event(
 
     if inp.periphery == pypck.lcn_defs.AccessControlPeriphery.TRANSMITTER:
         event_data.update(
-            {"level": inp.level, "key": inp.key, "action": inp.action.value}
+            {
+                "level": inp.level,
+                "key": inp.key,
+                "action": inp.action.value,
+                "battery": inp.battery.value,
+            }
         )
 
     event_name = f"lcn_{inp.periphery.value.lower()}"

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -1,7 +1,12 @@
 """Tests for LCN device triggers."""
 from pypck.inputs import ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
-from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
+from pypck.lcn_defs import (
+    AccessControlPeriphery,
+    BatteryStatus,
+    KeyAction,
+    SendKeyCommand,
+)
 import voluptuous_serialize
 
 from homeassistant.components import automation
@@ -186,6 +191,7 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry, lcn_connection)
         level=0,
         key=0,
         action=KeyAction.HIT,
+        battery=BatteryStatus.WEAK,
     )
 
     await lcn_connection.async_process_input(inp)

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -1,7 +1,12 @@
 """Tests for LCN events."""
 from pypck.inputs import Input, ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
-from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
+from pypck.lcn_defs import (
+    AccessControlPeriphery,
+    BatteryStatus,
+    KeyAction,
+    SendKeyCommand,
+)
 
 from tests.common import async_capture_events
 
@@ -53,6 +58,7 @@ async def test_fire_transmitter_event(hass, lcn_connection):
         level=0,
         key=0,
         action=KeyAction.HIT,
+        battery=BatteryStatus.WEAK,
     )
 
     await lcn_connection.async_process_input(inp)
@@ -64,6 +70,7 @@ async def test_fire_transmitter_event(hass, lcn_connection):
     assert events[0].data["level"] == 0
     assert events[0].data["key"] == 0
     assert events[0].data["action"] == "hit"
+    assert events[0].data["battery"] == "weak"
 
 
 async def test_fire_sendkeys_event(hass, lcn_connection):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add battery status attribute to lcn_transmitter event.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22985

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
