### PR TITLE
Add UniFi Protect media source

### DIFF
--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -35,7 +35,9 @@ from homeassistant.util.network import is_ip_address
 from .const import (
     CONF_ALL_UPDATES,
     CONF_DISABLE_RTSP,
+    CONF_MAX_MEDIA,
     CONF_OVERRIDE_CHOST,
+    DEFAULT_MAX_MEDIA,
     DEFAULT_PORT,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -221,6 +223,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_DISABLE_RTSP: False,
                 CONF_ALL_UPDATES: False,
                 CONF_OVERRIDE_CHOST: False,
+                CONF_MAX_MEDIA: DEFAULT_MAX_MEDIA,
             },
         )
 
@@ -383,6 +386,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_OVERRIDE_CHOST, False
                         ),
                     ): bool,
+                    vol.Optional(
+                        CONF_MAX_MEDIA,
+                        default=self.config_entry.options.get(
+                            CONF_MAX_MEDIA, DEFAULT_MAX_MEDIA
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=100, max=10000)),
                 }
             ),
         )

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -19,6 +19,7 @@ ATTR_ANONYMIZE = "anonymize"
 CONF_DISABLE_RTSP = "disable_rtsp"
 CONF_ALL_UPDATES = "all_updates"
 CONF_OVERRIDE_CHOST = "override_connection_host"
