### PR TITLE
Implement a cooldown period for config entry reloads

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1031,6 +1031,9 @@ class ConfigEntries:
             entry.state != ConfigEntryState.NOT_LOADED
             and not await support_entry_unload(self.hass, entry.domain)
         ):
+            # If its already loaded and it doesn't support
+            # unloads let async_unload take care of handling
+            # this situation
             return await self.async_unload(entry_id)
 
         ratelimit = self._reload_ratelimit

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -467,10 +467,9 @@ class ConfigEntry:
                 return True
 
         component = integration.get_component()
+        self._async_set_supported(component)
 
         if integration.domain == self.domain:
-            self._async_set_supported(component)
-
             if not self.state.recoverable:
                 return False
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1027,8 +1027,12 @@ class ConfigEntries:
             raise UnknownEntry
         if not entry.state.recoverable:
             raise OperationNotAllowed
-        if not entry.supports_unload:
-            return entry.state == ConfigEntryState.NOT_LOADED
+        if (
+            entry.state != ConfigEntryState.NOT_LOADED
+            and not await support_entry_unload(self.hass, entry.domain)
+        ):
+            entry.state = ConfigEntryState.FAILED_UNLOAD
+            return False
 
         ratelimit = self._reload_ratelimit
         now = dt_util.utcnow()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -144,8 +144,7 @@ class ConfigEntryDisabler(StrEnum):
 # DISABLED_* is deprecated, to be removed in 2022.3
 DISABLED_USER = ConfigEntryDisabler.USER.value
 
-RELOAD_AFTER_UPDATE_DELAY = 30
-RELOAD_COOLDOWN = timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY)
+RELOAD_COOLDOWN = timedelta(seconds=30)
 
 # Deprecated: Connection classes
 # These aren't used anymore since 2021.6.0

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1041,7 +1041,7 @@ class ConfigEntries:
                 entry_id,
                 rate_limit_expire_time,
             )
-            return not entry.disabled_by
+            return entry.state.recoverable and not entry.disabled_by
 
         ratelimit.async_triggered(entry_id, now)
         return await self._async_reload(entry_id)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -467,6 +467,11 @@ class ConfigEntry:
                 return True
 
         component = integration.get_component()
+
+        # Tests that rely on calling hass.config_entries.async_forward_entry_unload
+        # need this to be called. If we are able to refactor these away in the future,
+        # we can move self._async_set_supported(component) into the if block
+        # of integration.domain == self.domain
         self._async_set_supported(component)
 
         if integration.domain == self.domain:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -144,7 +144,8 @@ class ConfigEntryDisabler(StrEnum):
 # DISABLED_* is deprecated, to be removed in 2022.3
 DISABLED_USER = ConfigEntryDisabler.USER.value
 
-RELOAD_COOLDOWN = timedelta(seconds=30)
+RELOAD_AFTER_UPDATE_DELAY = 30
+RELOAD_COOLDOWN = timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY)
 
 # Deprecated: Connection classes
 # These aren't used anymore since 2021.6.0

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1031,8 +1031,7 @@ class ConfigEntries:
             entry.state != ConfigEntryState.NOT_LOADED
             and not await support_entry_unload(self.hass, entry.domain)
         ):
-            entry.state = ConfigEntryState.FAILED_UNLOAD
-            return False
+            return await self.async_unload(entry_id)
 
         ratelimit = self._reload_ratelimit
         now = dt_util.utcnow()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from enum import Enum
 import functools
 import logging
-from types import MappingProxyType, MethodType
+from types import MappingProxyType, MethodType, ModuleType
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 import weakref
 
@@ -285,6 +285,13 @@ class ConfigEntry:
         # Hold list for functions to call on unload.
         self._on_unload: list[CALLBACK_TYPE] | None = None
 
