### PR TITLE
Add ability to run plugin on unannotated functions

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -595,10 +595,8 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
                 "default": True,
                 "type": "yn",
                 "metavar": "<y or n>",
-                "help": (
-                    "Set to ``no`` if you wish to check functions that do not ",
-                    "have any type hints.",
-                ),
+                "help": "Set to ``no`` if you wish to check functions that do not "
+                "have any type hints.",
             },
         ),
     )

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -12,6 +12,9 @@ from homeassistant.const import Platform
 
 UNDEFINED = object()
 
+# Keep default as True on CI, but adds ability to enable locally
+# when methods do not have any type hints
+_IGNORE_MISSING_ANNOTATIONS = True
 _PLATFORMS: set[str] = {platform.value for platform in Platform}
 
 
@@ -641,7 +644,11 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
     def _check_function(self, node: nodes.FunctionDef, match: TypeHintMatch) -> None:
         # Check that at least one argument is annotated.
         annotations = _get_all_annotations(node)
-        if node.returns is None and not _has_valid_annotations(annotations):
+        if (
+            _IGNORE_MISSING_ANNOTATIONS
+            and node.returns is None
+            and not _has_valid_annotations(annotations)
+        ):
             return
 
         # Check that all arguments are correctly annotated.

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -12,9 +12,6 @@ from homeassistant.const import Platform
 
 UNDEFINED = object()
 
-# Keep default as True on CI, but adds ability to enable locally
-# when methods do not have any type hints
-_IGNORE_MISSING_ANNOTATIONS = True
 _PLATFORMS: set[str] = {platform.value for platform in Platform}
 
 
@@ -591,7 +588,20 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
             "Used when method return type is incorrect",
         ),
     }
-    options = ()
+    options = (
+        (
+            "ignore-missing-annotations",
+            {
+                "default": True,
+                "type": "yn",
+                "metavar": "<y or n>",
+                "help": (
+                    "Set to ``no`` if you wish to check functions that do not ",
+                    "have any type hints.",
+                ),
+            },
+        ),
+    )
 
     def __init__(self, linter: PyLinter | None = None) -> None:
         super().__init__(linter)
@@ -645,7 +655,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         # Check that at least one argument is annotated.
         annotations = _get_all_annotations(node)
         if (
-            _IGNORE_MISSING_ANNOTATIONS
+            self.linter.config.ignore_missing_annotations
             and node.returns is None
             and not _has_valid_annotations(annotations)
         ):

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -116,7 +116,7 @@ def test_regex_a_or_b(
     """
     ],
 )
-def test_ignore_not_annotations(
+def test_ignore_no_annotations(
     hass_enforce_type_hints: ModuleType, type_hint_checker: BaseChecker, code: str
 ) -> None:
     """Ensure that _is_valid_type is not run if there are no annotations."""
@@ -131,6 +131,41 @@ def test_ignore_not_annotations(
     ) as is_valid_type:
         type_hint_checker.visit_asyncfunctiondef(func_node)
         is_valid_type.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        """
+    async def setup( #@
+        arg1, arg2
+    ):
+        pass
+    """
+    ],
+)
+def test_bypass_ignore_no_annotations(
+    hass_enforce_type_hints: ModuleType, type_hint_checker: BaseChecker, code: str
+) -> None:
+    """Test `ignore-missing-annotations` option.
+
+    Ensure that `_is_valid_type` is run if there are no annotations
+    but `ignore-missing-annotations` option is forced to False.
+    """
+    # Set bypass option
+    type_hint_checker.config.ignore_missing_annotations = False
+
+    func_node = astroid.extract_node(
+        code,
+        "homeassistant.components.pylint_test",
+    )
+    type_hint_checker.visit_module(func_node.parent)
+
+    with patch.object(
+        hass_enforce_type_hints, "_is_valid_type", return_value=True
+    ) as is_valid_type:
+        type_hint_checker.visit_asyncfunctiondef(func_node)
+        is_valid_type.assert_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When enforcing type hints, we decided to only enable it when the type hints are incorrect or partial. If the functions did not have any type hints, then they would be ignored.
See https://github.com/home-assistant/architecture/discussions/712#discussioncomment-1988745

This PR makes it easier to check locally for methods which do not have any type hints using:
`pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=no homeassistant`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
