### PR TITLE
Update UniFi Protect to use MAC address for unique ID

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -128,5 +128,5 @@ async def async_remove_config_entry_device(
     assert api is not None
     return api.bootstrap.nvr.mac not in unifi_macs and not any(
         device.mac in unifi_macs
-        for device in async_get_devices(api, DEVICES_THAT_ADOPT)
+        for device in async_get_devices(api.bootstrap, DEVICES_THAT_ADOPT)
     )

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -110,10 +110,10 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
         super().__init__(data, camera)
 
         if self._secure:
-            self._attr_unique_id = f"{self.device.id}_{self.channel.id}"
+            self._attr_unique_id = f"{self.device.mac}_{self.channel.id}"
             self._attr_name = f"{self.device.name} {self.channel.name}"
         else:
-            self._attr_unique_id = f"{self.device.id}_{self.channel.id}_insecure"
+            self._attr_unique_id = f"{self.device.mac}_{self.channel.id}_insecure"
             self._attr_name = f"{self.device.name} {self.channel.name} Insecure"
         # only the default (first) channel is enabled by default
         self._attr_entity_registry_enabled_default = is_default and secure

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -21,7 +21,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import CONF_DISABLE_RTSP, DEVICES_THAT_ADOPT, DEVICES_WITH_ENTITIES, DOMAIN
-from .utils import async_get_adoptable_devices_by_type, async_get_devices
+from .utils import async_get_devices, async_get_devices_by_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,9 +70,7 @@ class ProtectData:
     ) -> Generator[ProtectAdoptableDeviceModel, None, None]:
         """Get all devices matching types."""
         for device_type in device_types:
-            yield from async_get_adoptable_devices_by_type(
-                self.api, device_type
-            ).values()
+            yield from async_get_devices_by_type(self.api, device_type).values()
 
     async def async_setup(self) -> None:
         """Subscribe and do the refresh."""

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -70,7 +70,9 @@ class ProtectData:
     ) -> Generator[ProtectAdoptableDeviceModel, None, None]:
         """Get all devices matching types."""
         for device_type in device_types:
-            yield from async_get_devices_by_type(self.api, device_type).values()
+            yield from async_get_devices_by_type(
+                self.api.bootstrap, device_type
+            ).values()
 
     async def async_setup(self) -> None:
         """Subscribe and do the refresh."""
@@ -151,7 +153,7 @@ class ProtectData:
             return
 
         self.async_signal_device_id_update(self.api.bootstrap.nvr.id)
-        for device in async_get_devices(self.api, DEVICES_THAT_ADOPT):
+        for device in async_get_devices(self.api.bootstrap, DEVICES_THAT_ADOPT):
             self.async_signal_device_id_update(device.id)
 
     @callback

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -154,7 +154,7 @@ class ProtectDeviceEntity(Entity):
         if self.data.last_update_success:
             assert self.device.model
             device = async_device_by_id(
-                self.data.api, self.device.id, device_type=self.device.model
+                self.data.api.bootstrap, self.device.id, device_type=self.device.model
             )
             assert device is not None
             self.device = device

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 from .const import ATTR_EVENT_SCORE, DEFAULT_ATTRIBUTION, DEFAULT_BRAND, DOMAIN
 from .data import ProtectData
 from .models import ProtectRequiredKeysMixin
-from .utils import async_get_adoptable_devices_by_type, get_nested_attr
+from .utils import async_device_by_id, get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,10 +153,11 @@ class ProtectDeviceEntity(Entity):
         """Update Entity object from Protect device."""
         if self.data.last_update_success:
             assert self.device.model
