### PR TITLE
Speed up mqtt tests

### DIFF
--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -110,6 +111,15 @@ DEFAULT_CONFIG_REMOTE_CODE_TEXT = {
         "code_arm_required": True,
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def alarm_control_panel_platform_only():
+    """Only setup the alarm_control_panel platform to speed up tests."""
+    with patch(
+        "homeassistant.components.mqtt.PLATFORMS", [Platform.ALARM_CONTROL_PANEL]
+    ):
+        yield
 
 
 async def test_fail_setup_without_state_topic(hass, mqtt_mock_entry_no_yaml_config):

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -60,6 +61,13 @@ DEFAULT_CONFIG = {
         "state_topic": "test-topic",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_platform_only():
+    """Only setup the binary_sensor platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR]):
+        yield
 
 
 async def test_setting_sensor_value_expires_availability_topic(

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import button
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -39,6 +44,13 @@ from .test_common import (
 DEFAULT_CONFIG = {
     button.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def button_platform_only():
+    """Only setup the button platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BUTTON]):
+        yield
 
 
 @pytest.mark.freeze_time("2021-11-08 13:31:44+00:00")

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -9,6 +9,7 @@ import pytest
 
 from homeassistant.components import camera
 from homeassistant.components.mqtt.camera import MQTT_CAMERA_ATTRIBUTES_BLOCKED
+from homeassistant.const import Platform
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -44,6 +45,13 @@ from tests.common import async_fire_mqtt_message
 DEFAULT_CONFIG = {
     camera.DOMAIN: {"platform": "mqtt", "name": "test", "topic": "test_topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def camera_platform_only():
+    """Only setup the camera platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CAMERA]):
+        yield
 
 
 async def test_run_camera_setup(

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -26,7 +26,7 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.components.mqtt.climate import MQTT_CLIMATE_ATTRIBUTES_BLOCKED
-from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.const import ATTR_TEMPERATURE, Platform
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -104,6 +104,13 @@ DEFAULT_LEGACY_CONFIG = {
         "hold_command_topic": "hold-topic",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def climate_platform_only():
+    """Only setup the climate platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CLIMATE]):
+        yield
 
 
 async def test_setup_params(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -43,6 +43,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -81,6 +82,13 @@ from tests.common import async_fire_mqtt_message
 DEFAULT_CONFIG = {
     cover.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def cover_platform_only():
+    """Only setup the cover platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.COVER]):
+        yield
 
 
 async def test_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -1,13 +1,22 @@
 """The tests for the MQTT device tracker platform using configuration.yaml."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.device_tracker.const import DOMAIN, SOURCE_TYPE_BLUETOOTH
-from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME
+from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME, Platform
 from homeassistant.setup import async_setup_component
 
 from .test_common import help_test_setup_manual_entity_from_yaml
 
 from tests.common import async_fire_mqtt_message
+
+
+@pytest.fixture(autouse=True)
+def device_tracker_platform_only():
+    """Only setup the device_tracker platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.DEVICE_TRACKER]):
+        yield
 
 
 # Deprecated in HA Core 2022.6

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -1,11 +1,13 @@
 """The tests for the  MQTT device_tracker discovery platform."""
 
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components import device_tracker
 from homeassistant.components.mqtt.const import DOMAIN as MQTT_DOMAIN
 from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED
-from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN, Platform
 from homeassistant.setup import async_setup_component
 
 from .test_common import help_test_setting_blocked_attribute_via_mqtt_json_message
@@ -19,6 +21,13 @@ DEFAULT_CONFIG = {
         "state_topic": "test-topic",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def device_tracker_platform_only():
+    """Only setup the device_tracker platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.DEVICE_TRACKER]):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -1,11 +1,13 @@
 """The tests for MQTT device triggers."""
 import json
+from unittest.mock import patch
 
 import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.mqtt import _LOGGER, DOMAIN, debug_info
