### PR TITLE
Fix homematicip cloud cover tilt position

### DIFF
--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -241,15 +241,15 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
         position = kwargs[ATTR_TILT_POSITION]
         # HmIP slats is closed:1 -> open:0
         level = 1 - position / 100.0
-        await self._device.set_slats_level(level, self._channel)
+        await self._device.set_slats_level(slatsLevel=level, channelIndex=self._channel)
 
     async def async_open_cover_tilt(self, **kwargs) -> None:
         """Open the slats."""
-        await self._device.set_slats_level(HMIP_SLATS_OPEN, self._channel)
+        await self._device.set_slats_level(slatsLevel=HMIP_SLATS_OPEN, channelIndex=self._channel)
 
     async def async_close_cover_tilt(self, **kwargs) -> None:
         """Close the slats."""
-        await self._device.set_slats_level(HMIP_SLATS_CLOSED, self._channel)
+        await self._device.set_slats_level(slatsLevel=HMIP_SLATS_CLOSED, channelIndex=self._channel)
 
     async def async_stop_cover_tilt(self, **kwargs) -> None:
         """Stop the device if in motion."""

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -245,11 +245,15 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
 
     async def async_open_cover_tilt(self, **kwargs) -> None:
         """Open the slats."""
-        await self._device.set_slats_level(slatsLevel=HMIP_SLATS_OPEN, channelIndex=self._channel)
+        await self._device.set_slats_level(
+            slatsLevel=HMIP_SLATS_OPEN, channelIndex=self._channel
+        )
 
     async def async_close_cover_tilt(self, **kwargs) -> None:
         """Close the slats."""
-        await self._device.set_slats_level(slatsLevel=HMIP_SLATS_CLOSED, channelIndex=self._channel)
+        await self._device.set_slats_level(
+            slatsLevel=HMIP_SLATS_CLOSED, channelIndex=self._channel
+        )
 
     async def async_stop_cover_tilt(self, **kwargs) -> None:
         """Stop the device if in motion."""

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -109,7 +109,7 @@ async def test_hmip_cover_slats(hass, default_mock_hap_factory):
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 1
     assert hmip_device.mock_calls[-1][0] == "set_slats_level"
-    assert hmip_device.mock_calls[-1][1] == (0, 1)
+    assert hmip_device.mock_calls[-1][2] == {"channelIndex": 1, "slatsLevel": 0}
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0)
     ha_state = hass.states.get(entity_id)
@@ -125,7 +125,7 @@ async def test_hmip_cover_slats(hass, default_mock_hap_factory):
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 4
     assert hmip_device.mock_calls[-1][0] == "set_slats_level"
-    assert hmip_device.mock_calls[-1][1] == (0.5, 1)
+    assert hmip_device.mock_calls[-1][2] == {"channelIndex": 1, "slatsLevel": 0.5}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0.5)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_OPEN
@@ -137,7 +137,7 @@ async def test_hmip_cover_slats(hass, default_mock_hap_factory):
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 6
     assert hmip_device.mock_calls[-1][0] == "set_slats_level"
-    assert hmip_device.mock_calls[-1][1] == (1, 1)
+    assert hmip_device.mock_calls[-1][2] == {"channelIndex": 1, "slatsLevel": 1}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_OPEN
@@ -187,7 +187,7 @@ async def test_hmip_multi_cover_slats(hass, default_mock_hap_factory):
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 1
     assert hmip_device.mock_calls[-1][0] == "set_slats_level"
-    assert hmip_device.mock_calls[-1][1] == (0, 4)
+    assert hmip_device.mock_calls[-1][2] == {"channelIndex": 4, "slatsLevel": 0}
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0, channel=4)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0, channel=4)
     ha_state = hass.states.get(entity_id)
@@ -203,7 +203,7 @@ async def test_hmip_multi_cover_slats(hass, default_mock_hap_factory):
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 4
     assert hmip_device.mock_calls[-1][0] == "set_slats_level"
-    assert hmip_device.mock_calls[-1][1] == (0.5, 4)
+    assert hmip_device.mock_calls[-1][2] == {"channelIndex": 4, "slatsLevel": 0.5}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0.5, channel=4)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_OPEN
@@ -215,7 +215,7 @@ async def test_hmip_multi_cover_slats(hass, default_mock_hap_factory):
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 6
     assert hmip_device.mock_calls[-1][0] == "set_slats_level"
-    assert hmip_device.mock_calls[-1][1] == (1, 4)
+    assert hmip_device.mock_calls[-1][2] == {"channelIndex": 4, "slatsLevel": 1}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1, channel=4)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_OPEN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR fixes a problem. No related issue is existing.
This problem fixes a problem with the HomematicIP device "HmIP-BBL" (a blind with slats)
It was not possible to set the slats tilt position.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
This integration uses the lib "homematicip-rest-api"
The called function `set_slats_level' has three parameters. The arguments where handed over wrong.
I've added the correct keywords to the arguments.
https://github.com/coreGreenberet/homematicip-rest-api/blob/master/homematicip/device.py#L1161

I've tested the fix locally with my on cover.
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
