### PR TITLE
Fix fan support in nest, removing FAN_ONLY which isn't supported

### DIFF
--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -33,15 +33,15 @@ from homeassistant.components.climate.const import (
     FAN_ON,
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
     PRESET_ECO,
     PRESET_NONE,
     PRESET_SLEEP,
+    ClimateEntityFeature,
 )
-from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -794,7 +794,7 @@ async def test_thermostat_fan_off(
             "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
             "sdm.devices.traits.ThermostatMode": {
                 "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                "mode": "OFF",
+                "mode": "COOL",
             },
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
@@ -806,18 +806,22 @@ async def test_thermostat_fan_off(
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_OFF
-    assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
+    assert thermostat.state == HVAC_MODE_COOL
+    assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
     assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+    assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.FAN_MODE
+    )
 
 
 async def test_thermostat_fan_on(
@@ -837,7 +841,7 @@ async def test_thermostat_fan_on(
             },
             "sdm.devices.traits.ThermostatMode": {
                 "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                "mode": "OFF",
+                "mode": "COOL",
             },
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
@@ -849,18 +853,22 @@ async def test_thermostat_fan_on(
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_FAN_ONLY
+    assert thermostat.state == HVAC_MODE_COOL
     assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
     assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+    assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.FAN_MODE
+    )
 
 
 async def test_thermostat_cool_with_fan(
@@ -895,14 +903,80 @@ async def test_thermostat_cool_with_fan(
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
     assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+    assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.FAN_MODE
+    )
 
 
 async def test_thermostat_set_fan(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+) -> None:
+    """Test a thermostat enabling the fan."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "ON",
+                "timerTimeout": "2019-05-10T03:22:54Z",
+            },
+            "sdm.devices.traits.ThermostatHvac": {
+                "status": "OFF",
+            },
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "HEAT",
+            },
+        }
+    )
+    await setup_platform()
+
+    assert len(hass.states.async_all()) == 1
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == HVAC_MODE_HEAT
+    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
+    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+    assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.FAN_MODE
+    )
+
+    # Turn off fan mode
+    await common.async_set_fan_mode(hass, FAN_OFF)
+    await hass.async_block_till_done()
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {"timerMode": "OFF"},
+    }
+
+    # Turn on fan mode
+    await common.async_set_fan_mode(hass, FAN_ON)
+    await hass.async_block_till_done()
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {
+            "duration": "43200s",
+            "timerMode": "ON",
+        },
+    }
+
+
+async def test_thermostat_set_fan_when_off(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,
     auth: FakeAuth,
@@ -929,34 +1003,17 @@ async def test_thermostat_set_fan(
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_FAN_ONLY
-    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
-    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+    assert thermostat.state == HVAC_MODE_OFF
+    assert ATTR_FAN_MODE not in thermostat.attributes
+    assert ATTR_FAN_MODES not in thermostat.attributes
+    assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    )
 
-    # Turn off fan mode
-    await common.async_set_fan_mode(hass, FAN_OFF)
-    await hass.async_block_till_done()
-
-    assert auth.method == "post"
-    assert auth.url == DEVICE_COMMAND
-    assert auth.json == {
-        "command": "sdm.devices.commands.Fan.SetTimer",
-        "params": {"timerMode": "OFF"},
-    }
-
-    # Turn on fan mode
-    await common.async_set_fan_mode(hass, FAN_ON)
-    await hass.async_block_till_done()
-
-    assert auth.method == "post"
-    assert auth.url == DEVICE_COMMAND
-    assert auth.json == {
-        "command": "sdm.devices.commands.Fan.SetTimer",
-        "params": {
-            "duration": "43200s",
-            "timerMode": "ON",
-        },
-    }
+    # Fan cannot be turned on when HVAC is off
+    with pytest.raises(HomeAssistantError):
+        await common.async_set_fan_mode(hass, FAN_ON, entity_id="climate.my_thermostat")
 
 
 async def test_thermostat_fan_empty(
@@ -994,6 +1051,10 @@ async def test_thermostat_fan_empty(
     }
     assert ATTR_FAN_MODE not in thermostat.attributes
     assert ATTR_FAN_MODES not in thermostat.attributes
+    assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    )
 
     # Ignores set_fan_mode since it is lacking SUPPORT_FAN_MODE
     await common.async_set_fan_mode(hass, FAN_ON)
@@ -1018,7 +1079,7 @@ async def test_thermostat_invalid_fan_mode(
             "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
             "sdm.devices.traits.ThermostatMode": {
                 "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                "mode": "OFF",
+                "mode": "COOL",
             },
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
@@ -1030,14 +1091,13 @@ async def test_thermostat_invalid_fan_mode(
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_FAN_ONLY
+    assert thermostat.state == HVAC_MODE_COOL
     assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
@@ -1046,58 +1106,6 @@ async def test_thermostat_invalid_fan_mode(
     with pytest.raises(ValueError):
         await common.async_set_fan_mode(hass, FAN_LOW)
         await hass.async_block_till_done()
-
-
-async def test_thermostat_set_hvac_fan_only(
-    hass: HomeAssistant,
-    setup_platform: PlatformSetup,
-    auth: FakeAuth,
-    create_device: CreateDevice,
-) -> None:
-    """Test a thermostat enabling the fan via hvac_mode."""
-    create_device.create(
-        {
-            "sdm.devices.traits.Fan": {
-                "timerMode": "OFF",
-                "timerTimeout": "2019-05-10T03:22:54Z",
-            },
-            "sdm.devices.traits.ThermostatHvac": {
-                "status": "OFF",
-            },
-            "sdm.devices.traits.ThermostatMode": {
-                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                "mode": "OFF",
-            },
-        }
-    )
-    await setup_platform()
-
-    assert len(hass.states.async_all()) == 1
-    thermostat = hass.states.get("climate.my_thermostat")
-    assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_OFF
-    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
-    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
-
-    await common.async_set_hvac_mode(hass, HVAC_MODE_FAN_ONLY)
-    await hass.async_block_till_done()
-
-    assert len(auth.captured_requests) == 2
-
-    (method, url, json, headers) = auth.captured_requests.pop(0)
-    assert method == "post"
-    assert url == DEVICE_COMMAND
-    assert json == {
-        "command": "sdm.devices.commands.Fan.SetTimer",
-        "params": {"duration": "43200s", "timerMode": "ON"},
-    }
-    (method, url, json, headers) = auth.captured_requests.pop(0)
-    assert method == "post"
-    assert url == DEVICE_COMMAND
-    assert json == {
-        "command": "sdm.devices.commands.ThermostatMode.SetMode",
-        "params": {"mode": "OFF"},
-    }
 
 
 async def test_thermostat_target_temp(
@@ -1397,7 +1405,7 @@ async def test_thermostat_hvac_mode_failure(
             "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
             "sdm.devices.traits.ThermostatMode": {
                 "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                "mode": "OFF",
+                "mode": "COOL",
             },
             "sdm.devices.traits.Fan": {
                 "timerMode": "OFF",
@@ -1416,8 +1424,8 @@ async def test_thermostat_hvac_mode_failure(
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_OFF
-    assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
+    assert thermostat.state == HVAC_MODE_COOL
+    assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
     with pytest.raises(HomeAssistantError):

--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -1004,15 +1004,16 @@ async def test_thermostat_set_fan_when_off(
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
     assert thermostat.state == HVAC_MODE_OFF
-    assert ATTR_FAN_MODE not in thermostat.attributes
-    assert ATTR_FAN_MODES not in thermostat.attributes
+    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
+    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
     assert thermostat.attributes[ATTR_SUPPORTED_FEATURES] == (
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.FAN_MODE
     )
 
     # Fan cannot be turned on when HVAC is off
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(ValueError):
         await common.async_set_fan_mode(hass, FAN_ON, entity_id="climate.my_thermostat")
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix fan support in nest, removing FAN_ONLY which isn't supported. Reading https://support.google.com/googlenest/answer/9296419?hl=en :
```
... you can only run the fan when your thermostat is set to a temperature mode (like Cool mode, for example). You cannot run the fan if your thermostat is set to [Off](https://nest.com/support/article/What-is-Off-mode-on-the-Nest-Thermostat).
```

This PR removes `FAN_ONLY` though still allows fan to be turned on and off when in heat / cool.  I a not calling this a breaking change since `FAN_ONLY` has always been broken.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65692
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
