### PR TITLE
Add temperature unit conversion support to NumberEntity

### DIFF
--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -1,13 +1,14 @@
 """Component to allow numeric input for platforms."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
 import inspect
 import logging
 from math import ceil, floor
-from typing import Any, Callable, final
+from typing import Any, final
 
 import voluptuous as vol
 
@@ -369,7 +370,7 @@ class NumberEntity(Entity):
             # Suppress ValueError (Could not convert value to float)
             with suppress(ValueError):
                 value_new: float = UNIT_CONVERSIONS[device_class](
-                    value_new,
+                    value,
                     native_unit_of_measurement,
                     unit_of_measurement,
                 )

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -1,16 +1,19 @@
 """Component to allow numeric input for platforms."""
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
+import inspect
 import logging
-from typing import Any, final
+from math import ceil, floor
+from typing import Any, Callable, final
 
 import voluptuous as vol
 
 from homeassistant.backports.enum import StrEnum
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_MODE
+from homeassistant.const import ATTR_MODE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -19,6 +22,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import temperature as temperature_util
 
 from .const import (
     ATTR_MAX,
@@ -41,12 +45,24 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 _LOGGER = logging.getLogger(__name__)
 
 
+class NumberDeviceClass(StrEnum):
+    """Device class for numbers."""
+
+    # temperature (C/F)
+    TEMPERATURE = "temperature"
+
+
 class NumberMode(StrEnum):
     """Modes for number entities."""
 
     AUTO = "auto"
     BOX = "box"
     SLIDER = "slider"
+
+
+UNIT_CONVERSIONS: dict[str, Callable[[float, str, str], float]] = {
+    NumberDeviceClass.TEMPERATURE: temperature_util.convert,
+}
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -72,7 +88,16 @@ async def async_set_value(entity: NumberEntity, service_call: ServiceCall) -> No
         raise ValueError(
             f"Value {value} for {entity.name} is outside valid range {entity.min_value} - {entity.max_value}"
         )
-    await entity.async_set_value(value)
+    try:
+        # pylint: disable-next=protected-access
+        native_value = entity._convert_to_native_value(value)
+        # Clamp to the native range
+        native_value = min(
+            max(native_value, entity.native_min_value), entity.native_max_value
+        )
+        await entity.async_set_native_value(native_value)
+    except NotImplementedError:
+        await entity.async_set_value(value)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -91,21 +116,83 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class NumberEntityDescription(EntityDescription):
     """A class that describes number entities."""
 
-    max_value: float | None = None
-    min_value: float | None = None
-    step: float | None = None
+    max_value: None = None
+    min_value: None = None
+    native_max_value: float | None = None
+    native_min_value: float | None = None
+    native_unit_of_measurement: str | None = None
+    native_step: float | None = None
+    step: None = None
+    unit_of_measurement: None = None  # Type override, use native_unit_of_measurement
+
+    def __post_init__(self) -> None:
+        """Post initialisation processing."""
+        if (
+            self.max_value is not None
+            or self.min_value is not None
+            or self.step is not None
+            or self.unit_of_measurement is not None
+        ):
+            caller = inspect.stack()[2]  # type: ignore[unreachable]
+            module = inspect.getmodule(caller[0])
+            if "custom_components" in module.__file__:
+                report_issue = "report it to the custom component author."
+            else:
+                report_issue = (
+                    "create a bug report at "
+                    "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
+                )
+            _LOGGER.warning(
+                "%s is setting deprecated attributes on an instance of "
+                "NumberEntityDescription, this is not valid and will be unsupported "
+                "from Home Assistant 2022.10. Please %s",
+                module.__name__,
+                report_issue,
+            )
+            self.native_unit_of_measurement = self.unit_of_measurement
+
+
+def ceil_decimal(value: float, precision: float = 0) -> float:
+    """Return the ceiling of f with d decimals.
+
+    This is a simple implementation which ignores floating point inexactness.
+    """
+    if precision == 0:
+        return ceil(value)
+    factor = 10**precision
+    return ceil(value * factor) / factor
+
+
+def floor_decimal(value: float, precision: float = 0) -> float:
+    """Return the floor of f with d decimals.
+
+    This is a simple implementation which ignores floating point inexactness.
+    """
+    if precision == 0:
+        return floor(value)
+    factor = 10**precision
+    return floor(value * factor) / factor
 
 
 class NumberEntity(Entity):
     """Representation of a Number entity."""
 
     entity_description: NumberEntityDescription
-    _attr_max_value: float
-    _attr_min_value: float
+    _attr_max_value: None
+    _attr_min_value: None
     _attr_state: None = None
-    _attr_step: float
+    _attr_step: None
     _attr_mode: NumberMode = NumberMode.AUTO
-    _attr_value: float
+    _attr_value: None
+    _attr_native_max_value: float
+    _attr_native_min_value: float
+    _attr_native_step: float
+    _attr_native_value: float
+    _attr_native_unit_of_measurement: str | None
+    _attr_unit_of_measurement: None = (
+        None  # Subclasses of NumberEntity should not set this
+    )
+    _deprecated_number_entity_reported = False
 
     @property
     def capability_attributes(self) -> dict[str, Any]:
@@ -118,39 +205,86 @@ class NumberEntity(Entity):
         }
 
     @property
+    def native_min_value(self) -> float:
+        """Return the minimum value."""
+        if hasattr(self, "_attr_native_min_value"):
+            return self._attr_native_min_value
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description.native_min_value is not None
+        ):
+            return self.entity_description.native_min_value
+        return DEFAULT_MIN_VALUE
+
+    @property
+    @final
     def min_value(self) -> float:
         """Return the minimum value."""
         if hasattr(self, "_attr_min_value"):
-            return self._attr_min_value
+            self._report_deprecated_number_entity()
+            return self._attr_min_value  # type: ignore[return-value]
         if (
             hasattr(self, "entity_description")
             and self.entity_description.min_value is not None
         ):
+            self._report_deprecated_number_entity()  # type: ignore[unreachable]
             return self.entity_description.min_value
-        return DEFAULT_MIN_VALUE
+        return self._convert_to_state_value(self.native_min_value, floor_decimal)
 
     @property
+    def native_max_value(self) -> float:
+        """Return the maximum value."""
+        if hasattr(self, "_attr_native_max_value"):
+            return self._attr_native_max_value
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description.native_max_value is not None
+        ):
+            return self.entity_description.native_max_value
+        return DEFAULT_MAX_VALUE
+
+    @property
+    @final
     def max_value(self) -> float:
         """Return the maximum value."""
         if hasattr(self, "_attr_max_value"):
-            return self._attr_max_value
+            self._report_deprecated_number_entity()
+            return self._attr_max_value  # type: ignore[return-value]
         if (
             hasattr(self, "entity_description")
             and self.entity_description.max_value is not None
         ):
+            self._report_deprecated_number_entity()  # type: ignore[unreachable]
             return self.entity_description.max_value
-        return DEFAULT_MAX_VALUE
+        return self._convert_to_state_value(self.native_max_value, ceil_decimal)
 
     @property
+    def native_step(self) -> float | None:
+        """Return the increment/decrement step."""
+        if hasattr(self, "_attr_native_step"):
+            return self._attr_native_step
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description.native_step is not None
+        ):
+            return self.entity_description.native_step
+        return None
+
+    @property
+    @final
     def step(self) -> float:
         """Return the increment/decrement step."""
         if hasattr(self, "_attr_step"):
-            return self._attr_step
+            self._report_deprecated_number_entity()
+            return self._attr_step  # type: ignore[return-value]
         if (
             hasattr(self, "entity_description")
             and self.entity_description.step is not None
         ):
+            self._report_deprecated_number_entity()  # type: ignore[unreachable]
             return self.entity_description.step
+        if (native_step := self.native_step) is not None:
+            return native_step
         step = DEFAULT_STEP
         value_range = abs(self.max_value - self.min_value)
         if value_range != 0:
@@ -170,14 +304,122 @@ class NumberEntity(Entity):
         return self.value
 
     @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement of the entity, if any."""
