### PR TITLE
Use create stream in generic config flow

### DIFF
--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -12,7 +12,6 @@
       "timeout": "Timeout while loading URL",
       "stream_no_route_to_host": "Could not find host while trying to connect to stream",
       "stream_io_error": "Input/Output error while trying to connect to stream. Wrong RTSP transport protocol?",
-      "stream_unauthorised": "Authorisation failed while trying to connect to stream",
       "stream_not_permitted": "Operation not permitted while trying to connect to stream. Wrong RTSP transport protocol?"
     },
     "abort": {

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -13,8 +13,7 @@
       "stream_no_route_to_host": "Could not find host while trying to connect to stream",
       "stream_io_error": "Input/Output error while trying to connect to stream. Wrong RTSP transport protocol?",
       "stream_unauthorised": "Authorisation failed while trying to connect to stream",
-      "stream_not_permitted": "Operation not permitted while trying to connect to stream. Wrong RTSP transport protocol?",
-      "stream_no_video": "Stream has no video"
+      "stream_not_permitted": "Operation not permitted while trying to connect to stream. Wrong RTSP transport protocol?"
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
@@ -78,15 +77,11 @@
       "unable_still_load": "[%key:component::generic::config::error::unable_still_load%]",
       "no_still_image_or_stream_url": "[%key:component::generic::config::error::no_still_image_or_stream_url%]",
       "invalid_still_image": "[%key:component::generic::config::error::invalid_still_image%]",
-      "stream_file_not_found": "[%key:component::generic::config::error::stream_file_not_found%]",
-      "stream_http_not_found": "[%key:component::generic::config::error::stream_http_not_found%]",
       "template_error": "[%key:component::generic::config::error::template_error%]",
       "timeout": "[%key:component::generic::config::error::timeout%]",
       "stream_no_route_to_host": "[%key:component::generic::config::error::stream_no_route_to_host%]",
       "stream_io_error": "[%key:component::generic::config::error::stream_io_error%]",
-      "stream_unauthorised": "[%key:component::generic::config::error::stream_unauthorised%]",
-      "stream_not_permitted": "[%key:component::generic::config::error::stream_not_permitted%]",
-      "stream_no_video": "[%key:component::generic::config::error::stream_no_video%]"
+      "stream_not_permitted": "[%key:component::generic::config::error::stream_not_permitted%]"
     }
   }
 }

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -1,7 +1,7 @@
 """Test fixtures for the generic component."""
 
 from io import BytesIO
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from PIL import Image
 import pytest
@@ -59,14 +59,20 @@ def fakeimg_gif(fakeimgbytes_gif):
 
 
 @pytest.fixture(scope="package")
-def mock_av_open():
-    """Fake container object with .streams.video[0] != None."""
-    fake = Mock()
-    fake.streams.video = ["fakevid"]
-    return patch(
-        "homeassistant.components.generic.config_flow.av.open",
-        return_value=fake,
+def mock_create_stream():
+    """Mock create stream."""
+    mock_stream = Mock()
+    mock_provider = Mock()
+    mock_provider.part_recv = AsyncMock()
+    mock_provider.part_recv.return_value = True
+    mock_stream.add_provider.return_value = mock_provider
+    mock_stream.start = AsyncMock()
+    mock_stream.stop = AsyncMock()
+    fake_create_stream = patch(
+        "homeassistant.components.generic.config_flow.create_stream",
+        return_value=mock_stream,
     )
+    return fake_create_stream
 
 
 @pytest.fixture

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -17,26 +17,25 @@ from tests.common import AsyncMock, Mock
 
 
 @respx.mock
-async def test_fetching_url(hass, hass_client, fakeimgbytes_png, mock_av_open):
+async def test_fetching_url(hass, hass_client, fakeimgbytes_png):
     """Test that it fetches the given url."""
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)
 
