### PR TITLE
Add unique ids to lutron_caseta scenes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -679,6 +679,7 @@ omit =
     homeassistant/components/lutron_caseta/light.py
     homeassistant/components/lutron_caseta/scene.py
     homeassistant/components/lutron_caseta/switch.py
+    homeassistant/components/lutron_caseta/util.py
     homeassistant/components/lw12wifi/light.py
     homeassistant/components/lyric/__init__.py
     homeassistant/components/lyric/api.py

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -5,7 +5,6 @@ from pylutron_caseta.smartbridge import Smartbridge
 
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_SUGGESTED_AREA
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -18,7 +17,6 @@ from .const import (
     CONFIG_URL,
     DOMAIN as CASETA_DOMAIN,
     MANUFACTURER,
-    UNASSIGNED_AREA,
 )
 from .util import serial_to_unique_id
 
@@ -49,23 +47,20 @@ class LutronCasetaScene(Scene):
         """Initialize the Lutron Caseta scene."""
         self._scene_id = scene["scene_id"]
         self._bridge: Smartbridge = bridge
-        area, name = _area_and_name_from_name(scene["name"])
+        _, name = _area_and_name_from_name(scene["name"])
         bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
-        full_name = f"{area} {name}"
         unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"
         info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, unique_id)},
             manufacturer=MANUFACTURER,
             model="Lutron Scene",
-            name=full_name,
+            name=name,
             via_device=(CASETA_DOMAIN, bridge_device["serial"]),
             configuration_url=CONFIG_URL,
             entry_type=DeviceEntryType.SERVICE,
         )
-        if area != UNASSIGNED_AREA:
-            info[ATTR_SUGGESTED_AREA] = area
         self._attr_device_info = info
-        self._attr_name = full_name
+        self._attr_name = name
         self._attr_unique_id = unique_id
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -1,12 +1,26 @@
 """Support for Lutron Caseta scenes."""
 from typing import Any
 
