### PR TITLE
Update pylint to 2.14.0

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -28,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 MAX_UPLOAD_SIZE = 1024 * 1024 * 1024
 
+# pylint: disable=implicit-str-concat
 NO_TIMEOUT = re.compile(
     r"^(?:"
     r"|homeassistant/update"
@@ -48,6 +49,7 @@ NO_AUTH = re.compile(
 )
 
 NO_STORE = re.compile(r"^(?:" r"|app/entrypoint.js" r")$")
+# pylint: enable=implicit-str-concat
 
 
 class HassIOView(HomeAssistantView):

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -38,9 +38,11 @@ SCHEMA_WEBSOCKET_EVENT = vol.Schema(
 )
 
 # Endpoints needed for ingress can't require admin because addons can set `panel_admin: false`
+# pylint: disable=implicit-str-concat
 WS_NO_ADMIN_ENDPOINTS = re.compile(
     r"^(?:" r"|/ingress/(session|validate_session)" r"|/addons/[^/]+/info" r")$"
 )
+# pylint: enable=implicit-str-concat
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -80,7 +80,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ),
         }
 
-    # pylint: disable-next=abstract-class-instantiated
     sentry_sdk.init(
         dsn=entry.data[CONF_DSN],
         environment=entry.options.get(CONF_ENVIRONMENT),

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable, Generator
 from datetime import datetime, timedelta
 import logging
 from time import monotonic
-from typing import Any, Generic, TypeVar  # pylint: disable=unused-import
+from typing import Any, Generic, TypeVar
 import urllib.error
 
 import aiohttp

--- a/pylint/plugins/hass_constructor.py
+++ b/pylint/plugins/hass_constructor.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 
 from astroid import nodes
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
 
 
 class HassConstructorFormatChecker(BaseChecker):  # type: ignore[misc]
     """Checker for __init__ definitions."""
-
-    __implements__ = IAstroidChecker
 
     name = "hass_constructor"
     priority = -1

--- a/pylint/plugins/hass_constructor.py
+++ b/pylint/plugins/hass_constructor.py
@@ -12,7 +12,7 @@ class HassConstructorFormatChecker(BaseChecker):  # type: ignore[misc]
     name = "hass_constructor"
     priority = -1
     msgs = {
-        "W0006": (
+        "W7411": (
             '__init__ should have explicit return type "None"',
             "hass-constructor-return",
             "Used when __init__ has all arguments typed "

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -6,7 +6,6 @@ import re
 
 from astroid import nodes
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
 
 from homeassistant.const import Platform
@@ -539,8 +538,6 @@ def _get_module_platform(module_name: str) -> str | None:
 
 class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
     """Checker for setup type hints."""
-
-    __implements__ = IAstroidChecker
 
     name = "hass_enforce_type_hints"
     priority = -1

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -542,12 +542,12 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
     name = "hass_enforce_type_hints"
     priority = -1
     msgs = {
-        "W0020": (
+        "W7431": (
             "Argument %d should be of type %s",
             "hass-argument-type",
             "Used when method argument type is incorrect",
         ),
-        "W0021": (
+        "W7432": (
             "Return type should be %s",
             "hass-return-type",
             "Used when method return type is incorrect",

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -6,7 +6,6 @@ import re
 
 from astroid import nodes
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
 
 
@@ -232,8 +231,6 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
 
 class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
     """Checker for imports."""
-
-    __implements__ = IAstroidChecker
 
     name = "hass_imports"
     priority = -1

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -235,12 +235,12 @@ class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
     name = "hass_imports"
     priority = -1
     msgs = {
-        "W0011": (
+        "W7421": (
             "Relative import should be used",
             "hass-relative-import",
             "Used when absolute import should be replaced with relative import",
         ),
-        "W0012": (
+        "W7422": (
             "%s is deprecated, %s",
             "hass-deprecated-import",
             "Used when import is deprecated",

--- a/pylint/plugins/hass_logger.py
+++ b/pylint/plugins/hass_logger.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from astroid import nodes
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
 
 LOGGER_NAMES = ("LOGGER", "_LOGGER")
@@ -12,8 +11,6 @@ LOG_LEVEL_ALLOWED_LOWER_START = ("debug",)
 
 class HassLoggerFormatChecker(BaseChecker):  # type: ignore[misc]
     """Checker for logger invocations."""
-
-    __implements__ = IAstroidChecker
 
     name = "hass_logger"
     priority = -1

--- a/pylint/plugins/hass_logger.py
+++ b/pylint/plugins/hass_logger.py
@@ -15,12 +15,12 @@ class HassLoggerFormatChecker(BaseChecker):  # type: ignore[misc]
     name = "hass_logger"
     priority = -1
     msgs = {
-        "W0001": (
+        "W7401": (
             "User visible logger messages must not end with a period",
             "hass-logger-period",
             "Periods are not permitted at the end of logger messages",
         ),
-        "W0002": (
+        "W7402": (
             "User visible logger messages must start with a capital letter or downgrade to debug",
             "hass-logger-capital",
             "All logger messages must start with a capital letter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ good-names = [
 # too-many-ancestors - it's too strict.
 # wrong-import-order - isort guards this
 # consider-using-f-string - str.format sometimes more readable
-# no-self-use - little added value with too many false-positives
 # ---
 # Enable once current issues are fixed:
 # consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
@@ -179,7 +178,6 @@ disable = [
     "unused-argument",
     "wrong-import-order",
     "consider-using-f-string",
-    "no-self-use",
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ forced_separate = [
 ]
 combine_as_imports = true
 
-[tool.pylint.MASTER]
+[tool.pylint.MAIN]
 py-version = "3.9"
 ignore = [
     "tests",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.2.1
 mock-open==1.4.0
 mypy==0.960
 pre-commit==2.19.0
-pylint==2.13.9
+pylint==2.14.0
 pipdeptree==2.2.1
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Proposed change
Release post: https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html
Compare view: https://github.com/PyCQA/pylint/compare/v2.13.9...v2.14.0

### Changes
* Some new small checkers
* Fixed bugs and some false-positives
* `no-self-use` is now optional (disabled by default)
* The main section can now be renamed to `[tool.pylint.MAIN]`
* Deprecations for pylint extensions. Relevant for us: the deprecation of `IAstroidChecker`

### Preparation for future updates
* Renamed pylint plugin message ids to avoid conflicts with builtin checkers. All custom messages start with `[EW]74..` now. /CC: @epenet


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
