### PR TITLE
Move Skybell attributes to their own sensors

### DIFF
--- a/homeassistant/components/skybell/binary_sensor.py
+++ b/homeassistant/components/skybell/binary_sensor.py
@@ -1,8 +1,6 @@
 """Binary sensor support for the Skybell HD Doorbell."""
 from __future__ import annotations
 
-from datetime import datetime
-
 from aioskybell.helpers import const as CONST
 import voluptuous as vol
 
@@ -68,16 +66,6 @@ class SkybellBinarySensor(SkybellEntity, BinarySensorEntity):
         """Initialize a binary sensor for a Skybell device."""
         super().__init__(coordinator, description)
         self._event: dict[str, str] = {}
-
-    @property
-    def extra_state_attributes(
-        self,
-    ) -> dict[str, str | int | datetime | tuple[str, str]]:
-        """Return the state attributes."""
-        attrs = super().extra_state_attributes
-        if event := self._event.get(CONST.CREATED_AT):
-            attrs["event_date"] = event
-        return attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/skybell/entity.py
+++ b/homeassistant/components/skybell/entity.py
@@ -1,8 +1,6 @@
 """Entity representing a Skybell HD Doorbell."""
 from __future__ import annotations
 
-from datetime import datetime
-
 from aioskybell import SkybellDevice
 
 from homeassistant.const import ATTR_CONNECTIONS
@@ -44,24 +42,6 @@ class SkybellEntity(CoordinatorEntity[SkybellDataUpdateCoordinator]):
     def _device(self) -> SkybellDevice:
         """Return the device."""
         return self.coordinator.device
-
-    @property
-    def extra_state_attributes(
-        self,
-    ) -> dict[str, str | int | datetime | tuple[str, str]]:
-        """Return the state attributes."""
-        attr: dict[str, str | int | datetime | tuple[str, str]] = {
-            "device_id": self._device.device_id,
-            "status": self._device.status,
-            "location": self._device.location,
-            "motion_threshold": self._device.motion_threshold,
-            "video_profile": self._device.video_profile,
-        }
-        if self._device.owner:
-            attr["wifi_ssid"] = self._device.wifi_ssid
-            attr["wifi_status"] = self._device.wifi_status
-            attr["last_check_in"] = self._device.last_check_in
-        return attr
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""

--- a/homeassistant/components/skybell/sensor.py
+++ b/homeassistant/components/skybell/sensor.py
@@ -1,10 +1,17 @@
 """Sensor support for Skybell Doorbells."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from aioskybell import SkybellDevice
+from aioskybell.helpers import const as CONST
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
@@ -12,15 +19,79 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENTITY_NAMESPACE, CONF_MONITORED_CONDITIONS
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import DOMAIN, SkybellEntity
 
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
+
+@dataclass
+class SkybellSensorEntityDescription(SensorEntityDescription):
+    """Class to describe a Skybell sensor."""
+
+    value_fn: Callable[[SkybellDevice], Any] = lambda val: val
+
+
+SENSOR_TYPES: tuple[SkybellSensorEntityDescription, ...] = (
+    SkybellSensorEntityDescription(
         key="chime_level",
         name="Chime Level",
         icon="mdi:bell-ring",
+        value_fn=lambda device: device.outdoor_chime_level,
+    ),
+    SkybellSensorEntityDescription(
+        key="last_button_event",
+        name="Last Button Event",
+        icon="mdi:clock",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda device: device.latest("button").get(CONST.CREATED_AT),
+    ),
+    SkybellSensorEntityDescription(
+        key="last_motion_event",
+        name="Last Motion Event",
+        icon="mdi:clock",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda device: device.latest("motion").get(CONST.CREATED_AT),
+    ),
+    SkybellSensorEntityDescription(
+        key=CONST.ATTR_LAST_CHECK_IN,
+        name="Last Check in",
+        icon="mdi:clock",
+        entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.last_check_in,
+    ),
+    SkybellSensorEntityDescription(
+        key="motion_threshold",
+        name="Motion Threshold",
+        icon="mdi:walk",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.motion_threshold,
+    ),
+    SkybellSensorEntityDescription(
+        key="video_profile",
+        name="Video Profile",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.video_profile,
+    ),
+    SkybellSensorEntityDescription(
+        key=CONST.ATTR_WIFI_SSID,
+        name="Wifi SSID",
+        icon="mdi:wifi-settings",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.wifi_ssid,
+    ),
+    SkybellSensorEntityDescription(
+        key=CONST.ATTR_WIFI_STATUS,
+        name="Wifi Status",
+        icon="mdi:wifi-strength-3",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.wifi_status,
     ),
 )
 
@@ -45,13 +116,16 @@ async def async_setup_entry(
         SkybellSensor(coordinator, description)
         for coordinator in hass.data[DOMAIN][entry.entry_id]
         for description in SENSOR_TYPES
+        if coordinator.device.owner or description.key not in CONST.ATTR_OWNER_STATS
     )
 
 
 class SkybellSensor(SkybellEntity, SensorEntity):
     """A sensor implementation for Skybell devices."""
 
+    entity_description: SkybellSensorEntityDescription
+
     @property
     def native_value(self) -> int:
         """Return the state of the sensor."""
-        return self._device.outdoor_chime_level
+        return self.entity_description.value_fn(self._device)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Skybell attributes now have their own sensors. Users will need to adjust any scripts or automations that used those attributes: last motion event, last button event, last check in, motion threshold, video profile, wifi ssid, wifi status.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move Skybell attributes to their own sensors
Address additional comments from #70887

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
