### PR TITLE
Weather unit conversion

### DIFF
--- a/homeassistant/components/demo/weather.py
+++ b/homeassistant/components/demo/weather.py
@@ -27,7 +27,14 @@ from homeassistant.components.weather import (
     WeatherEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import (
+    PRESSURE_HPA,
+    PRESSURE_INHG,
+    SPEED_METERS_PER_SECOND,
+    SPEED_MILES_PER_HOUR,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -77,6 +84,8 @@ def setup_platform(
                 1099,
                 0.5,
                 TEMP_CELSIUS,
+                PRESSURE_HPA,
+                SPEED_METERS_PER_SECOND,
                 [
                     [ATTR_CONDITION_RAINY, 1, 22, 15, 60],
                     [ATTR_CONDITION_RAINY, 5, 19, 8, 30],
@@ -95,6 +104,8 @@ def setup_platform(
                 987,
                 4.8,
                 TEMP_FAHRENHEIT,
+                PRESSURE_INHG,
+                SPEED_MILES_PER_HOUR,
                 [
                     [ATTR_CONDITION_SNOWY, 2, -10, -15, 60],
                     [ATTR_CONDITION_PARTLYCLOUDY, 1, -13, -14, 25],
@@ -121,16 +132,20 @@ class DemoWeather(WeatherEntity):
         pressure,
         wind_speed,
         temperature_unit,
+        pressure_unit,
+        wind_speed_unit,
         forecast,
     ):
         """Initialize the Demo weather."""
         self._name = name
         self._condition = condition
-        self._temperature = temperature
-        self._temperature_unit = temperature_unit
+        self._native_temperature = temperature
+        self._native_temperature_unit = temperature_unit
         self._humidity = humidity
-        self._pressure = pressure
-        self._wind_speed = wind_speed
+        self._native_pressure = pressure
+        self._native_pressure_unit = pressure_unit
+        self._native_wind_speed = wind_speed
+        self._native_wind_speed_unit = wind_speed_unit
         self._forecast = forecast
 
     @property
@@ -144,14 +159,14 @@ class DemoWeather(WeatherEntity):
         return False
 
     @property
-    def temperature(self):
+    def native_temperature(self):
         """Return the temperature."""
-        return self._temperature
+        return self._native_temperature
 
     @property
-    def temperature_unit(self):
+    def native_temperature_unit(self):
         """Return the unit of measurement."""
-        return self._temperature_unit
+        return self._native_temperature_unit
 
     @property
     def humidity(self):
@@ -159,14 +174,24 @@ class DemoWeather(WeatherEntity):
         return self._humidity
 
     @property
-    def wind_speed(self):
+    def native_wind_speed(self):
         """Return the wind speed."""
-        return self._wind_speed
+        return self._native_wind_speed
 
     @property
-    def pressure(self):
+    def native_wind_speed_unit(self):
+        """Return the wind speed."""
+        return self._native_wind_speed_unit
+
+    @property
+    def native_pressure(self):
         """Return the pressure."""
-        return self._pressure
+        return self._native_pressure
+
+    @property
+    def native_pressure_unit(self):
+        """Return the pressure."""
+        return self._native_pressure_unit
 
     @property
     def condition(self):

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -349,6 +349,7 @@ class WeatherEntity(Entity):
         """
         return self._attr_temperature_unit
 
+    @final
     @property
     def _default_temperature_unit(self) -> str:
         """Return the default unit of measurement for temperature.
@@ -357,6 +358,7 @@ class WeatherEntity(Entity):
         """
         return self.hass.config.units.temperature_unit
 
+    @final
     @property
     def _temperature_unit(self) -> str:
         """Return the converted unit of measurement for temperature.
@@ -402,6 +404,7 @@ class WeatherEntity(Entity):
         """
         return self._attr_pressure_unit
 
+    @final
     @property
     def _default_pressure_unit(self) -> str:
         """Return the default unit of measurement for pressure.
@@ -410,6 +413,7 @@ class WeatherEntity(Entity):
         """
         return PRESSURE_HPA if self.hass.config.units.is_metric else PRESSURE_INHG
 
+    @final
     @property
     def _pressure_unit(self) -> str:
         """Return the converted unit of measurement for pressure.
@@ -460,6 +464,7 @@ class WeatherEntity(Entity):
         """
         return self._attr_wind_speed_unit
 
+    @final
     @property
     def _default_wind_speed_unit(self) -> str:
         """Return the default unit of measurement for wind speed.
@@ -472,6 +477,7 @@ class WeatherEntity(Entity):
             else SPEED_MILES_PER_HOUR
         )
 
+    @final
     @property
     def _wind_speed_unit(self) -> str:
         """Return the converted unit of measurement for wind speed.
@@ -527,6 +533,7 @@ class WeatherEntity(Entity):
         """
         return self._attr_visibility_unit
 
+    @final
     @property
     def _default_visibility_unit(self) -> str:
         """Return the default unit of measurement for visibility.
@@ -535,6 +542,7 @@ class WeatherEntity(Entity):
         """
         return self.hass.config.units.length_unit
 
+    @final
     @property
     def _visibility_unit(self) -> str:
         """Return the converted unit of measurement for visibility.
@@ -569,6 +577,7 @@ class WeatherEntity(Entity):
         """
         return self._attr_precipitation_unit
 
+    @final
     @property
     def _default_precipitation_unit(self) -> str:
         """Return the default unit of measurement for precipitation.
@@ -577,6 +586,7 @@ class WeatherEntity(Entity):
         """
         return self.hass.config.units.accumulated_precipitation_unit
 
+    @final
     @property
     def _precipitation_unit(self) -> str:
         """Return the converted unit of measurement for precipitation.

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -116,15 +116,20 @@ class WeatherEntity(Entity):
     _attr_precision: float
     _attr_pressure: float | None = None
     _attr_pressure_unit: str | None = None
+    _attr_native_pressure_unit: str | None = None
     _attr_state: None = None
     _attr_temperature_unit: str
+    _attr_native_temperature_unit: str
     _attr_temperature: float | None
     _attr_visibility: float | None = None
     _attr_visibility_unit: str | None = None
+    _attr_native_visibility_unit: str | None = None
     _attr_precipitation_unit: str | None = None
+    _attr_native_precipitation_unit: str | None = None
     _attr_wind_bearing: float | str | None = None
     _attr_wind_speed: float | None = None
     _attr_wind_speed_unit: str | None = None
+    _attr_native_wind_speed_unit: str | None = None
 
     @property
     def temperature(self) -> float | None:

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -189,7 +189,7 @@ class WeatherEntity(Entity):
     _attr_humidity: float | None = None
     _attr_ozone: float | None = None
     _attr_precision: float
-    _attr_pressure: float | None = None
+    _attr_native_pressure: float | None = None
     _attr_pressure_unit: None = None  # Subclasses of WeatherEntity should not set this
     _attr_native_pressure_unit: str | None = None
     _attr_state: None = None
@@ -197,8 +197,8 @@ class WeatherEntity(Entity):
         None  # Subclasses of WeatherEntity should not set this
     )
     _attr_native_temperature_unit: str
-    _attr_temperature: float | None
-    _attr_visibility: float | None = None
+    _attr_native_temperature: float | None
+    _attr_native_visibility: float | None = None
     _attr_visibility_unit: None = (
         None  # Subclasses of WeatherEntity should not set this
     )
@@ -208,7 +208,7 @@ class WeatherEntity(Entity):
     )
     _attr_native_precipitation_unit: str | None = None
     _attr_wind_bearing: float | str | None = None
-    _attr_wind_speed: float | None = None
+    _attr_native_wind_speed: float | None = None
     _attr_wind_speed_unit: None = (
         None  # Subclasses of WeatherEntity should not set this
     )
@@ -228,9 +228,9 @@ class WeatherEntity(Entity):
         self.async_registry_entry_updated()
 
     @property
-    def temperature(self) -> float | None:
+    def native_temperature(self) -> float | None:
         """Return the platform temperature in native units (i.e. not converted)."""
-        return self._attr_temperature
+        return self._attr_native_temperature
 
     @property
     def native_temperature_unit(self) -> str | None:
@@ -248,9 +248,9 @@ class WeatherEntity(Entity):
         return self.hass.config.units.temperature_unit
 
     @property
-    def pressure(self) -> float | None:
+    def native_pressure(self) -> float | None:
         """Return the pressure in native units."""
-        return self._attr_pressure
+        return self._attr_native_pressure
 
     @property
     def native_pressure_unit(self) -> str | None:
@@ -275,9 +275,9 @@ class WeatherEntity(Entity):
         return self._attr_humidity
 
     @property
-    def wind_speed(self) -> float | None:
+    def native_wind_speed(self) -> float | None:
         """Return the wind speed in native units."""
-        return self._attr_wind_speed
+        return self._attr_native_wind_speed
 
     @property
     def native_wind_speed_unit(self) -> str | None:
@@ -307,9 +307,9 @@ class WeatherEntity(Entity):
         return self._attr_ozone
 
     @property
-    def visibility(self) -> float | None:
+    def native_visibility(self) -> float | None:
         """Return the visibility in native units."""
-        return self._attr_visibility
+        return self._attr_native_visibility
 
     @property
     def native_visibility_unit(self) -> str | None:
@@ -374,7 +374,7 @@ class WeatherEntity(Entity):
             else 0
         )
 
-        if (temperature := self.temperature) is not None:
+        if (temperature := self.native_temperature) is not None:
             with suppress(ValueError):
                 float(temperature)
                 value_temp = UNIT_CONVERSIONS[CONF_TEMPERATURE_UOM](
@@ -393,7 +393,7 @@ class WeatherEntity(Entity):
         if (ozone := self.ozone) is not None:
             data[ATTR_WEATHER_OZONE] = ozone
 
-        if (pressure := self.pressure) is not None:
+        if (pressure := self.native_pressure) is not None:
             with suppress(ValueError):
                 float(pressure)
                 value_pressure = UNIT_CONVERSIONS[CONF_PRESSURE_UOM](
@@ -405,7 +405,7 @@ class WeatherEntity(Entity):
         if (wind_bearing := self.wind_bearing) is not None:
             data[ATTR_WEATHER_WIND_BEARING] = wind_bearing
 
-        if (wind_speed := self.wind_speed) is not None:
+        if (wind_speed := self.native_wind_speed) is not None:
             with suppress(ValueError):
                 float(wind_speed)
                 value_wind_speed = UNIT_CONVERSIONS[CONF_WIND_SPEED_UOM](
@@ -416,7 +416,7 @@ class WeatherEntity(Entity):
                 )
                 data[ATTR_WEATHER_WIND_SPEED_UNIT] = self.wind_speed_unit
 
-        if (visibility := self.visibility) is not None:
+        if (visibility := self.native_visibility) is not None:
             with suppress(ValueError):
                 float(visibility)
                 value_visibility = UNIT_CONVERSIONS[CONF_VISIBILITY_UOM](

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -816,7 +816,6 @@ class WeatherEntity(Entity):
     def async_registry_entry_updated(self) -> None:
         """Run when the entity registry entry has been updated."""
         assert self.registry_entry
-        weather_options = self.registry_entry.options.get(DOMAIN)
         self._weather_option_temperature_unit = None
         self._weather_option_pressure_unit = None
         self._weather_option_precipitation_unit = None

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -628,8 +628,9 @@ class WeatherEntity(Entity):
                     to_temp_unit = self.hass.config.units.temperature_unit
 
                 with suppress(ValueError):
+                    temperature_f = float(temperature)
                     value_temp = UNIT_CONVERSIONS[ATTR_TEMPERATURE_UOM](
-                        temperature,
+                        temperature_f,
                         from_temp_unit,
                         to_temp_unit,
                     )
@@ -642,8 +643,9 @@ class WeatherEntity(Entity):
                     forecast_entry.get(ATTR_FORECAST_TEMP_LOW),
                 ):
                     with suppress(ValueError):
+                        forecast_temp_low_f = float(forecast_temp_low)
                         value_temp_low = UNIT_CONVERSIONS[ATTR_TEMPERATURE_UOM](
-                            forecast_temp_low,
+                            forecast_temp_low_f,
                             from_temp_unit,
                             to_temp_unit,
                         )
@@ -663,9 +665,10 @@ class WeatherEntity(Entity):
                         from_pressure_unit = self.pressure_unit
                         to_pressure_unit = self.hass.config.units.pressure_unit
                     with suppress(ValueError):
+                        forecast_pressure_f = float(forecast_pressure)
                         forecast_entry[ATTR_FORECAST_PRESSURE] = round(
                             UNIT_CONVERSIONS[ATTR_PRESSURE_UOM](
-                                forecast_pressure,
+                                forecast_pressure_f,
                                 from_pressure_unit,
                                 to_pressure_unit,
                             ),
@@ -685,15 +688,20 @@ class WeatherEntity(Entity):
                         from_wind_speed_unit = self.wind_speed_unit
                         to_wind_speed_unit = self.hass.config.units.wind_speed_unit
                     with suppress(ValueError):
+                        forecast_wind_speed_f = float(forecast_wind_speed)
                         forecast_entry[ATTR_FORECAST_WIND_SPEED] = round(
                             UNIT_CONVERSIONS[ATTR_WIND_SPEED_UOM](
-                                forecast_wind_speed,
+                                forecast_wind_speed_f,
                                 from_wind_speed_unit,
                                 to_wind_speed_unit,
                             ),
                             ROUNDING_PRECISION,
                         )
 
+                from_precipitation_unit = self.precipitation_unit
+                to_precipitation_unit = (
+                    self.hass.config.units.accumulated_precipitation_unit
+                )
                 if forecast_precipitation := forecast_entry.get(
                     ATTR_FORECAST_NATIVE_PRECIPITATION,
                     forecast_entry.get(ATTR_FORECAST_PRECIPITATION),
@@ -703,15 +711,11 @@ class WeatherEntity(Entity):
                     ) is not None:
                         from_precipitation_unit = native_precipitation_unit
                         to_precipitation_unit = self.precipitation_unit
-                    else:
-                        from_precipitation_unit = self.precipitation_unit
-                        to_precipitation_unit = (
-                            self.hass.config.units.accumulated_precipitation_unit
-                        )
                     with suppress(ValueError):
+                        forecast_precipitation_f = float(forecast_precipitation)
                         forecast_entry[ATTR_FORECAST_PRECIPITATION] = round(
                             UNIT_CONVERSIONS[ATTR_PRECIPITATION_UOM](
-                                forecast_precipitation,
+                                forecast_precipitation_f,
                                 from_precipitation_unit,
                                 to_precipitation_unit,
                             ),

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -307,15 +307,15 @@ class WeatherEntity(Entity):
         self.async_registry_entry_updated()
 
     @property
-    def temperature(self) -> float:
+    def temperature(self) -> float | None:
         """Return the temperature for backward compatibility."""
         if self._override_temperature is not None:
             return self._override_temperature
         self._override_temperature = self._attr_temperature
-        return self._attr_temperature  # type: ignore[return-value]
+        return self._attr_temperature
 
     @property
-    def native_temperature(self) -> float:
+    def native_temperature(self) -> float | None:
         """Return the platform temperature in native units (i.e. not converted)."""
         if hasattr(self, "_attr_native_temperature"):
             return self._attr_native_temperature

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -322,11 +322,9 @@ class WeatherEntity(Entity):
         return self.temperature
 
     @property
-    def native_temperature_unit(self) -> str | None:
+    def native_temperature_unit(self) -> str:
         """Return the native unit of measurement for temperature."""
-        if hasattr(self, "_attr_native_temperature_unit"):
-            return self._attr_native_temperature_unit
-        return None
+        return self._attr_native_temperature_unit
 
     @property
     def temperature_unit(self) -> str:
@@ -334,17 +332,15 @@ class WeatherEntity(Entity):
         if weather_option_temperature_uom := self._weather_option_temperature_uom:
             return weather_option_temperature_uom
 
-        return self.native_temperature_unit  # type: ignore[return-value]
+        return self.native_temperature_unit
 
     @property
     def pressure(self) -> float | None:
         """Return the pressure for backward compatibility."""
         if self._override_pressure is not None:
             return self._override_pressure
-        if hasattr(self, "_attr_pressure"):
-            self._override_pressure = self._attr_pressure
-            return self._attr_pressure
-        return None
+        self._override_pressure = self._attr_pressure
+        return self._attr_pressure
 
     @property
     def native_pressure(self) -> float | None:
@@ -356,9 +352,7 @@ class WeatherEntity(Entity):
     @property
     def native_pressure_unit(self) -> str | None:
         """Return the native unit of measurement for pressure."""
-        if hasattr(self, "_attr_native_pressure_unit"):
-            return self._attr_native_pressure_unit
-        return None
+        return self._attr_native_pressure_unit
 
     @property
     def pressure_unit(self) -> str | None:
@@ -381,10 +375,8 @@ class WeatherEntity(Entity):
         """Return the wind_speed for backward compatibility."""
         if self._override_wind_speed is not None:
             return self._override_wind_speed
-        if hasattr(self, "_attr_wind_speed"):
-            self._override_wind_speed = self._attr_wind_speed
-            return self._attr_wind_speed
-        return None
+        self._override_wind_speed = self._attr_wind_speed
+        return self._attr_wind_speed
 
     @property
     def native_wind_speed(self) -> float | None:
@@ -396,9 +388,7 @@ class WeatherEntity(Entity):
     @property
     def native_wind_speed_unit(self) -> str | None:
         """Return the native unit of measurement for wind speed."""
-        if hasattr(self, "_attr_native_wind_speed_unit"):
-            return self._attr_native_wind_speed_unit
-        return None
+        return self._attr_native_wind_speed_unit
 
     @property
     def wind_speed_unit(self) -> str | None:
@@ -426,10 +416,8 @@ class WeatherEntity(Entity):
         """Return the visibility for backward compatibility."""
         if self._override_visibility is not None:
             return self._override_visibility
-        if hasattr(self, "_attr_visibility"):
-            self._override_visibility = self._attr_visibility
-            return self._attr_visibility
-        return None
+        self._override_visibility = self._attr_visibility
+        return self._attr_visibility
 
     @property
     def native_visibility(self) -> float | None:
@@ -441,9 +429,7 @@ class WeatherEntity(Entity):
     @property
     def native_visibility_unit(self) -> str | None:
         """Return the native unit of measurement for visibility."""
-        if hasattr(self, "_attr_native_visibility_unit"):
-            return self._attr_native_visibility_unit
-        return None
+        return self._attr_native_visibility_unit
 
     @property
     def visibility_unit(self) -> str | None:
@@ -464,9 +450,7 @@ class WeatherEntity(Entity):
     @property
     def native_precipitation_unit(self) -> str | None:
         """Return the native unit of measurement for accumulated precipitation."""
-        if hasattr(self, "_attr_native_precipitation_unit"):
-            return self._attr_native_precipitation_unit
-        return None
+        return self._attr_native_precipitation_unit
 
     @property
     def precipitation_unit(self) -> str | None:
@@ -486,7 +470,7 @@ class WeatherEntity(Entity):
             return self._attr_precision
         return (
             PRECISION_TENTHS
-            if self.temperature_unit == TEMP_CELSIUS
+            if self.native_temperature_unit == TEMP_CELSIUS
             else PRECISION_WHOLE
         )
 
@@ -496,12 +480,10 @@ class WeatherEntity(Entity):
         """Return the state attributes, converted from native units to user-configured units."""
         data = {}
 
-        precision_str = str(self.precision)
-        precision = (
-            len(precision_str) - precision_str.index(".") - 1
-            if "." in precision_str
-            else 0
-        )
+        if self.precision == PRECISION_WHOLE:
+            precision = 0
+        else:
+            precision = 1
 
         if (
             (temperature := self.native_temperature) is not None

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -325,7 +325,10 @@ class WeatherEntity(Entity):
 
     @property
     def temperature(self) -> float | None:
-        """Return the temperature for backward compatibility."""
+        """Return the temperature for backward compatibility.
+
+        Should not be set by integrations.
+        """
         return self._attr_temperature
 
     @property
@@ -340,7 +343,10 @@ class WeatherEntity(Entity):
 
     @property
     def temperature_unit(self) -> str:
-        """Return the converted unit of measurement for temperature."""
+        """Return the converted unit of measurement for temperature.
+
+        Should not be set by integrations.
+        """
         if (
             weather_option_temperature_uom := self._weather_option_temperature_uom
         ) is not None:
@@ -356,7 +362,10 @@ class WeatherEntity(Entity):
 
     @property
     def pressure(self) -> float | None:
-        """Return the pressure for backward compatibility."""
+        """Return the pressure for backward compatibility.
+
+        Should not be set by integrations.
+        """
         return self._attr_pressure
 
     @property
@@ -371,7 +380,10 @@ class WeatherEntity(Entity):
 
     @property
     def pressure_unit(self) -> str:
-        """Return the converted unit of measurement for pressure."""
+        """Return the converted unit of measurement for pressure.
+
+        Should not be set by integrations.
+        """
         if (
             weather_option_pressure_uom := self._weather_option_pressure_uom
         ) is not None:
@@ -392,7 +404,10 @@ class WeatherEntity(Entity):
 
     @property
     def wind_speed(self) -> float | None:
-        """Return the wind_speed for backward compatibility."""
+        """Return the wind_speed for backward compatibility.
+
+        Should not be set by integrations.
+        """
         return self._attr_wind_speed
 
     @property
@@ -407,7 +422,10 @@ class WeatherEntity(Entity):
 
     @property
     def wind_speed_unit(self) -> str:
-        """Return the converted unit of measurement for wind speed."""
+        """Return the converted unit of measurement for wind speed.
+
+        Should not be set by integrations.
+        """
         if (
             weather_option_wind_speed_uom := self._weather_option_wind_speed_uom
         ) is not None:
@@ -433,7 +451,10 @@ class WeatherEntity(Entity):
 
     @property
     def visibility(self) -> float | None:
-        """Return the visibility for backward compatibility."""
+        """Return the visibility for backward compatibility.
+
+        Should not be set by integrations.
+        """
         return self._attr_visibility
 
     @property
@@ -448,7 +469,10 @@ class WeatherEntity(Entity):
 
     @property
     def visibility_unit(self) -> str:
-        """Return the converted unit of measurement for visibility."""
+        """Return the converted unit of measurement for visibility.
+
+        Should not be set by integrations.
+        """
         if (
             weather_option_visibility_uom := self._weather_option_visibility_uom
         ) is not None:
@@ -474,7 +498,10 @@ class WeatherEntity(Entity):
 
     @property
     def precipitation_unit(self) -> str:
-        """Return the converted unit of measurement for precipitation."""
+        """Return the converted unit of measurement for precipitation.
+
+        Should not be set by integrations.
+        """
         if (
             weather_option_precipitation_uom := self._weather_option_precipitation_uom
         ) is not None:

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -683,7 +683,7 @@ class WeatherEntity(Entity):
             for forecast_entry in self.forecast:
                 forecast_entry = dict(forecast_entry)
 
-                temperature = forecast_entry.get(
+                temperature = forecast_entry.pop(
                     ATTR_FORECAST_NATIVE_TEMP, forecast_entry.get(ATTR_FORECAST_TEMP)
                 )
 
@@ -706,7 +706,7 @@ class WeatherEntity(Entity):
                             value_temp, precision
                         )
 
-                if forecast_temp_low := forecast_entry.get(
+                if forecast_temp_low := forecast_entry.pop(
                     ATTR_FORECAST_NATIVE_TEMP_LOW,
                     forecast_entry.get(ATTR_FORECAST_TEMP_LOW),
                 ):
@@ -724,7 +724,7 @@ class WeatherEntity(Entity):
                             value_temp_low, precision
                         )
 
-                if forecast_pressure := forecast_entry.get(
+                if forecast_pressure := forecast_entry.pop(
                     ATTR_FORECAST_NATIVE_PRESSURE,
                     forecast_entry.get(ATTR_FORECAST_PRESSURE),
                 ):
@@ -743,7 +743,7 @@ class WeatherEntity(Entity):
                             ROUNDING_PRECISION,
                         )
 
-                if forecast_wind_speed := forecast_entry.get(
+                if forecast_wind_speed := forecast_entry.pop(
                     ATTR_FORECAST_NATIVE_WIND_SPEED,
                     forecast_entry.get(ATTR_FORECAST_WIND_SPEED),
                 ):
@@ -762,7 +762,7 @@ class WeatherEntity(Entity):
                             ROUNDING_PRECISION,
                         )
 
-                if forecast_precipitation := forecast_entry.get(
+                if forecast_precipitation := forecast_entry.pop(
                     ATTR_FORECAST_NATIVE_PRECIPITATION,
                     forecast_entry.get(ATTR_FORECAST_PRECIPITATION),
                 ):

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -455,9 +455,15 @@ class WeatherEntity(Entity):
         """Return the precision of the temperature value, after unit conversion."""
         if hasattr(self, "_attr_precision"):
             return self._attr_precision
+        if self._override:
+            return (
+                PRECISION_TENTHS
+                if self.hass.config.units.temperature_unit == TEMP_CELSIUS
+                else PRECISION_WHOLE
+            )
         return (
             PRECISION_TENTHS
-            if self.native_temperature_unit == TEMP_CELSIUS
+            if self.temperature_unit == TEMP_CELSIUS
             else PRECISION_WHOLE
         )
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -557,7 +557,7 @@ class WeatherEntity(Entity):
             return self._attr_precision
         return (
             PRECISION_TENTHS
-            if self.temperature_unit == TEMP_CELSIUS
+            if self._temperature_unit == TEMP_CELSIUS
             else PRECISION_WHOLE
         )
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -499,7 +499,9 @@ class WeatherEntity(Entity):
                 )
 
         if (temp_unit := self.temperature_unit) is not None:
-            data[ATTR_WEATHER_TEMPERATURE_UNIT] = temp_unit
+            data[ATTR_WEATHER_TEMPERATURE_UNIT] = (
+                self.hass.config.units.temperature_unit if self._override else temp_unit
+            )
 
         if (humidity := self.humidity) is not None:
             data[ATTR_WEATHER_HUMIDITY] = round(humidity)

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -254,11 +254,11 @@ class WeatherEntity(Entity):
     _attr_native_wind_speed: float | None = None
     _attr_native_wind_speed_unit: str | None = None
 
-    _weather_option_temperature_uom: str | None = None
-    _weather_option_pressure_uom: str | None = None
-    _weather_option_visibility_uom: str | None = None
-    _weather_option_precipitation_uom: str | None = None
-    _weather_option_wind_speed_uom: str | None = None
+    _weather_option_temperature_unit: str | None = None
+    _weather_option_pressure_unit: str | None = None
+    _weather_option_visibility_unit: str | None = None
+    _weather_option_precipitation_unit: str | None = None
+    _weather_option_wind_speed_unit: str | None = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Post initialisation processing."""
@@ -364,9 +364,9 @@ class WeatherEntity(Entity):
         Should not be set by integrations.
         """
         if (
-            weather_option_temperature_uom := self._weather_option_temperature_uom
+            weather_option_temperature_unit := self._weather_option_temperature_unit
         ) is not None:
-            return weather_option_temperature_uom
+            return weather_option_temperature_unit
 
         return self._default_temperature_unit
 
@@ -417,9 +417,9 @@ class WeatherEntity(Entity):
         Should not be set by integrations.
         """
         if (
-            weather_option_pressure_uom := self._weather_option_pressure_uom
+            weather_option_pressure_unit := self._weather_option_pressure_unit
         ) is not None:
-            return weather_option_pressure_uom
+            return weather_option_pressure_unit
 
         return self._default_pressure_unit
 
@@ -479,9 +479,9 @@ class WeatherEntity(Entity):
         Should not be set by integrations.
         """
         if (
-            weather_option_wind_speed_uom := self._weather_option_wind_speed_uom
+            weather_option_wind_speed_unit := self._weather_option_wind_speed_unit
         ) is not None:
-            return weather_option_wind_speed_uom
+            return weather_option_wind_speed_unit
 
         return self._default_wind_speed_unit
 
@@ -542,9 +542,9 @@ class WeatherEntity(Entity):
         Should not be set by integrations.
         """
         if (
-            weather_option_visibility_uom := self._weather_option_visibility_uom
+            weather_option_visibility_unit := self._weather_option_visibility_unit
         ) is not None:
-            return weather_option_visibility_uom
+            return weather_option_visibility_unit
 
         return self._default_visibility_unit
 
@@ -584,9 +584,9 @@ class WeatherEntity(Entity):
         Should not be set by integrations.
         """
         if (
-            weather_option_precipitation_uom := self._weather_option_precipitation_uom
+            weather_option_precipitation_unit := self._weather_option_precipitation_unit
         ) is not None:
-            return weather_option_precipitation_uom
+            return weather_option_precipitation_unit
 
         return self._default_precipitation_unit
 
@@ -609,12 +609,6 @@ class WeatherEntity(Entity):
 
         precision = self.precision
 
-        data[ATTR_WEATHER_PRECIPITATION_UNIT] = self._precipitation_unit
-        data[ATTR_WEATHER_PRESSURE_UNIT] = self._pressure_unit
-        data[ATTR_WEATHER_TEMPERATURE_UNIT] = self._temperature_unit
-        data[ATTR_WEATHER_VISIBILITY_UNIT] = self._visibility_unit
-        data[ATTR_WEATHER_WIND_SPEED_UNIT] = self._wind_speed_unit
-
         if (temperature := self.native_temperature) is not None:
             from_unit = self.native_temperature_unit or self._default_temperature_unit
             to_unit = self._temperature_unit
@@ -628,6 +622,8 @@ class WeatherEntity(Entity):
                 )
             except (TypeError, ValueError):
                 data[ATTR_WEATHER_TEMPERATURE] = temperature
+
+        data[ATTR_WEATHER_TEMPERATURE_UNIT] = self._temperature_unit
 
         if (humidity := self.humidity) is not None:
             data[ATTR_WEATHER_HUMIDITY] = round(humidity)
@@ -647,6 +643,8 @@ class WeatherEntity(Entity):
             except (TypeError, ValueError):
                 data[ATTR_WEATHER_PRESSURE] = pressure
 
+        data[ATTR_WEATHER_PRESSURE_UNIT] = self._pressure_unit
+
         if (wind_bearing := self.wind_bearing) is not None:
             data[ATTR_WEATHER_WIND_BEARING] = wind_bearing
 
@@ -664,6 +662,8 @@ class WeatherEntity(Entity):
             except (TypeError, ValueError):
                 data[ATTR_WEATHER_WIND_SPEED] = wind_speed
 
+        data[ATTR_WEATHER_WIND_SPEED_UNIT] = self._wind_speed_unit
+
         if (visibility := self.native_visibility) is not None:
             from_unit = self.native_visibility_unit or self._default_visibility_unit
             to_unit = self._visibility_unit
@@ -677,6 +677,9 @@ class WeatherEntity(Entity):
                 )
             except (TypeError, ValueError):
                 data[ATTR_WEATHER_VISIBILITY] = visibility
+
+        data[ATTR_WEATHER_VISIBILITY_UNIT] = self._visibility_unit
+        data[ATTR_WEATHER_PRECIPITATION_UNIT] = self._precipitation_unit
 
         if self.forecast is not None:
             forecast = []
@@ -804,22 +807,22 @@ class WeatherEntity(Entity):
         """Run when the entity registry entry has been updated."""
         assert self.registry_entry
         weather_options = self.registry_entry.options.get(DOMAIN)
-        self._weather_option_temperature_uom = None
-        self._weather_option_pressure_uom = None
-        self._weather_option_precipitation_uom = None
-        self._weather_option_wind_speed_uom = None
-        self._weather_option_visibility_uom = None
+        self._weather_option_temperature_unit = None
+        self._weather_option_pressure_unit = None
+        self._weather_option_precipitation_unit = None
+        self._weather_option_wind_speed_unit = None
+        self._weather_option_visibility_unit = None
         if weather_options := self.registry_entry.options.get(DOMAIN):
             if (
                 custom_unit_temperature := weather_options.get(
                     ATTR_WEATHER_TEMPERATURE_UNIT
                 )
             ) and custom_unit_temperature in VALID_UNITS[ATTR_WEATHER_TEMPERATURE_UNIT]:
-                self._weather_option_temperature_uom = custom_unit_temperature
+                self._weather_option_temperature_unit = custom_unit_temperature
             if (
                 custom_unit_pressure := weather_options.get(ATTR_WEATHER_PRESSURE_UNIT)
             ) and custom_unit_pressure in VALID_UNITS[ATTR_WEATHER_PRESSURE_UNIT]:
-                self._weather_option_pressure_uom = custom_unit_pressure
+                self._weather_option_pressure_unit = custom_unit_pressure
             if (
                 custom_unit_precipitation := weather_options.get(
                     ATTR_WEATHER_PRECIPITATION_UNIT
@@ -827,16 +830,16 @@ class WeatherEntity(Entity):
             ) and custom_unit_precipitation in VALID_UNITS[
                 ATTR_WEATHER_PRECIPITATION_UNIT
             ]:
-                self._weather_option_precipitation_uom = custom_unit_precipitation
+                self._weather_option_precipitation_unit = custom_unit_precipitation
             if (
                 custom_unit_wind_speed := weather_options.get(
                     ATTR_WEATHER_WIND_SPEED_UNIT
                 )
             ) and custom_unit_wind_speed in VALID_UNITS[ATTR_WEATHER_WIND_SPEED_UNIT]:
-                self._weather_option_wind_speed_uom = custom_unit_wind_speed
+                self._weather_option_wind_speed_unit = custom_unit_wind_speed
             if (
                 custom_unit_visibility := weather_options.get(
                     ATTR_WEATHER_VISIBILITY_UNIT
                 )
             ) and custom_unit_visibility in VALID_UNITS[ATTR_WEATHER_VISIBILITY_UNIT]:
-                self._weather_option_visibility_uom = custom_unit_visibility
+                self._weather_option_visibility_unit = custom_unit_visibility

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -46,7 +46,7 @@ async def test_weather_without_forecast(hass):
     assert state.attributes.get(ATTR_WEATHER_TEMPERATURE) == 22.6
     assert state.attributes.get(ATTR_WEATHER_VISIBILITY) == 16.1
     assert state.attributes.get(ATTR_WEATHER_WIND_BEARING) == 180
-    assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 4.03
+    assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 14.5  # 4.03 m/s -> km/h
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
 
     entry = registry.async_get("weather.home")
@@ -68,7 +68,7 @@ async def test_weather_with_forecast(hass):
     assert state.attributes.get(ATTR_WEATHER_TEMPERATURE) == 22.6
     assert state.attributes.get(ATTR_WEATHER_VISIBILITY) == 16.1
     assert state.attributes.get(ATTR_WEATHER_WIND_BEARING) == 180
-    assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 4.03
+    assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 14.5  # 4.03 m/s -> km/h
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     forecast = state.attributes.get(ATTR_FORECAST)[0]
     assert forecast.get(ATTR_FORECAST_CONDITION) == "lightning-rainy"
@@ -78,7 +78,7 @@ async def test_weather_with_forecast(hass):
     assert forecast.get(ATTR_FORECAST_TEMP_LOW) == 15.4
     assert forecast.get(ATTR_FORECAST_TIME) == "2020-07-26T05:00:00+00:00"
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == 166
-    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 3.61
+    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 13.0  # 3.61 m/s -> km/h
 
     entry = registry.async_get("weather.home")
     assert entry

--- a/tests/components/aemet/test_weather.py
+++ b/tests/components/aemet/test_weather.py
@@ -42,10 +42,10 @@ async def test_aemet_weather(hass):
     assert state.state == ATTR_CONDITION_SNOWY
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_WEATHER_HUMIDITY) == 99.0
-    assert state.attributes.get(ATTR_WEATHER_PRESSURE) == 100440.0
+    assert state.attributes.get(ATTR_WEATHER_PRESSURE) == 1004.4  # 100440.0 Pa -> hPa
     assert state.attributes.get(ATTR_WEATHER_TEMPERATURE) == -0.7
     assert state.attributes.get(ATTR_WEATHER_WIND_BEARING) == 90.0
-    assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 4.17
+    assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 15.0  # 4.17 m/s -> km/h
     forecast = state.attributes.get(ATTR_FORECAST)[0]
     assert forecast.get(ATTR_FORECAST_CONDITION) == ATTR_CONDITION_PARTLYCLOUDY
     assert forecast.get(ATTR_FORECAST_PRECIPITATION) is None
@@ -57,7 +57,7 @@ async def test_aemet_weather(hass):
         == dt_util.parse_datetime("2021-01-10 00:00:00+00:00").isoformat()
     )
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == 45.0
-    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 5.56
+    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 20.0  # 5.56 m/s -> km/h
 
     state = hass.states.get("weather.aemet_hourly")
     assert state is None

--- a/tests/components/climacell/test_weather.py
+++ b/tests/components/climacell/test_weather.py
@@ -132,7 +132,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-12T00:00:00-08:00",
-            ATTR_FORECAST_PRECIPITATION: 0.0457,
+            ATTR_FORECAST_PRECIPITATION: 0.05,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 25,
             ATTR_FORECAST_TEMP: 19.9,
             ATTR_FORECAST_TEMP_LOW: 12.1,
@@ -148,7 +148,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_RAINY,
             ATTR_FORECAST_TIME: "2021-03-14T00:00:00-08:00",
-            ATTR_FORECAST_PRECIPITATION: 1.0744,
+            ATTR_FORECAST_PRECIPITATION: 1.07,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 75,
             ATTR_FORECAST_TEMP: 6.4,
             ATTR_FORECAST_TEMP_LOW: 3.2,
@@ -156,7 +156,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_SNOWY,
             ATTR_FORECAST_TIME: "2021-03-15T00:00:00-07:00",  # DST starts
-            ATTR_FORECAST_PRECIPITATION: 7.3050,
+            ATTR_FORECAST_PRECIPITATION: 7.3,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 95,
             ATTR_FORECAST_TEMP: 1.2,
             ATTR_FORECAST_TEMP_LOW: 0.2,
@@ -164,7 +164,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-16T00:00:00-07:00",
-            ATTR_FORECAST_PRECIPITATION: 0.0051,
+            ATTR_FORECAST_PRECIPITATION: 0.01,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 5,
             ATTR_FORECAST_TEMP: 6.1,
             ATTR_FORECAST_TEMP_LOW: -1.6,
@@ -188,7 +188,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-19T00:00:00-07:00",
-            ATTR_FORECAST_PRECIPITATION: 0.1778,
+            ATTR_FORECAST_PRECIPITATION: 0.18,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 45,
             ATTR_FORECAST_TEMP: 9.4,
             ATTR_FORECAST_TEMP_LOW: 4.7,
@@ -196,7 +196,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_RAINY,
             ATTR_FORECAST_TIME: "2021-03-20T00:00:00-07:00",
-            ATTR_FORECAST_PRECIPITATION: 1.2319,
+            ATTR_FORECAST_PRECIPITATION: 1.23,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 55,
             ATTR_FORECAST_TEMP: 5.0,
             ATTR_FORECAST_TEMP_LOW: 3.1,
@@ -204,7 +204,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-21T00:00:00-07:00",
-            ATTR_FORECAST_PRECIPITATION: 0.0432,
+            ATTR_FORECAST_PRECIPITATION: 0.04,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 20,
             ATTR_FORECAST_TEMP: 6.8,
             ATTR_FORECAST_TEMP_LOW: 0.9,
@@ -213,11 +213,11 @@ async def test_v3_weather(
     assert weather_state.attributes[ATTR_FRIENDLY_NAME] == "ClimaCell - Daily"
     assert weather_state.attributes[ATTR_WEATHER_HUMIDITY] == 24
     assert weather_state.attributes[ATTR_WEATHER_OZONE] == 52.625
-    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 1028.1246
+    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 1028.12
     assert weather_state.attributes[ATTR_WEATHER_TEMPERATURE] == 6.6
-    assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 9.9940
+    assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 9.99
     assert weather_state.attributes[ATTR_WEATHER_WIND_BEARING] == 320.31
-    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 14.6289
+    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 14.63
     assert weather_state.attributes[ATTR_CLOUD_COVER] == 100
     assert weather_state.attributes[ATTR_WIND_GUST] == 24.0758
     assert weather_state.attributes[ATTR_PRECIPITATION_TYPE] == "rain"

--- a/tests/components/demo/test_weather.py
+++ b/tests/components/demo/test_weather.py
@@ -53,20 +53,3 @@ async def test_attributes(hass):
         data.get(ATTR_FORECAST)[6].get(ATTR_FORECAST_PRECIPITATION_PROBABILITY) == 100
     )
     assert len(data.get(ATTR_FORECAST)) == 7
-
-
-async def test_temperature_convert(hass):
-    """Test temperature conversion."""
-    assert await async_setup_component(
-        hass, weather.DOMAIN, {"weather": {"platform": "demo"}}
-    )
-    hass.config.units = METRIC_SYSTEM
-    await hass.async_block_till_done()
-
-    state = hass.states.get("weather.demo_weather_north")
-    assert state is not None
-
-    assert state.state == "rainy"
-
-    data = state.attributes
-    assert data.get(ATTR_WEATHER_TEMPERATURE) == -24.4

--- a/tests/components/demo/test_weather.py
+++ b/tests/components/demo/test_weather.py
@@ -36,7 +36,7 @@ async def test_attributes(hass):
     assert data.get(ATTR_WEATHER_TEMPERATURE) == 21.6
     assert data.get(ATTR_WEATHER_HUMIDITY) == 92
     assert data.get(ATTR_WEATHER_PRESSURE) == 1099
-    assert data.get(ATTR_WEATHER_WIND_SPEED) == 0.5
+    assert data.get(ATTR_WEATHER_WIND_SPEED) == 1.8  # 0.5 m/s -> km/h
     assert data.get(ATTR_WEATHER_WIND_BEARING) is None
     assert data.get(ATTR_WEATHER_OZONE) is None
     assert data.get(ATTR_ATTRIBUTION) == "Powered by Home Assistant"

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -198,7 +198,7 @@ async def test_daily_forecast(hass):
     assert forecast.get(ATTR_FORECAST_TEMP) == 16.2
     assert forecast.get(ATTR_FORECAST_TEMP_LOW) == 10.6
     assert forecast.get(ATTR_FORECAST_PRECIPITATION_PROBABILITY) == "100.0"
-    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == "10"
+    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 10.0
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == "S"
 
 
@@ -222,5 +222,5 @@ async def test_hourly_forecast(hass):
     assert forecast.get(ATTR_FORECAST_CONDITION) == "rainy"
     assert forecast.get(ATTR_FORECAST_TEMP) == 7.7
     assert forecast.get(ATTR_FORECAST_PRECIPITATION_PROBABILITY) == 80.0
-    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == "32.7"
+    assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 32.7
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == "S"

--- a/tests/components/knx/test_weather.py
+++ b/tests/components/knx/test_weather.py
@@ -85,8 +85,8 @@ async def test_weather(hass: HomeAssistant, knx: KNXTestKit):
     state = hass.states.get("weather.test")
     assert state.attributes["temperature"] == 0.4
     assert state.attributes["wind_bearing"] == 270
-    assert state.attributes["wind_speed"] == 1.4400000000000002
-    assert state.attributes["pressure"] == 980.5824
+    assert state.attributes["wind_speed"] == 1.44
+    assert state.attributes["pressure"] == 980.58
     assert state.state is ATTR_CONDITION_SUNNY
 
     # update from KNX - set rain alarm

--- a/tests/components/tomorrowio/test_weather.py
+++ b/tests/components/tomorrowio/test_weather.py
@@ -99,13 +99,13 @@ async def test_v4_weather(hass: HomeAssistant) -> None:
         ATTR_FORECAST_TEMP: 45.9,
         ATTR_FORECAST_TEMP_LOW: 26.1,
         ATTR_FORECAST_WIND_BEARING: 239.6,
-        ATTR_FORECAST_WIND_SPEED: 9.49,
+        ATTR_FORECAST_WIND_SPEED: 34.16,  # 9.49 m/s -> km/h
     }
     assert weather_state.attributes[ATTR_FRIENDLY_NAME] == "Tomorrow.io - Daily"
     assert weather_state.attributes[ATTR_WEATHER_HUMIDITY] == 23
     assert weather_state.attributes[ATTR_WEATHER_OZONE] == 46.53
-    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 3035.0
+    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 30.35
     assert weather_state.attributes[ATTR_WEATHER_TEMPERATURE] == 44.1
     assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 8.15
     assert weather_state.attributes[ATTR_WEATHER_WIND_BEARING] == 315.14
-    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 9.33
+    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 33.59  # 9.33 m/s ->km/h

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -10,7 +10,6 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_WIND_SPEED,
-    ATTR_WEATHER_PRECIPITATION,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_VISIBILITY,
@@ -150,9 +149,6 @@ async def test_precipitation(
     forecast = state.attributes[ATTR_FORECAST][0]
 
     expected = native_value
-    assert float(state.attributes[ATTR_WEATHER_PRECIPITATION]) == approx(
-        expected, rel=1e-2
-    )
     assert float(forecast[ATTR_FORECAST_PRECIPITATION]) == approx(expected, rel=1e-2)
 
 
@@ -183,8 +179,6 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
     """Test custom unit."""
     wind_speed_value = 5
     wind_speed_unit = SPEED_METERS_PER_SECOND
-    precipitation_value = 2
-    precipitation_unit = LENGTH_MILLIMETERS
     pressure_value = 110
     pressure_unit = PRESSURE_HPA
     temperature_value = 20
@@ -218,8 +212,6 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
             native_wind_speed_unit=wind_speed_unit,
             native_pressure=pressure_value,
             native_pressure_unit=pressure_unit,
-            native_precipitation=precipitation_value,
-            native_precipitation_unit=precipitation_unit,
             native_visibility=visibility_value,
             native_visibility_unit=visibility_unit,
             unique_id="very_unique",
@@ -244,10 +236,6 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
         convert_pressure(pressure_value, pressure_unit, PRESSURE_INHG),
         ROUNDING_PRECISION,
     )
-    expected_precipitation = round(
-        convert_distance(precipitation_value, precipitation_unit, LENGTH_INCHES),
-        ROUNDING_PRECISION,
-    )
     expected_visibility = round(
         convert_distance(visibility_value, visibility_unit, LENGTH_MILES),
         ROUNDING_PRECISION,
@@ -260,9 +248,6 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
         expected_temperature, rel=0.1
     )
     assert float(state.attributes[ATTR_WEATHER_PRESSURE]) == approx(expected_pressure)
-    assert float(state.attributes[ATTR_WEATHER_PRECIPITATION]) == approx(
-        expected_precipitation
-    )
     assert float(state.attributes[ATTR_WEATHER_VISIBILITY]) == approx(
         expected_visibility
     )

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -10,10 +10,12 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_WIND_SPEED,
+    ATTR_WEATHER_PRECIPITATION,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_VISIBILITY,
     ATTR_WEATHER_WIND_SPEED,
+    ROUNDING_PRECISION,
 )
 from homeassistant.const import (
     LENGTH_INCHES,
@@ -34,7 +36,6 @@ from homeassistant.util.distance import convert as convert_distance
 from homeassistant.util.pressure import convert as convert_pressure
 from homeassistant.util.speed import convert as convert_speed
 from homeassistant.util.temperature import convert as convert_temperature
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 from tests.testing_config.custom_components.test import weather as WeatherPlatform
 
@@ -58,14 +59,11 @@ async def create_entity(hass: HomeAssistant, **kwargs):
     return entity0
 
 
-@pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
-async def test_temperature_conversion(
-    hass: HomeAssistant, enable_custom_integrations, unit_system: UnitSystem
-):
-    """Test temperature conversion."""
-    hass.config.units = unit_system
+@pytest.mark.parametrize("unit", [TEMP_FAHRENHEIT, TEMP_CELSIUS])
+async def test_temperature(hass: HomeAssistant, enable_custom_integrations, unit: str):
+    """Test temperature."""
     native_value = 38
-    native_unit = TEMP_FAHRENHEIT
+    native_unit = unit
 
     entity0 = await create_entity(
         hass, native_temperature=native_value, native_temperature_unit=native_unit
@@ -74,9 +72,7 @@ async def test_temperature_conversion(
     state = hass.states.get(entity0.entity_id)
     forecast = state.attributes[ATTR_FORECAST][0]
 
-    expected = convert_temperature(native_value, native_unit, TEMP_FAHRENHEIT)
-    if unit_system == METRIC_SYSTEM:
-        expected = convert_temperature(native_value, native_unit, TEMP_CELSIUS)
+    expected = native_value
     assert float(state.attributes[ATTR_WEATHER_TEMPERATURE]) == approx(
         expected, rel=0.1
     )
@@ -84,14 +80,11 @@ async def test_temperature_conversion(
     assert float(forecast[ATTR_FORECAST_TEMP_LOW]) == approx(expected, rel=0.1)
 
 
-@pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
-async def test_pressure_conversion(
-    hass: HomeAssistant, enable_custom_integrations, unit_system: UnitSystem
-):
-    """Test pressure conversion."""
-    hass.config.units = unit_system
+@pytest.mark.parametrize("unit", [PRESSURE_INHG, PRESSURE_HPA])
+async def test_pressure(hass: HomeAssistant, enable_custom_integrations, unit: str):
+    """Test pressure."""
     native_value = 30
-    native_unit = PRESSURE_INHG
+    native_unit = unit
 
     entity0 = await create_entity(
         hass, native_pressure=native_value, native_pressure_unit=native_unit
@@ -99,21 +92,16 @@ async def test_pressure_conversion(
     state = hass.states.get(entity0.entity_id)
     forecast = state.attributes[ATTR_FORECAST][0]
 
-    expected = convert_pressure(native_value, native_unit, PRESSURE_INHG)
-    if unit_system == METRIC_SYSTEM:
-        expected = convert_pressure(native_value, native_unit, PRESSURE_HPA)
+    expected = native_value
     assert float(state.attributes[ATTR_WEATHER_PRESSURE]) == approx(expected, rel=1e-2)
     assert float(forecast[ATTR_FORECAST_PRESSURE]) == approx(expected, rel=1e-2)
 
 
-@pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
-async def test_wind_speed_conversion(
-    hass: HomeAssistant, enable_custom_integrations, unit_system: UnitSystem
-):
-    """Test wind speed conversion."""
-    hass.config.units = unit_system
+@pytest.mark.parametrize("unit", [SPEED_MILES_PER_HOUR, SPEED_METERS_PER_SECOND])
+async def test_wind_speed(hass: HomeAssistant, enable_custom_integrations, unit: str):
+    """Test wind speed."""
     native_value = 10
-    native_unit = SPEED_METERS_PER_SECOND
+    native_unit = unit
 
     entity0 = await create_entity(
         hass, native_wind_speed=native_value, native_wind_speed_unit=native_unit
@@ -122,45 +110,37 @@ async def test_wind_speed_conversion(
     state = hass.states.get(entity0.entity_id)
     forecast = state.attributes[ATTR_FORECAST][0]
 
-    expected = convert_speed(native_value, native_unit, SPEED_MILES_PER_HOUR)
-    if unit_system == METRIC_SYSTEM:
-        expected = convert_speed(native_value, native_unit, SPEED_METERS_PER_SECOND)
+    expected = native_value
     assert float(state.attributes[ATTR_WEATHER_WIND_SPEED]) == approx(
         expected, rel=1e-2
     )
     assert float(forecast[ATTR_FORECAST_WIND_SPEED]) == approx(expected, rel=1e-2)
 
 
-@pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
-async def test_visibility_conversion(
-    hass: HomeAssistant, enable_custom_integrations, unit_system: UnitSystem
-):
-    """Test visibility conversion."""
-    hass.config.units = unit_system
+@pytest.mark.parametrize("unit", [LENGTH_KILOMETERS, LENGTH_MILES])
+async def test_visibility(hass: HomeAssistant, enable_custom_integrations, unit: str):
+    """Test visibility."""
     native_value = 10
-    native_unit = LENGTH_MILES
+    native_unit = unit
 
     entity0 = await create_entity(
         hass, native_visibility=native_value, native_visibility_unit=native_unit
     )
 
     state = hass.states.get(entity0.entity_id)
-    expected = convert_distance(native_value, native_unit, LENGTH_MILES)
-    if unit_system == METRIC_SYSTEM:
-        expected = convert_distance(native_value, native_unit, LENGTH_KILOMETERS)
+    expected = native_value
     assert float(state.attributes[ATTR_WEATHER_VISIBILITY]) == approx(
         expected, rel=1e-2
     )
 
 
-@pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
-async def test_precipitation_conversion(
-    hass: HomeAssistant, enable_custom_integrations, unit_system: UnitSystem
+@pytest.mark.parametrize("unit", [LENGTH_INCHES, LENGTH_MILLIMETERS])
+async def test_precipitation(
+    hass: HomeAssistant, enable_custom_integrations, unit: str
 ):
-    """Test precipitation conversion."""
-    hass.config.units = unit_system
+    """Test precipitation."""
     native_value = 30
-    native_unit = LENGTH_MILLIMETERS
+    native_unit = unit
 
     entity0 = await create_entity(
         hass, native_precipitation=native_value, native_precipitation_unit=native_unit
@@ -169,9 +149,10 @@ async def test_precipitation_conversion(
     state = hass.states.get(entity0.entity_id)
     forecast = state.attributes[ATTR_FORECAST][0]
 
-    expected = convert_distance(native_value, native_unit, LENGTH_INCHES)
-    if unit_system == METRIC_SYSTEM:
-        expected = convert_distance(native_value, native_unit, LENGTH_MILLIMETERS)
+    expected = native_value
+    assert float(state.attributes[ATTR_WEATHER_PRECIPITATION]) == approx(
+        expected, rel=1e-2
+    )
     assert float(forecast[ATTR_FORECAST_PRECIPITATION]) == approx(expected, rel=1e-2)
 
 
@@ -200,16 +181,29 @@ async def test_none_forecast(
 
 async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> None:
     """Test custom unit."""
-    native_value = 5
-    native_unit = SPEED_METERS_PER_SECOND
-    custom_unit = SPEED_MILES_PER_HOUR
+    wind_speed_value = 5
+    wind_speed_unit = SPEED_METERS_PER_SECOND
+    precipitation_value = 2
+    precipitation_unit = LENGTH_MILLIMETERS
+    pressure_value = 110
+    pressure_unit = PRESSURE_HPA
+    temperature_value = 20
+    temperature_unit = TEMP_CELSIUS
+    visibility_value = 11
+    visibility_unit = LENGTH_KILOMETERS
+
+    set_options = {
+        "wind_speed_unit_of_measurement": SPEED_MILES_PER_HOUR,
+        "precipitation_unit_of_measurement": LENGTH_INCHES,
+        "pressure_unit_of_measurement": PRESSURE_INHG,
+        "temperature_unit_of_measurement": TEMP_FAHRENHEIT,
+        "visibility_unit_of_measurement": LENGTH_MILES,
+    }
 
     entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get_or_create("weather", "test", "very_unique")
-    entity_registry.async_update_entity_options(
-        entry.entity_id, "weather", {"wind_speed_unit_of_measurement": custom_unit}
-    )
+    entity_registry.async_update_entity_options(entry.entity_id, "weather", set_options)
     await hass.async_block_till_done()
 
     platform: WeatherPlatform = getattr(hass.components, "test.weather")
@@ -218,10 +212,16 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
         platform.MockWeather(
             name="Test",
             condition=ATTR_CONDITION_SUNNY,
-            native_temperature=None,
-            native_temperature_unit=None,
-            native_wind_speed=native_value,
-            native_wind_speed_unit=native_unit,
+            native_temperature=temperature_value,
+            native_temperature_unit=temperature_unit,
+            native_wind_speed=wind_speed_value,
+            native_wind_speed_unit=wind_speed_unit,
+            native_pressure=pressure_value,
+            native_pressure_unit=pressure_unit,
+            native_precipitation=precipitation_value,
+            native_precipitation_unit=precipitation_unit,
+            native_visibility=visibility_value,
+            native_visibility_unit=visibility_unit,
             unique_id="very_unique",
         )
     )
@@ -233,7 +233,36 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    expected = convert_speed(native_value, native_unit, SPEED_MILES_PER_HOUR)
+    expected_wind_speed = round(
+        convert_speed(wind_speed_value, wind_speed_unit, SPEED_MILES_PER_HOUR),
+        ROUNDING_PRECISION,
+    )
+    expected_temperature = convert_temperature(
+        temperature_value, temperature_unit, TEMP_FAHRENHEIT
+    )
+    expected_pressure = round(
+        convert_pressure(pressure_value, pressure_unit, PRESSURE_INHG),
+        ROUNDING_PRECISION,
+    )
+    expected_precipitation = round(
+        convert_distance(precipitation_value, precipitation_unit, LENGTH_INCHES),
+        ROUNDING_PRECISION,
+    )
+    expected_visibility = round(
+        convert_distance(visibility_value, visibility_unit, LENGTH_MILES),
+        ROUNDING_PRECISION,
+    )
+
     assert float(state.attributes[ATTR_WEATHER_WIND_SPEED]) == approx(
-        expected, rel=1e-2
+        expected_wind_speed
+    )
+    assert float(state.attributes[ATTR_WEATHER_TEMPERATURE]) == approx(
+        expected_temperature, rel=0.1
+    )
+    assert float(state.attributes[ATTR_WEATHER_PRESSURE]) == approx(expected_pressure)
+    assert float(state.attributes[ATTR_WEATHER_PRECIPITATION]) == approx(
+        expected_precipitation
+    )
+    assert float(state.attributes[ATTR_WEATHER_VISIBILITY]) == approx(
+        expected_visibility
     )

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -587,6 +587,22 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
         expected_precipitation, rel=1e-2
     )
 
+    assert (
+        state.attributes[ATTR_WEATHER_PRECIPITATION_UNIT]
+        == set_options["precipitation_unit"]
+    )
+    assert state.attributes[ATTR_WEATHER_PRESSURE_UNIT] == set_options["pressure_unit"]
+    assert (
+        state.attributes[ATTR_WEATHER_TEMPERATURE_UNIT]
+        == set_options["temperature_unit"]
+    )
+    assert (
+        state.attributes[ATTR_WEATHER_VISIBILITY_UNIT] == set_options["visibility_unit"]
+    )
+    assert (
+        state.attributes[ATTR_WEATHER_WIND_SPEED_UNIT] == set_options["wind_speed_unit"]
+    )
+
 
 async def test_backwards_compatibility(
     hass: HomeAssistant, enable_custom_integrations

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -20,12 +20,16 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
     ATTR_WEATHER_WIND_SPEED_UNIT,
     ROUNDING_PRECISION,
+    round_temperature,
 )
 from homeassistant.const import (
     LENGTH_INCHES,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
     LENGTH_MILLIMETERS,
+    PRECISION_HALVES,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
     PRESSURE_HPA,
     PRESSURE_INHG,
     PRESSURE_PA,
@@ -394,3 +398,11 @@ async def test_backwards_compatibility_convert_temperature(
         expected_temperature, rel=0.1
     )
     assert state.attributes[ATTR_WEATHER_TEMPERATURE_UNIT] == TEMP_FAHRENHEIT
+
+
+async def test_backwards_compatibility_round_temperature(hass: HomeAssistant) -> None:
+    """Test backward compatibility for rounding temperature."""
+
+    assert round_temperature(20.3, PRECISION_HALVES) == 20.5
+    assert round_temperature(20.3, PRECISION_TENTHS) == 20.3
+    assert round_temperature(20.3, PRECISION_WHOLE) == 20

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -22,15 +22,16 @@ from homeassistant.const import (
     SPEED_METERS_PER_SECOND,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.distance import convert as convert_distance
 from homeassistant.util.pressure import convert as convert_pressure
 from homeassistant.util.speed import convert as convert_speed
 from homeassistant.util.temperature import convert as convert_temperature
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 
-async def create_entity(hass, **kwargs):
+async def create_entity(hass: HomeAssistant, **kwargs):
     """Create the weather entity to run tests on."""
     kwargs = {"temperature": None, "temperature_unit": None, **kwargs}
     platform = getattr(hass.components, "test.weather")
@@ -51,9 +52,9 @@ async def create_entity(hass, **kwargs):
 
 @pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
 async def test_temperature_conversion(
-    hass,
+    hass: HomeAssistant,
     enable_custom_integrations,
-    unit_system,
+    unit_system: UnitSystem,
 ):
     """Test temperature conversion."""
     hass.config.units = unit_system
@@ -79,9 +80,9 @@ async def test_temperature_conversion(
 
 @pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
 async def test_pressure_conversion(
-    hass,
+    hass: HomeAssistant,
     enable_custom_integrations,
-    unit_system,
+    unit_system: UnitSystem,
 ):
     """Test pressure conversion."""
     hass.config.units = unit_system
@@ -101,9 +102,9 @@ async def test_pressure_conversion(
 
 @pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
 async def test_wind_speed_conversion(
-    hass,
+    hass: HomeAssistant,
     enable_custom_integrations,
-    unit_system,
+    unit_system: UnitSystem,
 ):
     """Test wind speed conversion."""
     hass.config.units = unit_system
@@ -126,9 +127,9 @@ async def test_wind_speed_conversion(
 
 @pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
 async def test_visibility_conversion(
-    hass,
+    hass: HomeAssistant,
     enable_custom_integrations,
-    unit_system,
+    unit_system: UnitSystem,
 ):
     """Test visibility conversion."""
     hass.config.units = unit_system
@@ -148,9 +149,9 @@ async def test_visibility_conversion(
 
 @pytest.mark.parametrize("unit_system", [IMPERIAL_SYSTEM, METRIC_SYSTEM])
 async def test_precipitation_conversion(
-    hass,
+    hass: HomeAssistant,
     enable_custom_integrations,
-    unit_system,
+    unit_system: UnitSystem,
 ):
     """Test precipitation conversion."""
     hass.config.units = unit_system
@@ -171,7 +172,7 @@ async def test_precipitation_conversion(
 
 
 async def test_none_forecast(
-    hass,
+    hass: HomeAssistant,
     enable_custom_integrations,
 ):
     """Test that conversion with None values succeeds."""

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     LENGTH_MILLIMETERS,
     PRESSURE_HPA,
     PRESSURE_INHG,
+    PRESSURE_PA,
     SPEED_METERS_PER_SECOND,
     SPEED_MILES_PER_HOUR,
     TEMP_CELSIUS,
@@ -265,7 +266,7 @@ async def test_backwards_compability(
     wind_speed_value = 5
     wind_speed_unit = SPEED_METERS_PER_SECOND
     pressure_value = 110
-    pressure_unit = PRESSURE_HPA
+    pressure_unit = PRESSURE_PA
     temperature_value = 20
     temperature_unit = TEMP_CELSIUS
     visibility_value = 11
@@ -332,7 +333,7 @@ async def test_backwards_compability(
     )
     assert state.attributes[ATTR_WEATHER_TEMPERATURE_UNIT] == TEMP_CELSIUS
     assert float(state.attributes[ATTR_WEATHER_PRESSURE]) == approx(pressure_value)
-    assert state.attributes[ATTR_WEATHER_PRESSURE_UNIT] == PRESSURE_HPA
+    assert state.attributes[ATTR_WEATHER_PRESSURE_UNIT] == PRESSURE_PA
     assert float(state.attributes[ATTR_WEATHER_VISIBILITY]) == approx(visibility_value)
     assert state.attributes[ATTR_WEATHER_VISIBILITY_UNIT] == LENGTH_KILOMETERS
     assert float(forecast[ATTR_FORECAST_PRECIPITATION]) == approx(

--- a/tests/testing_config/custom_components/test/weather.py
+++ b/tests/testing_config/custom_components/test/weather.py
@@ -108,6 +108,80 @@ class MockWeather(MockEntity, WeatherEntity):
         return self._handle("condition")
 
 
+class MockWeatherCompat(MockEntity, WeatherEntity):
+    """Mock weather class for backwards compatibility check."""
+
+    @property
+    def temperature(self) -> float | None:
+        """Return the platform temperature."""
+        return self._handle("temperature")
+
+    @property
+    def temperature_unit(self) -> str | None:
+        """Return the unit of measurement for temperature."""
+        return self._handle("temperature_unit")
+
+    @property
+    def pressure(self) -> float | None:
+        """Return the pressure."""
+        return self._handle("pressure")
+
+    @property
+    def pressure_unit(self) -> str | None:
+        """Return the unit of measurement for pressure."""
+        return self._handle("pressure_unit")
+
+    @property
+    def humidity(self) -> float | None:
+        """Return the humidity."""
+        return self._handle("humidity")
+
+    @property
+    def wind_speed(self) -> float | None:
+        """Return the wind speed."""
+        return self._handle("wind_speed")
+
+    @property
+    def wind_speed_unit(self) -> str | None:
+        """Return the unit of measurement for wind speed."""
+        return self._handle("wind_speed_unit")
+
+    @property
+    def wind_bearing(self) -> float | str | None:
+        """Return the wind bearing."""
+        return self._handle("wind_bearing")
+
+    @property
+    def ozone(self) -> float | None:
+        """Return the ozone level."""
+        return self._handle("ozone")
+
+    @property
+    def visibility(self) -> float | None:
+        """Return the visibility."""
+        return self._handle("visibility")
+
+    @property
+    def visibility_unit(self) -> str | None:
+        """Return the unit of measurement for visibility."""
+        return self._handle("visibility_unit")
+
+    @property
+    def forecast(self) -> list[Forecast] | None:
+        """Return the forecast."""
+        return self._handle("forecast")
+
+    @property
+    def precipitation_unit(self) -> str | None:
+        """Return the unit of measurement for accumulated precipitation."""
+        return self._handle("precipitation_unit")
+
+    @property
+    def condition(self) -> str | None:
+        """Return the current condition."""
+        return self._handle("condition")
+
+
 class MockWeatherMockForecast(MockWeather):
     """Mock weather class with mocked forecast."""
 
@@ -122,5 +196,23 @@ class MockWeatherMockForecast(MockWeather):
                 ATTR_FORECAST_WIND_SPEED: self.native_wind_speed,
                 ATTR_FORECAST_WIND_BEARING: self.wind_bearing,
                 ATTR_FORECAST_PRECIPITATION: self._values.get("native_precipitation"),
+            }
+        ]
+
+
+class MockWeatherMockForecastCompat(MockWeatherCompat):
+    """Mock weather class with mocked forecast for compatibility check."""
+
+    @property
+    def forecast(self) -> list[Forecast] | None:
+        """Return the forecast."""
+        return [
+            {
+                ATTR_FORECAST_TEMP: self.native_temperature,
+                ATTR_FORECAST_TEMP_LOW: self.native_temperature,
+                ATTR_FORECAST_PRESSURE: self.native_pressure,
+                ATTR_FORECAST_WIND_SPEED: self.native_wind_speed,
+                ATTR_FORECAST_WIND_BEARING: self.wind_bearing,
+                ATTR_FORECAST_PRECIPITATION: self._values.get("precipitation"),
             }
         ]

--- a/tests/testing_config/custom_components/test/weather.py
+++ b/tests/testing_config/custom_components/test/weather.py
@@ -98,11 +98,6 @@ class MockWeather(MockEntity, WeatherEntity):
         return self._handle("forecast")
 
     @property
-    def native_precipitation(self) -> float | None:
-        """Return the accumulated precipitation."""
-        return self._handle("native_precipitation")
-
-    @property
     def native_precipitation_unit(self) -> str | None:
         """Return the native unit of measurement for accumulated precipitation."""
         return self._handle("native_precipitation_unit")
@@ -126,6 +121,6 @@ class MockWeatherMockForecast(MockWeather):
                 ATTR_FORECAST_PRESSURE: self.native_pressure,
                 ATTR_FORECAST_WIND_SPEED: self.native_wind_speed,
                 ATTR_FORECAST_WIND_BEARING: self.wind_bearing,
-                ATTR_FORECAST_PRECIPITATION: self.native_precipitation,
+                ATTR_FORECAST_PRECIPITATION: self._values.get("native_precipitation"),
             }
         ]

--- a/tests/testing_config/custom_components/test/weather.py
+++ b/tests/testing_config/custom_components/test/weather.py
@@ -6,6 +6,11 @@ Call init before using it in your tests to ensure clean test data.
 from __future__ import annotations
 
 from homeassistant.components.weather import (
+    ATTR_FORECAST_NATIVE_PRECIPITATION,
+    ATTR_FORECAST_NATIVE_PRESSURE,
+    ATTR_FORECAST_NATIVE_TEMP,
+    ATTR_FORECAST_NATIVE_TEMP_LOW,
+    ATTR_FORECAST_NATIVE_WIND_SPEED,
     ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_PRESSURE,
     ATTR_FORECAST_TEMP,
@@ -190,12 +195,14 @@ class MockWeatherMockForecast(MockWeather):
         """Return the forecast."""
         return [
             {
-                ATTR_FORECAST_TEMP: self.native_temperature,
-                ATTR_FORECAST_TEMP_LOW: self.native_temperature,
-                ATTR_FORECAST_PRESSURE: self.native_pressure,
-                ATTR_FORECAST_WIND_SPEED: self.native_wind_speed,
+                ATTR_FORECAST_NATIVE_TEMP: self.native_temperature,
+                ATTR_FORECAST_NATIVE_TEMP_LOW: self.native_temperature,
+                ATTR_FORECAST_NATIVE_PRESSURE: self.native_pressure,
+                ATTR_FORECAST_NATIVE_WIND_SPEED: self.native_wind_speed,
                 ATTR_FORECAST_WIND_BEARING: self.wind_bearing,
-                ATTR_FORECAST_PRECIPITATION: self._values.get("native_precipitation"),
+                ATTR_FORECAST_NATIVE_PRECIPITATION: self._values.get(
+                    "native_precipitation"
+                ),
             }
         ]
 

--- a/tests/testing_config/custom_components/test/weather.py
+++ b/tests/testing_config/custom_components/test/weather.py
@@ -208,10 +208,10 @@ class MockWeatherMockForecastCompat(MockWeatherCompat):
         """Return the forecast."""
         return [
             {
-                ATTR_FORECAST_TEMP: self.native_temperature,
-                ATTR_FORECAST_TEMP_LOW: self.native_temperature,
-                ATTR_FORECAST_PRESSURE: self.native_pressure,
-                ATTR_FORECAST_WIND_SPEED: self.native_wind_speed,
+                ATTR_FORECAST_TEMP: self.temperature,
+                ATTR_FORECAST_TEMP_LOW: self.temperature,
+                ATTR_FORECAST_PRESSURE: self.pressure,
+                ATTR_FORECAST_WIND_SPEED: self.wind_speed,
                 ATTR_FORECAST_WIND_BEARING: self.wind_bearing,
                 ATTR_FORECAST_PRECIPITATION: self._values.get("precipitation"),
             }

--- a/tests/testing_config/custom_components/test/weather.py
+++ b/tests/testing_config/custom_components/test/weather.py
@@ -38,24 +38,24 @@ class MockWeather(MockEntity, WeatherEntity):
     """Mock weather class."""
 
     @property
-    def temperature(self) -> float | None:
+    def native_temperature(self) -> float | None:
         """Return the platform temperature."""
-        return self._handle("temperature")
+        return self._handle("native_temperature")
 
     @property
-    def temperature_unit(self) -> str | None:
+    def native_temperature_unit(self) -> str | None:
         """Return the unit of measurement for temperature."""
-        return self._handle("temperature_unit")
+        return self._handle("native_temperature_unit")
 
     @property
-    def pressure(self) -> float | None:
+    def native_pressure(self) -> float | None:
         """Return the pressure."""
-        return self._handle("pressure")
+        return self._handle("native_pressure")
 
     @property
-    def pressure_unit(self) -> str | None:
+    def native_pressure_unit(self) -> str | None:
         """Return the unit of measurement for pressure."""
-        return self._handle("pressure_unit")
+        return self._handle("native_pressure_unit")
 
     @property
     def humidity(self) -> float | None:
@@ -63,14 +63,14 @@ class MockWeather(MockEntity, WeatherEntity):
         return self._handle("humidity")
 
     @property
-    def wind_speed(self) -> float | None:
+    def native_wind_speed(self) -> float | None:
         """Return the wind speed."""
-        return self._handle("wind_speed")
+        return self._handle("native_wind_speed")
 
     @property
-    def wind_speed_unit(self) -> str | None:
+    def native_wind_speed_unit(self) -> str | None:
         """Return the unit of measurement for wind speed."""
-        return self._handle("wind_speed_unit")
+        return self._handle("native_wind_speed_unit")
 
     @property
     def wind_bearing(self) -> float | str | None:
@@ -83,14 +83,14 @@ class MockWeather(MockEntity, WeatherEntity):
         return self._handle("ozone")
 
     @property
-    def visibility(self) -> float | None:
+    def native_visibility(self) -> float | None:
         """Return the visibility."""
-        return self._handle("visibility")
+        return self._handle("native_visibility")
 
     @property
-    def visibility_unit(self) -> str | None:
+    def native_visibility_unit(self) -> str | None:
         """Return the unit of measurement for visibility."""
-        return self._handle("visibility_unit")
+        return self._handle("native_visibility_unit")
 
     @property
     def forecast(self) -> list[Forecast] | None:
@@ -98,9 +98,14 @@ class MockWeather(MockEntity, WeatherEntity):
         return self._handle("forecast")
 
     @property
-    def precipitation_unit(self) -> str | None:
+    def native_precipitation(self) -> float | None:
+        """Return the accumulated precipitation."""
+        return self._handle("native_precipitation")
+
+    @property
+    def native_precipitation_unit(self) -> str | None:
         """Return the native unit of measurement for accumulated precipitation."""
-        return self._handle("precipitation_unit")
+        return self._handle("native_precipitation_unit")
 
     @property
     def condition(self) -> str | None:
@@ -116,11 +121,11 @@ class MockWeatherMockForecast(MockWeather):
         """Return the forecast."""
         return [
             {
-                ATTR_FORECAST_TEMP: self.temperature,
-                ATTR_FORECAST_TEMP_LOW: self.temperature,
-                ATTR_FORECAST_PRESSURE: self.pressure,
-                ATTR_FORECAST_WIND_SPEED: self.wind_speed,
+                ATTR_FORECAST_TEMP: self.native_temperature,
+                ATTR_FORECAST_TEMP_LOW: self.native_temperature,
+                ATTR_FORECAST_PRESSURE: self.native_pressure,
+                ATTR_FORECAST_WIND_SPEED: self.native_wind_speed,
                 ATTR_FORECAST_WIND_BEARING: self.wind_bearing,
-                ATTR_FORECAST_PRECIPITATION: self._values.get("precipitation"),
+                ATTR_FORECAST_PRECIPITATION: self.native_precipitation,
             }
         ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously the units for Weather had not been corresponding correctly with the documentation.
These units are now aligned for pressure and wind speed:
- If unit system is metric, default pressure unit is hPa and the default wind speed unit is km/h
- If unit system is imperial, default pressure unit is inHg and the default wind speed unit is mi/h

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR provides the necessary support for core to handle setting the unit of measure via options from frontend.
It is fully backwards compatible so integrations using the non-native attributes or properties will continue to work so they can be changed one by one to support the native attributes and native unit of measurements.

The PR also aligns default units for pressure and wind speed with the documentation:
- If unit system is metric, default pressure unit is hPa and the default wind speed unit is km/h
- If unit system is imperial, default pressure unit is inHg and the default wind speed unit is mi/h

References:
Architectural discussion: https://github.com/home-assistant/architecture/discussions/772
Frontend PR: https://github.com/home-assistant/frontend/pull/12947
Developers PR: https://github.com/home-assistant/developers.home-assistant/pull/1370

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
