### PR TITLE
Use IP address instead of hostname in Brother integration

### DIFF
--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -83,8 +83,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
-        # Hostname is format: brother.local.
-        self.host = discovery_info.hostname.rstrip(".")
+        self.host = discovery_info.host
 
         # Do not probe the device if the host is already configured
         self._async_abort_entries_match({CONF_HOST: self.host})
@@ -102,7 +101,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if already configured
         await self.async_set_unique_id(self.brother.serial.lower())
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
         self.context.update(
             {

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_TYPE
 
 from tests.common import MockConfigEntry, load_fixture
 
-CONFIG = {CONF_HOST: "localhost", CONF_TYPE: "laser"}
+CONFIG = {CONF_HOST: "127.0.0.1", CONF_TYPE: "laser"}
 
 
 async def test_show_form(hass):
@@ -32,13 +32,15 @@ async def test_create_entry_with_hostname(hass):
         return_value=json.loads(load_fixture("printer_data.json", "brother")),
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={CONF_HOST: "example.local", CONF_TYPE: "laser"},
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == "HL-L2340DW 0123456789"
-        assert result["data"][CONF_HOST] == CONFIG[CONF_HOST]
-        assert result["data"][CONF_TYPE] == CONFIG[CONF_TYPE]
+        assert result["data"][CONF_HOST] == "example.local"
+        assert result["data"][CONF_TYPE] == "laser"
 
 
 async def test_create_entry_with_ipv4_address(hass):
@@ -48,9 +50,7 @@ async def test_create_entry_with_ipv4_address(hass):
         return_value=json.loads(load_fixture("printer_data.json", "brother")),
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-            data={CONF_HOST: "127.0.0.1", CONF_TYPE: "laser"},
+            DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -145,7 +145,7 @@ async def test_zeroconf_snmp_error(hass):
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="mock_host",
+                host="127.0.0.1",
                 addresses=["mock_host"],
                 hostname="example.local.",
                 name="Brother Printer",
@@ -166,7 +166,7 @@ async def test_zeroconf_unsupported_model(hass):
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="mock_host",
+                host="127.0.0.1",
                 addresses=["mock_host"],
                 hostname="example.local.",
                 name="Brother Printer",
@@ -187,15 +187,18 @@ async def test_zeroconf_device_exists_abort(hass):
         "brother.Brother._get_data",
         return_value=json.loads(load_fixture("printer_data.json", "brother")),
     ):
-        MockConfigEntry(domain=DOMAIN, unique_id="0123456789", data=CONFIG).add_to_hass(
-            hass
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="0123456789",
+            data={CONF_HOST: "example.local", CONF_TYPE: "laser"},
         )
+        entry.add_to_hass(hass)
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="mock_host",
+                host="127.0.0.1",
                 addresses=["mock_host"],
                 hostname="example.local.",
                 name="Brother Printer",
@@ -208,6 +211,9 @@ async def test_zeroconf_device_exists_abort(hass):
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
 
+    # Test config entry got updated with latest IP
+    assert entry.data["host"] == "127.0.0.1"
+
 
 async def test_zeroconf_no_probe_existing_device(hass):
     """Test we do not probe the device is the host is already configured."""
@@ -218,9 +224,9 @@ async def test_zeroconf_no_probe_existing_device(hass):
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="mock_host",
+                host="127.0.0.1",
                 addresses=["mock_host"],
-                hostname="localhost",
+                hostname="example.local.",
                 name="Brother Printer",
                 port=None,
                 properties={},
@@ -245,7 +251,7 @@ async def test_zeroconf_confirm_create_entry(hass):
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
             data=zeroconf.ZeroconfServiceInfo(
-                host="mock_host",
+                host="127.0.0.1",
                 addresses=["mock_host"],
                 hostname="example.local.",
                 name="Brother Printer",
@@ -266,5 +272,5 @@ async def test_zeroconf_confirm_create_entry(hass):
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == "HL-L2340DW 0123456789"
-        assert result["data"][CONF_HOST] == "example.local"
+        assert result["data"][CONF_HOST] == "127.0.0.1"
         assert result["data"][CONF_TYPE] == "laser"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The integration sometimes loses connection with the printer if the mDNS hostname `brother.local` (from zeroconf) is used. This PR changes the approach so the IP address is used instead of the hostname.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #72452 #70307 #67044
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