-    with mock_av_open:
-        await async_setup_component(
-            hass,
-            "camera",
-            {
-                "camera": {
-                    "name": "config_test",
-                    "platform": "generic",
-                    "still_image_url": "http://example.com",
-                    "username": "user",
-                    "password": "pass",
-                    "authentication": "basic",
-                }
-            },
-        )
-        await hass.async_block_till_done()
+    await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "http://example.com",
+                "username": "user",
+                "password": "pass",
+                "authentication": "basic",
+            }
+        },
+    )
+    await hass.async_block_till_done()
 
     client = await hass_client()
 
@@ -179,30 +178,27 @@ async def test_limit_refetch(hass, hass_client, fakeimgbytes_png, fakeimgbytes_j
 
 
 @respx.mock
-async def test_stream_source(
-    hass, hass_client, hass_ws_client, fakeimgbytes_png, mock_av_open
-):
+async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png):
     """Test that the stream source is rendered."""
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)
     respx.get("http://example.com/0a").respond(stream=fakeimgbytes_png)
 
     hass.states.async_set("sensor.temp", "0")
-    with mock_av_open:
-        assert await async_setup_component(
-            hass,
-            "camera",
-            {
-                "camera": {
-                    "name": "config_test",
-                    "platform": "generic",
-                    "still_image_url": "http://example.com",
-                    "stream_source": 'http://example.com/{{ states.sensor.temp.state + "a" }}',
-                    "limit_refetch_to_url_change": True,
-                },
+    assert await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "http://example.com",
+                "stream_source": 'http://example.com/{{ states.sensor.temp.state + "a" }}',
+                "limit_refetch_to_url_change": True,
             },
-        )
-        assert await async_setup_component(hass, "stream", {})
-        await hass.async_block_till_done()
+        },
+    )
+    assert await async_setup_component(hass, "stream", {})
+    await hass.async_block_till_done()
 
     hass.states.async_set("sensor.temp", "5")
 
@@ -227,29 +223,26 @@ async def test_stream_source(
 
 
 @respx.mock
-async def test_stream_source_error(
-    hass, hass_client, hass_ws_client, fakeimgbytes_png, mock_av_open
-):
+async def test_stream_source_error(hass, hass_client, hass_ws_client, fakeimgbytes_png):
     """Test that the stream source has an error."""
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)
 
-    with mock_av_open:
-        assert await async_setup_component(
-            hass,
-            "camera",
-            {
-                "camera": {
-                    "name": "config_test",
-                    "platform": "generic",
-                    "still_image_url": "http://example.com",
-                    # Does not exist
-                    "stream_source": 'http://example.com/{{ states.sensor.temp.state + "a" }}',
-                    "limit_refetch_to_url_change": True,
-                },
+    assert await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "http://example.com",
+                # Does not exist
+                "stream_source": 'http://example.com/{{ states.sensor.temp.state + "a" }}',
+                "limit_refetch_to_url_change": True,
             },
-        )
-        assert await async_setup_component(hass, "stream", {})
-        await hass.async_block_till_done()
+        },
+    )
+    assert await async_setup_component(hass, "stream", {})
+    await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.camera.Stream.endpoint_url",
@@ -275,30 +268,27 @@ async def test_stream_source_error(
 
 
 @respx.mock
-async def test_setup_alternative_options(
-    hass, hass_ws_client, fakeimgbytes_png, mock_av_open
-):
+async def test_setup_alternative_options(hass, hass_ws_client, fakeimgbytes_png):
     """Test that the stream source is setup with different config options."""
     respx.get("https://example.com").respond(stream=fakeimgbytes_png)
 
-    with mock_av_open:
-        assert await async_setup_component(
-            hass,
-            "camera",
-            {
-                "camera": {
-                    "name": "config_test",
-                    "platform": "generic",
-                    "still_image_url": "https://example.com",
-                    "authentication": "digest",
-                    "username": "user",
-                    "password": "pass",
-                    "stream_source": "rtsp://example.com:554/rtsp/",
-                    "rtsp_transport": "udp",
-                },
+    assert await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "https://example.com",
+                "authentication": "digest",
+                "username": "user",
+                "password": "pass",
+                "stream_source": "rtsp://example.com:554/rtsp/",
+                "rtsp_transport": "udp",
             },
-        )
-        await hass.async_block_till_done()
+        },
+    )
+    await hass.async_block_till_done()
     assert hass.states.get("camera.config_test")
 
 
