### PR TITLE
Add power sensor to WiZ

### DIFF
--- a/homeassistant/components/wiz/__init__.py
+++ b/homeassistant/components/wiz/__init__.py
@@ -1,4 +1,6 @@
 """WiZ Platform integration."""
+from __future__ import annotations
+
 import asyncio
 from datetime import timedelta
 import logging
@@ -80,10 +82,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Found bulb {bulb.mac} at {ip_address}, expected {entry.unique_id}"
         )
 
-    async def _async_update() -> None:
+    async def _async_update() -> float | None:
         """Update the WiZ device."""
         try:
             await bulb.updateState()
+            if bulb.power_monitoring is not False:
+                power: float | None = await bulb.get_power()
+                return power
+            return None
         except WIZ_EXCEPTIONS as ex:
             raise UpdateFailed(f"Failed to update device at {ip_address}: {ex}") from ex
 
@@ -117,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def _async_push_update(state: PilotParser) -> None:
         """Receive a push update."""
         _LOGGER.debug("%s: Got push update: %s", bulb.mac, state.pilotResult)
-        coordinator.async_set_updated_data(None)
+        coordinator.async_set_updated_data(coordinator.data)
         if state.get_source() == PIR_SOURCE:
             async_dispatcher_send(hass, SIGNAL_WIZ_PIR.format(bulb.mac))
 

--- a/homeassistant/components/wiz/entity.py
+++ b/homeassistant/components/wiz/entity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Optional
 
 from pywizlight.bulblibrary import BulbType
 
@@ -10,12 +10,15 @@ from homeassistant.const import ATTR_HW_VERSION, ATTR_MODEL
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo, Entity, ToggleEntity
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .models import WizData
 
 
-class WizEntity(CoordinatorEntity, Entity):
+class WizEntity(CoordinatorEntity[DataUpdateCoordinator[Optional[float]]], Entity):
     """Representation of WiZ entity."""
 
     def __init__(self, wiz_data: WizData, name: str) -> None:

--- a/homeassistant/components/wiz/manifest.json
+++ b/homeassistant/components/wiz/manifest.json
@@ -13,7 +13,7 @@
   "dependencies": ["network"],
   "quality_scale": "platinum",
   "documentation": "https://www.home-assistant.io/integrations/wiz",
-  "requirements": ["pywizlight==0.5.13"],
+  "requirements": ["pywizlight==0.5.14"],
   "iot_class": "local_push",
   "codeowners": ["@sbidy"]
 }

--- a/homeassistant/components/wiz/sensor.py
+++ b/homeassistant/components/wiz/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+from homeassistant.const import POWER_WATT, SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -30,6 +30,17 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
 )
 
 
+POWER_SENSORS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="power",
+        name="Current Power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=POWER_WATT,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -37,9 +48,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up the wiz sensor."""
     wiz_data: WizData = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
+    entities = [
         WizSensor(wiz_data, entry.title, description) for description in SENSORS
-    )
+    ]
+    if wiz_data.coordinator.data is not None:
+        entities.extend(
+            [
+                WizPowerSensor(wiz_data, entry.title, description)
+                for description in POWER_SENSORS
+            ]
+        )
+    async_add_entities(entities)
 
 
 class WizSensor(WizEntity, SensorEntity):
@@ -63,3 +82,12 @@ class WizSensor(WizEntity, SensorEntity):
         self._attr_native_value = self._device.state.pilotResult.get(
             self.entity_description.key
         )
