### PR TITLE
Fix initial data load for System Bridge

### DIFF
--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -98,25 +98,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    _LOGGER.debug("Data: %s", coordinator.data)
-
     try:
         # Wait for initial data
         async with async_timeout.timeout(30):
-            while coordinator.data is None or all(
-                getattr(coordinator.data, module) is None for module in MODULES
-            ):
+            while not coordinator.is_ready:
                 _LOGGER.debug(
-                    "Waiting for initial data from %s (%s): %s",
+                    "Waiting for initial data from %s (%s)",
                     entry.title,
                     entry.data[CONF_HOST],
-                    coordinator.data,
                 )
                 await asyncio.sleep(1)
     except asyncio.TimeoutError as exception:
         raise ConfigEntryNotReady(
             f"Timed out waiting for {entry.title} ({entry.data[CONF_HOST]})."
         ) from exception
+
+    _LOGGER.debug(
+        "Is coordinator ready for %s (%s): %s",
+        entry.title,
+        entry.data[CONF_HOST],
+        coordinator.is_ready,
+    )
+
+    _LOGGER.debug(
+        "Initial coordinator data for %s (%s):\n%s",
+        entry.title,
+        entry.data[CONF_HOST],
+        coordinator.data.json(),
+    )
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         # Wait for initial data
         async with async_timeout.timeout(30):
-            while not coordinator.is_ready:
+            while not coordinator.is_ready():
                 _LOGGER.debug(
                     "Waiting for initial data from %s (%s)",
                     entry.title,
@@ -112,13 +112,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(
             f"Timed out waiting for {entry.title} ({entry.data[CONF_HOST]})."
         ) from exception
-
-    _LOGGER.debug(
-        "Is coordinator ready for %s (%s): %s",
-        entry.title,
-        entry.data[CONF_HOST],
-        coordinator.is_ready,
-    )
 
     _LOGGER.debug(
         "Initial coordinator data for %s (%s):\n%s",

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -75,7 +75,6 @@ class SystemBridgeDataUpdateCoordinator(
             hass, LOGGER, name=DOMAIN, update_interval=timedelta(seconds=30)
         )
 
-    @property
     def is_ready(self) -> bool:
         """Return if the data is ready."""
         if self.data is None:

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -75,6 +75,17 @@ class SystemBridgeDataUpdateCoordinator(
             hass, LOGGER, name=DOMAIN, update_interval=timedelta(seconds=30)
         )
 
+    @property
+    def is_ready(self) -> bool:
+        """Return if the data is ready."""
+        if self.data is None:
+            return False
+        for module in MODULES:
+            if getattr(self.data, module) is None:
+                self.logger.debug("%s - Module %s is None", self.title, module)
+                return False
+        return True
+
     async def async_get_data(
         self,
         modules: list[str],

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridgeconnector==3.1.3"],
+  "requirements": ["systembridgeconnector==3.1.5"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._tcp.local."],
   "after_dependencies": ["zeroconf"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2268,7 +2268,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridgeconnector==3.1.3
+systembridgeconnector==3.1.5
 
 # homeassistant.components.tailscale
 tailscale==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1504,7 +1504,7 @@ sunwatcher==0.2.1
 surepy==0.7.2
 
 # homeassistant.components.system_bridge
-systembridgeconnector==3.1.3
+systembridgeconnector==3.1.5
 
 # homeassistant.components.tailscale
 tailscale==0.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The initial data for the integration was allowing items to be None previously. This adds an is_ready property to the coordinator, which makes sure all modules are not None.

The package has also been updated which fixes a couple of issues with recent patches where some optional fields were being treated as non-optional in the models.

https://github.com/timmo001/system-bridge/releases/tag/3.1.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

<!--
## Additional information
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] 🥈 Silver

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
