### PR TITLE
Speed up zha tests

### DIFF
--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -22,6 +22,21 @@ from .common import async_enable_traffic, find_entity_id
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 
+@pytest.fixture(autouse=True)
+def alarm_control_panel_platform_only():
+    """Only setup the alarm_control_panel and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.ALARM_CONTROL_PANEL,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def zigpy_device(zigpy_device_mock):
     """Device tracker zigpy device."""

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -37,7 +37,7 @@ from homeassistant.components.zha.core.const import (
     GROUP_IDS,
     GROUP_NAME,
 )
-from homeassistant.const import ATTR_NAME
+from homeassistant.const import ATTR_NAME, Platform
 from homeassistant.core import Context
 
 from .conftest import (
@@ -51,6 +51,20 @@ from .conftest import (
 
 IEEE_SWITCH_DEVICE = "01:2d:6f:00:0a:90:69:e7"
 IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
+
+
+@pytest.fixture(autouse=True)
+def required_platform_only():
+    """Only setup the required and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.SELECT,
+            Platform.SENSOR,
+            Platform.SWITCH,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -1,4 +1,6 @@
 """Test zha binary sensor."""
+from unittest.mock import patch
+
 import pytest
 import zigpy.profiles.zha
 import zigpy.zcl.clusters.measurement as measurement
