### PR TITLE
Remove deprecated temperature conversion of non sensors

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -32,17 +32,8 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
 )
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    Context,
-    Event,
-    HomeAssistant,
-    callback,
-    split_entity_id,
-)
+from homeassistant.core import CALLBACK_TYPE, Context, Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, NoEntitySpecifiedError
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
@@ -258,9 +249,6 @@ class Entity(ABC):
 
     # If we reported this entity is updated while disabled
     _disabled_reported = False
-
-    # If we reported this entity is relying on deprecated temperature conversion
-    _temperature_reported = False
 
     # Protect for multiple updates
     _update_staged = False
@@ -617,58 +605,6 @@ class Entity(ABC):
         # Overwrite properties that have been set in the config file.
         if DATA_CUSTOMIZE in self.hass.data:
             attr.update(self.hass.data[DATA_CUSTOMIZE].get(self.entity_id))
-
-        def _convert_temperature(state: str, attr: dict[str, Any]) -> str:
-            # Convert temperature if we detect one
-            # pylint: disable-next=import-outside-toplevel
-            from homeassistant.components.sensor import SensorEntity
-
-            unit_of_measure = attr.get(ATTR_UNIT_OF_MEASUREMENT)
-            units = self.hass.config.units
-            if unit_of_measure == units.temperature_unit or unit_of_measure not in (
-                TEMP_CELSIUS,
-                TEMP_FAHRENHEIT,
-            ):
-                return state
-
-            domain = split_entity_id(self.entity_id)[0]
-            if domain != "sensor":
-                if not self._temperature_reported:
-                    self._temperature_reported = True
-                    report_issue = self._suggest_report_issue()
-                    _LOGGER.warning(
-                        "Entity %s (%s) relies on automatic temperature conversion, this will "
-                        "be unsupported in Home Assistant Core 2022.7. Please %s",
-                        self.entity_id,
-                        type(self),
-                        report_issue,
-                    )
-            elif not isinstance(self, SensorEntity):
-                if not self._temperature_reported:
-                    self._temperature_reported = True
-                    report_issue = self._suggest_report_issue()
-                    _LOGGER.warning(
-                        "Temperature sensor %s (%s) does not inherit SensorEntity, "
-                        "this will be unsupported in Home Assistant Core 2022.7."
-                        "Please %s",
-                        self.entity_id,
-                        type(self),
-                        report_issue,
-                    )
-            else:
-                return state
-
-            try:
-                prec = len(state) - state.index(".") - 1 if "." in state else 0
-                temp = units.temperature(float(state), unit_of_measure)
-                state = str(round(temp) if prec == 0 else round(temp, prec))
-                attr[ATTR_UNIT_OF_MEASUREMENT] = units.temperature_unit
-            except ValueError:
-                # Could not convert state to float
-                pass
-            return state
-
-        state = _convert_temperature(state, attr)
 
         if (
             self._context_set is not None

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
-    TEMP_FAHRENHEIT,
 )
 from homeassistant.core import Context, HomeAssistantError
 from homeassistant.helpers import entity, entity_registry
@@ -814,64 +813,6 @@ async def test_float_conversion(hass):
     state = hass.states.get("hello.world")
     assert state is not None
     assert state.state == "3.6"
-
-
-async def test_temperature_conversion(hass, caplog):
-    """Test conversion of temperatures."""
-    # Non sensor entity reporting a temperature
-    with patch.object(
-        entity.Entity, "state", PropertyMock(return_value=100)
-    ), patch.object(
-        entity.Entity, "unit_of_measurement", PropertyMock(return_value=TEMP_FAHRENHEIT)
-    ):
-        ent = entity.Entity()
-        ent.hass = hass
-        ent.entity_id = "hello.world"
-        ent.async_write_ha_state()
-
-    state = hass.states.get("hello.world")
-    assert state is not None
-    assert state.state == "38"
-    assert (
-        "Entity hello.world (<class 'homeassistant.helpers.entity.Entity'>) relies on automatic "
-        "temperature conversion, this will be unsupported in Home Assistant Core 2022.7. "
-        "Please create a bug report" in caplog.text
-    )
-
-    # Sensor entity, not extending SensorEntity, reporting a temperature
-    with patch.object(
-        entity.Entity, "state", PropertyMock(return_value=100)
-    ), patch.object(
-        entity.Entity, "unit_of_measurement", PropertyMock(return_value=TEMP_FAHRENHEIT)
-    ):
-        ent = entity.Entity()
-        ent.hass = hass
-        ent.entity_id = "sensor.temp"
-        ent.async_write_ha_state()
-
-    state = hass.states.get("sensor.temp")
-    assert state is not None
-    assert state.state == "38"
-    assert (
-        "Temperature sensor sensor.temp (<class 'homeassistant.helpers.entity.Entity'>) "
-        "does not inherit SensorEntity, this will be unsupported in Home Assistant Core "
-        "2022.7.Please create a bug report" in caplog.text
-    )
-
-    # Sensor entity, not extending SensorEntity, not reporting a number
-    with patch.object(
-        entity.Entity, "state", PropertyMock(return_value="really warm")
-    ), patch.object(
-        entity.Entity, "unit_of_measurement", PropertyMock(return_value=TEMP_FAHRENHEIT)
-    ):
-        ent = entity.Entity()
-        ent.hass = hass
-        ent.entity_id = "sensor.temp"
-        ent.async_write_ha_state()
-
-    state = hass.states.get("sensor.temp")
-    assert state is not None
-    assert state.state == "really warm"
 
 
 async def test_attribution_attribute(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Entities other than sensors reporting a temperature will no longer have their values converted.
For background, refer to: https://github.com/home-assistant/core/pull/48261

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated temperature conversion of non sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
