### PR TITLE
Remove deprecated services from Mazda integration

### DIFF
--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DATA_CLIENT, DATA_COORDINATOR, DATA_VEHICLES, DOMAIN, SERVICES
+from .const import DATA_CLIENT, DATA_COORDINATOR, DATA_VEHICLES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,34 +109,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if vehicle_id == 0 or api_client is None:
             raise HomeAssistantError("Vehicle ID not found")
 
-        if service_call.service in (
-            "start_engine",
-            "stop_engine",
-            "turn_on_hazard_lights",
-            "turn_off_hazard_lights",
-        ):
-            _LOGGER.warning(
-                "The mazda.%s service is deprecated and has been replaced by a button entity; "
-                "Please use the button entity instead",
-                service_call.service,
-            )
-
-        if service_call.service in ("start_charging", "stop_charging"):
-            _LOGGER.warning(
-                "The mazda.%s service is deprecated and has been replaced by a switch entity; "
-                "Please use the charging switch entity instead",
-                service_call.service,
-            )
-
         api_method = getattr(api_client, service_call.service)
         try:
-            if service_call.service == "send_poi":
-                latitude = service_call.data["latitude"]
-                longitude = service_call.data["longitude"]
-                poi_name = service_call.data["poi_name"]
-                await api_method(vehicle_id, latitude, longitude, poi_name)
-            else:
-                await api_method(vehicle_id)
+            latitude = service_call.data["latitude"]
+            longitude = service_call.data["longitude"]
+            poi_name = service_call.data["poi_name"]
+            await api_method(vehicle_id, latitude, longitude, poi_name)
         except Exception as ex:
             raise HomeAssistantError(ex) from ex
 
@@ -157,12 +135,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return device_id
 