+
+
+class WizPowerSensor(WizSensor):
+    """Defines a WiZ power sensor."""
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Handle updating _attr values."""
+        self._attr_native_value = self.coordinator.data

--- a/homeassistant/components/wiz/sensor.py
+++ b/homeassistant/components/wiz/sensor.py
@@ -90,4 +90,8 @@ class WizPowerSensor(WizSensor):
     @callback
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
-        self._attr_native_value = self.coordinator.data
+        # Newer firmwares will have the power in their state
+        # Older firmwares will be polled and in the coordinator data
+        self._attr_native_value = (
+            self._device.state.get_power() or self.coordinator.data
+        )

--- a/homeassistant/components/wiz/sensor.py
+++ b/homeassistant/components/wiz/sensor.py
@@ -91,7 +91,7 @@ class WizPowerSensor(WizSensor):
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
         # Newer firmwares will have the power in their state
+        watts_push = self._device.state.get_power()
         # Older firmwares will be polled and in the coordinator data
-        self._attr_native_value = (
-            self._device.state.get_power() or self.coordinator.data
-        )
+        watts_poll = self.coordinator.data
+        self._attr_native_value = watts_poll if watts_push is None else watts_push

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2029,7 +2029,7 @@ pywemo==0.9.1
 pywilight==0.0.70
 
 # homeassistant.components.wiz
-pywizlight==0.5.13
+pywizlight==0.5.14
 
 # homeassistant.components.ws66i
 pyws66i==1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1349,7 +1349,7 @@ pywemo==0.9.1
 pywilight==0.0.70
 
 # homeassistant.components.wiz
-pywizlight==0.5.13
+pywizlight==0.5.14
 
 # homeassistant.components.ws66i
 pyws66i==1.1

--- a/tests/components/wiz/__init__.py
+++ b/tests/components/wiz/__init__.py
@@ -150,6 +150,17 @@ FAKE_SOCKET = BulbType(
     white_channels=2,
     white_to_color_ratio=80,
 )
+FAKE_SOCKET_WITH_POWER_MONITORING = BulbType(
+    bulb_type=BulbClass.SOCKET,
+    name="ESP25_SOCKET_01",
+    features=Features(
+        color=False, color_tmp=False, effect=False, brightness=False, dual_head=False
+    ),
+    kelvin_range=KelvinRange(2700, 6500),
+    fw_version="1.26.2",
+    white_channels=2,
+    white_to_color_ratio=80,
+)
 FAKE_OLD_FIRMWARE_DIMMABLE_BULB = BulbType(
     bulb_type=BulbClass.DW,
     name=None,
@@ -197,6 +208,7 @@ def _mocked_wizlight(device, extended_white_range, bulb_type) -> wizlight:
     )
     bulb.getMac = AsyncMock(return_value=FAKE_MAC)
     bulb.turn_on = AsyncMock()
+    bulb.get_power = AsyncMock(return_value=None)
     bulb.turn_off = AsyncMock()
     bulb.updateState = AsyncMock(return_value=FAKE_STATE)
     bulb.getSupportedScenes = AsyncMock(return_value=list(SCENES.values()))

--- a/tests/components/wiz/__init__.py
+++ b/tests/components/wiz/__init__.py
@@ -210,6 +210,7 @@ def _mocked_wizlight(device, extended_white_range, bulb_type) -> wizlight:
     bulb.turn_on = AsyncMock()
     bulb.get_power = AsyncMock(return_value=None)
     bulb.turn_off = AsyncMock()
+    bulb.power_monitoring = False
     bulb.updateState = AsyncMock(return_value=FAKE_STATE)
     bulb.getSupportedScenes = AsyncMock(return_value=list(SCENES.values()))
     bulb.start_push = AsyncMock(side_effect=_save_setup_callback)

--- a/tests/components/wiz/test_sensor.py
+++ b/tests/components/wiz/test_sensor.py
@@ -62,3 +62,5 @@ async def test_power_monitoring(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == "5.123"
+    await async_push_update(hass, socket, {"mac": FAKE_MAC, "pc": 800})
+    assert hass.states.get(entity_id).state == "0.8"

--- a/tests/components/wiz/test_sensor.py
+++ b/tests/components/wiz/test_sensor.py
@@ -1,11 +1,15 @@
 """Tests for the sensor platform."""
 
+from unittest.mock import AsyncMock
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import (
     FAKE_DUAL_HEAD_RGBWW_BULB,
     FAKE_MAC,
+    FAKE_SOCKET_WITH_POWER_MONITORING,
+    _mocked_wizlight,
     _patch_discovery,
     _patch_wizlight,
     async_push_update,
@@ -35,3 +39,26 @@ async def test_signal_strength(hass: HomeAssistant) -> None:
 
     await async_push_update(hass, bulb, {"mac": FAKE_MAC, "rssi": -50})
     assert hass.states.get(entity_id).state == "-50"
+
+
+async def test_power_monitoring(hass: HomeAssistant) -> None:
+    """Test power monitoring."""
+    socket = _mocked_wizlight(None, None, FAKE_SOCKET_WITH_POWER_MONITORING)
+    socket.get_power = AsyncMock(return_value=5.123)
+    _, entry = await async_setup_integration(
+        hass, wizlight=socket, bulb_type=FAKE_SOCKET_WITH_POWER_MONITORING
+    )
+    entity_id = "sensor.mock_title_current_power"
+    entity_registry = er.async_get(hass)
+    reg_entry = entity_registry.async_get(entity_id)
+    assert reg_entry.unique_id == f"{FAKE_MAC}_power"
+    updated_entity = entity_registry.async_update_entity(
+        entity_id=entity_id, disabled_by=None
+    )
+    assert not updated_entity.disabled
+
+    with _patch_discovery(), _patch_wizlight(device=socket):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "5.123"

--- a/tests/components/wiz/test_sensor.py
+++ b/tests/components/wiz/test_sensor.py
@@ -44,6 +44,7 @@ async def test_signal_strength(hass: HomeAssistant) -> None:
 async def test_power_monitoring(hass: HomeAssistant) -> None:
     """Test power monitoring."""
     socket = _mocked_wizlight(None, None, FAKE_SOCKET_WITH_POWER_MONITORING)
+    socket.power_monitoring = None
     socket.get_power = AsyncMock(return_value=5.123)
     _, entry = await async_setup_integration(
         hass, wizlight=socket, bulb_type=FAKE_SOCKET_WITH_POWER_MONITORING


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Only following modules supports power sensors:

ESP25_SOCKET_01
ESP20_SHDW_31R
ESP20_SHRGB_31R
ESP20_SHTW_31R

They don't seem to be available in the US market yet, but I was able to get an EU one and use a voltage adapter for testng.

Changelog: https://github.com/sbidy/pywizlight/compare/v0.5.13...v0.5.14

![wiz_power](https://user-images.githubusercontent.com/663432/172768426-264bc5af-a7a2-46ac-8621-05d92f17fe4b.gif)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23067

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