+CONF_MAX_MEDIA = "max_media"
 
 CONFIG_OPTIONS = [
     CONF_ALL_UPDATES,
@@ -31,6 +32,7 @@ DEFAULT_ATTRIBUTION = "Powered by UniFi Protect Server"
 DEFAULT_BRAND = "Ubiquiti"
 DEFAULT_SCAN_INTERVAL = 5
 DEFAULT_VERIFY_SSL = False
+DEFAULT_MAX_MEDIA = 1000
 
 DEVICES_THAT_ADOPT = {
     ModelType.CAMERA,

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -26,6 +26,8 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     CONF_DISABLE_RTSP,
+    CONF_MAX_MEDIA,
+    DEFAULT_MAX_MEDIA,
     DEVICES_THAT_ADOPT,
     DISPATCH_ADOPT,
     DISPATCH_CHANNELS,
@@ -81,6 +83,11 @@ class ProtectData:
     def disable_stream(self) -> bool:
         """Check if RTSP is disabled."""
         return self._entry.options.get(CONF_DISABLE_RTSP, False)
+
+    @property
+    def max_events(self) -> int:
+        """Max number of events to load at once."""
+        return self._entry.options.get(CONF_MAX_MEDIA, DEFAULT_MAX_MEDIA)
 
     def get_by_types(
         self, device_types: Iterable[ModelType]

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -1,0 +1,776 @@
+"""UniFi Protect media sources."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime, timedelta
+from enum import Enum
+from typing import Any, cast
+
+from pyunifiprotect.data import Camera, Event, EventType, SmartDetectObjectType
+from pyunifiprotect.exceptions import NvrError
+from pyunifiprotect.utils import from_js_time
+
+from homeassistant.components.media_player.const import (
+    MEDIA_CLASS_DIRECTORY,
+    MEDIA_CLASS_IMAGE,
+    MEDIA_CLASS_VIDEO,
+)
+from homeassistant.components.media_player.errors import BrowseError
+from homeassistant.components.media_source.models import (
+    BrowseMediaSource,
+    MediaSource,
+    MediaSourceItem,
+    PlayMedia,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .data import ProtectData
+from .views import async_generate_event_video_url, async_generate_thumbnail_url
+
+VIDEO_FORMAT = "video/mp4"
+
+
+class SimpleEventType(str, Enum):
+    """Enum to Camera Video events."""
+
+    ALL = "All Events"
+    RING = "Ring Events"
+    MOTION = "Motion Events"
+    SMART = "Smart Detections"
+
+    @classmethod
+    def get_from_name(cls, name: str) -> SimpleEventType:
+        """Get SimpleEventType from name."""
+
+        if name.lower() == "smart_detect":
+            return SimpleEventType.SMART
+
+        types: list[SimpleEventType] = list(cls)
+        for event_type in types:
+            if event_type.name.lower() == name.lower():
+                return event_type
+        raise ValueError("Invalid event_type")
+
+    @classmethod
+    def get_event_type(cls, event_type: SimpleEventType) -> EventType | None:
+        """Get UniFi Protect event type from SimpleEventType."""
+
+        if event_type == SimpleEventType.ALL:
+            return None
+        if event_type == SimpleEventType.RING:
+            return EventType.RING
+        if event_type == SimpleEventType.MOTION:
+            return EventType.MOTION
+        return EventType.SMART_DETECT
+
+
+async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
+    """Set up UniFi Protect media source."""
+
+    data_sources: dict[str, ProtectData] = {}
+    for data in hass.data[DOMAIN].values():
+        if isinstance(data, ProtectData):
+            data_sources[data.api.bootstrap.nvr.id] = data
+
+    return ProtectMediaSource(hass, data_sources)
+
+
+@callback
+def _get_start_end(hass: HomeAssistant, start: datetime) -> tuple[datetime, datetime]:
+    start = dt_util.as_local(start)
+    end = dt_util.now()
+
+    start = start.replace(day=1, hour=1, minute=0, second=0, microsecond=0)
+    end = end.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    return start, end
+
+
+@callback
+def _bad_identifier(identifier: str, err: Exception | None = None) -> BrowseMediaSource:
+    msg = f"Unexpected identifier: {identifier}"
+    if err is None:
+        raise BrowseError(msg)
+    raise BrowseError(msg) from err
+
+
+@callback
+def _bad_identifier_media(identifier: str, err: Exception | None = None) -> PlayMedia:
+    return cast(PlayMedia, _bad_identifier(identifier, err))
+
+
+@callback
+def _format_duration(duration: timedelta) -> str:
+    formatted = ""
+    seconds = int(duration.total_seconds())
+    if seconds > 3600:
+        hours = seconds // 3600
+        formatted += f"{hours}h "
+        seconds -= hours * 3600
+    if seconds > 60:
+        minutes = seconds // 60
+        formatted += f"{minutes}m "
+        seconds -= minutes * 60
+    if seconds > 0:
+        formatted += f"{seconds}s "
+
+    return formatted.strip()
+
+
+class ProtectMediaSource(MediaSource):
+    """Represents all UniFi Protect NVRs."""
+
+    name: str = "UniFi Protect"
+
+    def __init__(
+        self, hass: HomeAssistant, data_sources: dict[str, ProtectData]
+    ) -> None:
+        """Initialize the UniFi Protect media source."""
+
+        super().__init__(DOMAIN)
+        self.hass = hass
+        self.data_sources = data_sources
+
+    async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
+        """Return a streamable URL and associated mime type for a UniFi Protect event.
+
+        Accepted identifier format are
+
+        * {nvr_id}:event:{event_id} - MP4 video clip for specific event
+        * {nvr_id}:eventthumb:{event_id} - Thumbnail JPEG for specific event
+        """
+
+        parts = item.identifier.split(":")
+        if len(parts) != 3 or parts[1] not in ("event", "eventthumb"):
+            return _bad_identifier_media(item.identifier)
+
+        thumbnail_only = parts[1] == "eventthumb"
+        try:
+            data = self.data_sources[parts[0]]
+        except IndexError as err:
+            return _bad_identifier_media(item.identifier, err)
+
+        event = data.api.bootstrap.events.get(parts[2])
+        if event is None:
+            try:
+                event = await data.api.get_event(parts[2])
+            except NvrError as err:
+                return _bad_identifier_media(item.identifier, err)
+            else:
+                # cache the event for later
+                data.api.bootstrap.events[event.id] = event
+
+        nvr = data.api.bootstrap.nvr
+        if thumbnail_only:
+            PlayMedia(async_generate_thumbnail_url(event.id, nvr.id), "image/jpeg")
+        return PlayMedia(async_generate_event_video_url(event), "video/mp4")
+
+    async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
+        """Return a browsable UniFi Protect media source.
+
+        Identifier formatters for UniFi Protect media sources are all in IDs from
+        the UniFi Protect instance since events may not always map 1:1 to a Home
+        Assistant device or entity. It also drasically speeds up resolution.
+
+        The UniFi Protect Media source is timebased for the events recorded by the NVR.
+        So its structure is a bit different then many other media players. All browsable
+        media is a video clip. The media source could be greatly cleaned up if/when the
+        frontend has filtering supporting.
+
+        * ... Each NVR Console (hidden if there is only one)
+            * All Cameras
+            * ... Camera X
+                * All Events
+                * ... Event Type X
+                    * Last 24 Hours -> Events
+                    * Last 7 Days -> Events
+                    * Last 30 Days -> Events
+                    * ... This Month - X
+                        * Whole Month -> Events
+                        * ... Day X -> Events
+
+        Accepted identifier formats:
+
+        * {nvr_id}
+            Root NVR source
+        * {nvr_id}:event:{event_id}
+            Specific Event for NVR
+        * {nvr_id}:eventthumb:{event_id}
+            Specific Event Thumbnail for NVR
+        * {nvr_id}:all|{camera_id}
+            Root Camera(s) source
+        * {nvr_id}:all|{camera_id}:all|{event_type}
+            Root Camera(s) Event Type(s) source
+        * {nvr_id}:all|{camera_id}:all|{event_type}:recent:{day_count}
+            Listing of all events in last {day_count}, sorted in reverse chronological order
+        * {nvr_id}:all|{camera_id}:all|{event_type}:browse:{year}:{month}
+            List of folders for each day in month + all events for month
+        * {nvr_id}:all|{camera_id}:all|{event_type}:browse:{year}:{month}:all|{day}
+            Listing of all events for give {day} + {month} + {year} combination in chronological order
+        """
+
+        if not item.identifier:
+            return await self._build_sources()
+
+        parts = item.identifier.split(":")
+
+        try:
+            data = self.data_sources[parts[0]]
+        except IndexError as err:
+            return _bad_identifier(item.identifier, err)
+
+        # {nvr_id}
+        if len(parts) == 1:
+            return await self._build_console(data)
+
+        # {nvr_id}:event:{id}
+        if len(parts) == 3 and parts[1] in ("event", "eventthumb"):
+            thumbnail_only = parts[1] == "eventthumb"
+            return await self._resolve_event(data, parts[2], thumbnail_only)
+
+        # {nvr_id}:all|{camera_id}
+        camera_id = parts[1]
+        if len(parts) == 2:
+            return await self._build_camera(data, camera_id, build_children=True)
+
+        # {nvr_id}:all|{camera_id}:all|{event_type}
+        try:
+            event_type = SimpleEventType.get_from_name(parts[2])
+        except (IndexError, ValueError) as err:
+            return _bad_identifier(item.identifier, err)
+
+        if len(parts) == 3:
+            return await self._build_events_type(
+                data, camera_id, event_type, build_children=True
+            )
+
+        # {nvr_id}:all|{camera_id}:all|{event_type}:recent:{day_count}
+        if parts[3] == "recent":
+            try:
+                days = int(parts[4])
+            except (IndexError, ValueError) as err:
+                return _bad_identifier(item.identifier, err)
+
+            return await self._build_recent(
+                data, camera_id, event_type, days, build_children=True
+            )
+
+        # {nvr_id}:all|{camera_id}:all|{event_type}:browse:{year}:{month}
+        # {nvr_id}:all|{camera_id}:all|{event_type}:browse:{year}:{month}:all|{day}
+        if parts[3] == "browse":
+            day = 1
+            is_root = True
+            is_all = True
+            try:
+                year = int(parts[4])
+                month = int(parts[5])
+                if len(parts) == 7:
+                    is_root = False
+                    if parts[6] != "all":
+                        is_all = False
+                        day = int(parts[6])
+            except (IndexError, ValueError) as err:
+                return _bad_identifier(item.identifier, err)
+
+            try:
+                start = date(year=year, month=month, day=day)
+            except ValueError as err:
+                return _bad_identifier(item.identifier, err)
+
+            if is_root:
+                return await self._build_month(
+                    data, camera_id, event_type, start, build_children=True
+                )
+            return await self._build_days(
+                data, camera_id, event_type, start, build_children=True, is_all=is_all
+            )
+
+        return _bad_identifier(item.identifier)
+
+    async def _resolve_event(
+        self, data: ProtectData, event_id: str, thumbnail_only: bool = False
+    ) -> BrowseMediaSource:
+        """Resolve a specific event."""
+
+        subtype = "eventthumb" if thumbnail_only else "event"
+        try:
+            event = await data.api.get_event(event_id)
+        except NvrError as err:
+            return _bad_identifier(
+                f"{data.api.bootstrap.nvr.id}:{subtype}:{event_id}", err
+            )
+
+        if event.start is None or event.end is None:
+            raise BrowseError("Event is still ongoing")
+
+        return await self._build_event(data, event, thumbnail_only)
+
+    def _breadcrumb(
+        self,
+        data: ProtectData,
+        base_title: str,
+        camera: Camera | None = None,
+        event_type: SimpleEventType | None = None,
+        count: int | None = None,
+    ) -> str:
+        title = base_title
+        if count is not None:
+            if count == data.max_events:
+                title = f"{title} ({count} TRUNCATED)"
+            else:
+                title = f"{title} ({count})"
+
+        if event_type is not None:
+            title = f"{event_type.value.title()} > {title}"
+
+        if camera is not None:
+            title = f"{camera.display_name} > {title}"
+        title = f"{data.api.bootstrap.nvr.display_name} > {title}"
+
+        return title
+
+    async def _build_event(
+        self,
+        data: ProtectData,
+        event: dict[str, Any] | Event,
+        thumbnail_only: bool = False,
+    ) -> BrowseMediaSource:
+        """Build media source for an individual event."""
+
+        if isinstance(event, Event):
+            event_id = event.id
+            event_type = event.type
+            start = event.start
+            end = event.end
+        else:
+            event_id = event["id"]
+            event_type = event["type"]
+            start = from_js_time(event["start"])
+            end = from_js_time(event["end"])
+
+        assert end is not None
+
+        title = dt_util.as_local(start).strftime("%x %X")
+        duration = end - start
+        title += f" {_format_duration(duration)}"
+        if event_type == EventType.RING.value:
+            event_text = "Ring Event"
+        elif event_type == EventType.MOTION.value:
+            event_text = "Motion Event"
+        elif event_type == EventType.SMART_DETECT.value:
+            if isinstance(event, Event):
+                smart_type = event.smart_detect_types[0]
+            else:
+                smart_type = SmartDetectObjectType(event["smartDetectTypes"][0])
+            event_text = f"Smart Detection - {smart_type.name.title()}"
+        title += f" {event_text}"
+
+        nvr = data.api.bootstrap.nvr
+        if thumbnail_only:
+            return BrowseMediaSource(
+                domain=DOMAIN,
+                identifier=f"{nvr.id}:eventthumb:{event_id}",
+                media_class=MEDIA_CLASS_IMAGE,
+                media_content_type="image/jpeg",
+                title=title,
+                can_play=True,
+                can_expand=False,
+                thumbnail=async_generate_thumbnail_url(event_id, nvr.id, 185, 185),
+            )
+
+        return BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=f"{nvr.id}:event:{event_id}",
+            media_class=MEDIA_CLASS_VIDEO,
+            media_content_type="video/mp4",
+            title=title,
+            can_play=True,
+            can_expand=False,
+            thumbnail=async_generate_thumbnail_url(event_id, nvr.id, 185, 185),
+        )
+
+    async def _build_events(
+        self,
+        data: ProtectData,
+        start: datetime,
+        end: datetime,
+        camera_id: str | None = None,
+        event_type: EventType | None = None,
+        reserve: bool = False,
+    ) -> list[BrowseMediaSource]:
+        """Build media source for a given range of time and event type."""
+
+        if event_type is None:
+            types = [
+                EventType.RING,
+                EventType.MOTION,
+                EventType.SMART_DETECT,
+            ]
+        else:
+            types = [event_type]
+
+        sources: list[BrowseMediaSource] = []
+        events = await data.api.get_events_raw(
+            start=start, end=end, types=types, limit=data.max_events
+        )
+        events = sorted(events, key=lambda e: cast(int, e["start"]), reverse=reserve)
+        for event in events:
+            # do not process ongoing events
+            if event.get("start") is None or event.get("end") is None:
+                continue
+
+            if camera_id is not None and event.get("camera") != camera_id:
+                continue
+
+            # smart detect events have a paired motion event
+            if (
+                event.get("type") == EventType.MOTION.value
+                and len(event.get("smartDetectTypes", [])) > 0
+            ):
+                continue
+
+            sources.append(await self._build_event(data, event))
+
+        return sources
+
+    async def _build_recent(
+        self,
+        data: ProtectData,
+        camera_id: str,
+        event_type: SimpleEventType,
+        days: int,
+        build_children: bool = False,
+    ) -> BrowseMediaSource:
+        """Build media source for events in relative days."""
+
+        base_id = f"{data.api.bootstrap.nvr.id}:{camera_id}:{event_type.name.lower()}"
+        title = f"Last {days} Days"
+        if days == 1:
+            title = "Last 24 Hours"
+
+        source = BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=f"{base_id}:recent:{days}",
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type="video/mp4",
+            title=title,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+        )
+
+        if not build_children:
+            return source
+
+        now = dt_util.now()
+
+        args = {
+            "data": data,
+            "start": now - timedelta(days=days),
+            "end": now,
+            "reserve": True,
+        }
+        if event_type != SimpleEventType.ALL:
+            args["event_type"] = SimpleEventType.get_event_type(event_type)
+
+        camera: Camera | None = None
+        if camera_id != "all":
+            camera = data.api.bootstrap.cameras.get(camera_id)
+            args["camera_id"] = camera_id
+
+        events = await self._build_events(**args)  # type: ignore[arg-type]
+        source.children = events  # type: ignore[assignment]
+        source.title = self._breadcrumb(
+            data,
+            title,
+            camera=camera,
+            event_type=event_type,
+            count=len(events),
+        )
+        return source
+
+    async def _build_month(
+        self,
+        data: ProtectData,
+        camera_id: str,
+        event_type: SimpleEventType,
+        start: date,
+        build_children: bool = False,
+    ) -> BrowseMediaSource:
+        """Build media source for selectors for a given month."""
+
+        base_id = f"{data.api.bootstrap.nvr.id}:{camera_id}:{event_type.name.lower()}"
+
+        title = f"{start.strftime('%B %Y')}"
+        source = BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=f"{base_id}:browse:{start.year}:{start.month}",
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type=VIDEO_FORMAT,
+            title=title,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+        )
+
+        if not build_children:
+            return source
+
+        month = start.month
+        children = [self._build_days(data, camera_id, event_type, start, is_all=True)]
+        while start.month == month:
+            children.append(
+                self._build_days(data, camera_id, event_type, start, is_all=False)
+            )
+            start = start + timedelta(hours=24)
+
+        camera: Camera | None = None
+        if camera_id != "all":
+            camera = data.api.bootstrap.cameras.get(camera_id)
+
+        source.children = await asyncio.gather(*children)
+        source.title = self._breadcrumb(
+            data,
+            title,
+            camera=camera,
+            event_type=event_type,
+        )
+
+        return source
+
+    async def _build_days(
+        self,
+        data: ProtectData,
+        camera_id: str,
+        event_type: SimpleEventType,
+        start: date,
+        is_all: bool = True,
+        build_children: bool = False,
+    ) -> BrowseMediaSource:
+        """Build media source for events for a given day or whole month."""
+
+        base_id = f"{data.api.bootstrap.nvr.id}:{camera_id}:{event_type.name.lower()}"
+
+        if is_all:
+            title = "Whole Month"
+            identifier = f"{base_id}:browse:{start.year}:{start.month}:all"
+        else:
+            title = f"{start.strftime('%x')}"
+            identifier = f"{base_id}:browse:{start.year}:{start.month}:{start.day}"
+        source = BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=identifier,
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type=VIDEO_FORMAT,
+            title=title,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+        )
+
+        if not build_children:
+            return source
+
+        start_dt = datetime(
+            year=start.year,
+            month=start.month,
+            day=start.day,
+            hour=0,
+            minute=0,
+            second=0,
+            tzinfo=dt_util.DEFAULT_TIME_ZONE,
+        )
+        if is_all:
+            if start_dt.month < 12:
+                end_dt = start_dt.replace(month=start_dt.month + 1)
+            else:
+                end_dt = start_dt.replace(year=start_dt.year + 1, month=1)
+        else:
+            end_dt = start_dt + timedelta(hours=24)
+
+        args = {
+            "data": data,
+            "start": start_dt,
+            "end": end_dt,
+            "reserve": False,
+        }
+        if event_type != SimpleEventType.ALL:
+            args["event_type"] = SimpleEventType.get_event_type(event_type)
+
+        camera: Camera | None = None
+        if camera_id != "all":
+            camera = data.api.bootstrap.cameras.get(camera_id)
+            args["camera_id"] = camera_id
+
+        title = f"{start.strftime('%B %Y')} > {title}"
+        events = await self._build_events(**args)  # type: ignore[arg-type]
+        source.children = events  # type: ignore[assignment]
+        source.title = self._breadcrumb(
+            data,
+            title,
+            camera=camera,
+            event_type=event_type,
+            count=len(events),
+        )
+
+        return source
+
+    async def _build_events_type(
+        self,
+        data: ProtectData,
+        camera_id: str,
+        event_type: SimpleEventType,
+        build_children: bool = False,
+    ) -> BrowseMediaSource:
+        """Build folder media source for a selectors for a given event type."""
+
+        base_id = f"{data.api.bootstrap.nvr.id}:{camera_id}:{event_type.name.lower()}"
+
+        title = event_type.value.title()
+        source = BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=base_id,
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type=VIDEO_FORMAT,
+            title=title,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+        )
+
+        if not build_children or data.api.bootstrap.recording_start is None:
+            return source
+
+        children = [
+            self._build_recent(data, camera_id, event_type, 1),
+            self._build_recent(data, camera_id, event_type, 7),
+            self._build_recent(data, camera_id, event_type, 30),
+        ]
+
+        start, end = _get_start_end(self.hass, data.api.bootstrap.recording_start)
+        while end > start:
+            children.append(self._build_month(data, camera_id, event_type, end.date()))
+            end = (end - timedelta(days=1)).replace(day=1)
+
+        camera: Camera | None = None
+        if camera_id != "all":
+            camera = data.api.bootstrap.cameras.get(camera_id)
+        source.children = await asyncio.gather(*children)
+        source.title = self._breadcrumb(data, title, camera=camera)
+
+        return source
+
+    async def _build_camera(
+        self, data: ProtectData, camera_id: str, build_children: bool = False
+    ) -> BrowseMediaSource:
+        """Build media source for selectors for a UniFi Protect camera."""
+
+        name = "All Cameras"
+        is_doorbell = data.api.bootstrap.has_doorbell
+        has_smart = data.api.bootstrap.has_smart_detections
+        camera: Camera | None = None
+        if camera_id != "all":
+            camera = data.api.bootstrap.cameras.get(camera_id)
+            if camera is None:
+                raise BrowseError(f"Unknown Camera ID: {camera_id}")
+            name = camera.name or camera.market_name or camera.type
+            is_doorbell = camera.feature_flags.has_chime
+            has_smart = camera.feature_flags.has_smart_detect
+
+        source = BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=f"{data.api.bootstrap.nvr.id}:{camera_id}",
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type=VIDEO_FORMAT,
+            title=name,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+        )
+
+        if not build_children:
+            return source
+
+        source.children = [
+            await self._build_events_type(data, camera_id, SimpleEventType.MOTION),
+        ]
+
+        if is_doorbell:
+            source.children.insert(
+                0,
+                await self._build_events_type(data, camera_id, SimpleEventType.RING),
+            )
+
+        if has_smart:
+            source.children.append(
+                await self._build_events_type(data, camera_id, SimpleEventType.SMART)
+            )
+
+        if is_doorbell or has_smart:
+            source.children.insert(
+                0,
+                await self._build_events_type(data, camera_id, SimpleEventType.ALL),
+            )
+
+        source.title = self._breadcrumb(data, name)
+
+        return source
+
+    async def _build_cameras(self, data: ProtectData) -> list[BrowseMediaSource]:
+        """Build media source for a single UniFi Protect NVR."""
+
+        cameras: list[BrowseMediaSource] = [await self._build_camera(data, "all")]
+
+        for camera in data.api.bootstrap.cameras.values():
+            if not camera.can_read_media(data.api.bootstrap.auth_user):
+                continue
+            cameras.append(await self._build_camera(data, camera.id))
+
+        return cameras
+
+    async def _build_console(self, data: ProtectData) -> BrowseMediaSource:
+        """Build media source for a single UniFi Protect NVR."""
+
+        base = BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=f"{data.api.bootstrap.nvr.id}",
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type=VIDEO_FORMAT,
+            title=data.api.bootstrap.nvr.name,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+            children=await self._build_cameras(data),
+        )
+
+        return base
+
+    async def _build_sources(self) -> BrowseMediaSource:
+        """Return all media source for all UniFi Protect NVRs."""
+
+        consoles: list[BrowseMediaSource] = []
+        for data_source in self.data_sources.values():
+            if not data_source.api.bootstrap.has_media:
+                continue
+            console_source = await self._build_console(data_source)
+            if console_source.children is None or len(console_source.children) == 0:
+                continue
+            consoles.append(console_source)
+
+        if len(consoles) == 1:
+            return consoles[0]
+
+        return BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=None,
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_type=VIDEO_FORMAT,
+            title=self.name,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MEDIA_CLASS_VIDEO,
+            children=consoles,
+        )

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -49,7 +49,7 @@ class SimpleEventType(str, Enum):
 
 
 class IdentifierType(str, Enum):
-    """UniFi Protect identifer type."""
+    """UniFi Protect identifier type."""
 
     EVENT = "event"
     EVENT_THUMB = "eventthumb"
@@ -57,7 +57,7 @@ class IdentifierType(str, Enum):
 
 
 class IdentifierTimeType(str, Enum):
-    """UniFi Protect identifer subtype."""
+    """UniFi Protect identifier subtype."""
 
     RECENT = "recent"
     RANGE = "range"

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -229,7 +229,7 @@ class ProtectMediaSource(MediaSource):
 
         try:
             data = self.data_sources[parts[0]]
-        except IndexError as err:
+        except (KeyError, IndexError) as err:
             return _bad_identifier(item.identifier, err)
 
         # {nvr_id}
@@ -693,6 +693,10 @@ class ProtectMediaSource(MediaSource):
         entity_id: str | None = None
         entity_registry = await self.get_registry()
         for channel in camera.channels:
+            # do not use the package camera
+            if channel.id == 3:
+                continue
+
             base_id = f"{camera.mac}_{channel.id}"
             entity_id = entity_registry.async_get_entity_id(
                 Platform.CAMERA, DOMAIN, base_id
@@ -809,12 +813,11 @@ class ProtectMediaSource(MediaSource):
         """Return all media source for all UniFi Protect NVRs."""
 
         consoles: list[BrowseMediaSource] = []
+        print(len(self.data_sources.values()))
         for data_source in self.data_sources.values():
             if not data_source.api.bootstrap.has_media:
                 continue
             console_source = await self._build_console(data_source)
-            if console_source.children is None or len(console_source.children) == 0:
-                continue
             consoles.append(console_source)
 
         if len(consoles) == 1:

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -77,7 +77,7 @@ async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up UniFi Protect media source."""
 
     data_sources: dict[str, ProtectData] = {}
-    for data in hass.data[DOMAIN].values():
+    for data in hass.data.get(DOMAIN, {}).values():
         if isinstance(data, ProtectData):
             data_sources[data.api.bootstrap.nvr.id] = data
 
@@ -158,7 +158,7 @@ class ProtectMediaSource(MediaSource):
         thumbnail_only = parts[1] == "eventthumb"
         try:
             data = self.data_sources[parts[0]]
-        except IndexError as err:
+        except (KeyError, IndexError) as err:
             return _bad_identifier_media(item.identifier, err)
 
         event = data.api.bootstrap.events.get(parts[2])
@@ -173,7 +173,9 @@ class ProtectMediaSource(MediaSource):
 
         nvr = data.api.bootstrap.nvr
         if thumbnail_only:
-            PlayMedia(async_generate_thumbnail_url(event.id, nvr.id), "image/jpeg")
+            return PlayMedia(
+                async_generate_thumbnail_url(event.id, nvr.id), "image/jpeg"
+            )
         return PlayMedia(async_generate_event_video_url(event), "video/mp4")
 
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from datetime import date, datetime, timedelta
-from enum import Enum
 from typing import Any, cast
 
 from pyunifiprotect.data import Camera, Event, EventType, SmartDetectObjectType
@@ -32,45 +31,12 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .data import ProtectData
+from .models import SimpleEventType
 from .views import async_generate_event_video_url, async_generate_thumbnail_url
 
 VIDEO_FORMAT = "video/mp4"
 THUMBNAIL_WIDTH = 185
 THUMBNAIL_HEIGHT = 185
-
-
-class SimpleEventType(str, Enum):
-    """Enum to Camera Video events."""
-
-    ALL = "All Events"
-    RING = "Ring Events"
-    MOTION = "Motion Events"
-    SMART = "Smart Detections"
-
-    @classmethod
-    def get_from_name(cls, name: str) -> SimpleEventType:
-        """Get SimpleEventType from name."""
-
-        if name.lower() == "smart_detect":
-            return SimpleEventType.SMART
-
-        types: list[SimpleEventType] = list(cls)
-        for event_type in types:
-            if event_type.name.lower() == name.lower():
-                return event_type
-        raise ValueError("Invalid event_type")
-
-    @classmethod
-    def get_event_type(cls, event_type: SimpleEventType) -> EventType | None:
-        """Get UniFi Protect event type from SimpleEventType."""
-
-        if event_type == SimpleEventType.ALL:
-            return None
-        if event_type == SimpleEventType.RING:
-            return EventType.RING
-        if event_type == SimpleEventType.MOTION:
-            return EventType.MOTION
-        return EventType.SMART_DETECT
 
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
@@ -449,7 +415,7 @@ class ProtectMediaSource(MediaSource):
             # smart detect events have a paired motion event
             if (
                 event.get("type") == EventType.MOTION.value
-                and len(event.get("smartDetectTypes", [])) > 0
+                and len(event.get("smartDetectEvents", [])) > 0
             ):
                 continue
 

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -701,7 +701,11 @@ class ProtectMediaSource(MediaSource):
                 )
 
             if entity_id:
-                break
+                # verify entity is avaiable
+                entry = entity_registry.async_get(entity_id)
+                if not entry.disabled:
+                    break
+                entity_id = None
 
         if entity_id is not None:
             url = URL(CameraImageView.url.format(entity_id=entity_id))

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -682,8 +682,8 @@ class ProtectMediaSource(MediaSource):
 
         return source
 
-    async def _get_camera_thumbnail_url(self, camera: Camera) -> str:
-        """Get camera thumbnail URL using the first avaiable camera entity."""
+    async def _get_camera_thumbnail_url(self, camera: Camera) -> str | None:
+        """Get camera thumbnail URL using the first available camera entity."""
 
         if not camera.is_connected or camera.is_privacy_on:
             return None

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -701,7 +701,7 @@ class ProtectMediaSource(MediaSource):
                 )
 
             if entity_id:
-                # verify entity is avaiable
+                # verify entity is available
                 entry = entity_registry.async_get(entity_id)
                 if not entry.disabled:
                     break

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -703,7 +703,7 @@ class ProtectMediaSource(MediaSource):
             if entity_id:
                 # verify entity is available
                 entry = entity_registry.async_get(entity_id)
-                if not entry.disabled:
+                if entry and not entry.disabled:
                     break
                 entity_id = None
 

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -7,7 +7,7 @@ from enum import Enum
 import logging
 from typing import Any, Generic, TypeVar, Union
 
-from pyunifiprotect.data import NVR, EventType, ProtectAdoptableDeviceModel
+from pyunifiprotect.data import NVR, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 
@@ -68,37 +68,3 @@ class ProtectSetableKeysMixin(ProtectRequiredKeysMixin[T]):
             await getattr(obj, self.ufp_set_method)(value)
         elif self.ufp_set_method_fn is not None:
             await self.ufp_set_method_fn(obj, value)
-
-
-class SimpleEventType(str, Enum):
-    """Enum to Camera Video events."""
-
-    ALL = "All Events"
-    RING = "Ring Events"
-    MOTION = "Motion Events"
-    SMART = "Smart Detections"
-
-    @classmethod
-    def get_from_name(cls, name: str) -> SimpleEventType:
-        """Get SimpleEventType from name."""
-
-        if name.lower() == "smart_detect":
-            return SimpleEventType.SMART
-
-        types: list[SimpleEventType] = list(cls)
-        for event_type in types:
-            if event_type.name.lower() == name.lower():
-                return event_type
-        raise ValueError("Invalid event_type")
-
-    @classmethod
-    def get_event_type(cls, event_type: SimpleEventType) -> EventType | None:
-        """Get UniFi Protect event type from SimpleEventType."""
-
-        if event_type == SimpleEventType.ALL:
-            return None
-        if event_type == SimpleEventType.RING:
-            return EventType.RING
-        if event_type == SimpleEventType.MOTION:
-            return EventType.MOTION
-        return EventType.SMART_DETECT

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -7,7 +7,7 @@ from enum import Enum
 import logging
 from typing import Any, Generic, TypeVar, Union
 
-from pyunifiprotect.data import NVR, ProtectAdoptableDeviceModel
+from pyunifiprotect.data import NVR, EventType, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 
@@ -68,3 +68,37 @@ class ProtectSetableKeysMixin(ProtectRequiredKeysMixin[T]):
             await getattr(obj, self.ufp_set_method)(value)
         elif self.ufp_set_method_fn is not None:
             await self.ufp_set_method_fn(obj, value)
+
+
+class SimpleEventType(str, Enum):
+    """Enum to Camera Video events."""
+
+    ALL = "All Events"
+    RING = "Ring Events"
+    MOTION = "Motion Events"
+    SMART = "Smart Detections"
+
+    @classmethod
+    def get_from_name(cls, name: str) -> SimpleEventType:
+        """Get SimpleEventType from name."""
+
+        if name.lower() == "smart_detect":
+            return SimpleEventType.SMART
+
+        types: list[SimpleEventType] = list(cls)
+        for event_type in types:
+            if event_type.name.lower() == name.lower():
+                return event_type
+        raise ValueError("Invalid event_type")
+
+    @classmethod
+    def get_event_type(cls, event_type: SimpleEventType) -> EventType | None:
+        """Get UniFi Protect event type from SimpleEventType."""
+
+        if event_type == SimpleEventType.ALL:
+            return None
+        if event_type == SimpleEventType.RING:
+            return EventType.RING
+        if event_type == SimpleEventType.MOTION:
+            return EventType.MOTION
+        return EventType.SMART_DETECT

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -49,7 +49,8 @@
         "data": {
           "disable_rtsp": "Disable the RTSP stream",
           "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
-          "override_connection_host": "Override Connection Host"
+          "override_connection_host": "Override Connection Host",
+          "max_media": "Max number of event to load for Media Browser (increases RAM usage)"
         }
       }
     }

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -47,6 +47,7 @@
                 "data": {
                     "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
                     "disable_rtsp": "Disable the RTSP stream",
+                    "max_media": "Max number of event to load for Media Browser (increases RAM usage)",
                     "override_connection_host": "Override Connection Host"
                 },
                 "description": "Realtime metrics option should only be enabled if you have enabled the diagnostics sensors and want them updated in realtime. If not enabled, they will only update once every 15 minutes.",

