### PR TITLE
Add support for async_remove_config_entry_device to lutron_caseta

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -679,6 +679,7 @@ omit =
     homeassistant/components/lutron_caseta/light.py
     homeassistant/components/lutron_caseta/scene.py
     homeassistant/components/lutron_caseta/switch.py
+    homeassistant/components/lutron_caseta/util.py
     homeassistant/components/lw12wifi/light.py
     homeassistant/components/lyric/__init__.py
     homeassistant/components/lyric/api.py

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -373,7 +373,6 @@ async def async_remove_config_entry_device(
     """Remove lutron_caseta config entry from a device."""
     bridge: Smartbridge = hass.data[DOMAIN][entry.entry_id][BRIDGE_LEAP]
     devices = bridge.get_devices()
-    scenes = bridge.get_scenes()
     buttons = bridge.buttons
     occupancy_groups = bridge.occupancy_groups
     bridge_device = devices[BRIDGE_DEVICE_ID]
@@ -387,11 +386,6 @@ async def async_remove_config_entry_device(
                 f"occupancygroup_{bridge_unique_id}_{device['occupancy_group_id']}"
             )
             for device in occupancy_groups.values()
-        ),
-        # Scenes
-        *(
-            _id_to_identifier(f"scene_{bridge_unique_id}_{device['scene_id']}")
-            for device in scenes.values()
         ),
         # Button devices such as pico remotes and all other devices
         *(

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -49,6 +49,7 @@ from .device_trigger import (
     DEVICE_TYPE_SUBTYPE_MAP_TO_LIP,
     LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP,
 )
+from .util import serial_to_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -376,7 +377,7 @@ async def async_remove_config_entry_device(
     buttons = bridge.buttons
     occupancy_groups = bridge.occupancy_groups
     bridge_device = devices[BRIDGE_DEVICE_ID]
-    bridge_unique_id = bridge_device["serial"]
+    bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
     all_identifiers: set[tuple[str, str]] = {
         # Base bridge
         _id_to_identifier(bridge_unique_id),

--- a/homeassistant/components/lutron_caseta/util.py
+++ b/homeassistant/components/lutron_caseta/util.py
@@ -1,0 +1,7 @@
+"""Support for Lutron Caseta."""
+from __future__ import annotations
+
+
+def serial_to_unique_id(serial: int) -> str:
+    """Convert a lutron serial number to a unique id."""
+    return hex(serial)[2:].zfill(8)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for async_remove_config_entry_device to lutron_caseta

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