@@ -346,7 +336,7 @@ async def test_no_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_
 
 @respx.mock
 async def test_camera_content_type(
-    hass, hass_client, fakeimgbytes_svg, fakeimgbytes_jpg, mock_av_open
+    hass, hass_client, fakeimgbytes_svg, fakeimgbytes_jpg
 ):
     """Test generic camera with custom content_type."""
     urlsvg = "https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
@@ -372,20 +362,18 @@ async def test_camera_content_type(
         "verify_ssl": True,
     }
 
-    with mock_av_open:
-        result1 = await hass.config_entries.flow.async_init(
-            "generic",
-            data=cam_config_jpg,
-            context={"source": SOURCE_IMPORT, "unique_id": 12345},
-        )
-        await hass.async_block_till_done()
-    with mock_av_open:
-        result2 = await hass.config_entries.flow.async_init(
-            "generic",
-            data=cam_config_svg,
-            context={"source": SOURCE_IMPORT, "unique_id": 54321},
-        )
-        await hass.async_block_till_done()
+    result1 = await hass.config_entries.flow.async_init(
+        "generic",
+        data=cam_config_jpg,
+        context={"source": SOURCE_IMPORT, "unique_id": 12345},
+    )
+    await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_init(
+        "generic",
+        data=cam_config_svg,
+        context={"source": SOURCE_IMPORT, "unique_id": 54321},
+    )
+    await hass.async_block_till_done()
 
     assert result1["type"] == "create_entry"
     assert result2["type"] == "create_entry"
@@ -457,21 +445,20 @@ async def test_timeout_cancelled(hass, hass_client, fakeimgbytes_png, fakeimgbyt
         assert await resp.read() == fakeimgbytes_png
 
 
-async def test_no_still_image_url(hass, hass_client, mock_av_open):
+async def test_no_still_image_url(hass, hass_client):
     """Test that the component can grab images from stream with no still_image_url."""
-    with mock_av_open:
-        assert await async_setup_component(
-            hass,
-            "camera",
-            {
-                "camera": {
-                    "name": "config_test",
-                    "platform": "generic",
-                    "stream_source": "rtsp://example.com:554/rtsp/",
-                },
+    assert await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "stream_source": "rtsp://example.com:554/rtsp/",
             },
-        )
-        await hass.async_block_till_done()
+        },
+    )
+    await hass.async_block_till_done()
 
     client = await hass_client()
 
@@ -503,23 +490,22 @@ async def test_no_still_image_url(hass, hass_client, mock_av_open):
         assert await resp.read() == b"stream_keyframe_image"
 
 
-async def test_frame_interval_property(hass, mock_av_open):
+async def test_frame_interval_property(hass):
     """Test that the frame interval is calculated and returned correctly."""
 
-    with mock_av_open:
-        await async_setup_component(
-            hass,
-            "camera",
-            {
-                "camera": {
-                    "name": "config_test",
-                    "platform": "generic",
-                    "stream_source": "rtsp://example.com:554/rtsp/",
-                    "framerate": 5,
-                },
+    await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "stream_source": "rtsp://example.com:554/rtsp/",
+                "framerate": 5,
             },
-        )
-        await hass.async_block_till_done()
+        },
+    )
+    await hass.async_block_till_done()
 
     request = Mock()
     with patch(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `generic camera` config flow uses PyAV directly to test the validity of a stream. This duplicates some of the code from stream and risks not fully mimicking the actual stream setup. It also imports av in the config flow which may be problematic for users on a few platforms who have trouble getting the binary wheels installed.
This PR uses `create_stream` instead of using PyAV directly. It also moves the (implicit) import of av to runtime to avoid using av until a stream is actually tested. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