--- a/homeassistant/components/unifiprotect/views.py
+++ b/homeassistant/components/unifiprotect/views.py
@@ -53,8 +53,8 @@ def async_generate_event_video_url(event: Event) -> str:
     url = url_format.format(
         nvr_id=event.api.bootstrap.nvr.id,
         camera_id=event.camera_id,
-        start=event.start.isoformat(),
-        end=event.end.isoformat(),
+        start=event.start.replace(microsecond=0).isoformat(),
+        end=event.end.replace(microsecond=0).isoformat(),
     )
 
     return url

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -238,6 +238,7 @@ async def test_form_options(hass: HomeAssistant, ufp_client: ProtectApiClient) -
             "id": "UnifiProtect",
             "port": 443,
             "verify_ssl": False,
+            "max_media": 1000,
         },
         version=2,
         unique_id=dr.format_mac(MAC_ADDR),
@@ -268,6 +269,7 @@ async def test_form_options(hass: HomeAssistant, ufp_client: ProtectApiClient) -
         "all_updates": True,
         "disable_rtsp": True,
         "override_connection_host": True,
+        "max_media": 1000,
     }
 
 

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -48,6 +48,7 @@ async def test_get_media_source(hass: HomeAssistant) -> None:
         "test_id:bad_type:test_id",
         "bad_id:event:test_id",
         "test_id:event:bad_id",
