### PR TITLE
Handle failures during initial Sonos subscription

### DIFF
--- a/homeassistant/components/sonos/exception.py
+++ b/homeassistant/components/sonos/exception.py
@@ -7,6 +7,10 @@ class UnknownMediaType(BrowseError):
     """Unknown media type."""
 
 
+class SonosSubscriptionsFailed(HomeAssistantError):
+    """Subscription creation failed."""
+
+
 class SonosUpdateError(HomeAssistantError):
     """Update failed."""
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -57,7 +57,7 @@ from .const import (
     SONOS_VANISHED,
     SUBSCRIPTION_TIMEOUT,
 )
-from .exception import S1BatteryMissing, SonosUpdateError
+from .exception import S1BatteryMissing, SonosSubscriptionsFailed, SonosUpdateError
 from .favorites import SonosFavorites
 from .helpers import soco_error
 from .media import SonosMedia
@@ -321,7 +321,12 @@ class SonosSpeaker:
         async with self._subscription_lock:
             if self._subscriptions:
                 return
-            await self._async_subscribe()
+            try:
+                await self._async_subscribe()
+            except SonosSubscriptionsFailed:
+                _LOGGER.warning("Creating subscriptions failed for %s", self.zone_name)
+                await self._async_offline()
+                await self.async_unsubscribe()
 
     async def _async_subscribe(self) -> None:
         """Create event subscriptions."""
@@ -338,9 +343,7 @@ class SonosSpeaker:
             )
 
         if any(isinstance(result, Exception) for result in results):
-            _LOGGER.warning("Subscriptions to %s failed", self.zone_name)
-            await self.async_offline()
-            return
+            raise SonosSubscriptionsFailed
 
         # Create a polling task in case subscriptions fail or callback events do not arrive
         if not self._poll_timer:
@@ -580,6 +583,12 @@ class SonosSpeaker:
 
     async def async_offline(self) -> None:
         """Handle removal of speaker when unavailable."""
+        async with self._subscription_lock:
+            await self._async_offline()
+            await self.async_unsubscribe()
+
+    async def _async_offline(self) -> None:
+        """Handle removal of speaker when unavailable."""
         if not self.available:
             return
 
@@ -595,9 +604,6 @@ class SonosSpeaker:
         if self._poll_timer:
             self._poll_timer()
             self._poll_timer = None
-
-        async with self._subscription_lock:
-            await self.async_unsubscribe()
 
         self.hass.data[DATA_SONOS].discovery_known.discard(self.soco.uid)
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -326,7 +326,6 @@ class SonosSpeaker:
             except SonosSubscriptionsFailed:
                 _LOGGER.warning("Creating subscriptions failed for %s", self.zone_name)
                 await self._async_offline()
-                await self.async_unsubscribe()
 
     async def _async_subscribe(self) -> None:
         """Create event subscriptions."""
@@ -585,7 +584,6 @@ class SonosSpeaker:
         """Handle removal of speaker when unavailable."""
         async with self._subscription_lock:
             await self._async_offline()
-            await self.async_unsubscribe()
 
     async def _async_offline(self) -> None:
         """Handle removal of speaker when unavailable."""
@@ -604,6 +602,8 @@ class SonosSpeaker:
         if self._poll_timer:
             self._poll_timer()
             self._poll_timer = None
+
+        await self.async_unsubscribe()
 
         self.hass.data[DATA_SONOS].discovery_known.discard(self.soco.uid)
 

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -29,3 +29,21 @@ async def test_fallback_to_polling(
     assert speaker.subscriptions_failed
     assert "falling back to polling" in caplog.text
     assert "Activity on Zone A from SonosSpeaker.update_volume" in caplog.text
+
+
+async def test_subscription_creation_fails(hass: HomeAssistant, async_setup_sonos):
+    """Test that subscription creation failures are handled."""
+    with patch(
+        "homeassistant.components.sonos.speaker.SonosSpeaker._subscribe",
+        side_effect=ConnectionError("Took too long"),
+    ):
+        await async_setup_sonos()
+
+    speaker = list(hass.data[DATA_SONOS].discovered.values())[0]
+    assert not speaker._subscriptions
+
+    with patch.object(speaker, "_resub_cooldown_expires_at", None):
+        speaker.speaker_activity("discovery")
+        await hass.async_block_till_done()
+
+    assert speaker._subscriptions


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While researching #66717, I ran into a single instance where I was able to reproduce the problem. This happened when a battery-powered speaker was repeatedly sleeping while in an area with flaky wifi reception. There was a race between creating the subscriptions (10s timeout) and the poll timer checking to see if a subscription had arrived (10s interval).

This adjusts the subscription logic for discovered Sonos devices to:
1. Mark the speaker offline if the subscription request fails. The subscription callbacks do not need to arrive, but a subscription request should never fail unless the device is unreachable for some reason (sleeping, bad network, etc).
2. Wait to create the polling timer until after the subscription requests succeed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66717
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
