### PR TITLE
Add support for playing latest activity video for Skybell

### DIFF
--- a/homeassistant/components/skybell/camera.py
+++ b/homeassistant/components/skybell/camera.py
@@ -1,6 +1,8 @@
 """Camera support for the Skybell HD Doorbell."""
 from __future__ import annotations
 
+from aiohttp import web
+from haffmpeg.camera import CameraMjpeg
 import voluptuous as vol
 
 from homeassistant.components.camera import (
@@ -8,9 +10,11 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityDescription,
 )
+from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -21,6 +25,7 @@ from .const import (
     DOMAIN,
     IMAGE_ACTIVITY,
     IMAGE_AVATAR,
+    LOGGER,
 )
 from .coordinator import SkybellDataUpdateCoordinator
 from .entity import SkybellEntity
@@ -46,11 +51,14 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Skybell switch."""
-    async_add_entities(
-        SkybellCamera(coordinator, description)
-        for description in CAMERA_TYPES
-        for coordinator in hass.data[DOMAIN][entry.entry_id]
-    )
+    entities = []
+    for description in CAMERA_TYPES:
+        for coordinator in hass.data[DOMAIN][entry.entry_id]:
+            if description.key == "avatar":
+                entities.append(SkybellCamera(coordinator, description))
+            else:
+                entities.append(SkybellActivityCamera(coordinator, description))
+    async_add_entities(entities)
 
 
 class SkybellCamera(SkybellEntity, Camera):
@@ -70,3 +78,26 @@ class SkybellCamera(SkybellEntity, Camera):
     ) -> bytes | None:
         """Get the latest camera image."""
         return self._device.images[self.entity_description.key]
+
+
+class SkybellActivityCamera(SkybellCamera):
+    """A camera implementation for latest Skybell activity."""
+
+    async def handle_async_mjpeg_stream(
+        self, request: web.Request
+    ) -> web.StreamResponse | None:
+        """Generate an HTTP MJPEG stream from the latest recorded activity."""
+        stream = CameraMjpeg(self.hass.data[DATA_FFMPEG].binary)
+        url = await self.coordinator.device.async_get_activity_video_url()
+        await stream.open_camera(url, extra_cmd="-r 210")
+
+        try:
+            return await async_aiohttp_proxy_stream(
+                self.hass,
+                request,
+                await stream.get_reader(),
+                self.hass.data[DATA_FFMPEG].ffmpeg_stream_content_type,
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            LOGGER.error("Error occurred while playing stream: %s", ex)
+            return None

--- a/homeassistant/components/skybell/camera.py
+++ b/homeassistant/components/skybell/camera.py
@@ -25,7 +25,6 @@ from .const import (
     DOMAIN,
     IMAGE_ACTIVITY,
     IMAGE_AVATAR,
-    LOGGER,
 )
 from .coordinator import SkybellDataUpdateCoordinator
 from .entity import SkybellEntity
@@ -85,7 +84,7 @@ class SkybellActivityCamera(SkybellCamera):
 
     async def handle_async_mjpeg_stream(
         self, request: web.Request
-    ) -> web.StreamResponse | None:
+    ) -> web.StreamResponse:
         """Generate an HTTP MJPEG stream from the latest recorded activity."""
         stream = CameraMjpeg(get_ffmpeg_manager(self.hass).binary)
         url = await self.coordinator.device.async_get_activity_video_url()
@@ -98,6 +97,5 @@ class SkybellActivityCamera(SkybellCamera):
                 await stream.get_reader(),
                 get_ffmpeg_manager(self.hass).ffmpeg_stream_content_type,
             )
-        except Exception as ex:  # pylint: disable=broad-except
-            LOGGER.error("Error occurred while playing stream: %s", ex)
-            return None
+        finally:
+            await stream.close()

--- a/homeassistant/components/skybell/camera.py
+++ b/homeassistant/components/skybell/camera.py
@@ -10,7 +10,7 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityDescription,
 )
-from homeassistant.components.ffmpeg import DATA_FFMPEG
+from homeassistant.components.ffmpeg import get_ffmpeg_manager
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.core import HomeAssistant
@@ -87,7 +87,7 @@ class SkybellActivityCamera(SkybellCamera):
         self, request: web.Request
     ) -> web.StreamResponse | None:
         """Generate an HTTP MJPEG stream from the latest recorded activity."""
-        stream = CameraMjpeg(self.hass.data[DATA_FFMPEG].binary)
+        stream = CameraMjpeg(get_ffmpeg_manager(self.hass).binary)
         url = await self.coordinator.device.async_get_activity_video_url()
         await stream.open_camera(url, extra_cmd="-r 210")
 
@@ -96,7 +96,7 @@ class SkybellActivityCamera(SkybellCamera):
                 self.hass,
                 request,
                 await stream.get_reader(),
-                self.hass.data[DATA_FFMPEG].ffmpeg_stream_content_type,
+                get_ffmpeg_manager(self.hass).ffmpeg_stream_content_type,
             )
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.error("Error occurred while playing stream: %s", ex)

--- a/homeassistant/components/skybell/manifest.json
+++ b/homeassistant/components/skybell/manifest.json
@@ -4,6 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/skybell",
   "requirements": ["aioskybell==22.6.1"],
+  "dependencies": ["ffmpeg"],
   "codeowners": ["@tkdrob"],
   "iot_class": "cloud_polling",
   "loggers": ["aioskybell"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The user can now click on the Latest Activity camera on a dashboard to make the latest recorded video play (no audio).
Live calls would have also been possible for the Avatar camera entity. However, the stream reader currently does not support `POST` requests. Perhaps this can be supported in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