+    @callback
+    def _async_set_supported(self, component: ModuleType) -> None:
+        self.supports_unload = hasattr(component, "async_unload_entry")
+        self.supports_remove_device = hasattr(
+            component, "async_remove_config_entry_device"
+        )
+
     async def async_setup(
         self,
         hass: HomeAssistant,
@@ -319,11 +326,7 @@ class ConfigEntry:
             return
 
         if self.domain == integration.domain:
-            self.supports_unload = hasattr(component, "async_unload_entry")
-            self.supports_remove_device = hasattr(
-                component, "async_remove_config_entry_device"
-            )
-
+            self._async_set_supported(component)
             try:
                 integration.get_platform("config_flow")
             except ImportError as err:
@@ -466,6 +469,8 @@ class ConfigEntry:
         component = integration.get_component()
 
         if integration.domain == self.domain:
+            self._async_set_supported(component)
+
             if not self.state.recoverable:
                 return False
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1031,7 +1031,8 @@ class ConfigEntries:
 
         @callback
         def _async_future_reload() -> None:
-            asyncio.create_task(self._async_reload(entry_id))
+            _LOGGER.debug("Trigging deferred reload of %s", entry_id)
+            self.hass.async_create_task(self._async_reload(entry_id))
 
         if rate_limit_expire_time := ratelimit.async_schedule_action(
             entry_id, RELOAD_COOLDOWN, now, _async_future_reload
@@ -1048,6 +1049,7 @@ class ConfigEntries:
 
     async def _async_reload(self, entry_id: str) -> bool:
         """Reload the entry."""
+        _LOGGER.debug("_async_reload running for %s", entry_id)
         if (entry := self.async_get_entry(entry_id)) is None:
             raise UnknownEntry
 
@@ -1056,7 +1058,11 @@ class ConfigEntries:
         if not unload_result or entry.disabled_by:
             return unload_result
 
-        return await self.async_setup(entry_id)
+        result = await self.async_setup(entry_id)
+        _LOGGER.debug(
+            "_async_reload completed for %s with result: %s", entry_id, result
+        )
+        return result
 
     async def async_set_disabled_by(
         self, entry_id: str, disabled_by: ConfigEntryDisabler | None

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1027,12 +1027,13 @@ class ConfigEntries:
         if (entry := self.async_get_entry(entry_id)) is None:
             raise UnknownEntry
 
+        ratelimit = self._reload_ratelimit
         async with entry.reload_lock:
             now = dt_util.utcnow()
-            if not self._reload_ratelimit.async_schedule_action(
+            if not ratelimit.async_schedule_action(
                 entry_id, RELOAD_COOLDOWN, now, self._async_reload, entry_id
             ):
-                self._reload_ratelimit.async_triggered(entry, now)
+                ratelimit.async_triggered(entry, now)
                 return await self._async_reload(entry_id)
 
             _LOGGER.debug(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1022,7 +1022,6 @@ class ConfigEntries:
         """
         if (entry := self.async_get_entry(entry_id)) is None:
             raise UnknownEntry
-
         if not entry.state.recoverable:
             raise OperationNotAllowed
 
@@ -1042,7 +1041,7 @@ class ConfigEntries:
                 entry_id,
                 rate_limit_expire_time,
             )
-            return entry.state.recoverable and not entry.disabled_by
+            return not entry.disabled_by
 
         ratelimit.async_triggered(entry_id, now)
         return await self._async_reload(entry_id)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1032,6 +1032,7 @@ class ConfigEntries:
             if not self._reload_ratelimit.async_schedule_action(
                 entry_id, RELOAD_COOLDOWN, now, self._async_reload, entry_id
             ):
+                self._reload_ratelimit.async_triggered(entry, now)
                 return await self._async_reload(entry_id)
 
             _LOGGER.debug(

--- a/tests/common.py
+++ b/tests/common.py
@@ -407,6 +407,19 @@ def async_fire_time_changed(
 fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)
 
 
+async def async_fire_reload_cooldown(hass: HomeAssistant) -> None:
+    """Simulate the reload cooldown."""
+    config_entries = hass.config_entries
+    for entry in config_entries.async_entries():
+        for timer in config_entries._reload_ratelimit._rate_limit_timers.values():
+            if timer.cancelled():
+                continue
+            timer._run()
+            timer.cancel()
+        config_entries._reload_ratelimit.async_cancel_timer(entry.entry_id)
+    await hass.async_block_till_done()
+
+
 def get_fixture_path(filename: str, integration: str | None = None) -> pathlib.Path:
     """Get path of fixture."""
     if integration is None and "/" in filename and not filename.startswith("helpers/"):

--- a/tests/common.py
+++ b/tests/common.py
@@ -409,7 +409,11 @@ fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)
 
 async def async_fire_reload_cooldown(hass: HomeAssistant) -> None:
     """Simulate the reload cooldown."""
+    # Make sure any events that generate a reload
+    # have finished
     await hass.async_block_till_done()
+
+    # Now fire any pending reloads
     config_entries = hass.config_entries
     for entry in config_entries.async_entries():
         for timer in config_entries._reload_ratelimit._rate_limit_timers.values():
@@ -418,6 +422,8 @@ async def async_fire_reload_cooldown(hass: HomeAssistant) -> None:
             timer._run()
             timer.cancel()
         config_entries._reload_ratelimit.async_cancel_timer(entry.entry_id)
+
+    # Wait for the reloads to finish
     await hass.async_block_till_done()
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -407,7 +407,7 @@ def async_fire_time_changed(
 fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)
 
 
-async def async_fire_reload_cooldown(hass: HomeAssistant) -> None:
+async def async_fire_deferred_config_entry_reloads(hass: HomeAssistant) -> None:
     """Simulate the reload cooldown."""
     # Make sure any events that generate a reload
     # have finished

--- a/tests/common.py
+++ b/tests/common.py
@@ -409,6 +409,7 @@ fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)
 
 async def async_fire_reload_cooldown(hass: HomeAssistant) -> None:
     """Simulate the reload cooldown."""
+    await hass.async_block_till_done()
     config_entries = hass.config_entries
     for entry in config_entries.async_entries():
         for timer in config_entries._reload_ratelimit._rate_limit_timers.values():

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -1,12 +1,9 @@
 """Test the Advantage Air Binary Sensor Platform."""
-from datetime import timedelta
 
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_reload_cooldown
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
     TEST_SET_URL,
@@ -81,11 +78,7 @@ async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
     registry.async_update_entity(entity_id=entity_id, disabled_by=None)
     await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
+    await async_fire_reload_cooldown(hass)
 
     state = hass.states.get(entity_id)
     assert state
@@ -103,11 +96,7 @@ async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
     registry.async_update_entity(entity_id=entity_id, disabled_by=None)
     await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
+    await async_fire_reload_cooldown(hass)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -3,7 +3,7 @@
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import async_fire_reload_cooldown
+from tests.common import async_fire_deferred_config_entry_reloads
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
     TEST_SET_URL,
@@ -78,7 +78,7 @@ async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
     registry.async_update_entity(entity_id=entity_id, disabled_by=None)
     await hass.async_block_till_done()
 
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
 
     state = hass.states.get(entity_id)
     assert state
@@ -96,7 +96,7 @@ async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
     registry.async_update_entity(entity_id=entity_id, disabled_by=None)
     await hass.async_block_till_done()
 
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.advantage_air.sensor import (
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import async_fire_reload_cooldown
+from tests.common import async_fire_deferred_config_entry_reloads
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
     TEST_SET_URL,
@@ -133,7 +133,7 @@ async def test_sensor_platform(hass, aioclient_mock):
     assert not hass.states.get(entity_id)
 
     registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -1,6 +1,5 @@
 """Test the Advantage Air Sensor Platform."""
 
-from datetime import timedelta
 from json import loads
 
 from homeassistant.components.advantage_air.const import DOMAIN as ADVANTAGE_AIR_DOMAIN
@@ -8,12 +7,10 @@ from homeassistant.components.advantage_air.sensor import (
     ADVANTAGE_AIR_SERVICE_SET_TIME_TO,
     ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
 )
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_reload_cooldown
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
     TEST_SET_URL,
@@ -136,13 +133,7 @@ async def test_sensor_platform(hass, aioclient_mock):
     assert not hass.states.get(entity_id)
 
     registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
+    await async_fire_reload_cooldown(hass)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -1,6 +1,5 @@
 """deCONZ sensor platform tests."""
 
-from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -11,15 +10,13 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.util import dt
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_deferred_config_entry_reloads
 
 
 async def test_no_sensors(hass, aioclient_mock):
@@ -619,13 +616,7 @@ async def test_sensors(
     # Enable in entity registry
     if expected.get("enable_entity"):
         ent_reg.async_update_entity(entity_id=expected["entity_id"], disabled_by=None)
-        await hass.async_block_till_done()
-
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await hass.async_block_till_done()
+        await async_fire_deferred_config_entry_reloads(hass)
 
     assert len(hass.states.async_all()) == expected["entity_count"]
 

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -24,9 +24,18 @@ from flux_led.protocol import (
 from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant.components import dhcp
-from homeassistant.components.flux_led.const import DOMAIN
+from homeassistant.components.flux_led.const import (
+    CONF_MINOR_VERSION,
+    CONF_MODEL_DESCRIPTION,
+    CONF_MODEL_INFO,
+    CONF_MODEL_NUM,
+    CONF_REMOTE_ACCESS_ENABLED,
+    CONF_REMOTE_ACCESS_HOST,
+    CONF_REMOTE_ACCESS_PORT,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -75,6 +84,19 @@ FLUX_DISCOVERY = FluxLEDDiscovery(
     remote_access_host="the.cloud",
     remote_access_port=8816,
 )
+
+DEFAULT_ENTRY_DATA = {
+    CONF_MINOR_VERSION: 4,
+    CONF_HOST: IP_ADDRESS,
+    CONF_MODEL: MODEL,
+    CONF_MODEL_NUM: MODEL_NUM,
+    CONF_MODEL_INFO: MODEL,
+    CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
+    CONF_REMOTE_ACCESS_ENABLED: True,
+    CONF_REMOTE_ACCESS_HOST: "the.cloud",
+    CONF_REMOTE_ACCESS_PORT: 8816,
+    CONF_MINOR_VERSION: 0x04,
+}
 
 
 def _mock_config_entry_for_bulb(hass: HomeAssistant) -> ConfigEntry:

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -29,6 +29,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from . import (
+    DEFAULT_ENTRY_DATA,
     DEFAULT_ENTRY_TITLE,
     DHCP_DISCOVERY,
     FLUX_DISCOVERY,
@@ -357,13 +358,9 @@ async def test_entry_is_reloaded_when_title_changes(hass: HomeAssistant) -> None
     """Test the entry gets reloaded when the title changes."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={
-            CONF_REMOTE_ACCESS_HOST: "any",
-            CONF_REMOTE_ACCESS_ENABLED: True,
-            CONF_REMOTE_ACCESS_PORT: 1234,
-            CONF_HOST: IP_ADDRESS,
-        },
+        data=DEFAULT_ENTRY_DATA,
         title=DEFAULT_ENTRY_TITLE,
+        unique_id=MAC_ADDRESS,
     )
     config_entry.add_to_hass(hass)
     with _patch_discovery(), _patch_wifibulb():

--- a/tests/components/flux_led/test_select.py
+++ b/tests/components/flux_led/test_select.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import (
+    DEFAULT_ENTRY_DATA,
     DEFAULT_ENTRY_TITLE,
     FLUX_DISCOVERY,
     IP_ADDRESS,
@@ -113,7 +114,7 @@ async def test_select_addressable_strip_config(hass: HomeAssistant) -> None:
     """Test selecting addressable strip configs."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        data=DEFAULT_ENTRY_DATA,
         unique_id=MAC_ADDRESS,
     )
     config_entry.add_to_hass(hass)
@@ -123,11 +124,11 @@ async def test_select_addressable_strip_config(hass: HomeAssistant) -> None:
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    wiring_entity_id = "select.bulb_rgbcw_ddeeff_wiring"
+    wiring_entity_id = "select.mock_title_wiring"
     state = hass.states.get(wiring_entity_id)
     assert state.state == "BGRW"
 
-    ic_type_entity_id = "select.bulb_rgbcw_ddeeff_ic_type"
+    ic_type_entity_id = "select.mock_title_ic_type"
     state = hass.states.get(ic_type_entity_id)
     assert state.state == "WS2812B"
 
@@ -173,7 +174,7 @@ async def test_select_mutable_0x25_strip_config(hass: HomeAssistant) -> None:
     """Test selecting mutable 0x25 strip configs."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        data=DEFAULT_ENTRY_DATA,
         unique_id=MAC_ADDRESS,
     )
     config_entry.add_to_hass(hass)
@@ -185,7 +186,7 @@ async def test_select_mutable_0x25_strip_config(hass: HomeAssistant) -> None:
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    operating_mode_entity_id = "select.bulb_rgbcw_ddeeff_operating_mode"
+    operating_mode_entity_id = "select.mock_title_operating_mode"
     state = hass.states.get(operating_mode_entity_id)
     assert state.state == "RGBWW"
 
@@ -257,7 +258,7 @@ async def test_select_white_channel_type(hass: HomeAssistant) -> None:
     """Test selecting the white channel type."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        data=DEFAULT_ENTRY_DATA,
         unique_id=MAC_ADDRESS,
     )
     config_entry.add_to_hass(hass)
@@ -269,7 +270,7 @@ async def test_select_white_channel_type(hass: HomeAssistant) -> None:
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    operating_mode_entity_id = "select.bulb_rgbcw_ddeeff_white_channel"
+    operating_mode_entity_id = "select.mock_title_white_channel"
     state = hass.states.get(operating_mode_entity_id)
     assert state.state == WhiteChannelType.WARM.name.title()
 

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.util import dt
 
 from tests.common import (
     MockConfigEntry,
-    async_fire_reload_cooldown,
+    async_fire_deferred_config_entry_reloads,
     async_fire_time_changed,
     load_fixture,
 )
@@ -100,6 +100,6 @@ async def enable_all_entities(hass, config_entry_id, time_till_next_update):
         if entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     ]:
         registry.async_update_entity(entry.entity_id, **{"disabled_by": None})
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
     async_fire_time_changed(hass, dt.utcnow() + time_till_next_update)
     await hass.async_block_till_done()

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -8,7 +8,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
-from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_reload_cooldown,
+    async_fire_time_changed,
+    load_fixture,
+)
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_HOST = "http://fronius"
@@ -95,6 +100,6 @@ async def enable_all_entities(hass, config_entry_id, time_till_next_update):
         if entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     ]:
         registry.async_update_entity(entry.entity_id, **{"disabled_by": None})
-    await hass.async_block_till_done()
+    await async_fire_reload_cooldown(hass)
     async_fire_time_changed(hass, dt.utcnow() + time_till_next_update)
     await hass.async_block_till_done()

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -11,7 +11,10 @@ from homeassistant.util import dt
 
 from . import enable_all_entities, mock_responses, setup_fronius_integration
 
-from tests.common import async_fire_reload_cooldown, async_fire_time_changed
+from tests.common import (
+    async_fire_deferred_config_entry_reloads,
+    async_fire_time_changed,
+)
 
 
 async def test_symo_inverter(hass, aioclient_mock):
@@ -46,7 +49,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusInverterUpdateCoordinator.default_interval
     )
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     # 4 additional AC entities
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 2.19)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.util import dt
 
 from . import enable_all_entities, mock_responses, setup_fronius_integration
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_reload_cooldown, async_fire_time_changed
 
 
 async def test_symo_inverter(hass, aioclient_mock):
@@ -46,6 +46,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusInverterUpdateCoordinator.default_interval
     )
+    await async_fire_reload_cooldown(hass)
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     # 4 additional AC entities
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 2.19)

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -1,7 +1,6 @@
 """Tests for the Hyperion integration."""
 from __future__ import annotations
 
-from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, call, patch
 
 from hyperion import const
@@ -26,12 +25,7 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntityFeature,
 )
-from homeassistant.config_entries import (
-    RELOAD_AFTER_UPDATE_DELAY,
-    SOURCE_REAUTH,
-    ConfigEntry,
-    ConfigEntryState,
-)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
@@ -43,7 +37,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
 import homeassistant.util.color as color_util
 
 from . import (
@@ -70,7 +63,7 @@ from . import (
     setup_test_config_entry,
 )
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_deferred_config_entry_reloads
 
 COLOR_BLACK = color_util.COLORS["black"]
 
@@ -1361,13 +1354,7 @@ async def test_lights_can_be_enabled(hass: HomeAssistant) -> None:
             TEST_PRIORITY_LIGHT_ENTITY_ID_1, disabled_by=None
         )
         assert not updated_entry.disabled
-        await hass.async_block_till_done()
-
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await hass.async_block_till_done()
+        await async_fire_deferred_config_entry_reloads(hass)
 
     entity_state = hass.states.get(TEST_PRIORITY_LIGHT_ENTITY_ID_1)
     assert entity_state

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -1,5 +1,4 @@
 """Tests for the Hyperion integration."""
-from datetime import timedelta
 from unittest.mock import AsyncMock, call, patch
 
 from hyperion.const import (
@@ -18,11 +17,10 @@ from homeassistant.components.hyperion.const import (
     TYPE_HYPERION_COMPONENT_SWITCH_BASE,
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt, slugify
+from homeassistant.util import slugify
 
 from . import (
     TEST_CONFIG_ENTRY_ID,
@@ -35,7 +33,7 @@ from . import (
     setup_test_config_entry,
 )
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_reload_cooldown
 
 TEST_COMPONENTS = [
     {"enabled": True, "name": "ALL"},
@@ -213,11 +211,7 @@ async def test_switches_can_be_enabled(hass: HomeAssistant) -> None:
             assert not updated_entry.disabled
             await hass.async_block_till_done()
 
-            async_fire_time_changed(
-                hass,
-                dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-            )
-            await hass.async_block_till_done()
+            await async_fire_reload_cooldown(hass)
 
         entity_state = hass.states.get(entity_id)
         assert entity_state

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -33,7 +33,7 @@ from . import (
     setup_test_config_entry,
 )
 
-from tests.common import async_fire_reload_cooldown
+from tests.common import async_fire_deferred_config_entry_reloads
 
 TEST_COMPONENTS = [
     {"enabled": True, "name": "ALL"},
@@ -211,7 +211,7 @@ async def test_switches_can_be_enabled(hass: HomeAssistant) -> None:
             assert not updated_entry.disabled
             await hass.async_block_till_done()
 
-            await async_fire_reload_cooldown(hass)
+            await async_fire_deferred_config_entry_reloads(hass)
 
         entity_state = hass.states.get(entity_id)
         assert entity_state

--- a/tests/components/motioneye/test_sensor.py
+++ b/tests/components/motioneye/test_sensor.py
@@ -1,6 +1,5 @@
 """Tests for the motionEye switch platform."""
 import copy
-from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 from motioneye_client.const import KEY_ACTIONS
@@ -11,7 +10,6 @@ from homeassistant.components.motioneye.const import (
     TYPE_MOTIONEYE_ACTION_SENSOR,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.util.dt as dt_util
@@ -25,7 +23,10 @@ from . import (
     setup_mock_motioneye_config_entry,
 )
 
-from tests.common import async_fire_time_changed
+from tests.common import (
+    async_fire_deferred_config_entry_reloads,
+    async_fire_time_changed,
+)
 
 
 async def test_sensor_actions(hass: HomeAssistant) -> None:
@@ -120,13 +121,7 @@ async def test_sensor_actions_can_be_enabled(hass: HomeAssistant) -> None:
             TEST_SENSOR_ACTION_ENTITY_ID, disabled_by=None
         )
         assert not updated_entry.disabled
-        await hass.async_block_till_done()
-
-        async_fire_time_changed(
-            hass,
-            dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await hass.async_block_till_done()
+        await async_fire_deferred_config_entry_reloads(hass)
 
     entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert entity_state

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -1,6 +1,5 @@
 """Tests for the motionEye switch platform."""
 import copy
-from datetime import timedelta
 from unittest.mock import AsyncMock, call, patch
 
 from motioneye_client.const import (
@@ -15,7 +14,6 @@ from motioneye_client.const import (
 from homeassistant.components.motioneye import get_motioneye_device_identifier
 from homeassistant.components.motioneye.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -31,7 +29,10 @@ from . import (
     setup_mock_motioneye_config_entry,
 )
 
-from tests.common import async_fire_time_changed
+from tests.common import (
+    async_fire_deferred_config_entry_reloads,
+    async_fire_time_changed,
+)
 
 
 async def test_switch_turn_on_off(hass: HomeAssistant) -> None:
@@ -172,13 +173,7 @@ async def test_disabled_switches_can_be_enabled(hass: HomeAssistant) -> None:
                 entity_id, disabled_by=None
             )
             assert not updated_entry.disabled
-            await hass.async_block_till_done()
-
-            async_fire_time_changed(
-                hass,
-                dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-            )
-            await hass.async_block_till_done()
+            await async_fire_deferred_config_entry_reloads(hass)
 
         entity_state = hass.states.get(entity_id)
         assert entity_state

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -1,13 +1,11 @@
 """The tests for the Picnic sensor platform."""
 import copy
-from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
 import pytest
 import requests
 
-from homeassistant import config_entries
 from homeassistant.components.picnic import const
 from homeassistant.components.picnic.const import CONF_COUNTRY_CODE, SENSOR_TYPES
 from homeassistant.components.sensor import SensorDeviceClass
@@ -18,11 +16,10 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
 
 from tests.common import (
     MockConfigEntry,
-    async_fire_time_changed,
+    async_fire_deferred_config_entry_reloads,
     async_test_home_assistant,
 )
 
@@ -171,15 +168,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
                 f"sensor.picnic_{sensor_type}", disabled_by=None
             )
             assert updated_entry.disabled is False
-        await self.hass.async_block_till_done()
-
-        # Trigger a reload of the data
-        async_fire_time_changed(
-            self.hass,
-            dt.utcnow()
-            + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await self.hass.async_block_till_done()
+        await async_fire_deferred_config_entry_reloads(self.hass)
 
     async def test_sensor_setup_platform_not_available(self):
         """Test the set-up of the sensor platform if API is not available."""

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -42,7 +42,7 @@ from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN, PLEX_DIRECT_URL
 from .helpers import trigger_plex_update, wait_for_debouncer
 from .mock_classes import MockGDM
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_reload_cooldown
 
 
 async def test_bad_credentials(hass, current_request_with_host):
@@ -757,6 +757,7 @@ async def test_trigger_reauth(
 
     assert len(hass.config_entries.flow.async_progress()) == 0
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    await async_fire_reload_cooldown(hass)
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.data[CONF_SERVER] == mock_plex_server.friendly_name

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -42,7 +42,7 @@ from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN, PLEX_DIRECT_URL
 from .helpers import trigger_plex_update, wait_for_debouncer
 from .mock_classes import MockGDM
 
-from tests.common import MockConfigEntry, async_fire_reload_cooldown
+from tests.common import MockConfigEntry, async_fire_deferred_config_entry_reloads
 
 
 async def test_bad_credentials(hass, current_request_with_host):
@@ -757,7 +757,7 @@ async def test_trigger_reauth(
 
     assert len(hass.config_entries.flow.async_progress()) == 0
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.data[CONF_SERVER] == mock_plex_server.friendly_name

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -13,7 +13,10 @@ from homeassistant.util import dt
 
 from .helpers import trigger_plex_update, wait_for_debouncer
 
-from tests.common import async_fire_reload_cooldown, async_fire_time_changed
+from tests.common import (
+    async_fire_deferred_config_entry_reloads,
+    async_fire_time_changed,
+)
 
 LIBRARY_UPDATE_PAYLOAD = {"StatusNotification": [{"title": "Library scan complete"}]}
 
@@ -184,7 +187,7 @@ async def test_library_sensor_values(
 
     media = [MockPlexMovie()]
     with patch("plexapi.library.LibrarySection.recentlyAdded", return_value=media):
-        await async_fire_reload_cooldown(hass)
+        await async_fire_deferred_config_entry_reloads(hass)
 
     library_movies_sensor = hass.states.get("sensor.plex_server_1_library_movies")
     assert library_movies_sensor.state == "1"
@@ -213,7 +216,7 @@ async def test_library_sensor_values(
     )
     media = [MockPlexMusic()]
     with patch("plexapi.library.LibrarySection.recentlyAdded", return_value=media):
-        await async_fire_reload_cooldown(hass)
+        await async_fire_deferred_config_entry_reloads(hass)
 
     library_music_sensor = hass.states.get("sensor.plex_server_1_library_music")
     assert library_music_sensor.state == "1"

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.util import dt
 
 from .helpers import trigger_plex_update, wait_for_debouncer
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_reload_cooldown, async_fire_time_changed
 
 LIBRARY_UPDATE_PAYLOAD = {"StatusNotification": [{"title": "Library scan complete"}]}
 
@@ -120,10 +120,7 @@ async def test_library_sensor_values(
     )
     await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
+    await async_fire_reload_cooldown(hass)
 
     media = [MockPlexTVEpisode()]
     with patch("plexapi.library.LibrarySection.recentlyAdded", return_value=media):

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -118,8 +118,6 @@ async def test_library_sensor_values(
     entity_registry.async_update_entity(
         entity_id="sensor.plex_server_1_library_tv_shows", disabled_by=None
     )
-    await hass.async_block_till_done()
-
     await async_fire_reload_cooldown(hass)
 
     media = [MockPlexTVEpisode()]

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -181,11 +181,10 @@ async def test_library_sensor_values(
     entity_registry.async_update_entity(
         entity_id="sensor.plex_server_1_library_movies", disabled_by=None
     )
-    await hass.async_block_till_done()
 
     media = [MockPlexMovie()]
     with patch("plexapi.library.LibrarySection.recentlyAdded", return_value=media):
-        await hass.async_block_till_done()
+        await async_fire_reload_cooldown(hass)
 
     library_movies_sensor = hass.states.get("sensor.plex_server_1_library_movies")
     assert library_movies_sensor.state == "1"

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -1,19 +1,20 @@
 """Tests for the Sonos battery sensor platform."""
-from datetime import timedelta
 from unittest.mock import PropertyMock, patch
 
 from soco.exceptions import NotSupportedException
 
 from homeassistant.components.sensor import SCAN_INTERVAL
 from homeassistant.components.sonos.binary_sensor import ATTR_BATTERY_POWER_SOURCE
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_registry as ent_reg
 from homeassistant.util import dt as dt_util
 
 from .conftest import SonosMockEvent
 
-from tests.common import async_fire_time_changed
+from tests.common import (
+    async_fire_deferred_config_entry_reloads,
+    async_fire_time_changed,
+)
 
 
 async def test_entity_registry_unsupported(hass, async_setup_sonos, soco):
@@ -199,14 +200,9 @@ async def test_favorites_sensor(hass, async_autosetup_sonos, soco):
     empty_event = SonosMockEvent(soco, service, {})
     subscription = service.subscribe.return_value
     subscription.callback(event=empty_event)
-    await hass.async_block_till_done()
 
     # Reload the integration to enable the sensor
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
+    await async_fire_deferred_config_entry_reloads(hass)
 
     favorites_updated_event = SonosMockEvent(
         soco, service, {"favorites_update_id": "2", "container_update_i_ds": "FV:2,2"}

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -1,6 +1,5 @@
 """Tests for the Sonos Alarm switch platform."""
 from copy import copy
-from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER
@@ -12,14 +11,12 @@ from homeassistant.components.sonos.switch import (
     ATTR_RECURRENCE,
     ATTR_VOLUME,
 )
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_TIME, STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_registry as ent_reg
-from homeassistant.util import dt
 
 from .conftest import SonosMockEvent
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_deferred_config_entry_reloads
 
 
 async def test_entity_registry(hass, async_autosetup_sonos):
@@ -95,15 +92,10 @@ async def test_switch_attributes(hass, async_autosetup_sonos, soco):
     empty_event = SonosMockEvent(soco, service, {})
     subscription = service.subscribe.return_value
     subscription.callback(event=empty_event)
-    await hass.async_block_till_done()
 
     # Mock shutdown calls during config entry reload
     with patch.object(hass.data[DATA_SONOS_DISCOVERY_MANAGER], "async_shutdown") as m:
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await hass.async_block_till_done()
+        await async_fire_deferred_config_entry_reloads(hass)
         assert m.called
 
     status_light_state = hass.states.get(status_light.entity_id)

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -1,7 +1,6 @@
 """The tests for the Tasmota sensor platform."""
 import copy
 import datetime
-from datetime import timedelta
 import json
 from unittest.mock import Mock, patch
 
@@ -13,7 +12,6 @@ from hatasmota.utils import (
 )
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN, Platform
@@ -34,7 +32,10 @@ from .test_common import (
     help_test_entity_id_update_subscriptions,
 )
 
-from tests.common import async_fire_mqtt_message, async_fire_time_changed
+from tests.common import (
+    async_fire_deferred_config_entry_reloads,
+    async_fire_mqtt_message,
+)
 
 BAD_INDEXED_SENSOR_CONFIG_3 = {
     "sn": {
@@ -840,13 +841,8 @@ async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
     )
     assert updated_entry != entry
     assert updated_entry.disabled is False
-    await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
+    await async_fire_deferred_config_entry_reloads(hass)
 
     # Fake re-send of retained discovery message
     async_fire_mqtt_message(

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -504,6 +504,7 @@ async def test_advanced_option_flow(hass, aioclient_mock):
         CONF_ALLOW_BANDWIDTH_SENSORS: True,
         CONF_ALLOW_UPTIME_SENSORS: True,
     }
+    await hass.async_block_till_done()
 
 
 async def test_simple_option_flow(hass, aioclient_mock):
@@ -540,6 +541,7 @@ async def test_simple_option_flow(hass, aioclient_mock):
         CONF_TRACK_DEVICES: False,
         CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
     }
+    await hass.async_block_till_done()
 
 
 async def test_option_flow_integration_not_setup(hass, aioclient_mock):

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -75,6 +75,7 @@ async def test_reconnect_client(hass, aioclient_mock):
         blocking=True,
     )
     assert aioclient_mock.call_count == 1
+    await hass.async_block_till_done()
 
 
 async def test_reconnect_non_existant_device(hass, aioclient_mock):
@@ -145,6 +146,7 @@ async def test_reconnect_client_controller_unavailable(hass, aioclient_mock):
         blocking=True,
     )
     assert aioclient_mock.call_count == 0
+    await hass.async_block_till_done()
 
 
 async def test_reconnect_client_unknown_mac(hass, aioclient_mock):
@@ -195,6 +197,7 @@ async def test_reconnect_wired_client(hass, aioclient_mock):
         blocking=True,
     )
     assert aioclient_mock.call_count == 0
+    await hass.async_block_till_done()
 
 
 async def test_remove_clients(hass, aioclient_mock):

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -271,7 +271,6 @@ async def enable_entity(
 
     updated_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
     assert not updated_entity.disabled
-    await hass.async_block_till_done()
     await async_fire_reload_cooldown(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -33,7 +33,12 @@ import homeassistant.util.dt as dt_util
 
 from . import _patch_discovery
 
-from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_reload_cooldown,
+    async_fire_time_changed,
+    load_fixture,
+)
 
 MAC_ADDR = "aa:bb:cc:dd:ee:ff"
 
@@ -267,6 +272,7 @@ async def enable_entity(
     updated_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
     assert not updated_entity.disabled
     await hass.config_entries.async_reload(entry_id)
+    await async_fire_reload_cooldown(hass)
     await hass.async_block_till_done()
 
     return updated_entity

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -35,7 +35,7 @@ from . import _patch_discovery
 
 from tests.common import (
     MockConfigEntry,
-    async_fire_reload_cooldown,
+    async_fire_deferred_config_entry_reloads,
     async_fire_time_changed,
     load_fixture,
 )
@@ -271,7 +271,7 @@ async def enable_entity(
 
     updated_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
     assert not updated_entity.disabled
-    await async_fire_reload_cooldown(hass)
+    await async_fire_deferred_config_entry_reloads(hass)
     await hass.async_block_till_done()
 
     return updated_entity

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -271,7 +271,7 @@ async def enable_entity(
 
     updated_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
     assert not updated_entity.disabled
-    await hass.config_entries.async_reload(entry_id)
+    await hass.async_block_till_done()
     await async_fire_reload_cooldown(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -273,6 +273,7 @@ async def test_form_options(hass: HomeAssistant, mock_client) -> None:
         "disable_rtsp": True,
         "override_connection_host": True,
     }
+    await hass.async_block_till_done()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/wiz/test_config_flow.py
+++ b/tests/components/wiz/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.wiz.config_flow import CONF_DEVICE
 from homeassistant.components.wiz.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
+from homeassistant.setup import async_setup_component
 
 from . import (
     FAKE_DIMMABLE_BULB,
@@ -24,7 +25,6 @@ from . import (
     _mocked_wizlight,
     _patch_discovery,
     _patch_wizlight,
-    async_setup_integration,
 )
 
 from tests.common import MockConfigEntry
@@ -324,7 +324,19 @@ async def test_discovered_by_dhcp_or_integration_discovery_avoid_waiting_for_ret
     """Test dhcp or discovery kicks off setup when in retry."""
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     bulb.getMac = AsyncMock(side_effect=OSError)
-    _, entry = await async_setup_integration(hass, wizlight=bulb)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=FAKE_MAC,
+        data={CONF_HOST: FAKE_IP},
+    )
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.wiz.discovery.find_wizlights",
+        return_value=[],
+    ), _patch_wizlight(device=bulb):
+        await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+
     assert entry.data[CONF_HOST] == FAKE_IP
     assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
     bulb.getMac = AsyncMock(return_value=FAKE_MAC)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -76,21 +76,21 @@ async def test_call_setup_entry(hass):
 
     mock_setup_entry = AsyncMock(return_value=True)
     mock_migrate_entry = AsyncMock(return_value=True)
+    mock_unload_entry = AsyncMock(return_value=True)
 
     mock_integration(
         hass,
         MockModule(
             "comp",
             async_setup_entry=mock_setup_entry,
+            async_unload_entry=mock_unload_entry,
             async_migrate_entry=mock_migrate_entry,
         ),
     )
     mock_entity_platform(hass, "config_flow.comp", None)
 
-    with patch("homeassistant.config_entries.support_entry_unload", return_value=True):
-        result = await async_setup_component(hass, "comp", {})
-        await hass.async_block_till_done()
-    assert result
+    assert await async_setup_component(hass, "comp", {})
+    await hass.async_block_till_done()
     assert len(mock_migrate_entry.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED
@@ -116,10 +116,8 @@ async def test_call_setup_entry_without_reload_support(hass):
     )
     mock_entity_platform(hass, "config_flow.comp", None)
 
-    with patch("homeassistant.config_entries.support_entry_unload", return_value=False):
-        result = await async_setup_component(hass, "comp", {})
-        await hass.async_block_till_done()
-    assert result
+    assert await async_setup_component(hass, "comp", {})
+    await hass.async_block_till_done()
     assert len(mock_migrate_entry.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1337,6 +1337,9 @@ async def test_entry_disable_succeed(hass, manager):
 
     # Enable
     assert await manager.async_set_disabled_by(entry.entry_id, None)
+    assert len(async_setup.mock_calls) == 0
+    async_fire_time_changed(hass, dt.utcnow() + config_entries.RELOAD_COOLDOWN)
+    await hass.async_block_till_done()
     assert len(async_unload_entry.mock_calls) == 1
     assert len(async_setup.mock_calls) == 1
     assert len(async_setup_entry.mock_calls) == 1
@@ -1407,6 +1410,8 @@ async def test_entry_enable_without_reload_support(hass, manager):
     assert not await manager.async_set_disabled_by(
         entry.entry_id, config_entries.ConfigEntryDisabler.USER
     )
+    async_fire_time_changed(hass, dt.utcnow() + config_entries.RELOAD_COOLDOWN)
+    await hass.async_block_till_done()
     assert len(async_setup.mock_calls) == 1
     assert len(async_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.FAILED_UNLOAD
@@ -1477,23 +1482,18 @@ async def test_reload_entry_entity_registry_works(hass):
     )
     registry.async_update_entity(entity_entry.entity_id, name="yo")
     await hass.async_block_till_done()
-    assert not handler.changed
-    assert handler._remove_call_later is None
 
     # Disable entity, we should not do anything, only act when enabled.
     registry.async_update_entity(
         entity_entry.entity_id, disabled_by=er.RegistryEntryDisabler.USER
     )
     await hass.async_block_till_done()
-    assert not handler.changed
-    assert handler._remove_call_later is None
 
     # Enable entity, check we are reloading config entry.
     registry.async_update_entity(entity_entry.entity_id, disabled_by=None)
     await hass.async_block_till_done()
-    assert handler.changed == {config_entry.entry_id}
-    assert handler._remove_call_later is not None
 
+    await hass.async_block_till_done()
     async_fire_time_changed(
         hass,
         dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -133,21 +133,21 @@ async def test_call_async_migrate_entry(hass):
 
     mock_migrate_entry = AsyncMock(return_value=True)
     mock_setup_entry = AsyncMock(return_value=True)
+    mock_unload_entry = AsyncMock(return_value=True)
 
     mock_integration(
         hass,
         MockModule(
             "comp",
             async_setup_entry=mock_setup_entry,
+            async_unload_entry=mock_unload_entry,
             async_migrate_entry=mock_migrate_entry,
         ),
     )
     mock_entity_platform(hass, "config_flow.comp", None)
 
-    with patch("homeassistant.config_entries.support_entry_unload", return_value=True):
-        result = await async_setup_component(hass, "comp", {})
-        await hass.async_block_till_done()
-    assert result
+    assert await async_setup_component(hass, "comp", {})
+    await hass.async_block_till_done()
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1496,7 +1496,7 @@ async def test_reload_entry_entity_registry_works(hass):
     await hass.async_block_till_done()
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt.utcnow() + config_entries.RELOAD_COOLDOWN,
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Config entry reloads now implement a 30s cooldown to prevent multiple successive reloads.  If multiple reloads are requested, the first one will happen immediately. Subsequent reload requests will be grouped and happen 30s after the last reload.

The EntityRegistryDisabledHandler now relies on this logic instead of implementing its own similar logic.

## Proposed change

#73387 #73145 #72636 fixed cases where the config entry could have been reloaded concurrently or before it was ever finished loading, and generally solved the issues where the setup and data being fetched to support the integration could get in a bad state.

However, the previous fixes did not address the case that entities may get added again or be in an unexpected state since forwarded platform setups happen in tasks via `async_add_entities` that we do not wait to be complete before declaring the reload complete when they happen after Home Assistant starts.

I expect this will fix at least some of these [classes](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+%22does+not+generate+unique+IDs%22) of previously unexplained bugs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #73400 likely fixes #73654 as well
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
