### PR TITLE
Migrate lutron caseta occupancygroup unique ids so they are actually unique

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -679,6 +679,7 @@ omit =
     homeassistant/components/lutron_caseta/light.py
     homeassistant/components/lutron_caseta/scene.py
     homeassistant/components/lutron_caseta/switch.py
+    homeassistant/components/lutron_caseta/util.py
     homeassistant/components/lw12wifi/light.py
     homeassistant/components/lyric/__init__.py
     homeassistant/components/lyric/api.py

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -124,7 +124,7 @@ async def _async_migrate_unique_ids(
             return None
         sensor_id = unique_id.split("_")[1]
         new_unique_id = f"occupancygroup_{bridge_unique_id}_{sensor_id}"
-        if dev_entry := dev_reg.async_get_device({DOMAIN, unique_id}):
+        if dev_entry := dev_reg.async_get_device({(DOMAIN, unique_id)}):
             dev_reg.async_update_device(
                 dev_entry.id, new_identifiers={(DOMAIN, new_unique_id)}
             )

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -112,22 +112,23 @@ async def _async_migrate_unique_ids(
     """Migrate entities since the occupancygroup were not actually unique."""
 
     dev_reg = dr.async_get(hass)
+    bridge_unique_id = entry.unique_id
 
     @callback
     def _async_migrator(entity_entry: er.RegistryEntry) -> dict[str, Any] | None:
-        if not (unique_id := entry.unique_id):
+        if not (unique_id := entity_entry.unique_id):
             return None
         if not unique_id.startswith("occupancygroup_") or unique_id.startswith(
-            f"occupancygroup_{entity_entry.unique_id}"
+            f"occupancygroup_{bridge_unique_id}"
         ):
             return None
         sensor_id = unique_id.split("_")[1]
-        new_unique_id = f"occupancygroup_{entity_entry.unique_id}_{sensor_id}"
+        new_unique_id = f"occupancygroup_{bridge_unique_id}_{sensor_id}"
         if dev_entry := dev_reg.async_get_device({DOMAIN, unique_id}):
             dev_reg.async_update_device(
                 dev_entry.id, new_identifiers={(DOMAIN, new_unique_id)}
             )
-        return {"new_unique_id": f"occupancygroup_{entity_entry.unique_id}_{sensor_id}"}
+        return {"new_unique_id": f"occupancygroup_{bridge_unique_id}_{sensor_id}"}
 
     await er.async_migrate_entries(hass, entry.entry_id, _async_migrator)
 

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import logging
 import ssl
+from typing import Any
 
 import async_timeout
 from pylutron_caseta import BUTTON_STATUS_PRESSED
@@ -15,7 +16,7 @@ from homeassistant import config_entries
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_SUGGESTED_AREA, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.typing import ConfigType
@@ -48,6 +49,7 @@ from .device_trigger import (
     DEVICE_TYPE_SUBTYPE_MAP_TO_LIP,
     LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP,
 )
+from .util import serial_to_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,6 +106,32 @@ async def async_setup(hass: HomeAssistant, base_config: ConfigType) -> bool:
     return True
 
 
+async def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: config_entries.ConfigEntry
+) -> None:
+    """Migrate entities since the occupancygroup were not actually unique."""
+
+    dev_reg = dr.async_get(hass)
+
+    @callback
+    def _async_migrator(entity_entry: er.RegistryEntry) -> dict[str, Any] | None:
+        if not (unique_id := entry.unique_id):
+            return None
+        if not unique_id.startswith("occupancygroup_") or unique_id.startswith(
+            f"occupancygroup_{entity_entry.unique_id}"
+        ):
+            return None
+        sensor_id = unique_id.split("_")[1]
+        new_unique_id = f"occupancygroup_{entity_entry.unique_id}_{sensor_id}"
+        if dev_entry := dev_reg.async_get_device({DOMAIN, unique_id}):
+            dev_reg.async_update_device(
+                dev_entry.id, new_identifiers={(DOMAIN, new_unique_id)}
+            )
+        return {"new_unique_id": f"occupancygroup_{entity_entry.unique_id}_{sensor_id}"}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _async_migrator)
+
+
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: config_entries.ConfigEntry
 ) -> bool:
