### PR TITLE
Add lcn_codelock event and corresponding device trigger

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -191,7 +191,7 @@ def async_host_input_received(
 def _async_fire_access_control_event(
     hass: HomeAssistant, device: dr.DeviceEntry, address: AddressType, inp: InputType
 ) -> None:
-    """Fire access control event (transponder, transmitter, fingerprint)."""
+    """Fire access control event (transponder, transmitter, fingerprint, codelock)."""
     event_data = {
         "segment_id": address[0],
         "module_id": address[1],

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -16,13 +16,14 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, KEY_ACTIONS, SENDKEYS
 
-TRIGGER_TYPES = {"transmitter", "transponder", "fingerprint", "send_keys"}
+TRIGGER_TYPES = {"transmitter", "transponder", "fingerprint", "codelock", "send_keys"}
 
 LCN_DEVICE_TRIGGER_BASE_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES)}
 )
 
 ACCESS_CONTROL_SCHEMA = {vol.Optional("code"): vol.All(vol.Lower, cv.string)}
+
 TRANSMITTER_SCHEMA = {
     **ACCESS_CONTROL_SCHEMA,
     vol.Optional("level"): cv.positive_int,
@@ -45,6 +46,7 @@ TYPE_SCHEMAS = {
     "transmitter": {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)},
     "transponder": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
     "fingerprint": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
+    "codelock": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
     "send_keys": {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)},
 }
 

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -4,6 +4,7 @@
       "transmitter": "transmitter code received",
       "transponder": "transponder code received",
       "fingerprint": "fingerprint code received",
+      "codelock": "code lock code received",
       "send_keys": "send keys received"
     }
   }

--- a/homeassistant/components/lcn/translations/en.json
+++ b/homeassistant/components/lcn/translations/en.json
@@ -1,6 +1,7 @@
 {
     "device_automation": {
         "trigger_type": {
+            "codelock": "code lock code received",
             "fingerprint": "fingerprint code received",
             "send_keys": "send keys received",
             "transmitter": "transmitter code received",

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -42,6 +42,24 @@ async def test_fire_fingerprint_event(hass, lcn_connection):
     assert events[0].data["code"] == "aabbcc"
 
 
+async def test_fire_codelock_event(hass, lcn_connection):
+    """Test the codelock event is fired."""
+    events = async_capture_events(hass, "lcn_codelock")
+
+    inp = ModStatusAccessControl(
+        LcnAddr(0, 7, False),
+        periphery=AccessControlPeriphery.CODELOCK,
+        code="aabbcc",
+    )
+
+    await lcn_connection.async_process_input(inp)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].event_type == "lcn_codelock"
+    assert events[0].data["code"] == "aabbcc"
+
+
 async def test_fire_transmitter_event(hass, lcn_connection):
     """Test the transmitter event is fired."""
     events = async_capture_events(hass, "lcn_transmitter")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Within the LCN integration add support for the following event:

`lcn_codelock` (Code lock activated by entering the correct code)

The event originates from an additional sensor devices connected to a LCN hardware module. The hardware modules are represented as DeviceEntities in HomeAssistant. Therefore also a device trigger has been implemented for those DeviceEntities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22986

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
