### PR TITLE
Remove logic to mark litterrobot vacuum entity as unavailable

### DIFF
--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -1,7 +1,6 @@
 """Support for Litter-Robot "Vacuum"."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any
 
@@ -46,7 +45,6 @@ LITTER_BOX_STATUS_STATE_MAP = {
     LitterBoxStatus.CAT_SENSOR_INTERRUPTED: STATE_PAUSED,
     LitterBoxStatus.OFF: STATE_OFF,
 }
-UNAVAILABLE_AFTER = timedelta(minutes=30)
 
 
 async def async_setup_entry(
@@ -95,11 +93,6 @@ class LitterRobotCleaner(LitterRobotControlEntity, StateVacuumEntity):
         | VacuumEntityFeature.TURN_OFF
         | VacuumEntityFeature.TURN_ON
     )
-
-    @property
-    def available(self) -> bool:
-        """Return True if the cleaner has been seen recently."""
-        return self.robot.last_seen > datetime.now(timezone.utc) - UNAVAILABLE_AFTER
 
     @property
     def state(self) -> str:

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -1,7 +1,6 @@
 """Configure pytest for Litter-Robot tests."""
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,7 +9,6 @@ from pylitterbot.exceptions import InvalidCommandException
 import pytest
 
 from homeassistant.components import litterrobot
-from homeassistant.components.litterrobot.vacuum import UNAVAILABLE_AFTER
 from homeassistant.core import HomeAssistant
 
 from .common import CONFIG, ROBOT_DATA
@@ -71,14 +69,6 @@ def mock_account_with_sleeping_robot() -> MagicMock:
 def mock_account_with_sleep_disabled_robot() -> MagicMock:
     """Mock a Litter-Robot account with a robot that has sleep mode disabled."""
     return create_mock_account({"sleepModeActive": "0"})
-
-
-@pytest.fixture
-def mock_account_with_robot_not_recently_seen() -> MagicMock:
-    """Mock a Litter-Robot account with a sleeping robot."""
-    return create_mock_account(
-        {"lastSeen": (datetime.now() - UNAVAILABLE_AFTER).isoformat()}
-    )
 
 
 @pytest.fixture

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -24,7 +24,7 @@ from homeassistant.components.vacuum import (
     STATE_DOCKED,
     STATE_ERROR,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
@@ -60,19 +60,6 @@ async def test_vacuum_status_when_sleeping(
     vacuum = hass.states.get(VACUUM_ENTITY_ID)
     assert vacuum
     assert vacuum.attributes.get(ATTR_STATUS) == "Ready (Sleeping)"
-
-
-async def test_vacuum_state_when_not_recently_seen(
-    hass: HomeAssistant, mock_account_with_robot_not_recently_seen: MagicMock
-) -> None:
-    """Tests the vacuum state when not seen recently."""
-    await setup_integration(
-        hass, mock_account_with_robot_not_recently_seen, PLATFORM_DOMAIN
-    )
-
-    vacuum = hass.states.get(VACUUM_ENTITY_ID)
-    assert vacuum
-    assert vacuum.state == STATE_UNAVAILABLE
 
 
 async def test_no_robots(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Other LR owners have reported that the last_seen timestamp of their robots only updates hourly or when an event is triggered from the unit itself (such as when a cat uses the LR) and that the unit is still manually controllable from the official whisker app. Because the last_seen timestamp is exposed as a separate sensor, the logic is being removed to make the vacuum entity unavailable and a user can instead set up their own custom alerting based on the value reported there.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/73285
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