-            devices = async_get_adoptable_devices_by_type(
-                self.data.api, self.device.model
+            device = async_device_by_id(
+                self.data.api, self.device.id, device_type=self.device.model
             )
-            self.device = devices[self.device.id]
+            assert device is not None
+            self.device = device
 
         is_connected = (
             self.data.last_update_success and self.device.state == StateType.CONNECTED

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -117,11 +117,11 @@ class ProtectDeviceEntity(Entity):
         self.device = device
 
         if description is None:
-            self._attr_unique_id = f"{self.device.id}"
+            self._attr_unique_id = f"{self.device.mac}"
             self._attr_name = f"{self.device.name}"
         else:
             self.entity_description = description
-            self._attr_unique_id = f"{self.device.id}_{description.key}"
+            self._attr_unique_id = f"{self.device.mac}_{description.key}"
             name = description.name or ""
             self._attr_name = f"{self.device.name} {name.title()}"
 

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -34,7 +34,7 @@ async def async_migrate_data(
 
 
 async def async_get_bootstrap(protect: ProtectApiClient) -> Bootstrap:
-    """Get UniFi Protect bootstrap or raise apporiate HA error."""
+    """Get UniFi Protect bootstrap or raise appropriate HA error."""
 
     try:
         bootstrap = await protect.get_bootstrap()

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -5,7 +5,7 @@ import logging
 
 from aiohttp.client_exceptions import ServerDisconnectedError
 from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import Bootstrap
+from pyunifiprotect.data import NVR, Bootstrap, ProtectAdoptableDeviceModel
 from pyunifiprotect.exceptions import ClientError
 
 from homeassistant.config_entries import ConfigEntry
@@ -127,7 +127,11 @@ async def async_migrate_device_ids(
     count = 0
     for entity in to_migrate:
         parts = entity.unique_id.split("_")
-        device = async_device_by_id(bootstrap, parts[0])
+        if parts[0] == bootstrap.nvr.id:
+            device: NVR | ProtectAdoptableDeviceModel | None = bootstrap.nvr
+        else:
+            device = async_device_by_id(bootstrap, parts[0])
+
         if device is None:
             continue
 

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -7,7 +7,6 @@ from enum import Enum
 import socket
 from typing import Any
 
-from pyunifiprotect import ProtectApiClient
 from pyunifiprotect.data import (
     Bootstrap,
     ProtectAdoptableDeviceModel,
@@ -65,22 +64,19 @@ async def _async_resolve(hass: HomeAssistant, host: str) -> str | None:
 
 @callback
 def async_get_devices_by_type(
-    api_bootstrap: ProtectApiClient | Bootstrap, device_type: ModelType
+    bootstrap: Bootstrap, device_type: ModelType
 ) -> dict[str, ProtectAdoptableDeviceModel]:
     """Get devices by type."""
 
-    if isinstance(api_bootstrap, ProtectApiClient):
-        api_bootstrap = api_bootstrap.bootstrap
-
     devices: dict[str, ProtectAdoptableDeviceModel] = getattr(
-        api_bootstrap, f"{device_type.value}s"
+        bootstrap, f"{device_type.value}s"
     )
     return devices
 
 
 @callback
 def async_device_by_id(
-    api_bootstrap: ProtectApiClient | Bootstrap,
+    bootstrap: Bootstrap,
     device_id: str,
     device_type: ModelType | None = None,
 ) -> ProtectAdoptableDeviceModel | None:
@@ -92,7 +88,7 @@ def async_device_by_id(
 
     device = None
     for model in device_types:
-        device = async_get_devices_by_type(api_bootstrap, model).get(device_id)
+        device = async_get_devices_by_type(bootstrap, model).get(device_id)
         if device is not None:
             break
     return device
@@ -100,11 +96,11 @@ def async_device_by_id(
 
 @callback
 def async_get_devices(
-    api: ProtectApiClient, model_type: Iterable[ModelType]
+    bootstrap: Bootstrap, model_type: Iterable[ModelType]
 ) -> Generator[ProtectDeviceModel, None, None]:
     """Return all device by type."""
     return (
         device
         for device_type in model_type
-        for device in async_get_devices_by_type(api, device_type).values()
+        for device in async_get_devices_by_type(bootstrap, device_type).values()
     )

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -366,7 +366,6 @@ async def test_binary_sensor_setup_sensor_none(
 
         state = hass.states.get(entity_id)
         assert state
-        print(entity_id)
         assert state.state == expected[index]
         assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 

--- a/tests/components/unifiprotect/test_button.py
+++ b/tests/components/unifiprotect/test_button.py
@@ -46,7 +46,7 @@ async def test_reboot_button(
 
     mock_entry.api.reboot_device = AsyncMock()
 
-    unique_id = f"{chime.id}_reboot"
+    unique_id = f"{chime.mac}_reboot"
     entity_id = "button.test_chime_reboot_device"
 
     entity_registry = er.async_get(hass)
@@ -75,7 +75,7 @@ async def test_chime_button(
 
     mock_entry.api.play_speaker = AsyncMock()
 
-    unique_id = f"{chime.id}_play"
+    unique_id = f"{chime.mac}_play"
     entity_id = "button.test_chime_play_chime"
 
     entity_registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -38,6 +38,7 @@ from .conftest import (
     MockEntityFixture,
     assert_entity_counts,
     enable_entity,
+    regenerate_device_ids,
     time_changed,
 )
 
@@ -124,7 +125,7 @@ def validate_default_camera_entity(
     channel = camera_obj.channels[channel_id]
 
     entity_name = f"{camera_obj.name} {channel.name}"
-    unique_id = f"{camera_obj.id}_{channel.id}"
+    unique_id = f"{camera_obj.mac}_{channel.id}"
     entity_id = f"camera.{entity_name.replace(' ', '_').lower()}"
 
     entity_registry = er.async_get(hass)
@@ -146,7 +147,7 @@ def validate_rtsps_camera_entity(
     channel = camera_obj.channels[channel_id]
 
     entity_name = f"{camera_obj.name} {channel.name}"
-    unique_id = f"{camera_obj.id}_{channel.id}"
+    unique_id = f"{camera_obj.mac}_{channel.id}"
     entity_id = f"camera.{entity_name.replace(' ', '_').lower()}"
 
     entity_registry = er.async_get(hass)
@@ -168,7 +169,7 @@ def validate_rtsp_camera_entity(
     channel = camera_obj.channels[channel_id]
 
     entity_name = f"{camera_obj.name} {channel.name} Insecure"
-    unique_id = f"{camera_obj.id}_{channel.id}_insecure"
+    unique_id = f"{camera_obj.mac}_{channel.id}_insecure"
     entity_id = f"camera.{entity_name.replace(' ', '_').lower()}"
 
     entity_registry = er.async_get(hass)
@@ -251,12 +252,12 @@ async def test_basic_setup(
     camera_high_only.channels[1]._api = mock_entry.api
     camera_high_only.channels[2]._api = mock_entry.api
     camera_high_only.name = "Test Camera 1"
-    camera_high_only.id = "test_high"
     camera_high_only.channels[0].is_rtsp_enabled = True
     camera_high_only.channels[0].name = "High"
     camera_high_only.channels[0].rtsp_alias = "test_high_alias"
     camera_high_only.channels[1].is_rtsp_enabled = False
     camera_high_only.channels[2].is_rtsp_enabled = False
+    regenerate_device_ids(camera_high_only)
 
     camera_medium_only = mock_camera.copy(deep=True)
     camera_medium_only._api = mock_entry.api
@@ -264,12 +265,12 @@ async def test_basic_setup(
     camera_medium_only.channels[1]._api = mock_entry.api
     camera_medium_only.channels[2]._api = mock_entry.api
     camera_medium_only.name = "Test Camera 2"
-    camera_medium_only.id = "test_medium"
     camera_medium_only.channels[0].is_rtsp_enabled = False
     camera_medium_only.channels[1].is_rtsp_enabled = True
     camera_medium_only.channels[1].name = "Medium"
     camera_medium_only.channels[1].rtsp_alias = "test_medium_alias"
     camera_medium_only.channels[2].is_rtsp_enabled = False
+    regenerate_device_ids(camera_medium_only)
 
     camera_all_channels = mock_camera.copy(deep=True)
     camera_all_channels._api = mock_entry.api
@@ -277,7 +278,6 @@ async def test_basic_setup(
     camera_all_channels.channels[1]._api = mock_entry.api
     camera_all_channels.channels[2]._api = mock_entry.api
     camera_all_channels.name = "Test Camera 3"
-    camera_all_channels.id = "test_all"
     camera_all_channels.channels[0].is_rtsp_enabled = True
     camera_all_channels.channels[0].name = "High"
     camera_all_channels.channels[0].rtsp_alias = "test_high_alias"
@@ -287,6 +287,7 @@ async def test_basic_setup(
     camera_all_channels.channels[2].is_rtsp_enabled = True
     camera_all_channels.channels[2].name = "Low"
     camera_all_channels.channels[2].rtsp_alias = "test_low_alias"
+    regenerate_device_ids(camera_all_channels)
 
     camera_no_channels = mock_camera.copy(deep=True)
     camera_no_channels._api = mock_entry.api
@@ -294,11 +295,11 @@ async def test_basic_setup(
     camera_no_channels.channels[1]._api = mock_entry.api
     camera_no_channels.channels[2]._api = mock_entry.api
     camera_no_channels.name = "Test Camera 4"
-    camera_no_channels.id = "test_none"
     camera_no_channels.channels[0].is_rtsp_enabled = False
     camera_no_channels.channels[0].name = "High"
     camera_no_channels.channels[1].is_rtsp_enabled = False
     camera_no_channels.channels[2].is_rtsp_enabled = False
+    regenerate_device_ids(camera_no_channels)
 
     camera_package = mock_camera.copy(deep=True)
     camera_package._api = mock_entry.api
@@ -306,12 +307,12 @@ async def test_basic_setup(
     camera_package.channels[1]._api = mock_entry.api
     camera_package.channels[2]._api = mock_entry.api
     camera_package.name = "Test Camera 5"
-    camera_package.id = "test_package"
     camera_package.channels[0].is_rtsp_enabled = True
     camera_package.channels[0].name = "High"
     camera_package.channels[0].rtsp_alias = "test_high_alias"
     camera_package.channels[1].is_rtsp_enabled = False
     camera_package.channels[2].is_rtsp_enabled = False
+    regenerate_device_ids(camera_package)
     package_channel = camera_package.channels[0].copy(deep=True)
     package_channel.is_rtsp_enabled = False
     package_channel.name = "Package Camera"

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -4,7 +4,7 @@ from pyunifiprotect.data import NVR, Light
 
 from homeassistant.core import HomeAssistant
 
-from .conftest import MockEntityFixture
+from .conftest import MockEntityFixture, regenerate_device_ids
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
@@ -17,7 +17,7 @@ async def test_diagnostics(
     light1 = mock_light.copy()
     light1._api = mock_entry.api
     light1.name = "Test Light 1"
-    light1.id = "lightid1"
+    regenerate_device_ids(light1)
 
     mock_entry.api.bootstrap.lights = {
         light1.id: light1,

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import _patch_discovery
-from .conftest import MockBootstrap, MockEntityFixture
+from .conftest import MockBootstrap, MockEntityFixture, regenerate_device_ids
 
 from tests.common import MockConfigEntry
 
@@ -212,8 +212,7 @@ async def test_device_remove_devices(
     light1 = mock_light.copy()
     light1._api = mock_entry.api
     light1.name = "Test Light 1"
-    light1.id = "lightid1"
-    light1.mac = "AABBCCDDEEFF"
+    regenerate_device_ids(light1)
 
     mock_entry.api.bootstrap.lights = {
         light1.id: light1,

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -57,7 +57,7 @@ async def test_light_setup(
 ):
     """Test light entity setup."""
 
-    unique_id = light[0].id
+    unique_id = light[0].mac
     entity_id = light[1]
 
     entity_registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -60,7 +60,7 @@ async def test_lock_setup(
 ):
     """Test lock entity setup."""
 
-    unique_id = f"{doorlock[0].id}_lock"
+    unique_id = f"{doorlock[0].mac}_lock"
     entity_id = doorlock[1]
 
     entity_registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -66,7 +66,7 @@ async def test_media_player_setup(
 ):
     """Test media_player entity setup."""
 
-    unique_id = f"{camera[0].id}_speaker"
+    unique_id = f"{camera[0].mac}_speaker"
     entity_id = camera[1]
 
     entity_registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .conftest import MockEntityFixture
+from .conftest import MockEntityFixture, regenerate_device_ids
 
 
 @pytest.fixture(name="device")
@@ -165,22 +165,22 @@ async def test_set_chime_paired_doorbells(
     }
 
     camera1 = mock_camera.copy()
-    camera1.id = "cameraid1"
     camera1.name = "Test Camera 1"
     camera1._api = mock_entry.api
     camera1.channels[0]._api = mock_entry.api
     camera1.channels[1]._api = mock_entry.api
     camera1.channels[2]._api = mock_entry.api
     camera1.feature_flags.has_chime = True
+    regenerate_device_ids(camera1)
 
     camera2 = mock_camera.copy()
-    camera2.id = "cameraid2"
     camera2.name = "Test Camera 2"
     camera2._api = mock_entry.api
     camera2.channels[0]._api = mock_entry.api
     camera2.channels[1]._api = mock_entry.api
     camera2.channels[2]._api = mock_entry.api
     camera2.feature_flags.has_chime = True
+    regenerate_device_ids(camera2)
 
     mock_entry.api.bootstrap.cameras = {
         camera1.id: camera1,
@@ -210,5 +210,5 @@ async def test_set_chime_paired_doorbells(
     )
 
     mock_entry.api.update_device.assert_called_once_with(
-        ModelType.CHIME, mock_chime.id, {"cameraIds": [camera1.id, camera2.id]}
+        ModelType.CHIME, mock_chime.id, {"cameraIds": sorted([camera1.id, camera2.id])}
     )

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -238,7 +238,7 @@ async def test_switch_setup_light(
 
     description = LIGHT_SWITCHES[0]
 
-    unique_id = f"{light.id}_{description.key}"
+    unique_id = f"{light.mac}_{description.key}"
     entity_id = f"switch.test_light_{description.name.lower().replace(' ', '_')}"
 
     entity = entity_registry.async_get(entity_id)
@@ -282,7 +282,7 @@ async def test_switch_setup_camera_all(
     description_entity_name = (
         description.name.lower().replace(":", "").replace(" ", "_")
     )
-    unique_id = f"{camera.id}_{description.key}"
+    unique_id = f"{camera.mac}_{description.key}"
     entity_id = f"switch.test_camera_{description_entity_name}"
 
     entity = entity_registry.async_get(entity_id)
@@ -329,7 +329,7 @@ async def test_switch_setup_camera_none(
     description_entity_name = (
         description.name.lower().replace(":", "").replace(" ", "_")
     )
-    unique_id = f"{camera_none.id}_{description.key}"
+    unique_id = f"{camera_none.mac}_{description.key}"
     entity_id = f"switch.test_camera_{description_entity_name}"
 
     entity = entity_registry.async_get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate unique IDs from `{device_id}_{name}` format to `{mac}_{name}` format.

This makes devices persist better with in HA. Anything a device is unadopted/readopted or
the Protect instance has to rebuild the disk array, the device IDs of Protect devices
can change. This causes a ton of orphaned entities and loss of historical data. MAC
addresses are the one persistent identifier a device has that does not change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
