### PR TITLE
Make radiotherm hold mode a switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -964,9 +964,12 @@ omit =
     homeassistant/components/radio_browser/__init__.py
     homeassistant/components/radio_browser/media_source.py
     homeassistant/components/radiotherm/__init__.py
+    homeassistant/components/radiotherm/entity.py
     homeassistant/components/radiotherm/climate.py
     homeassistant/components/radiotherm/coordinator.py
     homeassistant/components/radiotherm/data.py
+    homeassistant/components/radiotherm/switch.py
+    homeassistant/components/radiotherm/util.py
     homeassistant/components/rainbird/*
     homeassistant/components/raincloud/*
     homeassistant/components/rainmachine/__init__.py

--- a/homeassistant/components/radiotherm/__init__.py
+++ b/homeassistant/components/radiotherm/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import RadioThermUpdateCoordinator
 from .data import RadioThermInitData, async_get_init_data
 from .util import async_set_time
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE]
+PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SWITCH]
 
 
 async def _async_call_or_raise_not_ready(

--- a/homeassistant/components/radiotherm/__init__.py
+++ b/homeassistant/components/radiotherm/__init__.py
@@ -41,7 +41,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     host = entry.data[CONF_HOST]
     init_coro = async_get_init_data(hass, host)
     init_data = await _async_call_or_raise_not_ready(init_coro, host)
-    assert init_data is not None
     coordinator = RadioThermUpdateCoordinator(hass, init_data)
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/radiotherm/__init__.py
+++ b/homeassistant/components/radiotherm/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Coroutine
 from socket import timeout
-from typing import Any
+from typing import Any, TypeVar
 
 from radiotherm.validate import RadiothermTstatError
 
@@ -14,15 +14,17 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 from .coordinator import RadioThermUpdateCoordinator
-from .data import RadioThermInitData, async_get_init_data
+from .data import async_get_init_data
 from .util import async_set_time
 
 PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SWITCH]
 
+_T = TypeVar("_T")
+
 
 async def _async_call_or_raise_not_ready(
-    coro: Coroutine[Any, Any, RadioThermInitData | None], host: str
-) -> RadioThermInitData | None:
+    coro: Coroutine[Any, Any, _T], host: str
+) -> _T:
     """Call a coro or raise ConfigEntryNotReady."""
     try:
         return await coro
@@ -37,9 +39,8 @@ async def _async_call_or_raise_not_ready(
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Radio Thermostat from a config entry."""
     host = entry.data[CONF_HOST]
-    init_data: RadioThermInitData | None = await _async_call_or_raise_not_ready(
-        async_get_init_data(hass, host), host
-    )
+    init_coro = async_get_init_data(hass, host)
+    init_data = await _async_call_or_raise_not_ready(init_coro, host)
     assert init_data is not None
     coordinator = RadioThermUpdateCoordinator(hass, init_data)
     await coordinator.async_config_entry_first_refresh()
@@ -49,9 +50,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # clears the hold for some strange design
     # choice
     if not coordinator.data.tstat["hold"]:
-        await _async_call_or_raise_not_ready(
-            async_set_time(hass, init_data.tstat), host
-        )
+        time_coro = async_set_time(hass, init_data.tstat)
+        await _async_call_or_raise_not_ready(time_coro, host)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -1,7 +1,6 @@
 """Support for Radio Thermostat wifi-enabled home thermostats."""
 from __future__ import annotations
 
-from functools import partial
 import logging
 from typing import Any
 
@@ -28,18 +27,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
-from .const import CONF_HOLD_TEMP
 from .coordinator import RadioThermUpdateCoordinator
-from .data import RadioThermUpdate
+from .entity import RadioThermostatEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,9 +86,10 @@ PRESET_MODE_TO_CODE = {
 
 CODE_TO_PRESET_MODE = {v: k for k, v in PRESET_MODE_TO_CODE.items()}
 
-CODE_TO_HOLD_STATE = {0: False, 1: True}
 
 PARALLEL_UPDATES = 1
+
+CONF_HOLD_TEMP = "hold_temp"
 
 
 def round_temp(temperature):
@@ -150,18 +145,17 @@ async def async_setup_platform(
         _LOGGER.error("No Radiotherm Thermostats detected")
         return
 
-    hold_temp: bool = config[CONF_HOLD_TEMP]
     for host in hosts:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": SOURCE_IMPORT},
-                data={CONF_HOST: host, CONF_HOLD_TEMP: hold_temp},
+                data={CONF_HOST: host},
             )
         )
 
 
-class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEntity):
+class RadioThermostat(RadioThermostatEntity, ClimateEntity):
     """Representation of a Radio Thermostat."""
 
     _attr_hvac_modes = OPERATION_LIST
@@ -171,44 +165,17 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
     def __init__(self, coordinator: RadioThermUpdateCoordinator) -> None:
         """Initialize the thermostat."""
         super().__init__(coordinator)
-        self.device = coordinator.init_data.tstat
-        self._attr_name = coordinator.init_data.name
-        self._hold_temp = coordinator.hold_temp
-        self._hold_set = False
-        self._attr_unique_id = coordinator.init_data.mac
-        self._attr_device_info = DeviceInfo(
-            name=coordinator.init_data.name,
-            model=coordinator.init_data.model,
-            manufacturer="Radio Thermostats",
-            sw_version=coordinator.init_data.fw_version,
-            connections={(dr.CONNECTION_NETWORK_MAC, coordinator.init_data.mac)},
-        )
-        self._is_model_ct80 = isinstance(self.device, radiotherm.thermostat.CT80)
+        self._attr_name = self.init_data.name
+        self._attr_unique_id = self.init_data.mac
+        self._attr_fan_modes = CT30_FAN_OPERATION_LIST
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
         )
-        self._process_data()
-        if not self._is_model_ct80:
-            self._attr_fan_modes = CT30_FAN_OPERATION_LIST
+        if not isinstance(self.device, radiotherm.thermostat.CT80):
             return
         self._attr_fan_modes = CT80_FAN_OPERATION_LIST
         self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
         self._attr_preset_modes = PRESET_MODES
-
-    @property
-    def data(self) -> RadioThermUpdate:
-        """Returnt the last update."""
-        return self.coordinator.data
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        # Set the time on the device.  This shouldn't be in the
-        # constructor because it's a network call.  We can't put it in
-        # update() because calling it will clear any temporary mode or
-        # temperature in the thermostat.  So add it as a future job
-        # for the event loop to run.
-        self.hass.async_add_job(self.set_time)
-        await super().async_added_to_hass()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Turn fan on/off."""
@@ -224,15 +191,10 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
         self.device.fmode = code
 
     @callback
-    def _handle_coordinator_update(self) -> None:
-        self._process_data()
-        return super()._handle_coordinator_update()
-
-    @callback
     def _process_data(self) -> None:
         """Update and validate the data from the thermostat."""
         data = self.data.tstat
-        if self._is_model_ct80:
+        if isinstance(self.device, radiotherm.thermostat.CT80):
             self._attr_current_humidity = self.data.humidity
             self._attr_preset_mode = CODE_TO_PRESET_MODE[data["program_mode"]]
         # Map thermostat values into various STATE_ flags.
@@ -242,7 +204,6 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
             ATTR_FAN_ACTION: CODE_TO_FAN_STATE[data["fstate"]]
         }
         self._attr_hvac_mode = CODE_TO_TEMP_MODE[data["tmode"]]
-        self._hold_set = CODE_TO_HOLD_STATE[data["hold"]]
         if self.hvac_mode == HVACMode.OFF:
             self._attr_hvac_action = None
         else:
@@ -264,15 +225,12 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
-        hold_changed = kwargs.get("hold_changed", False)
-        await self.hass.async_add_executor_job(
-            partial(self._set_temperature, temperature, hold_changed)
-        )
+        await self.hass.async_add_executor_job(self._set_temperature, temperature)
         self._attr_target_temperature = temperature
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
-    def _set_temperature(self, temperature: int, hold_changed: bool) -> None:
+    def _set_temperature(self, temperature: int) -> None:
         """Set new target temperature."""
         temperature = round_temp(temperature)
         if self.hvac_mode == HVACMode.COOL:
@@ -284,26 +242,6 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
                 self.device.t_cool = temperature
             elif self.hvac_action == HVACAction.HEATING:
                 self.device.t_heat = temperature
-
-        # Only change the hold if requested or if hold mode was turned
-        # on and we haven't set it yet.
-        if hold_changed or not self._hold_set:
-            if self._hold_temp:
-                self.device.hold = 1
-                self._hold_set = True
-            else:
-                self.device.hold = 0
-
-    def set_time(self) -> None:
-        """Set device time."""
-        # Calling this clears any local temperature override and
-        # reverts to the scheduled temperature.
-        now = dt_util.now()
-        self.device.time = {
-            "day": now.weekday(),
-            "hour": now.hour,
-            "minute": now.minute,
-        }
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set operation mode (auto, cool, heat, off)."""
@@ -325,7 +263,7 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set Preset mode (Home, Alternate, Away, Holiday)."""
         if preset_mode not in PRESET_MODES:
-            raise HomeAssistantError("{preset_mode} is not a valid preset_mode")
+            raise HomeAssistantError(f"{preset_mode} is not a valid preset_mode")
         await self.hass.async_add_executor_job(self._set_preset_mode, preset_mode)
         self._attr_preset_mode = preset_mode
         self.async_write_ha_state()
@@ -333,4 +271,5 @@ class RadioThermostat(CoordinatorEntity[RadioThermUpdateCoordinator], ClimateEnt
 
     def _set_preset_mode(self, preset_mode: str) -> None:
         """Set Preset mode (Home, Alternate, Away, Holiday)."""
+        assert isinstance(self.device, radiotherm.thermostat.CT80)
         self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -26,7 +26,6 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -180,7 +179,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Turn fan on/off."""
         if (code := FAN_MODE_TO_CODE.get(fan_mode)) is None:
-            raise HomeAssistantError(f"{fan_mode} is not a valid fan mode")
+            raise ValueError(f"{fan_mode} is not a valid fan mode")
         await self.hass.async_add_executor_job(self._set_fan_mode, code)
         self._attr_fan_mode = fan_mode
         self.async_write_ha_state()
@@ -263,7 +262,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set Preset mode (Home, Alternate, Away, Holiday)."""
         if preset_mode not in PRESET_MODES:
-            raise HomeAssistantError(f"{preset_mode} is not a valid preset_mode")
+            raise ValueError(f"{preset_mode} is not a valid preset_mode")
         await self.hass.async_add_executor_job(self._set_preset_mode, preset_mode)
         self._attr_preset_mode = preset_mode
         self.async_write_ha_state()

--- a/homeassistant/components/radiotherm/config_flow.py
+++ b/homeassistant/components/radiotherm/config_flow.py
@@ -11,11 +11,11 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import CONF_HOLD_TEMP, DOMAIN
+from .const import DOMAIN
 from .data import RadioThermInitData, async_get_init_data
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,7 +68,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=init_data.name,
                 data={CONF_HOST: ip_address},
-                options={CONF_HOLD_TEMP: False},
             )
 
         self._set_confirm_only()
@@ -100,7 +99,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=init_data.name,
             data={CONF_HOST: import_info[CONF_HOST]},
-            options={CONF_HOLD_TEMP: import_info[CONF_HOLD_TEMP]},
         )
 
     async def async_step_user(
@@ -125,42 +123,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=init_data.name,
                     data=user_input,
-                    options={CONF_HOLD_TEMP: False},
                 )
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
             errors=errors,
-        )
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
-
-
-class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle a option flow for radiotherm."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Handle options flow."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_HOLD_TEMP,
-                        default=self.config_entry.options[CONF_HOLD_TEMP],
-                    ): bool
-                }
-            ),
         )

--- a/homeassistant/components/radiotherm/const.py
+++ b/homeassistant/components/radiotherm/const.py
@@ -2,6 +2,4 @@
 
 DOMAIN = "radiotherm"
 
-CONF_HOLD_TEMP = "hold_temp"
-
 TIMEOUT = 25

--- a/homeassistant/components/radiotherm/coordinator.py
+++ b/homeassistant/components/radiotherm/coordinator.py
@@ -20,12 +20,9 @@ UPDATE_INTERVAL = timedelta(seconds=15)
 class RadioThermUpdateCoordinator(DataUpdateCoordinator[RadioThermUpdate]):
     """DataUpdateCoordinator to gather data for radio thermostats."""
 
-    def __init__(
-        self, hass: HomeAssistant, init_data: RadioThermInitData, hold_temp: bool
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, init_data: RadioThermInitData) -> None:
         """Initialize DataUpdateCoordinator."""
         self.init_data = init_data
-        self.hold_temp = hold_temp
         self._description = f"{init_data.name} ({init_data.host})"
         super().__init__(
             hass,
@@ -39,10 +36,8 @@ class RadioThermUpdateCoordinator(DataUpdateCoordinator[RadioThermUpdate]):
         try:
             return await async_get_data(self.hass, self.init_data.tstat)
         except RadiothermTstatError as ex:
-            raise UpdateFailed(
-                f"{self._description} was busy (invalid value returned): {ex}"
-            ) from ex
+            msg = f"{self._description} was busy (invalid value returned): {ex}"
+            raise UpdateFailed(msg) from ex
         except timeout as ex:
-            raise UpdateFailed(
-                f"{self._description}) timed out waiting for a response: {ex}"
-            ) from ex
+            msg = f"{self._description}) timed out waiting for a response: {ex}"
+            raise UpdateFailed(msg) from ex

--- a/homeassistant/components/radiotherm/entity.py
+++ b/homeassistant/components/radiotherm/entity.py
@@ -1,0 +1,44 @@
+"""The radiotherm integration base entity."""
+
+from abc import abstractmethod
+
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import RadioThermUpdateCoordinator
+from .data import RadioThermUpdate
+
+
+class RadioThermostatEntity(CoordinatorEntity[RadioThermUpdateCoordinator]):
+    """Base class for radiotherm entities."""
+
+    def __init__(self, coordinator: RadioThermUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.init_data = coordinator.init_data
+        self.device = coordinator.init_data.tstat
+        self._attr_device_info = DeviceInfo(
+            name=self.init_data.name,
+            model=self.init_data.model,
+            manufacturer="Radio Thermostats",
+            sw_version=self.init_data.fw_version,
+            connections={(dr.CONNECTION_NETWORK_MAC, self.init_data.mac)},
+        )
+        self._process_data()
+
+    @property
+    def data(self) -> RadioThermUpdate:
+        """Returnt the last update."""
+        return self.coordinator.data
+
+    @callback
+    @abstractmethod
+    def _process_data(self) -> None:
+        """Update and validate the data from the thermostat."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._process_data()
+        return super()._handle_coordinator_update()

--- a/homeassistant/components/radiotherm/switch.py
+++ b/homeassistant/components/radiotherm/switch.py
@@ -12,6 +12,8 @@ from .const import DOMAIN
 from .coordinator import RadioThermUpdateCoordinator
 from .entity import RadioThermostatEntity
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/radiotherm/switch.py
+++ b/homeassistant/components/radiotherm/switch.py
@@ -45,7 +45,7 @@ class RadioThermHoldSwitch(RadioThermostatEntity, SwitchEntity):
 
     def _set_hold(self, hold: bool) -> None:
         """Set hold mode."""
-        self.device.hold = bool(hold)
+        self.device.hold = int(hold)
 
     async def _async_set_hold(self, hold: bool) -> None:
         """Set hold mode."""

--- a/homeassistant/components/radiotherm/switch.py
+++ b/homeassistant/components/radiotherm/switch.py
@@ -1,0 +1,63 @@
+"""Support for radiotherm switches."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import RadioThermUpdateCoordinator
+from .entity import RadioThermostatEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches for a radiotherm device."""
+    coordinator: RadioThermUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([RadioThermHoldSwitch(coordinator)])
+
+
+class RadioThermHoldSwitch(RadioThermostatEntity, SwitchEntity):
+    """Provides radiotherm hold switch support."""
+
+    def __init__(self, coordinator: RadioThermUpdateCoordinator) -> None:
+        """Initialize the hold mode switch."""
+        super().__init__(coordinator)
+        self._attr_name = f"{coordinator.init_data.name} Hold"
+        self._attr_unique_id = f"{coordinator.init_data.mac}_hold"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the switch."""
+        return "mdi:timer-off" if self.is_on else "mdi:timer"
+
+    @callback
+    def _process_data(self) -> None:
+        """Update and validate the data from the thermostat."""
+        data = self.data.tstat
+        self._attr_is_on = bool(data["hold"])
+
+    def _set_hold(self, hold: bool) -> None:
+        """Set hold mode."""
+        self.device.hold = bool(hold)
+
+    async def _async_set_hold(self, hold: bool) -> None:
+        """Set hold mode."""
+        await self.hass.async_add_executor_job(self._set_hold, hold)
+        self._attr_is_on = hold
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable permanent hold."""
+        await self._async_set_hold(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable permanent hold."""
+        await self._async_set_hold(False)

--- a/homeassistant/components/radiotherm/util.py
+++ b/homeassistant/components/radiotherm/util.py
@@ -1,0 +1,24 @@
+"""Utils for radiotherm."""
+from __future__ import annotations
+
+from radiotherm.thermostat import CommonThermostat
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+
+async def async_set_time(hass: HomeAssistant, device: CommonThermostat) -> None:
+    """Sync time to the thermostat."""
+    await hass.async_add_executor_job(_set_time, device)
+
+
+def _set_time(device: CommonThermostat) -> None:
+    """Set device time."""
+    # Calling this clears any local temperature override and
+    # reverts to the scheduled temperature.
+    now = dt_util.now()
+    device.time = {
+        "day": now.weekday(),
+        "hour": now.hour,
+        "minute": now.minute,
+    }


### PR DESCRIPTION
## Breaking change

Radio Thermostat's hold mode is now configured via a switch.  This replaces the original YAML configuration option named `hold_temp`

The integration now only synchronizes time when loaded if the hold mode is not active. Synchronizing the time when the hold mode is active causes the hold mode to disable unexpectedly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make radiotherm hold mode a switch
https://github.com/home-assistant/core/pull/72874#discussion_r889611194

This PR removes the options flow that was added in #72874 which
was only done to avoid adding another platform in the same PR as
a config flow conversion since it would have made that PR larger.

Removal of the options flow is not a breaking change as long as
this PR merges before 2022.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23010

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