+from pylutron_caseta.smartbridge import Smartbridge
+
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_SUGGESTED_AREA
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import BRIDGE_LEAP, DOMAIN as CASETA_DOMAIN
+from . import _area_and_name_from_name
+from .const import (
+    BRIDGE_DEVICE,
+    BRIDGE_LEAP,
+    CONFIG_URL,
+    DOMAIN as CASETA_DOMAIN,
+    MANUFACTURER,
+    UNASSIGNED_AREA,
+)
+from .util import serial_to_unique_id
 
 
 async def async_setup_entry(
@@ -20,19 +34,41 @@ async def async_setup_entry(
     scene entities.
     """
     data = hass.data[CASETA_DOMAIN][config_entry.entry_id]
-    bridge = data[BRIDGE_LEAP]
+    bridge: Smartbridge = data[BRIDGE_LEAP]
+    bridge_device = data[BRIDGE_DEVICE]
     scenes = bridge.get_scenes()
-    async_add_entities(LutronCasetaScene(scenes[scene], bridge) for scene in scenes)
+    async_add_entities(
+        LutronCasetaScene(scenes[scene], bridge, bridge_device) for scene in scenes
+    )
 
 
 class LutronCasetaScene(Scene):
     """Representation of a Lutron Caseta scene."""
 
-    def __init__(self, scene, bridge):
+    def __init__(self, scene, bridge, bridge_device):
         """Initialize the Lutron Caseta scene."""
-        self._attr_name = scene["name"]
+        self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         self._scene_id = scene["scene_id"]
-        self._bridge = bridge
+        self._bridge: Smartbridge = bridge
+        area, name = _area_and_name_from_name(scene["name"])
+        self._attr_name = full_name = f"{area} {name}"
+        info = DeviceInfo(
+            identifiers={(CASETA_DOMAIN, self.unique_id)},
+            manufacturer=MANUFACTURER,
+            model="Lutron Scene",
+            name=full_name,
+            via_device=(CASETA_DOMAIN, bridge_device["serial"]),
+            configuration_url=CONFIG_URL,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+        if area != UNASSIGNED_AREA:
+            info[ATTR_SUGGESTED_AREA] = area
+        self._attr_device_info = info
+
+    @property
+    def unique_id(self):
+        """Return the unique identifier."""
+        return f"scene_{self._bridge_unique_id}_{self._scene_id}"
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -47,12 +47,12 @@ class LutronCasetaScene(Scene):
 
     def __init__(self, scene, bridge, bridge_device):
         """Initialize the Lutron Caseta scene."""
-        self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         self._scene_id = scene["scene_id"]
         self._bridge: Smartbridge = bridge
         area, name = _area_and_name_from_name(scene["name"])
+        bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         full_name = f"{area} {name}"
-        unique_id = f"scene_{self._bridge_unique_id}_{self._scene_id}"
+        unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"
         info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, unique_id)},
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -40,12 +40,11 @@ class LutronCasetaScene(Scene):
         """Initialize the Lutron Caseta scene."""
         self._scene_id = scene["scene_id"]
         self._bridge: Smartbridge = bridge
-        _, name = _area_and_name_from_name(scene["name"])
         bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         self._attr_device_info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, bridge_device["serial"])},
         )
-        self._attr_name = name
+        self._attr_name = _area_and_name_from_name(scene["name"])[1]
         self._attr_unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -51,9 +51,10 @@ class LutronCasetaScene(Scene):
         self._scene_id = scene["scene_id"]
         self._bridge: Smartbridge = bridge
         area, name = _area_and_name_from_name(scene["name"])
-        self._attr_name = full_name = f"{area} {name}"
+        full_name = f"{area} {name}"
+        unique_id = f"scene_{self._bridge_unique_id}_{self._scene_id}"
         info = DeviceInfo(
-            identifiers={(CASETA_DOMAIN, self.unique_id)},
+            identifiers={(CASETA_DOMAIN, unique_id)},
             manufacturer=MANUFACTURER,
             model="Lutron Scene",
             name=full_name,
@@ -64,11 +65,8 @@ class LutronCasetaScene(Scene):
         if area != UNASSIGNED_AREA:
             info[ATTR_SUGGESTED_AREA] = area
         self._attr_device_info = info
-
-    @property
-    def unique_id(self):
-        """Return the unique identifier."""
-        return f"scene_{self._bridge_unique_id}_{self._scene_id}"
+        self._attr_name = full_name
+        self._attr_unique_id = unique_id
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -6,18 +6,11 @@ from pylutron_caseta.smartbridge import Smartbridge
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import _area_and_name_from_name
-from .const import (
-    BRIDGE_DEVICE,
-    BRIDGE_LEAP,
-    CONFIG_URL,
-    DOMAIN as CASETA_DOMAIN,
-    MANUFACTURER,
-)
+from .const import BRIDGE_DEVICE, BRIDGE_LEAP, DOMAIN as CASETA_DOMAIN
 from .util import serial_to_unique_id
 
 
@@ -49,19 +42,11 @@ class LutronCasetaScene(Scene):
         self._bridge: Smartbridge = bridge
         _, name = _area_and_name_from_name(scene["name"])
         bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
-        unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"
-        info = DeviceInfo(
-            identifiers={(CASETA_DOMAIN, unique_id)},
-            manufacturer=MANUFACTURER,
-            model="Lutron Scene",
-            name=name,
-            via_device=(CASETA_DOMAIN, bridge_device["serial"]),
-            configuration_url=CONFIG_URL,
-            entry_type=DeviceEntryType.SERVICE,
+        self._attr_device_info = DeviceInfo(
+            identifiers={(CASETA_DOMAIN, bridge_device["serial"])},
         )
-        self._attr_device_info = info
         self._attr_name = name
-        self._attr_unique_id = unique_id
+        self._attr_unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""

--- a/homeassistant/components/lutron_caseta/util.py
+++ b/homeassistant/components/lutron_caseta/util.py
@@ -1,0 +1,7 @@
+"""Support for Lutron Caseta."""
+from __future__ import annotations
+
+
+def serial_to_unique_id(serial: int) -> str:
+    """Convert a lutron serial number to a unique id."""
+    return hex(serial)[2:].zfill(8)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While migrating the occupancy groups, I noticed the scenes were missing unique ids as well.  This PR uses the same format as #73378

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