@@ -32,6 +34,21 @@ DEVICE_OCCUPANCY = {
         SIG_EP_OUTPUT: [],
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_platform_only():
+    """Only setup the binary_sensor and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BINARY_SENSOR,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
 
 
 async def async_test_binary_sensor_on_off(hass, cluster, entity_id):

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     ENTITY_CATEGORY_CONFIG,
     ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.helpers import entity_registry as er
 
@@ -35,6 +36,23 @@ from .common import find_entity_id
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 
 from tests.common import mock_coro
+
+
+@pytest.fixture(autouse=True)
+def button_platform_only():
+    """Only setup the button and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BINARY_SENSOR,
+            Platform.BUTTON,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SELECT,
+            Platform.SENSOR,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -20,6 +20,13 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from tests.common import async_capture_events
 
 
+@pytest.fixture(autouse=True)
+def disable_platform_only():
+    """Disable platforms to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", []):
+        yield
+
+
 @pytest.fixture
 def ieee():
     """IEEE fixture."""

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -171,6 +171,24 @@ ZCL_ATTR_PLUG = {
 }
 
 
+@pytest.fixture(autouse=True)
+def climate_platform_only():
+    """Only setup the climate and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BUTTON,
+            Platform.CLIMATE,
+            Platform.BINARY_SENSOR,
+            Platform.NUMBER,
+            Platform.SELECT,
+            Platform.SENSOR,
+            Platform.SWITCH,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def device_climate_mock(hass, zigpy_device_mock, zha_device_joined):
     """Test regular thermostat device."""

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -34,6 +34,13 @@ from homeassistant.data_entry_flow import (
 from tests.common import MockConfigEntry
 
 
+@pytest.fixture(autouse=True)
+def disable_platform_only():
+    """Disable platforms to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", []):
+        yield
+
+
 def com_port():
     """Mock of a serial port."""
     port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -39,6 +39,21 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from tests.common import async_capture_events, mock_coro, mock_restore_cache
 
 
+@pytest.fixture(autouse=True)
+def cover_platform_only():
+    """Only setup the cover and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.COVER,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def zigpy_cover_device(zigpy_device_mock):
     """Zigpy cover device."""

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -12,7 +12,7 @@ from homeassistant.components.zha.core.const import (
     CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
     CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
 )
-from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
+from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE, Platform
 import homeassistant.helpers.device_registry as dr
 import homeassistant.util.dt as dt_util
 
@@ -20,6 +20,16 @@ from .common import async_enable_traffic, make_zcl_header
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 
 from tests.common import async_fire_time_changed
+
+
+@pytest.fixture(autouse=True)
+def required_platforms_only():
+    """Only setup the required platform and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (Platform.SENSOR, Platform.SELECT, Platform.SWITCH, Platform.BINARY_SENSOR),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -27,7 +27,13 @@ def required_platforms_only():
     """Only setup the required platform and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
-        (Platform.SENSOR, Platform.SELECT, Platform.SWITCH, Platform.BINARY_SENSOR),
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.SENSOR,
+            Platform.SELECT,
+            Platform.SWITCH,
+            Platform.BINARY_SENSOR,
+        ),
     ):
         yield
 

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -31,6 +31,8 @@ def required_platforms_only():
         "homeassistant.components.zha.PLATFORMS",
         (
             Platform.BINARY_SENSOR,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
             Platform.SELECT,
             Platform.SENSOR,
             Platform.SIREN,

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -24,6 +24,21 @@ COMMAND = "command"
 COMMAND_SINGLE = "single"
 
 
+@pytest.fixture(autouse=True)
+def required_platforms_only():
+    """Only setup the required platforms and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BINARY_SENSOR,
+            Platform.SELECT,
+            Platform.SENSOR,
+            Platform.SIREN,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 async def device_ias(hass, zigpy_device_mock, zha_device_joined_restored):
     """IAS device fixture."""

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -1,6 +1,7 @@
 """Test ZHA Device Tracker."""
 from datetime import timedelta
 import time
+from unittest.mock import patch
 
 import pytest
 import zigpy.profiles.zha
@@ -22,6 +23,23 @@ from .common import (
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 from tests.common import async_fire_time_changed
+
+
+@pytest.fixture(autouse=True)
+def device_tracker_platforms_only():
+    """Only setup the device_tracker platforms and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.BUTTON,
+            Platform.SELECT,
+            Platform.NUMBER,
+            Platform.BINARY_SENSOR,
+            Platform.SENSOR,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -1,6 +1,7 @@
 """ZHA device automation trigger tests."""
 from datetime import timedelta
 import time
+from unittest.mock import patch
 
 import pytest
 import zigpy.profiles.zha
@@ -8,6 +9,7 @@ import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.const import Platform
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -34,6 +36,13 @@ DOUBLE_PRESS = "remote_button_double_press"
 SHORT_PRESS = "remote_button_short_press"
 LONG_PRESS = "remote_button_long_press"
 LONG_RELEASE = "remote_button_long_release"
+
+
+@pytest.fixture(autouse=True)
+def sensor_platforms_only():
+    """Only setup the sensor platform and required base platforms to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", (Platform.SENSOR,)):
+        yield
 
 
 def _same_lists(list_a, list_b):

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -1,6 +1,8 @@
 """Tests for the diagnostics data provided by the ESPHome integration."""
 
 
+from unittest.mock import patch
+
 import pytest
 import zigpy.profiles.zha as zha
 import zigpy.zcl.clusters.security as security
@@ -8,6 +10,7 @@ import zigpy.zcl.clusters.security as security
 from homeassistant.components.diagnostics.const import REDACTED
 from homeassistant.components.zha.core.device import ZHADevice
 from homeassistant.components.zha.diagnostics import KEYS_TO_REDACT
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get
 
@@ -24,6 +27,15 @@ CONFIG_ENTRY_DIAGNOSTICS_KEYS = [
     "application_state",
     "versions",
 ]
+
+
+@pytest.fixture(autouse=True)
+def required_platforms_only():
+    """Only setup the required platform and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS", (Platform.ALARM_CONTROL_PANEL,)
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -51,6 +51,22 @@ IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
 IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
 
 
+@pytest.fixture(autouse=True)
+def fan_platform_only():
+    """Only setup the fan and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.FAN,
+            Platform.LIGHT,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def zigpy_device(zigpy_device_mock):
     """Device tracker zigpy device."""

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -35,6 +35,22 @@ def zigpy_dev_basic(zigpy_device_mock):
     )
 
 
+@pytest.fixture(autouse=True)
+def required_platform_only():
+    """Only setup the required and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.SENSOR,
+            Platform.LIGHT,
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 async def zha_dev_basic(hass, zha_device_restored, zigpy_dev_basic):
     """ZHA device with just a basic cluster."""

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -20,6 +20,13 @@ DATA_RADIO_TYPE = "deconz"
 DATA_PORT_PATH = "/dev/serial/by-id/FTDI_USB__-__Serial_Cable_12345678-if00-port0"
 
 
+@pytest.fixture(autouse=True)
+def disable_platform_only():
+    """Disable platforms to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", []):
+        yield
+
+
 @pytest.fixture
 def config_entry_v1(hass):
     """Config entry version 1 fixture."""

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -80,6 +80,24 @@ LIGHT_COLOR = {
 }
 
 
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Only setup the light and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BINARY_SENSOR,
+            Platform.DEVICE_TRACKER,
+            Platform.BUTTON,
+            Platform.LIGHT,
+            Platform.SENSOR,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 async def coordinator(hass, zigpy_device_mock, zha_device_joined):
     """Test zha light platform."""

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -27,6 +27,20 @@ CLEAR_PIN_CODE = 7
 SET_USER_STATUS = 9
 
 
+@pytest.fixture(autouse=True)
+def lock_platform_only():
+    """Only setup the lock and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.LOCK,
+            Platform.SENSOR,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 async def lock(hass, zigpy_device_mock, zha_device_joined_restored):
     """Lock cluster fixture."""

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -1,11 +1,13 @@
 """ZHA logbook describe events tests."""
 
+from unittest.mock import patch
+
 import pytest
 import zigpy.profiles.zha
 import zigpy.zcl.clusters.general as general
 
 from homeassistant.components.zha.core.const import ZHA_EVENT
-from homeassistant.const import CONF_DEVICE_ID, CONF_UNIQUE_ID
+from homeassistant.const import CONF_DEVICE_ID, CONF_UNIQUE_ID, Platform
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -27,6 +29,13 @@ LONG_PRESS = "remote_button_long_press"
 LONG_RELEASE = "remote_button_long_release"
 UP = "up"
 DOWN = "down"
+
+
+@pytest.fixture(autouse=True)
+def sensor_platform_only():
+    """Only setup the sensor and required base platforms to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", (Platform.SENSOR,)):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -24,6 +24,23 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from tests.common import mock_coro
 
 
+@pytest.fixture(autouse=True)
+def number_platform_only():
+    """Only setup the number and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BUTTON,
+            Platform.DEVICE_TRACKER,
+            Platform.LIGHT,
+            Platform.NUMBER,
+            Platform.SELECT,
+            Platform.SENSOR,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def zigpy_analog_output_device(zigpy_device_mock):
     """Zigpy analog_output device."""

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -1,6 +1,6 @@
 """Test ZHA select entities."""
 
-from unittest.mock import call
+from unittest.mock import call, patch
 
 import pytest
 from zigpy.const import SIG_EP_PROFILE
@@ -14,6 +14,24 @@ from homeassistant.util import dt as dt_util
 
 from .common import find_entity_id
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+
+
+@pytest.fixture(autouse=True)
+def select_select_only():
+    """Only setup the select and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BUTTON,
+            Platform.DEVICE_TRACKER,
+            Platform.SIREN,
+            Platform.LIGHT,
+            Platform.NUMBER,
+            Platform.SELECT,
+            Platform.SENSOR,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,5 +1,6 @@
 """Test zha sensor."""
 import math
+from unittest.mock import patch
 
 import pytest
 import zigpy.profiles.zha
@@ -48,6 +49,19 @@ from .common import (
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 ENTITY_ID_PREFIX = "sensor.fakemanufacturer_fakemodel_e769900a_{}"
+
+
+@pytest.fixture(autouse=True)
+def sensor_platform_only():
+    """Only setup the sensor and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.SENSOR,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -28,6 +28,22 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from tests.common import async_fire_time_changed, mock_coro
 
 
+@pytest.fixture(autouse=True)
+def siren_platform_only():
+    """Only setup the siren and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.NUMBER,
+            Platform.SENSOR,
+            Platform.SELECT,
+            Platform.SIREN,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 async def siren(hass, zigpy_device_mock, zha_device_joined_restored):
     """Siren fixture."""

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -41,6 +41,21 @@ IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
 IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
 
 
+@pytest.fixture(autouse=True)
+def switch_platform_only():
+    """Only setup the switch and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.SENSOR,
+            Platform.SELECT,
+            Platform.SWITCH,
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def zigpy_device(zigpy_device_mock):
     """Device tracker zigpy device."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Only setup the platforms each test is testing

test_discovery didn't get this speedup since each test's PLATFORMs
would need to be patched for what it discovered and that would
make this change much larger. Doing so would likely shave at
least another minute of the tests

Before Results (274.96s)
After Results (189.37s)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
