### PR TITLE
Use more specific exception and simplify aurora_abb_powerone

### DIFF
--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -10,15 +10,13 @@
 
 import logging
 
-from aurorapy.client import AuroraError, AuroraSerialClient
+from aurorapy.client import AuroraSerialClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 
-from .config_flow import validate_and_connect
-from .const import ATTR_SERIAL_NUMBER, DOMAIN
+from .const import DOMAIN
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -31,42 +29,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     comport = entry.data[CONF_PORT]
     address = entry.data[CONF_ADDRESS]
     ser_client = AuroraSerialClient(address, comport, parity="N", timeout=1)
-    # To handle yaml import attempts in darkness, (re)try connecting only if
-    # unique_id not yet assigned.
-    if entry.unique_id is None:
-        try:
-            res = await hass.async_add_executor_job(
-                validate_and_connect, hass, entry.data
-            )
-        except AuroraError as error:
-            if "No response after" in str(error):
-                raise ConfigEntryNotReady("No response (could be dark)") from error
-            _LOGGER.error("Failed to connect to inverter: %s", error)
-            return False
-        except OSError as error:
-            if error.errno == 19:  # No such device.
-                _LOGGER.error("Failed to connect to inverter: no such COM port")
-                return False
-            _LOGGER.error("Failed to connect to inverter: %s", error)
-            return False
-        else:
-            # If we got here, the device is now communicating (maybe after
-            # being in darkness). But there's a small risk that the user has
-            # configured via the UI since we last attempted the yaml setup,
-            # which means we'd get a duplicate unique ID.
-            new_id = res[ATTR_SERIAL_NUMBER]
-            # Check if this unique_id has already been used
-            for existing_entry in hass.config_entries.async_entries(DOMAIN):
-                if existing_entry.unique_id == new_id:
-                    _LOGGER.debug(
-                        "Remove already configured config entry for id %s", new_id
-                    )
-                    hass.async_create_task(
-                        hass.config_entries.async_remove(entry.entry_id)
-                    )
-                    return False
-            hass.config_entries.async_update_entry(entry, unique_id=new_id)
-
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = ser_client
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-from aurorapy.client import AuroraError, AuroraSerialClient
+from aurorapy.client import AuroraError, AuroraSerialClient, AuroraTimeoutError
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -102,22 +102,16 @@ class AuroraSensor(AuroraEntity, SensorEntity):
                 self._attr_native_value = round(energy_wh / 1000, 2)
             self._attr_available = True
 
+        except AuroraTimeoutError:
+            self._attr_state = None
+            self._attr_native_value = None
+            self._attr_available = False
+            _LOGGER.debug("No response from inverter (could be dark)")
         except AuroraError as error:
             self._attr_state = None
             self._attr_native_value = None
             self._attr_available = False
-            # aurorapy does not have different exceptions (yet) for dealing
-            # with timeout vs other comms errors.
-            # This means the (normal) situation of no response during darkness
-            # raises an exception.
-            # aurorapy (gitlab) pull request merged 29/5/2019. When >0.2.6 is
-            # released, this could be modified to :
-            # except AuroraTimeoutError as e:
-            # Workaround: look at the text of the exception
-            if "No response after" in str(error):
-                _LOGGER.debug("No response from inverter (could be dark)")
-            else:
-                raise error
+            raise error
         finally:
             if self._attr_available != self.available_prev:
                 if self._attr_available:

--- a/tests/components/aurora_abb_powerone/test_config_flow.py
+++ b/tests/components/aurora_abb_powerone/test_config_flow.py
@@ -2,7 +2,7 @@
 from logging import INFO
 from unittest.mock import patch
 
-from aurorapy.client import AuroraError
+from aurorapy.client import AuroraError, AuroraTimeoutError
 from serial.tools import list_ports_common
 
 from homeassistant import config_entries, data_entry_flow, setup
@@ -127,7 +127,7 @@ async def test_form_invalid_com_ports(hass):
 
     with patch(
         "aurorapy.client.AuroraSerialClient.connect",
-        side_effect=AuroraError("...No response after..."),
+        side_effect=AuroraTimeoutError("...No response after..."),
         return_value=None,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from aurorapy.client import AuroraError
+from aurorapy.client import AuroraError, AuroraTimeoutError
 
 from homeassistant.components.aurora_abb_powerone.const import (
     ATTR_DEVICE_NAME,
@@ -126,7 +126,7 @@ async def test_sensor_dark(hass):
     # sunset
     with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None), patch(
         "aurorapy.client.AuroraSerialClient.measure",
-        side_effect=AuroraError("No response after 10 seconds"),
+        side_effect=AuroraTimeoutError("No response after 10 seconds"),
     ):
         async_fire_time_changed(hass, utcnow + timedelta(seconds=60))
         await hass.async_block_till_done()
@@ -144,7 +144,7 @@ async def test_sensor_dark(hass):
     # sunset
     with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None), patch(
         "aurorapy.client.AuroraSerialClient.measure",
-        side_effect=AuroraError("No response after 10 seconds"),
+        side_effect=AuroraTimeoutError("No response after 10 seconds"),
     ):
         async_fire_time_changed(hass, utcnow + timedelta(seconds=60))
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following #73327 there is now a more specific exception for detecting normal timeouts that occur every evening when the panels are in darkness.  This means we no longer need the hack of looking at the exception text to distinguish between darkness timeouts and 'real' errors.

In addition the PR removes some more legacy yaml support code that is no longer needed now that the deprecation period is over.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #73327 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