+        if hasattr(self, "_attr_native_unit_of_measurement"):
+            return self._attr_native_unit_of_measurement
+        if hasattr(self, "entity_description"):
+            return self.entity_description.native_unit_of_measurement
+        return None
+
+    @property
+    @final
+    def unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement of the entity, after unit conversion."""
+        native_unit_of_measurement = self.native_unit_of_measurement
+
+        if (
+            self.device_class == NumberDeviceClass.TEMPERATURE
+            and native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+        ):
+            return self.hass.config.units.temperature_unit
+
+        return native_unit_of_measurement
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the value reported by the sensor."""
+        return self._attr_native_value
+
+    @property
+    @final
     def value(self) -> float | None:
         """Return the entity value to represent the entity state."""
-        return self._attr_value
+        if hasattr(self, "_attr_value"):
+            self._report_deprecated_number_entity()
+            return self._attr_value
 
+        if (native_value := self.native_value) is None:
+            return native_value
+        return self._convert_to_state_value(native_value, round)
+
+    def set_native_value(self, value: float) -> None:
+        """Set new value."""
+        raise NotImplementedError()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        await self.hass.async_add_executor_job(self.set_native_value, value)
+
+    @final
     def set_value(self, value: float) -> None:
         """Set new value."""
         raise NotImplementedError()
 