+        "test_id",
     ],
 )
 async def test_resolve_media_bad_identifier(
@@ -134,15 +135,20 @@ async def test_resolve_media_event(
     "identifier",
     [
         "bad_id:event:test_id",
-        "test_id:all:bad_event",
-        "test_id:all:all:recent:not_a_num",
-        "test_id:all:all:browse:not_a_num",
-        "test_id:all:all:browse:2022:not_a_num",
-        "test_id:all:all:browse:2022:1:not_a_num",
-        "test_id:all:all:browse:2022:1:50",
-        "test_id:all:all:invalid",
+        "test_id",
+        "test_id:bad_type",
+        "test_id:browse:all:all:bad_type",
+        "test_id:browse:all:bad_event",
+        "test_id:browse:all:all:recent",
+        "test_id:browse:all:all:recent:not_a_num",
+        "test_id:browse:all:all:range",
+        "test_id:browse:all:all:range:not_a_num",
+        "test_id:browse:all:all:range:2022:not_a_num",
+        "test_id:browse:all:all:range:2022:1:not_a_num",
+        "test_id:browse:all:all:range:2022:1:50",
+        "test_id:browse:all:all:invalid",
         "test_id:event:bad_event_id",
-        "test_id:bad_camera_id",
+        "test_id:browse:bad_camera_id",
     ],
 )
 async def test_browse_media_bad_identifier(
@@ -306,10 +312,10 @@ async def test_browse_media_root_multiple_consoles_only_one_media(
     browse = await source.async_browse_media(media_item)
 
     assert browse.title == "UnifiProtect"
-    assert browse.identifier == "test_id"
+    assert browse.identifier == "test_id:browse"
     assert len(browse.children) == 1
     assert browse.children[0].title == "All Cameras"
-    assert browse.children[0].identifier == "test_id:all"
+    assert browse.children[0].identifier == "test_id:browse:all"
 
 
 async def test_browse_media_root_single_console(
@@ -326,12 +332,12 @@ async def test_browse_media_root_single_console(
     browse = await source.async_browse_media(media_item)
 
     assert browse.title == "UnifiProtect"
-    assert browse.identifier == "test_id"
+    assert browse.identifier == "test_id:browse"
     assert len(browse.children) == 2
     assert browse.children[0].title == "All Cameras"
-    assert browse.children[0].identifier == "test_id:all"
+    assert browse.children[0].identifier == "test_id:browse:all"
     assert browse.children[1].title == doorbell.name
-    assert browse.children[1].identifier == f"test_id:{doorbell.id}"
+    assert browse.children[1].identifier == f"test_id:browse:{doorbell.id}"
     assert browse.children[1].thumbnail is not None
 
 
@@ -359,17 +365,17 @@ async def test_browse_media_camera(
     await hass.async_block_till_done()
 
     source = await async_get_media_source(hass)
-    media_item = MediaSourceItem(hass, DOMAIN, "test_id", None)
+    media_item = MediaSourceItem(hass, DOMAIN, "test_id:browse", None)
 
     browse = await source.async_browse_media(media_item)
 
     assert browse.title == "UnifiProtect"
-    assert browse.identifier == "test_id"
+    assert browse.identifier == "test_id:browse"
     assert len(browse.children) == 2
     assert browse.children[0].title == "All Cameras"
-    assert browse.children[0].identifier == "test_id:all"
+    assert browse.children[0].identifier == "test_id:browse:all"
     assert browse.children[1].title == doorbell.name
-    assert browse.children[1].identifier == f"test_id:{doorbell.id}"
+    assert browse.children[1].identifier == f"test_id:browse:{doorbell.id}"
     assert browse.children[1].thumbnail is None
 
 
@@ -384,17 +390,17 @@ async def test_browse_media_camera_offline(
     await init_entry(hass, ufp, [doorbell])
 
     source = await async_get_media_source(hass)
-    media_item = MediaSourceItem(hass, DOMAIN, "test_id", None)
+    media_item = MediaSourceItem(hass, DOMAIN, "test_id:browse", None)
 
     browse = await source.async_browse_media(media_item)
 
     assert browse.title == "UnifiProtect"
-    assert browse.identifier == "test_id"
+    assert browse.identifier == "test_id:browse"
     assert len(browse.children) == 2
     assert browse.children[0].title == "All Cameras"
-    assert browse.children[0].identifier == "test_id:all"
+    assert browse.children[0].identifier == "test_id:browse:all"
     assert browse.children[1].title == doorbell.name
-    assert browse.children[1].identifier == f"test_id:{doorbell.id}"
+    assert browse.children[1].identifier == f"test_id:browse:{doorbell.id}"
     assert browse.children[1].thumbnail is None
 
 
@@ -407,21 +413,21 @@ async def test_browse_media_event_type(
     await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
 
     source = await async_get_media_source(hass)
-    media_item = MediaSourceItem(hass, DOMAIN, "test_id:all", None)
+    media_item = MediaSourceItem(hass, DOMAIN, "test_id:browse:all", None)
 
     browse = await source.async_browse_media(media_item)
 
     assert browse.title == "UnifiProtect > All Cameras"
-    assert browse.identifier == "test_id:all"
+    assert browse.identifier == "test_id:browse:all"
     assert len(browse.children) == 4
     assert browse.children[0].title == "All Events"
-    assert browse.children[0].identifier == "test_id:all:all"
+    assert browse.children[0].identifier == "test_id:browse:all:all"
     assert browse.children[1].title == "Ring Events"
-    assert browse.children[1].identifier == "test_id:all:ring"
+    assert browse.children[1].identifier == "test_id:browse:all:ring"
     assert browse.children[2].title == "Motion Events"
-    assert browse.children[2].identifier == "test_id:all:motion"
+    assert browse.children[2].identifier == "test_id:browse:all:motion"
     assert browse.children[3].title == "Smart Detections"
-    assert browse.children[3].identifier == "test_id:all:smart"
+    assert browse.children[3].identifier == "test_id:browse:all:smart"
 
 
 async def test_browse_media_time(
@@ -435,7 +441,7 @@ async def test_browse_media_time(
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
     await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
 
-    base_id = f"test_id:{doorbell.id}:all"
+    base_id = f"test_id:browse:{doorbell.id}:all"
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 
@@ -453,7 +459,7 @@ async def test_browse_media_time(
     assert browse.children[3].title == f"{fixed_now.strftime('%B %Y')}"
     assert (
         browse.children[3].identifier
-        == f"{base_id}:browse:{fixed_now.year}:{fixed_now.month}"
+        == f"{base_id}:range:{fixed_now.year}:{fixed_now.month}"
     )
 
 
@@ -478,7 +484,7 @@ async def test_browse_media_recent(
     event._api = ufp.api
     ufp.api.get_events_raw = AsyncMock(return_value=[event.unifi_dict()])
 
-    base_id = f"test_id:{doorbell.id}:motion:recent:1"
+    base_id = f"test_id:browse:{doorbell.id}:motion:recent:1"
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 
@@ -516,7 +522,7 @@ async def test_browse_media_recent_truncated(
     event._api = ufp.api
     ufp.api.get_events_raw = AsyncMock(return_value=[event.unifi_dict()])
 
-    base_id = f"test_id:{doorbell.id}:motion:recent:1"
+    base_id = f"test_id:browse:{doorbell.id}:motion:recent:1"
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 
@@ -604,7 +610,9 @@ async def test_browse_media_day(
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
     await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
 
-    base_id = f"test_id:{doorbell.id}:all:browse:{fixed_now.year}:{fixed_now.month}"
+    base_id = (
+        f"test_id:browse:{doorbell.id}:all:range:{fixed_now.year}:{fixed_now.month}"
+    )
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 
@@ -644,9 +652,7 @@ async def test_browse_media_browse_day(
     event._api = ufp.api
     ufp.api.get_events_raw = AsyncMock(return_value=[event.unifi_dict()])
 
-    base_id = (
-        f"test_id:{doorbell.id}:motion:browse:{fixed_now.year}:{fixed_now.month}:1"
-    )
+    base_id = f"test_id:browse:{doorbell.id}:motion:range:{fixed_now.year}:{fixed_now.month}:1"
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 
@@ -687,7 +693,9 @@ async def test_browse_media_browse_whole_month(
     event._api = ufp.api
     ufp.api.get_events_raw = AsyncMock(return_value=[event.unifi_dict()])
 
-    base_id = f"test_id:{doorbell.id}:all:browse:{fixed_now.year}:{fixed_now.month}:all"
+    base_id = (
+        f"test_id:browse:{doorbell.id}:all:range:{fixed_now.year}:{fixed_now.month}:all"
+    )
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 
@@ -768,7 +776,9 @@ async def test_browse_media_browse_whole_month_december(
         ]
     )
 
-    base_id = f"test_id:{doorbell.id}:all:browse:{fixed_now.year}:{fixed_now.month}:all"
+    base_id = (
+        f"test_id:browse:{doorbell.id}:all:range:{fixed_now.year}:{fixed_now.month}:all"
+    )
     source = await async_get_media_source(hass)
     media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
 

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -1,0 +1,115 @@
+"""Tests for unifiprotect.media_source."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from pyunifiprotect.data import Camera, Event, EventType
+from pyunifiprotect.exceptions import NvrError
+
+from homeassistant.components.media_player.errors import BrowseError
+from homeassistant.components.media_source import MediaSourceItem
+from homeassistant.components.unifiprotect.const import DOMAIN
+from homeassistant.components.unifiprotect.media_source import (
+    ProtectMediaSource,
+    async_get_media_source,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockUFPFixture
+from .utils import init_entry
+
+
+async def test_get_media_source(hass: HomeAssistant) -> None:
+    """Test the async_get_media_source function and ProtectMediaSource constructor."""
+    source = await async_get_media_source(hass)
+    assert isinstance(source, ProtectMediaSource)
+    assert source.domain == DOMAIN
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "test_id:bad_type:test_id",
+        "bad_id:event:test_id",
+        "test_id:event:bad_id",
+    ],
+)
+async def test_resolve_media_bad_identifier(
+    hass: HomeAssistant, ufp: MockUFPFixture, identifier: str
+):
+    """Test resolving bad identifiers."""
+
+    ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
+    ufp.api.get_event = AsyncMock(side_effect=NvrError)
+    await init_entry(hass, ufp, [], regenerate_ids=False)
+
+    source = await async_get_media_source(hass)
+    media_item = MediaSourceItem(hass, DOMAIN, identifier, None)
+    with pytest.raises(BrowseError):
+        await source.async_resolve_media(media_item)
+
+
+async def test_resolve_media_thumbnail(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
+):
+    """Test resolving event thumbnails."""
+
+    ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
+    await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
+
+    event = Event(
+        id="test_event_id",
+        type=EventType.MOTION,
+        start=fixed_now - timedelta(seconds=20),
+        end=fixed_now,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+    )
+    event._api = ufp.api
+    ufp.api.bootstrap.events = {"test_event_id": event}
+
+    source = await async_get_media_source(hass)
+    media_item = MediaSourceItem(hass, DOMAIN, "test_id:eventthumb:test_event_id", None)
+    play_media = await source.async_resolve_media(media_item)
+
+    assert play_media.mime_type == "image/jpeg"
+    assert play_media.url.startswith(
+        "/api/unifiprotect/thumbnail/test_id/test_event_id"
+    )
+
+
+async def test_resolve_media_event(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
+):
+    """Test resolving event clips."""
+
+    ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
+    await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
+
+    event = Event(
+        id="test_event_id",
+        type=EventType.MOTION,
+        start=fixed_now - timedelta(seconds=20),
+        end=fixed_now,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+    )
+    event._api = ufp.api
+    ufp.api.get_event = AsyncMock(return_value=event)
+
+    source = await async_get_media_source(hass)
+    media_item = MediaSourceItem(hass, DOMAIN, "test_id:event:test_event_id", None)
+    play_media = await source.async_resolve_media(media_item)
+
+    start = event.start.replace(microsecond=0).isoformat()
+    end = event.end.replace(microsecond=0).isoformat()
+
+    assert play_media.mime_type == "video/mp4"
+    assert play_media.url.startswith(
+        f"/api/unifiprotect/video/test_id/{event.camera_id}/{start}/{end}"
+    )

--- a/tests/components/unifiprotect/test_views.py
+++ b/tests/components/unifiprotect/test_views.py
@@ -341,7 +341,7 @@ async def test_video_bad_params(
     url = async_generate_event_video_url(event)
     from_value = event_start if start is not None else fixed_now
     to_value = start if start is not None else end
-    url = url.replace(from_value.isoformat(), to_value)
+    url = url.replace(from_value.replace(microsecond=0).isoformat(), to_value)
 
     http_client = await hass_client()
     response = cast(ClientResponse, await http_client.get(url))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds new UniFi Protect media source to retrieve video clips and thumbnails from events on connected UniFi Protect NVRs. The media source is structured like so:

```
* [Console Selector] ... Each NVR Console (hidden if there is only one)
  * [Camera Selector] All Cameras
  * ... Camera X
    * [Event Selector] All Events
    * ... Event Type X
      * [Time Selector] Last 24 Hours -> Events
      * Last 7 Days -> Events
      * Last 30 Days -> Events
      * ... This Month - X
        * [Time Selector 2] Whole Month -> Events
        * ... Day X -> Events
```

By default, the max number events that can be return from your UniFi Protect console is capped at 1,000. This is because Media Sources have no way to pagination, infinite source or "load more" so all of the events must be loaded into memory at once. Loading more than 1,000 events at once could cause out of memory issues on lower memory devices. A Config Entry Option has been added to increase or decrease this limit.

Below are examples of all of the media source views:

Optional Root Level (not pictured): Console Selector if you have multiple UniFi Protect config entries.

First Level. Camera Selector
![image](https://user-images.githubusercontent.com/490848/177664227-dad624b4-7158-41e2-8263-490f80f01f48.png)

Second Level: Event Selector
![msedge_oX5qpbPQHF](https://user-images.githubusercontent.com/490848/176560085-e71f36b6-cda4-4774-8001-c4e3729ffe68.png)

Third Level: Time Selector
![msedge_4uK9GpzSVr](https://user-images.githubusercontent.com/490848/176560107-1837bea1-089c-46d4-9879-bee60ee1bce4.png)

Time Selector Part 2: Day Select within Month:
![msedge_V8sP4xAkdd](https://user-images.githubusercontent.com/490848/176560150-47d4e3ab-1e08-4386-8d57-afe0abc318f5.png)

Fourth Level: Actual Events
![msedge_V5XKkeLGXs](https://user-images.githubusercontent.com/490848/176560163-e520e988-fc39-4c5c-835d-90aac721e88e.png)

Fourth Level: Actual Events (but truncated)

The events will be truncated based on a new Config Option for how many events can be pulled at once. Pulling a large number of events at once causes a large increase in RAM (~10K events is about 1.6GB increase in RAM while downloading and parsing events). 

![msedge_FwmJzzxDz3](https://user-images.githubusercontent.com/490848/176560506-8711c61f-4e68-4d20-9129-6348d30fd2c5.png)




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23655

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
