### PR TITLE
Add missing exception handlers to radiotherm

### DIFF
--- a/homeassistant/components/radiotherm/__init__.py
+++ b/homeassistant/components/radiotherm/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Coroutine
 from socket import timeout
 from typing import Any, TypeVar
+from urllib.error import URLError
 
 from radiotherm.validate import RadiothermTstatError
 
@@ -30,6 +31,9 @@ async def _async_call_or_raise_not_ready(
         return await coro
     except RadiothermTstatError as ex:
         msg = f"{host} was busy (invalid value returned): {ex}"
+        raise ConfigEntryNotReady(msg) from ex
+    except (OSError, URLError) as ex:
+        msg = f"{host} connection error: {ex}"
         raise ConfigEntryNotReady(msg) from ex
     except timeout as ex:
         msg = f"{host} timed out waiting for a response: {ex}"

--- a/homeassistant/components/radiotherm/config_flow.py
+++ b/homeassistant/components/radiotherm/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from socket import timeout
 from typing import Any
+from urllib.error import URLError
 
 from radiotherm.validate import RadiothermTstatError
 import voluptuous as vol
@@ -29,7 +30,7 @@ async def validate_connection(hass: HomeAssistant, host: str) -> RadioThermInitD
     """Validate the connection."""
     try:
         return await async_get_init_data(hass, host)
-    except (timeout, RadiothermTstatError) as ex:
+    except (timeout, RadiothermTstatError, URLError, OSError) as ex:
         raise CannotConnect(f"Failed to connect to {host}: {ex}") from ex
 
 

--- a/homeassistant/components/radiotherm/coordinator.py
+++ b/homeassistant/components/radiotherm/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 from socket import timeout
+from urllib.error import URLError
 
 from radiotherm.validate import RadiothermTstatError
 
@@ -37,6 +38,9 @@ class RadioThermUpdateCoordinator(DataUpdateCoordinator[RadioThermUpdate]):
             return await async_get_data(self.hass, self.init_data.tstat)
         except RadiothermTstatError as ex:
             msg = f"{self._description} was busy (invalid value returned): {ex}"
+            raise UpdateFailed(msg) from ex
+        except (OSError, URLError) as ex:
+            msg = f"{self._description} connection error: {ex}"
             raise UpdateFailed(msg) from ex
         except timeout as ex:
             msg = f"{self._description}) timed out waiting for a response: {ex}"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After upgrading access point firmware and restarting HA,
radiotherm failed to setup due to the following exceptions:

```
Traceback (most recent call last):
....
  File "/usr/local/lib/python3.9/socket.py", line 832, in create_connection
    sock.connect(sa)
OSError: [Errno 113] Host is unreachable

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 339, in async_setup
    result = await component.async_setup_entry(hass, self)
...
  File "/usr/local/lib/python3.9/urllib/request.py", line 1349, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno 113] Host is unreachable>
```

This PR adds exception catches for these to ensure config entry
setup is retried later when the network is available again


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