+    @final
     async def async_set_value(self, value: float) -> None:
         """Set new value."""
         await self.hass.async_add_executor_job(self.set_value, value)
+
+    def _convert_to_state_value(self, value: float, method: Callable) -> float:
+
+        native_unit_of_measurement = self.native_unit_of_measurement
+        unit_of_measurement = self.unit_of_measurement
+        device_class = self.device_class
+
+        if (
+            native_unit_of_measurement != unit_of_measurement
+            and device_class in UNIT_CONVERSIONS
+        ):
+            assert native_unit_of_measurement
+            assert unit_of_measurement
+
+            value_s = str(value)
+            prec = len(value_s) - value_s.index(".") - 1 if "." in value_s else 0
+
+            # Suppress ValueError (Could not convert value to float)
+            with suppress(ValueError):
+                value_new: float = UNIT_CONVERSIONS[device_class](
+                    value_new,
+                    native_unit_of_measurement,
+                    unit_of_measurement,
+                )
+
+                # Round to the wanted precision
+                value = method(value_new) if prec == 0 else method(value_new, prec)
+
+        return value
+
+    def _convert_to_native_value(self, value: float) -> float:
+
+        native_unit_of_measurement = self.native_unit_of_measurement
+        unit_of_measurement = self.unit_of_measurement
+        device_class = self.device_class
+
+        if (
+            value is not None
+            and native_unit_of_measurement != unit_of_measurement
+            and device_class in UNIT_CONVERSIONS
+        ):
+            assert native_unit_of_measurement
+            assert unit_of_measurement
+
+            value = UNIT_CONVERSIONS[device_class](
+                value,
+                unit_of_measurement,
+                native_unit_of_measurement,
+            )
+
+        return value
+
+    def _report_deprecated_number_entity(self) -> None:
+        """Report that the number entity has not been upgraded."""
+        if not self._deprecated_number_entity_reported:
+            self._deprecated_number_entity_reported = True
+            report_issue = self._suggest_report_issue()
+            _LOGGER.warning(
+                "Entity %s (%s) is using deprecated NumberEntity features, please %s",
+                self.entity_id,
+                type(self),
+                report_issue,
+            )

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -306,7 +306,10 @@ class NumberEntity(Entity):
         """Return the unit of measurement of the entity, after unit conversion."""
         if hasattr(self, "_attr_unit_of_measurement"):
             return self._attr_unit_of_measurement
-        if hasattr(self, "entity_description"):
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description.unit_of_measurement is not None
+        ):
             return self.entity_description.unit_of_measurement
 
         native_unit_of_measurement = self.native_unit_of_measurement

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -309,6 +309,11 @@ class NumberEntity(Entity):
     @property
     def unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the entity, after unit conversion."""
+        if hasattr(self, "_attr_unit_of_measurement"):
+            return self._attr_unit_of_measurement
+        if hasattr(self, "entity_description"):
+            return self.entity_description.unit_of_measurement
+
         native_unit_of_measurement = self.native_unit_of_measurement
 
         if (

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -4,15 +4,25 @@ from unittest.mock import MagicMock
 import pytest
 
 from homeassistant.components.number import (
+    ATTR_MAX,
+    ATTR_MIN,
     ATTR_STEP,
     ATTR_VALUE,
     DOMAIN,
     SERVICE_SET_VALUE,
+    NumberDeviceClass,
     NumberEntity,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_PLATFORM,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 
 class MockDefaultNumberEntity(NumberEntity):
@@ -41,9 +51,11 @@ class MockNumberEntity(NumberEntity):
 async def test_step(hass: HomeAssistant) -> None:
     """Test the step calculation."""
     number = MockDefaultNumberEntity()
+    number.hass = hass
     assert number.step == 1.0
 
     number_2 = MockNumberEntity()
+    number_2.hass = hass
     assert number_2.step == 0.1
 
 
@@ -59,9 +71,7 @@ async def test_sync_set_value(hass: HomeAssistant) -> None:
     assert number.set_value.call_args[0][0] == 42
 
 
-async def test_custom_integration_and_validation(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+async def test_set_value(hass: HomeAssistant, enable_custom_integrations: None) -> None:
     """Test we can only set valid values."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -79,9 +89,8 @@ async def test_custom_integration_and_validation(
         {ATTR_VALUE: 60.0, ATTR_ENTITY_ID: "number.test"},
         blocking=True,
     )