+from homeassistant.const import Platform
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
@@ -37,6 +39,16 @@ def entity_reg(hass):
 def calls(hass):
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_and_sensor_only():
+    """Only setup the binary_sensor and sensor platform to speed up tests."""
+    with patch(
+        "homeassistant.components.mqtt.PLATFORMS",
+        [Platform.BINARY_SENSOR, Platform.SENSOR],
+    ):
+        yield
 
 
 async def test_get_triggers(

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 from homeassistant.components import mqtt
+from homeassistant.const import Platform
 
 from tests.common import async_fire_mqtt_message, mock_device_registry
 from tests.components.diagnostics import (
@@ -32,9 +33,12 @@ default_config = {
 
 
 @pytest.fixture(autouse=True)
-def no_platforms():
-    """Skip platform setup to speed up tests."""
-    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+def sensor_only():
+    """Only setup the sensor platform to speed up tests."""
+    with patch(
+        "homeassistant.components.mqtt.PLATFORMS",
+        [Platform.DEVICE_TRACKER, Platform.SENSOR],
+    ):
         yield
 
 

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -33,8 +33,8 @@ default_config = {
 
 
 @pytest.fixture(autouse=True)
-def sensor_only():
-    """Only setup the sensor platform to speed up tests."""
+def device_tracker_sensor_only():
+    """Only setup the device_tracekr and sensor platforms to speed up tests."""
     with patch(
         "homeassistant.components.mqtt.PLATFORMS",
         [Platform.DEVICE_TRACKER, Platform.SENSOR],

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -34,7 +34,7 @@ default_config = {
 
 @pytest.fixture(autouse=True)
 def device_tracker_sensor_only():
-    """Only setup the device_tracekr and sensor platforms to speed up tests."""
+    """Only setup the device_tracker and sensor platforms to speed up tests."""
     with patch(
         "homeassistant.components.mqtt.PLATFORMS",
         [Platform.DEVICE_TRACKER, Platform.SENSOR],

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -1,7 +1,7 @@
 """Test MQTT diagnostics."""
 
 import json
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -29,6 +29,13 @@ default_config = {
         "topic": "homeassistant/status",
     },
 }
+
+
+@pytest.fixture(autouse=True)
+def no_platforms():
+    """Skip platform setup to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -44,13 +45,6 @@ def entity_reg(hass):
     return mock_registry(hass)
 
 
-@pytest.fixture(autouse=True)
-def no_platforms():
-    """Skip platform setup to speed up tests."""
-    with patch("homeassistant.components.mqtt.PLATFORMS", []):
-        yield
-
-
 @pytest.mark.parametrize(
     "mqtt_config",
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_DISCOVERY: False}],
@@ -72,6 +66,7 @@ async def test_subscribing_config_topic(hass, mqtt_mock_entry_no_yaml_config):
     assert discovery_topic + "/+/+/+/config" in topics
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 @pytest.mark.parametrize(
     "topic, log",
     [
@@ -99,6 +94,7 @@ async def test_invalid_topic(hass, mqtt_mock_entry_no_yaml_config, caplog, topic
         caplog.clear()
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_invalid_json(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test sending in invalid JSON."""
     await mqtt_mock_entry_no_yaml_config()
@@ -138,6 +134,7 @@ async def test_only_valid_components(hass, mqtt_mock_entry_no_yaml_config, caplo
     assert not mock_dispatcher_send.called
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_correct_config_discovery(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test sending in correct JSON."""
     await mqtt_mock_entry_no_yaml_config()
@@ -155,6 +152,7 @@ async def test_correct_config_discovery(hass, mqtt_mock_entry_no_yaml_config, ca
     assert ("binary_sensor", "bla") in hass.data[ALREADY_DISCOVERED]
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.FAN])
 async def test_discover_fan(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test discovering an MQTT fan."""
     await mqtt_mock_entry_no_yaml_config()
@@ -172,6 +170,7 @@ async def test_discover_fan(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert ("fan", "bla") in hass.data[ALREADY_DISCOVERED]
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CLIMATE])
 async def test_discover_climate(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test discovering an MQTT climate component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -191,6 +190,7 @@ async def test_discover_climate(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert ("climate", "bla") in hass.data[ALREADY_DISCOVERED]
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
 async def test_discover_alarm_control_panel(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
@@ -372,6 +372,7 @@ async def test_discovery_with_object_id(
     assert (domain, "object bla") in hass.data[ALREADY_DISCOVERED]
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_discovery_incl_nodeid(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test sending in correct JSON with optional node_id included."""
     await mqtt_mock_entry_no_yaml_config()
@@ -389,6 +390,7 @@ async def test_discovery_incl_nodeid(hass, mqtt_mock_entry_no_yaml_config, caplo
     assert ("binary_sensor", "my_node_id bla") in hass.data[ALREADY_DISCOVERED]
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_non_duplicate_discovery(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test for a non duplicate component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -413,6 +415,7 @@ async def test_non_duplicate_discovery(hass, mqtt_mock_entry_no_yaml_config, cap
     assert "Component has already been discovered: binary_sensor bla" in caplog.text
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test removal of component through empty discovery message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -431,6 +434,7 @@ async def test_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert state is None
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_rediscover(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test rediscover of removed component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -458,6 +462,7 @@ async def test_rediscover(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert state is not None
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_rapid_rediscover(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test immediate rediscover of removed component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -507,6 +512,7 @@ async def test_rapid_rediscover(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert events[4].data["old_state"] is None
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_rapid_rediscover_unique(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test immediate rediscover of removed component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -566,6 +572,7 @@ async def test_rapid_rediscover_unique(hass, mqtt_mock_entry_no_yaml_config, cap
     assert events[3].data["old_state"] is None
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_rapid_reconfigure(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test immediate reconfigure of added component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -618,6 +625,7 @@ async def test_rapid_reconfigure(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert events[2].data["new_state"].attributes["friendly_name"] == "Wine"
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_duplicate_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test for a non duplicate component."""
     await mqtt_mock_entry_no_yaml_config()
@@ -695,6 +703,7 @@ async def test_cleanup_device(
     )
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
 async def test_cleanup_device_mqtt(
     hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
 ):
@@ -737,6 +746,7 @@ async def test_cleanup_device_mqtt(
     mqtt_mock.async_publish.assert_not_called()
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
 async def test_cleanup_device_multiple_config_entries(
     hass, hass_ws_client, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
 ):
@@ -912,6 +922,7 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
     mqtt_mock.async_publish.assert_not_called()
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SWITCH])
 async def test_discovery_expansion(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test expansion of abbreviated discovery payload."""
     await mqtt_mock_entry_no_yaml_config()
@@ -970,6 +981,7 @@ async def test_discovery_expansion(hass, mqtt_mock_entry_no_yaml_config, caplog)
     assert state.state == STATE_UNAVAILABLE
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SWITCH])
 async def test_discovery_expansion_2(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test expansion of abbreviated discovery payload."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1010,6 +1022,7 @@ async def test_discovery_expansion_2(hass, mqtt_mock_entry_no_yaml_config, caplo
     assert state.state == STATE_UNKNOWN
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SWITCH])
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_expansion_3(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test expansion of broken discovery payload."""
@@ -1091,6 +1104,7 @@ async def test_discovery_expansion_without_encoding_and_value_template_1(
     assert state.state == STATE_UNAVAILABLE
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SWITCH])
 async def test_discovery_expansion_without_encoding_and_value_template_2(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
@@ -1197,6 +1211,7 @@ async def test_missing_discover_abbreviations(
     assert not missing
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SWITCH])
 async def test_no_implicit_state_topic_switch(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
@@ -1221,6 +1236,7 @@ async def test_no_implicit_state_topic_switch(
     assert state.state == STATE_UNKNOWN
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 @pytest.mark.parametrize(
     "mqtt_config",
     [
@@ -1249,6 +1265,7 @@ async def test_complex_discovery_topic_prefix(
     assert ("binary_sensor", "node1 object1") in hass.data[ALREADY_DISCOVERED]
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [])
 async def test_mqtt_integration_discovery_subscribe_unsubscribe(
     hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
 ):
@@ -1290,6 +1307,7 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
         assert not mqtt_client_mock.unsubscribe.called
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [])
 async def test_mqtt_discovery_unsubscribe_once(
     hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
 ):

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -44,6 +44,13 @@ def entity_reg(hass):
     return mock_registry(hass)
 
 
+@pytest.fixture(autouse=True)
+def no_platforms():
+    """Skip platform setup to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        yield
+
+
 @pytest.mark.parametrize(
     "mqtt_config",
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_DISCOVERY: False}],

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -72,6 +73,13 @@ DEFAULT_CONFIG = {
         "command_topic": "command-topic",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def fan_platform_only():
+    """Only setup the fan platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.FAN]):
+        yield
 
 
 async def test_fail_setup_if_no_command_topic(

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -73,6 +74,13 @@ DEFAULT_CONFIG = {
         "target_humidity_command_topic": "humidity-command-topic",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def humidifer_platform_only():
+    """Only setup the humidifer platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.HUMIDIFIER]):
+        yield
 
 
 async def async_turn_on(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -53,9 +53,12 @@ class RecordCallsPartial(partial):
 
 
 @pytest.fixture(autouse=True)
-def light_platform_only():
-    """Only setup the light platform to speed up tests."""
-    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT]):
+def sensor_platforms_only():
+    """Only setup the sensor platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.mqtt.PLATFORMS",
+        [Platform.SENSOR, Platform.BINARY_SENSOR],
+    ):
         yield
 
 
@@ -1370,6 +1373,7 @@ async def test_setup_override_configuration(hass, caplog, tmp_path):
             assert calls_username_password_set[0][1] == "somepassword"
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_setup_manual_mqtt_with_platform_key(hass, caplog):
     """Test set up a manual MQTT item with a platform key."""
     config = {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
@@ -1380,6 +1384,7 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog):
     )
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_setup_manual_mqtt_with_invalid_config(hass, caplog):
     """Test set up a manual MQTT item with an invalid config."""
     config = {"name": "test"}
@@ -2021,6 +2026,7 @@ async def test_mqtt_ws_get_device_debug_info(
     assert response["result"] == expected_result
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CAMERA])
 async def test_mqtt_ws_get_device_debug_info_binary(
     hass, device_reg, hass_ws_client, mqtt_mock_entry_no_yaml_config
 ):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     TEMP_CELSIUS,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.core import CoreState, HomeAssistant, callback
@@ -49,6 +50,13 @@ class RecordCallsPartial(partial):
     """Wrapper class for partial."""
 
     __name__ = "RecordCallPartialTest"
+
+
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Only setup the light platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT]):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -29,7 +29,7 @@ from homeassistant.components.vacuum import (
     ATTR_STATUS,
     VacuumEntityFeature,
 )
-from homeassistant.const import CONF_NAME, CONF_PLATFORM, STATE_OFF, STATE_ON
+from homeassistant.const import CONF_NAME, CONF_PLATFORM, STATE_OFF, STATE_ON, Platform
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -87,6 +87,13 @@ DEFAULT_CONFIG = {
 }
 
 DEFAULT_CONFIG_2 = {vacuum.DOMAIN: {"platform": "mqtt", "name": "test"}}
+
+
+@pytest.fixture(autouse=True)
+def vacuum_platform_only():
+    """Only setup the vacuum platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.VACUUM]):
+        yield
 
 
 async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -209,6 +209,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -249,6 +250,13 @@ from tests.components.light import common
 DEFAULT_CONFIG = {
     light.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Only setup the light platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT]):
+        yield
 
 
 async def test_fail_setup_if_no_command_topic(hass, mqtt_mock_entry_no_yaml_config):

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -103,6 +103,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -148,6 +149,13 @@ DEFAULT_CONFIG = {
         "command_topic": "test-topic",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Only setup the light platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT]):
+        yield
 
 
 class JsonValidator:

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -41,6 +41,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -88,6 +89,13 @@ DEFAULT_CONFIG = {
         "command_off_template": "off,{{ transition|d }}",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Only setup the light platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT]):
+        yield
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -56,6 +57,13 @@ from tests.common import async_fire_mqtt_message
 DEFAULT_CONFIG = {
     LOCK_DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def lock_platform_only():
+    """Only setup the lock platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LOCK]):
+        yield
 
 
 async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -62,6 +63,13 @@ from tests.common import async_fire_mqtt_message
 DEFAULT_CONFIG = {
     number.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def number_platform_only():
+    """Only setup the number platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.NUMBER]):
+        yield
 
 
 async def test_run_number_setup(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import scene
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNKNOWN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNKNOWN, Platform
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
 
@@ -32,6 +32,13 @@ DEFAULT_CONFIG = {
         "payload_on": "test-payload-on",
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def scene_platform_only():
+    """Only setup the scene platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SCENE]):
+        yield
 
 
 async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -13,7 +13,12 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ASSUMED_STATE, ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    ATTR_ENTITY_ID,
+    STATE_UNKNOWN,
+    Platform,
+)
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
 
@@ -57,6 +62,13 @@ DEFAULT_CONFIG = {
         "options": ["milk", "beer"],
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def select_platform_only():
+    """Only setup the select platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SELECT]):
+        yield
 
 
 async def test_run_select_setup(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.helpers import device_registry as dr
@@ -70,6 +71,13 @@ from tests.common import (
 DEFAULT_CONFIG = {
     sensor.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def sensor_platform_only():
+    """Only setup the sensor platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR]):
+        yield
 
 
 async def test_setting_sensor_value_via_mqtt_message(

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -53,6 +54,13 @@ from tests.common import async_fire_mqtt_message
 DEFAULT_CONFIG = {
     siren.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def siren_platform_only():
+    """Only setup the siren platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SIREN]):
+        yield
 
 
 async def async_turn_on(hass, entity_id=ENTITY_MATCH_ALL, parameters={}) -> None:

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     ENTITY_MATCH_ALL,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -85,6 +86,13 @@ DEFAULT_CONFIG = {
 DEFAULT_CONFIG_2 = {
     vacuum.DOMAIN: {"platform": "mqtt", "schema": "state", "name": "test"}
 }
+
+
+@pytest.fixture(autouse=True)
+def vacuum_platform_only():
+    """Only setup the vacuum platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.VACUUM]):
+        yield
 
 
 async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -1,5 +1,7 @@
 """The tests for the MQTT subscription component."""
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
+
+import pytest
 
 from homeassistant.components.mqtt.subscription import (
     async_prepare_subscribe_topics,
@@ -9,6 +11,13 @@ from homeassistant.components.mqtt.subscription import (
 from homeassistant.core import callback
 
 from tests.common import async_fire_mqtt_message
+
+
+@pytest.fixture(autouse=True)
+def no_platforms():
+    """Skip platform setup to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        yield
 
 
 async def test_subscribe_topics(hass, mqtt_mock_entry_no_yaml_config, caplog):

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
+    Platform,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -51,6 +52,13 @@ from tests.components.switch import common
 DEFAULT_CONFIG = {
     switch.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
+
+
+@pytest.fixture(autouse=True)
+def switch_platform_only():
+    """Only setup the switch platform to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SWITCH]):
+        yield
 
 
 async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.mqtt.const import DOMAIN as MQTT_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -43,9 +44,9 @@ DEFAULT_TAG_SCAN_JSON = (
 
 
 @pytest.fixture(autouse=True)
-def no_platforms():
-    """Skip platform setup to speed up tests."""
-    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+def binary_sensor_only():
+    """Only setup the binary_sensor platform to speed up test."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield
 
 

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -42,6 +42,13 @@ DEFAULT_TAG_SCAN_JSON = (
 )
 
 
+@pytest.fixture(autouse=True)
+def no_platforms():
+    """Skip platform setup to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        yield
+
+
 @pytest.fixture
 def device_reg(hass):
     """Return an empty, loaded, registry."""

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -1,5 +1,5 @@
 """The tests for the MQTT automation."""
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -15,6 +15,13 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 def calls(hass):
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
+
+
+@pytest.fixture(autouse=True)
+def no_platforms():
+    """Skip platform setup to speed up tests."""
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up mqtt tests by only setting up the platforms we are testing.

Before: Results (178.46s)
After: Results (94.45s)

This was on my M1 mac laptop so YMMV 

There is more than can be done, but this was low hanging fruit.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io