-    service_schema = vol.Schema(
-        {vol.Required("device_id"): vol.All(cv.string, validate_mazda_device_id)}
-    )
-
-    service_schema_send_poi = service_schema.extend(
+    service_schema_send_poi = vol.Schema(
         {
+            vol.Required("device_id"): vol.All(cv.string, validate_mazda_device_id),
             vol.Required("latitude"): cv.latitude,
             vol.Required("longitude"): cv.longitude,
             vol.Required("poi_name"): cv.string,
@@ -220,13 +195,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     # Register services
-    for service in SERVICES:
-        hass.services.async_register(
-            DOMAIN,
-            service,
-            async_handle_service_call,
-            schema=service_schema_send_poi if service == "send_poi" else service_schema,
-        )
+    hass.services.async_register(
+        DOMAIN,
+        "send_poi",
+        async_handle_service_call,
+        schema=service_schema_send_poi,
+    )
 
     return True
 
@@ -237,8 +211,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Only remove services if it is the last config entry
     if len(hass.data[DOMAIN]) == 1:
-        for service in SERVICES:
-            hass.services.async_remove(DOMAIN, service)
+        hass.services.async_remove(DOMAIN, "send_poi")
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/homeassistant/components/mazda/const.py
+++ b/homeassistant/components/mazda/const.py
@@ -7,13 +7,3 @@ DATA_COORDINATOR = "coordinator"
 DATA_VEHICLES = "vehicles"
 
 MAZDA_REGIONS = {"MNAO": "North America", "MME": "Europe", "MJO": "Japan"}
-
-SERVICES = [
-    "send_poi",
-    "start_charging",
-    "start_engine",
-    "stop_charging",
-    "stop_engine",
-    "turn_off_hazard_lights",
-    "turn_on_hazard_lights",
-]

--- a/homeassistant/components/mazda/services.yaml
+++ b/homeassistant/components/mazda/services.yaml
@@ -1,47 +1,3 @@
-start_engine:
-  name: Start engine
-  description: Start the vehicle engine.
-  fields:
-    device_id:
-      name: Vehicle
-      description: The vehicle to start
-      required: true
-      selector:
-        device:
-          integration: mazda
-stop_engine:
-  name: Stop engine
-  description: Stop the vehicle engine.
-  fields:
-    device_id:
-      name: Vehicle
-      description: The vehicle to stop
-      required: true
-      selector:
-        device:
-          integration: mazda
-turn_on_hazard_lights:
-  name: Turn on hazard lights
-  description: Turn on the vehicle hazard lights. The lights will flash briefly and then turn off.
-  fields:
-    device_id:
-      name: Vehicle
-      description: The vehicle to turn hazard lights on
-      required: true
-      selector:
-        device:
-          integration: mazda
-turn_off_hazard_lights:
-  name: Turn off hazard lights
-  description: Turn off the vehicle hazard lights if they have been manually turned on from inside the vehicle.
-  fields:
-    device_id:
-      name: Vehicle
-      description: The vehicle to turn hazard lights off
-      required: true
-      selector:
-        device:
-          integration: mazda
 send_poi:
   name: Send POI
   description: Send a GPS location to the vehicle's navigation system as a POI (Point of Interest). Requires a navigation SD card installed in the vehicle.
@@ -82,25 +38,3 @@ send_poi:
       required: true
       selector:
         text:
-start_charging:
-  name: Start charging
-  description: Start charging the vehicle. For electric vehicles only.
-  fields:
-    device_id:
-      name: Vehicle
-      description: The vehicle to start charging
-      required: true
-      selector:
-        device:
-          integration: mazda
-stop_charging:
-  name: Stop charging
-  description: Stop charging the vehicle. For electric vehicles only.
-  fields:
-    device_id:
-      name: Vehicle
-      description: The vehicle to stop charging
-      required: true
-      selector:
-        device:
-          integration: mazda

--- a/tests/components/mazda/test_init.py
+++ b/tests/components/mazda/test_init.py
@@ -203,12 +203,6 @@ async def test_device_no_nickname(hass):
 @pytest.mark.parametrize(
     "service, service_data, expected_args",
     [
-        ("start_charging", {}, [12345]),
-        ("start_engine", {}, [12345]),
-        ("stop_charging", {}, [12345]),
-        ("stop_engine", {}, [12345]),
-        ("turn_off_hazard_lights", {}, [12345]),
-        ("turn_on_hazard_lights", {}, [12345]),
         (
             "send_poi",
             {"latitude": 1.2345, "longitude": 2.3456, "poi_name": "Work"},
@@ -241,7 +235,15 @@ async def test_service_invalid_device_id(hass):
 
     with pytest.raises(vol.error.MultipleInvalid) as err:
         await hass.services.async_call(
-            DOMAIN, "start_engine", {"device_id": "invalid"}, blocking=True
+            DOMAIN,
+            "send_poi",
+            {
+                "device_id": "invalid",
+                "latitude": 1.2345,
+                "longitude": 6.7890,
+                "poi_name": "poi_name",
+            },
+            blocking=True,
         )
         await hass.async_block_till_done()
 
@@ -262,7 +264,15 @@ async def test_service_device_id_not_mazda_vehicle(hass):
 
     with pytest.raises(vol.error.MultipleInvalid) as err:
         await hass.services.async_call(
-            DOMAIN, "start_engine", {"device_id": other_device.id}, blocking=True
+            DOMAIN,
+            "send_poi",
+            {
+                "device_id": other_device.id,
+                "latitude": 1.2345,
+                "longitude": 6.7890,
+                "poi_name": "poi_name",
+            },
+            blocking=True,
         )
         await hass.async_block_till_done()
 
@@ -287,7 +297,15 @@ async def test_service_vehicle_id_not_found(hass):
 
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
-            DOMAIN, "start_engine", {"device_id": device_id}, blocking=True
+            DOMAIN,
+            "send_poi",
+            {
+                "device_id": device_id,
+                "latitude": 1.2345,
+                "longitude": 6.7890,
+                "poi_name": "poi_name",
+            },
+            blocking=True,
         )
         await hass.async_block_till_done()
 
@@ -324,11 +342,19 @@ async def test_service_mazda_api_error(hass):
     device_id = reg_device.id
 
     with patch(
-        "homeassistant.components.mazda.MazdaAPI.start_engine",
+        "homeassistant.components.mazda.MazdaAPI.send_poi",
         side_effect=MazdaException("Test error"),
     ), pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
-            DOMAIN, "start_engine", {"device_id": device_id}, blocking=True
+            DOMAIN,
+            "send_poi",
+            {
+                "device_id": device_id,
+                "latitude": 1.2345,
+                "longitude": 6.7890,
+                "poi_name": "poi_name",
+            },
+            blocking=True,
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `start_engine`, `stop_engine`, `turn_on_hazard_lights`, `turn_off_hazard_lights`, `start_charging`, and `stop_charging` services are removed from the Mazda integration. They were deprecated in 2022.4 and were replaced by button entities and a switch entity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated services from the Mazda integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