-
-    hass.states.async_set("number.test", 60.0)
     await hass.async_block_till_done()
+
     state = hass.states.get("number.test")
     assert state.state == "60.0"
 
@@ -97,3 +106,252 @@ async def test_custom_integration_and_validation(
     await hass.async_block_till_done()
     state = hass.states.get("number.test")
     assert state.state == "60.0"
+
+
+async def test_deprecated_attributes(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
+    """Test entity using deprecated attributes."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init(empty=True)
+    platform.ENTITIES.append(platform.LegacyMockNumberEntity())
+    entity = platform.ENTITIES[0]
+    entity._attr_name = "Test"
+    entity._attr_max_value = 25
+    entity._attr_min_value = -25
+    entity._attr_step = 2.5
+    entity._attr_value = 51.0
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test")
+    assert state.state == "51.0"
+    assert state.attributes.get(ATTR_MAX) == 25.0
+    assert state.attributes.get(ATTR_MIN) == -25.0
+    assert state.attributes.get(ATTR_STEP) == 2.5
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 0.0, ATTR_ENTITY_ID: "number.test"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test")
+    assert state.state == "0.0"
+
+    # test ValueError trigger
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: 110.0, ATTR_ENTITY_ID: "number.test"},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    state = hass.states.get("number.test")
+    assert state.state == "0.0"
+
+
+async def test_deprecated_methods(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
+    """Test entity using deprecated methods."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init(empty=True)
+    platform.ENTITIES.append(
+        platform.LegacyMockNumberEntity(
+            name="Test",
+            max_value=25.0,
+            min_value=-25.0,
+            step=2.5,
+            value=51.0,
+        )
+    )
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test")
+    assert state.state == "51.0"
+    assert state.attributes.get(ATTR_MAX) == 25.0
+    assert state.attributes.get(ATTR_MIN) == -25.0
+    assert state.attributes.get(ATTR_STEP) == 2.5
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 0.0, ATTR_ENTITY_ID: "number.test"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test")
+    assert state.state == "0.0"
+
+    # test ValueError trigger
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: 110.0, ATTR_ENTITY_ID: "number.test"},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    state = hass.states.get("number.test")
+    assert state.state == "0.0"
+
+
+@pytest.mark.parametrize(
+    "unit_system, native_unit, state_unit, initial_native_value, initial_state_value, "
+    "updated_native_value, updated_state_value, native_max_value, state_max_value, "
+    "native_min_value, state_min_value, native_step, state_step",
+    [
+        (
+            IMPERIAL_SYSTEM,
+            TEMP_FAHRENHEIT,
+            TEMP_FAHRENHEIT,
+            100,
+            100,
+            50,
+            50,
+            140,
+            140,
+            -9,
+            -9,
+            3,
+            3,
+        ),
+        (
+            IMPERIAL_SYSTEM,
+            TEMP_CELSIUS,
+            TEMP_FAHRENHEIT,
+            38,
+            100,
+            10,
+            50,
+            60,
+            140,
+            -23,
+            -10,
+            3,
+            3,
+        ),
+        (
+            METRIC_SYSTEM,
+            TEMP_FAHRENHEIT,
+            TEMP_CELSIUS,
+            100,
+            38,
+            50,
+            10,
+            140,
+            60,
+            -9,
+            -23,
+            3,
+            3,
+        ),
+        (
+            METRIC_SYSTEM,
+            TEMP_CELSIUS,
+            TEMP_CELSIUS,
+            38,
+            38,
+            10,
+            10,
+            60,
+            60,
+            -23,
+            -23,
+            3,
+            3,
+        ),
+    ],
+)
+async def test_temperature_conversion(
+    hass,
+    enable_custom_integrations,
+    unit_system,
+    native_unit,
+    state_unit,
+    initial_native_value,
+    initial_state_value,
+    updated_native_value,
+    updated_state_value,
+    native_max_value,
+    state_max_value,
+    native_min_value,
+    state_min_value,
+    native_step,
+    state_step,
+):
+    """Test temperature conversion."""
+    hass.config.units = unit_system
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init(empty=True)
+    platform.ENTITIES.append(
+        platform.MockNumberEntity(
+            name="Test",
+            native_max_value=native_max_value,
+            native_min_value=native_min_value,
+            native_step=native_step,
+            native_unit_of_measurement=native_unit,
+            native_value=initial_native_value,
+            device_class=NumberDeviceClass.TEMPERATURE,
+        )
+    )
+
+    entity0 = platform.ENTITIES[0]
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert float(state.state) == pytest.approx(float(initial_state_value))
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == state_unit
+    assert state.attributes[ATTR_MAX] == state_max_value
+    assert state.attributes[ATTR_MIN] == state_min_value
+    assert state.attributes[ATTR_STEP] == state_step
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: updated_state_value, ATTR_ENTITY_ID: entity0.entity_id},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert float(state.state) == pytest.approx(float(updated_state_value))
+    assert entity0._values["native_value"] == updated_native_value
+
+    # Set to the minimum value
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: state_min_value, ATTR_ENTITY_ID: entity0.entity_id},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert float(state.state) == pytest.approx(float(state_min_value), rel=0.1)
+
+    # Set to the maximum value
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: state_max_value, ATTR_ENTITY_ID: entity0.entity_id},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert float(state.state) == pytest.approx(float(state_max_value), rel=0.1)

