### PR TITLE
Add Entity.entity_name attribute

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -440,15 +440,6 @@ class EntityPlatform:
 
         # Get entity_id from unique ID registration
         if entity.unique_id is not None:
-            if entity.entity_id is not None:
-                requested_entity_id = entity.entity_id
-                suggested_object_id = split_entity_id(entity.entity_id)[1]
-            else:
-                suggested_object_id = entity.name  # type: ignore[unreachable]
-
-            if self.entity_namespace is not None:
-                suggested_object_id = f"{self.entity_namespace} {suggested_object_id}"
-
             if self.config_entry is not None:
                 config_entry_id: str | None = self.config_entry.entry_id
             else:
@@ -502,6 +493,18 @@ class EntityPlatform:
                     device_id = device.id
                 except RequiredParameterMissing:
                     pass
+
+            if entity.entity_id is not None:
+                requested_entity_id = entity.entity_id
+                suggested_object_id = split_entity_id(entity.entity_id)[1]
+            else:
+                if device:  # type: ignore[unreachable]
+                    suggested_object_id = entity.async_full_name(device)
+                if not suggested_object_id:
+                    suggested_object_id = entity.name
+
+            if self.entity_namespace is not None:
+                suggested_object_id = f"{self.entity_namespace} {suggested_object_id}"
 
             disabled_by: RegistryEntryDisabler | None = None
             if not entity.entity_registry_enabled_default:

--- a/tests/common.py
+++ b/tests/common.py
@@ -1002,6 +1002,11 @@ class MockEntity(entity.Entity):
         return self._handle("entity_category")
 
     @property
+    def entity_name(self):
+        """Return the entity name."""
+        return self._handle("entity_name")
+
+    @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry."""
         return self._handle("entity_registry_enabled_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `Entity.entity_name` attribute:
  - UNDEFINED (the default): Entity falls back to the existing name property.
  - None; the entity should have the same name as the device. For example, a device named “Table Lamp” doesn’t need to have an entity named “Table Lamp light”. 
  - A string; this is the name of the entity just identifying the data point. So for a sensor that represents the power usage of its device, this would be “Power Usage”.

This offers a solution which allows us to distinguish what part of the entity name is the actual name of the entity versus what part of the entity name identifies what the entity belongs to (a device or area).

### Background

Home Assistant models the home of a user into three levels:
- Area (eg. Living Room)
- Device (eg. Switch)
- Entity (eg. Power usage)

Entities in Home Assistant are the data points provided by a device and can represent specific controls (a switch of the device, a light of the device).

Because Home Assistant used to only have entities in the first many years of its existence, a lot of functionality is based around entities in Home Assistant. The main one being the UI.

A typical integration will name a device with a switch and a sensor like this:
- Device name: Dishwasher
  - Switch name: Dishwasher switch
  - Sensor name: Dishwasher power usage

Reasons for this naming scheme are:
- Home Assistant started out with only entities, devices and areas were added later
- `entity_id` is automatically generated only from the entity's name, if the entity name is non-specific (switch, power usage), that will be true also for the `entity_id`
- While the frontend in some cases logically sorts entities by area and device it doesn't do that in other

It's also common for users to rename entities to include the area. For example a motion sensor may be renamed to "Living Room motion"

This means there is no single source of truth for a device name because entities include the device name in their name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
