### PR TITLE
Add half-hourly option to Utility meter component

### DIFF
--- a/homeassistant/components/utility_meter/config_flow.py
+++ b/homeassistant/components/utility_meter/config_flow.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_TARIFFS,
     DAILY,
     DOMAIN,
+    HALF_HOURLY,
     HOURLY,
     MONTHLY,
     QUARTER_HOURLY,
@@ -36,6 +37,7 @@ from .const import (
 METER_TYPES = [
     selector.SelectOptionDict(value="none", label="No cycle"),
     selector.SelectOptionDict(value=QUARTER_HOURLY, label="Every 15 minutes"),
+    selector.SelectOptionDict(value=HALF_HOURLY, label="Every 30 minutes"),
     selector.SelectOptionDict(value=HOURLY, label="Hourly"),
     selector.SelectOptionDict(value=DAILY, label="Daily"),
     selector.SelectOptionDict(value=WEEKLY, label="Weekly"),

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -4,6 +4,7 @@ DOMAIN = "utility_meter"
 TARIFF_ICON = "mdi:clock-outline"
 
 QUARTER_HOURLY = "quarter-hourly"
+HALF_HOURLY = "half-hourly"
 HOURLY = "hourly"
 DAILY = "daily"
 WEEKLY = "weekly"
@@ -14,6 +15,7 @@ YEARLY = "yearly"
 
 METER_TYPES = [
     QUARTER_HOURLY,
+    HALF_HOURLY,
     HOURLY,
     DAILY,
     WEEKLY,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -58,6 +58,7 @@ from .const import (
     DAILY,
     DATA_TARIFF_SENSORS,
     DATA_UTILITY,
+    HALF_HOURLY,
     HOURLY,
     MONTHLY,
     QUARTER_HOURLY,
@@ -70,6 +71,7 @@ from .const import (
 
 PERIOD2CRON = {
     QUARTER_HOURLY: "{minute}/15 * * * *",
+    HALF_HOURLY: "{minute}/30 * * * *",
     HOURLY: "{minute} * * * *",
     DAILY: "{minute} {hour} * * *",
     WEEKLY: "{minute} {hour} * * {day}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This change adds a new half-hourly option to the Utility meter component to suit peak demand metering in Australia. 


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