--- a/tests/testing_config/custom_components/test/number.py
+++ b/tests/testing_config/custom_components/test/number.py
@@ -13,10 +13,55 @@ ENTITIES = []
 
 
 class MockNumberEntity(MockEntity, NumberEntity):
-    """Mock Select class."""
+    """Mock number class."""
 
-    _attr_value = 50.0
-    _attr_step = 1.0
+    @property
+    def native_max_value(self):
+        """Return the native native_max_value."""
+        return self._handle("native_max_value")
+
+    @property
+    def native_min_value(self):
+        """Return the native native_min_value."""
+        return self._handle("native_min_value")
+
+    @property
+    def native_step(self):
+        """Return the native native_step."""
+        return self._handle("native_step")
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return the native unit_of_measurement."""
+        return self._handle("native_unit_of_measurement")
+
+    @property
+    def native_value(self):
+        """Return the native value of this sensor."""
+        return self._handle("native_value")
+
+    def set_native_value(self, value: float) -> None:
+        """Change the selected option."""
+        self._values["native_value"] = value
+
+
+class LegacyMockNumberEntity(MockEntity, NumberEntity):
+    """Mock Number class using deprecated features."""
+
+    @property
+    def max_value(self):
+        """Return the native max_value."""
+        return self._handle("max_value")
+
+    @property
+    def min_value(self):
+        """Return the native min_value."""
+        return self._handle("min_value")
+
+    @property
+    def step(self):
+        """Return the native step."""
+        return self._handle("step")
 
     @property
     def value(self):
@@ -25,7 +70,7 @@ class MockNumberEntity(MockEntity, NumberEntity):
 
     def set_value(self, value: float) -> None:
         """Change the selected option."""
-        self._attr_value = value
+        self._values["value"] = value
 
 
 def init(empty=False):
@@ -39,6 +84,7 @@ def init(empty=False):
             MockNumberEntity(
                 name="test",
                 unique_id=UNIQUE_NUMBER,
+                native_value=50.0,
             ),
         ]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Although not a breaking change from a user's perspective, this is a significant change from a developer's perspective.
More details here: https://github.com/home-assistant/developers.home-assistant/pull/1367

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add temperature unit conversion support to `NumberEntity` following a similar pattern as the unit conversion supported by `SensorEntity`

Temperature conversion will be done for number entities with device class set to `temperature`.

Migration of number platform in integrations will be done in follow-up PRs.
Once all core integrations are migrated, implementing the deprecated methods will be prevented by type annotations.

Full list of PRs migrating number integrations:
- #73486
- #73485
- #73488
- #73536
- #73534
- #73493
- #73537
- #73491
- #73579
- #73580
- #73581
- #73582

PR which adds type annotations to prevent using the deprecated features:
- #73578

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
