### PR TITLE
Only update unifiprotect ips from discovery when the console is offline  

### DIFF
--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 from aiohttp import CookieJar
 from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
 from pyunifiprotect.data import NVR
+from unifi_discovery import async_console_is_alive
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -22,7 +23,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import (
+    async_create_clientsession,
+    async_get_clientsession,
+)
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.loader import async_get_integration
 from homeassistant.util.network import is_ip_address
@@ -37,10 +41,16 @@ from .const import (
     MIN_REQUIRED_PROTECT_V,
     OUTDATED_LOG_MESSAGE,
 )
+from .data import async_last_update_was_successful
 from .discovery import async_start_discovery
 from .utils import _async_resolve, _async_short_mac, _async_unifi_mac_from_hass
 
 _LOGGER = logging.getLogger(__name__)
+
+ENTRY_FAILURE_STATES = (
+    config_entries.ConfigEntryState.SETUP_ERROR,
+    config_entries.ConfigEntryState.SETUP_RETRY,
+)
 
 
 async def async_local_user_documentation_url(hass: HomeAssistant) -> str:
@@ -52,6 +62,25 @@ async def async_local_user_documentation_url(hass: HomeAssistant) -> str:
 def _host_is_direct_connect(host: str) -> bool:
     """Check if a host is a unifi direct connect domain."""
     return host.endswith(".ui.direct")
+
+
+async def _async_console_is_offline(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+) -> bool:
+    """Check if a console is offline.
+
+    We define offline by the config entry
+    is in a failure/retry state or the updates
+    are failing and the console is unreachable
+    since protect may be updating.
+    """
+    return bool(
+        entry.state in ENTRY_FAILURE_STATES
+        or not async_last_update_was_successful(hass, entry)
+    ) and not await async_console_is_alive(
+        async_get_clientsession(hass, verify_ssl=False), entry.data[CONF_HOST]
+    )
 
 
 class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -111,6 +140,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     not entry_has_direct_connect
                     and is_ip_address(entry_host)
                     and entry_host != source_ip
+                    and await _async_console_is_offline(self.hass, entry)
                 ):
                     new_host = source_ip
                 if new_host:

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -26,6 +26,16 @@ from .utils import async_get_adoptable_devices_by_type, async_get_devices
 _LOGGER = logging.getLogger(__name__)
 
 
+@callback
+def async_last_update_was_successful(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Check if the last update was successful for a config entry."""
+    return bool(
+        DOMAIN in hass.data
+        and entry.entry_id in hass.data[DOMAIN]
+        and hass.data[DOMAIN][entry.entry_id].last_update_success
+    )
+
+
 class ProtectData:
     """Coordinate updates."""
 

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -3,7 +3,7 @@
   "name": "UniFi Protect",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
-  "requirements": ["pyunifiprotect==3.9.2", "unifi-discovery==1.1.3"],
+  "requirements": ["pyunifiprotect==3.9.2", "unifi-discovery==1.1.4"],
   "dependencies": ["http"],
   "codeowners": ["@briis", "@AngellusMortis", "@bdraco"],
   "quality_scale": "platinum",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2355,7 +2355,7 @@ twitchAPI==2.5.2
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-unifi-discovery==1.1.3
+unifi-discovery==1.1.4
 
 # homeassistant.components.unifiled
 unifiled==0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1552,7 +1552,7 @@ twitchAPI==2.5.2
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-unifi-discovery==1.1.3
+unifi-discovery==1.1.4
 
 # homeassistant.components.upb
 upb_lib==0.4.12


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Only update unifiprotect ips from discovery when the console is offline

Changelog: https://github.com/bdraco/unifi-discovery/compare/v1.1.3...v1.1.4

Fixes #73013

We spent a few days discussing how to fix this.  This seems to be the only solution that doesn't break all the use cases. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