@@ -114,6 +142,8 @@ async def async_setup_entry(
     certfile = hass.config.path(config_entry.data[CONF_CERTFILE])
     ca_certs = hass.config.path(config_entry.data[CONF_CA_CERTS])
     bridge = None
+
+    await _async_migrate_unique_ids(hass, config_entry)
 
     try:
         bridge = Smartbridge.create_tls(
@@ -142,7 +172,7 @@ async def async_setup_entry(
     bridge_device = devices[BRIDGE_DEVICE_ID]
     if not config_entry.unique_id:
         hass.config_entries.async_update_entry(
-            config_entry, unique_id=hex(bridge_device["serial"])[2:].zfill(8)
+            config_entry, unique_id=serial_to_unique_id(bridge_device["serial"])
         )
 
     buttons = bridge.buttons
@@ -310,6 +340,7 @@ class LutronCasetaDevice(Entity):
         self._device = device
         self._smartbridge = bridge
         self._bridge_device = bridge_device
+        self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         if "serial" not in self._device:
             return
         area, name = _area_and_name_from_name(device["name"])

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -77,7 +77,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
     @property
     def unique_id(self):
         """Return a unique identifier."""
-        return f"occupancygroup_{self.device_id}"
+        return f"occupancygroup_{self._bridge_unique_id}_{self.device_id}"
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -6,14 +6,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_SUGGESTED_AREA
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN as CASETA_DOMAIN, LutronCasetaDevice, _area_and_name_from_name
-from .const import BRIDGE_DEVICE, BRIDGE_LEAP, CONFIG_URL, MANUFACTURER, UNASSIGNED_AREA
+from .const import BRIDGE_DEVICE, BRIDGE_LEAP, CONFIG_URL, MANUFACTURER
 
 
 async def async_setup_entry(
@@ -44,7 +43,9 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
     def __init__(self, device, bridge, bridge_device):
         """Init an occupancy sensor."""
         super().__init__(device, bridge, bridge_device)
-        info = DeviceInfo(
+        _, name = _area_and_name_from_name(device["name"])
+        self._attr_name = name
+        self._attr_device_info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, self.unique_id)},
             manufacturer=MANUFACTURER,
             model="Lutron Occupancy",
@@ -53,10 +54,6 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
             configuration_url=CONFIG_URL,
             entry_type=DeviceEntryType.SERVICE,
         )
-        area, _ = _area_and_name_from_name(device["name"])
-        if area != UNASSIGNED_AREA:
-            info[ATTR_SUGGESTED_AREA] = area
-        self._attr_device_info = info
 
     @property
     def is_on(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -44,17 +44,16 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
     def __init__(self, device, bridge, bridge_device):
         """Init an occupancy sensor."""
         super().__init__(device, bridge, bridge_device)
-        area, name = _area_and_name_from_name(device["name"])
-        self._attr_name = full_name = f"{area} {name}"
         info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, self.unique_id)},
             manufacturer=MANUFACTURER,
             model="Lutron Occupancy",
-            name=full_name,
+            name=self.name,
             via_device=(CASETA_DOMAIN, self._bridge_device["serial"]),
             configuration_url=CONFIG_URL,
             entry_type=DeviceEntryType.SERVICE,
         )
+        area, _ = _area_and_name_from_name(device["name"])
         if area != UNASSIGNED_AREA:
             info[ATTR_SUGGESTED_AREA] = area
         self._attr_device_info = info

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -44,16 +44,17 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
     def __init__(self, device, bridge, bridge_device):
         """Init an occupancy sensor."""
         super().__init__(device, bridge, bridge_device)
+        area, name = _area_and_name_from_name(device["name"])
+        self._attr_name = full_name = f"{area} {name}"
         info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, self.unique_id)},
             manufacturer=MANUFACTURER,
             model="Lutron Occupancy",
-            name=self.name,
+            name=full_name,
             via_device=(CASETA_DOMAIN, self._bridge_device["serial"]),
             configuration_url=CONFIG_URL,
             entry_type=DeviceEntryType.SERVICE,
         )
-        area, _ = _area_and_name_from_name(device["name"])
         if area != UNASSIGNED_AREA:
             info[ATTR_SUGGESTED_AREA] = area
         self._attr_device_info = info

--- a/homeassistant/components/lutron_caseta/util.py
+++ b/homeassistant/components/lutron_caseta/util.py
@@ -1,0 +1,7 @@
+"""Support for Lutron Caseta."""
+from __future__ import annotations
+
+
+def serial_to_unique_id(serial: int) -> str:
+    """Convert a lutron serial number to a unique id."""
+    return hex(serial)[2:].zfill(8)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The unique id value was not actually unique and would conflict if the setup has multiple caseta bridges.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
