### PR TITLE
Use a TypedDict for REPORT_CONFIG in zha

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -49,7 +49,7 @@ _LOGGER = logging.getLogger(__name__)
 class AttrReportConfig(TypedDict, total=True):
     """Configuration to report for the attributes."""
 
-    attr: str
+    attr: str | int
     config: tuple[int, int, int | float]
 
 

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -46,8 +46,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class ReportConfig(TypedDict, total=True):
-    """Matcher for the dhcp integration for required fields."""
+class AttrReportConfig(TypedDict, total=True):
+    """Configuration to report for the attributes."""
 
     attr: str
     config: tuple[int, int, int | float]
@@ -106,7 +106,7 @@ class ChannelStatus(Enum):
 class ZigbeeChannel(LogMixin):
     """Base channel for a Zigbee cluster."""
 
-    REPORT_CONFIG: tuple[ReportConfig] = ()
+    REPORT_CONFIG: tuple[AttrReportConfig] = ()
     BIND: bool = True
 
     # Dict of attributes to read on channel initialization.

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -49,7 +49,10 @@ _LOGGER = logging.getLogger(__name__)
 class AttrReportConfig(TypedDict, total=True):
     """Configuration to report for the attributes."""
 
+    # Could be either an attribute name or attribute id
     attr: str | int
+    # The config for the attribute reporting configuration consists of a tuple for
+    # (minimum_reported_time_interval_s, maximum_reported_time_interval_s, value_delta)
     config: tuple[int, int, int | float]
 
 

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from enum import Enum
 from functools import partialmethod, wraps
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import zigpy.exceptions
 import zigpy.zcl
@@ -44,6 +45,13 @@ if TYPE_CHECKING:
     from . import ChannelPool
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class ReportConfig(TypedDict, total=True):
+    """Matcher for the dhcp integration for required fields."""
+
+    attr: str
+    config: tuple(int, int, int)
 
 
 def parse_and_log_command(channel, tsn, command_id, args):
@@ -99,7 +107,7 @@ class ChannelStatus(Enum):
 class ZigbeeChannel(LogMixin):
     """Base channel for a Zigbee cluster."""
 
-    REPORT_CONFIG: tuple[dict[int | str, tuple[int, int, int | float]]] = ()
+    REPORT_CONFIG: Sequence[ReportConfig] = ()
     BIND: bool = True
 
     # Dict of attributes to read on channel initialization.

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -51,7 +51,7 @@ class ReportConfig(TypedDict, total=True):
     """Matcher for the dhcp integration for required fields."""
 
     attr: str
-    config: tuple(int, int, int)
+    config: tuple[int, int, int]
 
 
 def parse_and_log_command(channel, tsn, command_id, args):

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -50,7 +50,7 @@ class ReportConfig(TypedDict, total=True):
     """Matcher for the dhcp integration for required fields."""
 
     attr: str
-    config: tuple[int, int, int]
+    config: tuple[int, int, int | float]
 
 
 def parse_and_log_command(channel, tsn, command_id, args):

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
 from enum import Enum
 from functools import partialmethod, wraps
 import logging
@@ -107,7 +106,7 @@ class ChannelStatus(Enum):
 class ZigbeeChannel(LogMixin):
     """Base channel for a Zigbee cluster."""
 
-    REPORT_CONFIG: Sequence[ReportConfig] = ()
+    REPORT_CONFIG: tuple[ReportConfig] = ()
     BIND: bool = True
 
     # Dict of attributes to read on channel initialization.

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -5,7 +5,7 @@ from homeassistant.core import callback
 
 from .. import registries
 from ..const import REPORT_CONFIG_IMMEDIATE, SIGNAL_ATTR_UPDATED
-from .base import ClientChannel, ZigbeeChannel
+from .base import ClientChannel, ReportConfig, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(closures.DoorLock.cluster_id)
@@ -13,7 +13,7 @@ class DoorLockChannel(ZigbeeChannel):
     """Door lock channel."""
 
     _value_attribute = 0
-    REPORT_CONFIG = ({"attr": "lock_state", "config": REPORT_CONFIG_IMMEDIATE},)
+    REPORT_CONFIG = (ReportConfig(attr="lock_state", config=REPORT_CONFIG_IMMEDIATE),)
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -121,7 +121,9 @@ class WindowCovering(ZigbeeChannel):
 
     _value_attribute = 8
     REPORT_CONFIG = (
-        {"attr": "current_position_lift_percentage", "config": REPORT_CONFIG_IMMEDIATE},
+        ReportConfig(
+            attr="current_position_lift_percentage", config=REPORT_CONFIG_IMMEDIATE
+        ),
     )
 
     async def async_update(self):

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -5,7 +5,7 @@ from homeassistant.core import callback
 
 from .. import registries
 from ..const import REPORT_CONFIG_IMMEDIATE, SIGNAL_ATTR_UPDATED
-from .base import ClientChannel, ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ClientChannel, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(closures.DoorLock.cluster_id)
@@ -13,7 +13,9 @@ class DoorLockChannel(ZigbeeChannel):
     """Door lock channel."""
 
     _value_attribute = 0
-    REPORT_CONFIG = (ReportConfig(attr="lock_state", config=REPORT_CONFIG_IMMEDIATE),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="lock_state", config=REPORT_CONFIG_IMMEDIATE),
+    )
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -121,7 +123,7 @@ class WindowCovering(ZigbeeChannel):
 
     _value_attribute = 8
     REPORT_CONFIG = (
-        ReportConfig(
+        AttrReportConfig(
             attr="current_position_lift_percentage", config=REPORT_CONFIG_IMMEDIATE
         ),
     )

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -27,7 +27,7 @@ from ..const import (
     SIGNAL_SET_LEVEL,
     SIGNAL_UPDATE_DEVICE,
 )
-from .base import ClientChannel, ZigbeeChannel, parse_and_log_command
+from .base import ClientChannel, ReportConfig, ZigbeeChannel, parse_and_log_command
 
 if TYPE_CHECKING:
     from . import ChannelPool
@@ -42,7 +42,7 @@ class Alarms(ZigbeeChannel):
 class AnalogInput(ZigbeeChannel):
     """Analog Input channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.BINDABLE_CLUSTERS.register(general.AnalogOutput.cluster_id)
@@ -50,7 +50,7 @@ class AnalogInput(ZigbeeChannel):
 class AnalogOutput(ZigbeeChannel):
     """Analog Output channel."""
 
-    REPORT_CONFIG = ({"attr": "present_value", "config": REPORT_CONFIG_DEFAULT},)
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
     ZCL_INIT_ATTRS = {
         "min_present_value": True,
         "max_present_value": True,
@@ -119,7 +119,7 @@ class AnalogOutput(ZigbeeChannel):
 class AnalogValue(ZigbeeChannel):
     """Analog Value channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.ApplianceControl.cluster_id)
@@ -151,21 +151,21 @@ class BasicChannel(ZigbeeChannel):
 class BinaryInput(ZigbeeChannel):
     """Binary Input channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryOutput.cluster_id)
 class BinaryOutput(ZigbeeChannel):
     """Binary Output channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryValue.cluster_id)
 class BinaryValue(ZigbeeChannel):
     """Binary Value channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.Commissioning.cluster_id)
@@ -225,7 +225,7 @@ class LevelControlChannel(ZigbeeChannel):
     """Channel for the LevelControl Zigbee cluster."""
 
     CURRENT_LEVEL = 0
-    REPORT_CONFIG = ({"attr": "current_level", "config": REPORT_CONFIG_ASAP},)
+    REPORT_CONFIG = (ReportConfig(attr="current_level", config=REPORT_CONFIG_ASAP),)
     ZCL_INIT_ATTRS = {
         "on_off_transition_time": True,
         "on_level": True,
@@ -275,21 +275,21 @@ class LevelControlChannel(ZigbeeChannel):
 class MultistateInput(ZigbeeChannel):
     """Multistate Input channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateOutput.cluster_id)
 class MultistateOutput(ZigbeeChannel):
     """Multistate Output channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateValue.cluster_id)
 class MultistateValue(ZigbeeChannel):
     """Multistate Value channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.CLIENT_CHANNELS_REGISTRY.register(general.OnOff.cluster_id)
@@ -303,7 +303,7 @@ class OnOffChannel(ZigbeeChannel):
     """Channel for the OnOff Zigbee cluster."""
 
     ON_OFF = 0
-    REPORT_CONFIG = ({"attr": "on_off", "config": REPORT_CONFIG_IMMEDIATE},)
+    REPORT_CONFIG = (ReportConfig(attr="on_off", config=REPORT_CONFIG_IMMEDIATE),)
     ZCL_INIT_ATTRS = {
         "start_up_on_off": True,
     }
@@ -472,8 +472,10 @@ class PowerConfigurationChannel(ZigbeeChannel):
     """Channel for the zigbee power configuration cluster."""
 
     REPORT_CONFIG = (
-        {"attr": "battery_voltage", "config": REPORT_CONFIG_BATTERY_SAVE},
-        {"attr": "battery_percentage_remaining", "config": REPORT_CONFIG_BATTERY_SAVE},
+        ReportConfig(attr="battery_voltage", config=REPORT_CONFIG_BATTERY_SAVE),
+        ReportConfig(
+            attr="battery_percentage_remaining", config=REPORT_CONFIG_BATTERY_SAVE
+        ),
     )
 
     def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -27,7 +27,7 @@ from ..const import (
     SIGNAL_SET_LEVEL,
     SIGNAL_UPDATE_DEVICE,
 )
-from .base import ClientChannel, ReportConfig, ZigbeeChannel, parse_and_log_command
+from .base import AttrReportConfig, ClientChannel, ZigbeeChannel, parse_and_log_command
 
 if TYPE_CHECKING:
     from . import ChannelPool
@@ -42,7 +42,9 @@ class Alarms(ZigbeeChannel):
 class AnalogInput(ZigbeeChannel):
     """Analog Input channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.BINDABLE_CLUSTERS.register(general.AnalogOutput.cluster_id)
@@ -50,7 +52,9 @@ class AnalogInput(ZigbeeChannel):
 class AnalogOutput(ZigbeeChannel):
     """Analog Output channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
     ZCL_INIT_ATTRS = {
         "min_present_value": True,
         "max_present_value": True,
@@ -119,7 +123,9 @@ class AnalogOutput(ZigbeeChannel):
 class AnalogValue(ZigbeeChannel):
     """Analog Value channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.ApplianceControl.cluster_id)
@@ -151,21 +157,27 @@ class BasicChannel(ZigbeeChannel):
 class BinaryInput(ZigbeeChannel):
     """Binary Input channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryOutput.cluster_id)
 class BinaryOutput(ZigbeeChannel):
     """Binary Output channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryValue.cluster_id)
 class BinaryValue(ZigbeeChannel):
     """Binary Value channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.Commissioning.cluster_id)
@@ -225,7 +237,7 @@ class LevelControlChannel(ZigbeeChannel):
     """Channel for the LevelControl Zigbee cluster."""
 
     CURRENT_LEVEL = 0
-    REPORT_CONFIG = (ReportConfig(attr="current_level", config=REPORT_CONFIG_ASAP),)
+    REPORT_CONFIG = (AttrReportConfig(attr="current_level", config=REPORT_CONFIG_ASAP),)
     ZCL_INIT_ATTRS = {
         "on_off_transition_time": True,
         "on_level": True,
@@ -275,21 +287,27 @@ class LevelControlChannel(ZigbeeChannel):
 class MultistateInput(ZigbeeChannel):
     """Multistate Input channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateOutput.cluster_id)
 class MultistateOutput(ZigbeeChannel):
     """Multistate Output channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateValue.cluster_id)
 class MultistateValue(ZigbeeChannel):
     """Multistate Value channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.CLIENT_CHANNELS_REGISTRY.register(general.OnOff.cluster_id)
@@ -303,7 +321,7 @@ class OnOffChannel(ZigbeeChannel):
     """Channel for the OnOff Zigbee cluster."""
 
     ON_OFF = 0
-    REPORT_CONFIG = (ReportConfig(attr="on_off", config=REPORT_CONFIG_IMMEDIATE),)
+    REPORT_CONFIG = (AttrReportConfig(attr="on_off", config=REPORT_CONFIG_IMMEDIATE),)
     ZCL_INIT_ATTRS = {
         "start_up_on_off": True,
     }
@@ -472,8 +490,8 @@ class PowerConfigurationChannel(ZigbeeChannel):
     """Channel for the zigbee power configuration cluster."""
 
     REPORT_CONFIG = (
-        ReportConfig(attr="battery_voltage", config=REPORT_CONFIG_BATTERY_SAVE),
-        ReportConfig(
+        AttrReportConfig(attr="battery_voltage", config=REPORT_CONFIG_BATTERY_SAVE),
+        AttrReportConfig(
             attr="battery_percentage_remaining", config=REPORT_CONFIG_BATTERY_SAVE
         ),
     )

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -42,7 +42,7 @@ class Alarms(ZigbeeChannel):
 class AnalogInput(ZigbeeChannel):
     """Analog Input channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.BINDABLE_CLUSTERS.register(general.AnalogOutput.cluster_id)
@@ -119,7 +119,7 @@ class AnalogOutput(ZigbeeChannel):
 class AnalogValue(ZigbeeChannel):
     """Analog Value channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.ApplianceControl.cluster_id)
@@ -151,21 +151,21 @@ class BasicChannel(ZigbeeChannel):
 class BinaryInput(ZigbeeChannel):
     """Binary Input channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryOutput.cluster_id)
 class BinaryOutput(ZigbeeChannel):
     """Binary Output channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryValue.cluster_id)
 class BinaryValue(ZigbeeChannel):
     """Binary Value channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.Commissioning.cluster_id)
@@ -177,12 +177,12 @@ class Commissioning(ZigbeeChannel):
 class DeviceTemperature(ZigbeeChannel):
     """Device Temperature channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "current_temperature",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 50),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.GreenPowerProxy.cluster_id)
@@ -275,21 +275,21 @@ class LevelControlChannel(ZigbeeChannel):
 class MultistateInput(ZigbeeChannel):
     """Multistate Input channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateOutput.cluster_id)
 class MultistateOutput(ZigbeeChannel):
     """Multistate Output channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateValue.cluster_id)
 class MultistateValue(ZigbeeChannel):
     """Multistate Value channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="present_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.CLIENT_CHANNELS_REGISTRY.register(general.OnOff.cluster_id)

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -12,7 +12,7 @@ from ..const import (
     REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import ZigbeeChannel
+from .base import ReportConfig, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -63,15 +63,15 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
         POWER_QUALITY_MEASUREMENT = 256
 
     REPORT_CONFIG = (
-        {"attr": "active_power", "config": REPORT_CONFIG_OP},
-        {"attr": "active_power_max", "config": REPORT_CONFIG_DEFAULT},
-        {"attr": "apparent_power", "config": REPORT_CONFIG_OP},
-        {"attr": "rms_current", "config": REPORT_CONFIG_OP},
-        {"attr": "rms_current_max", "config": REPORT_CONFIG_DEFAULT},
-        {"attr": "rms_voltage", "config": REPORT_CONFIG_OP},
-        {"attr": "rms_voltage_max", "config": REPORT_CONFIG_DEFAULT},
-        {"attr": "ac_frequency", "config": REPORT_CONFIG_OP},
-        {"attr": "ac_frequency_max", "config": REPORT_CONFIG_DEFAULT},
+        ReportConfig(attr="active_power", config=REPORT_CONFIG_OP),
+        ReportConfig(attr="active_power_max", config=REPORT_CONFIG_DEFAULT),
+        ReportConfig(attr="apparent_power", config=REPORT_CONFIG_OP),
+        ReportConfig(attr="rms_current", config=REPORT_CONFIG_OP),
+        ReportConfig(attr="rms_current_max", config=REPORT_CONFIG_DEFAULT),
+        ReportConfig(attr="rms_voltage", config=REPORT_CONFIG_OP),
+        ReportConfig(attr="rms_voltage_max", config=REPORT_CONFIG_DEFAULT),
+        ReportConfig(attr="ac_frequency", config=REPORT_CONFIG_OP),
+        ReportConfig(attr="ac_frequency_max", config=REPORT_CONFIG_DEFAULT),
     )
     ZCL_INIT_ATTRS = {
         "ac_current_divisor": True,

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -12,7 +12,7 @@ from ..const import (
     REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -63,15 +63,15 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
         POWER_QUALITY_MEASUREMENT = 256
 
     REPORT_CONFIG = (
-        ReportConfig(attr="active_power", config=REPORT_CONFIG_OP),
-        ReportConfig(attr="active_power_max", config=REPORT_CONFIG_DEFAULT),
-        ReportConfig(attr="apparent_power", config=REPORT_CONFIG_OP),
-        ReportConfig(attr="rms_current", config=REPORT_CONFIG_OP),
-        ReportConfig(attr="rms_current_max", config=REPORT_CONFIG_DEFAULT),
-        ReportConfig(attr="rms_voltage", config=REPORT_CONFIG_OP),
-        ReportConfig(attr="rms_voltage_max", config=REPORT_CONFIG_DEFAULT),
-        ReportConfig(attr="ac_frequency", config=REPORT_CONFIG_OP),
-        ReportConfig(attr="ac_frequency_max", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="active_power", config=REPORT_CONFIG_OP),
+        AttrReportConfig(attr="active_power_max", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="apparent_power", config=REPORT_CONFIG_OP),
+        AttrReportConfig(attr="rms_current", config=REPORT_CONFIG_OP),
+        AttrReportConfig(attr="rms_current_max", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="rms_voltage", config=REPORT_CONFIG_OP),
+        AttrReportConfig(attr="rms_voltage_max", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="ac_frequency", config=REPORT_CONFIG_OP),
+        AttrReportConfig(attr="ac_frequency_max", config=REPORT_CONFIG_DEFAULT),
     )
     ZCL_INIT_ATTRS = {
         "ac_current_divisor": True,

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -22,7 +22,7 @@ from ..const import (
     REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import ZigbeeChannel
+from .base import ReportConfig, ZigbeeChannel
 
 AttributeUpdateRecord = namedtuple("AttributeUpdateRecord", "attr_id, attr_name, value")
 REPORT_CONFIG_CLIMATE = (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 25)
@@ -41,7 +41,7 @@ class FanChannel(ZigbeeChannel):
 
     _value_attribute = 0
 
-    REPORT_CONFIG = ({"attr": "fan_mode", "config": REPORT_CONFIG_OP},)
+    REPORT_CONFIG = (ReportConfig(attr="fan_mode", config=REPORT_CONFIG_OP),)
     ZCL_INIT_ATTRS = {"fan_mode_sequence": True}
 
     @property
@@ -90,17 +90,17 @@ class ThermostatChannel(ZigbeeChannel):
     """Thermostat channel."""
 
     REPORT_CONFIG = (
-        {"attr": "local_temperature", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "occupied_cooling_setpoint", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "occupied_heating_setpoint", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "unoccupied_cooling_setpoint", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "unoccupied_heating_setpoint", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "running_mode", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "running_state", "config": REPORT_CONFIG_CLIMATE_DEMAND},
-        {"attr": "system_mode", "config": REPORT_CONFIG_CLIMATE},
-        {"attr": "occupancy", "config": REPORT_CONFIG_CLIMATE_DISCRETE},
-        {"attr": "pi_cooling_demand", "config": REPORT_CONFIG_CLIMATE_DEMAND},
-        {"attr": "pi_heating_demand", "config": REPORT_CONFIG_CLIMATE_DEMAND},
+        ReportConfig(attr="local_temperature", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="occupied_cooling_setpoint", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="occupied_heating_setpoint", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="unoccupied_cooling_setpoint", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="unoccupied_heating_setpoint", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="running_mode", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="running_state", config=REPORT_CONFIG_CLIMATE_DEMAND),
+        ReportConfig(attr="system_mode", config=REPORT_CONFIG_CLIMATE),
+        ReportConfig(attr="occupancy", config=REPORT_CONFIG_CLIMATE_DISCRETE),
+        ReportConfig(attr="pi_cooling_demand", config=REPORT_CONFIG_CLIMATE_DEMAND),
+        ReportConfig(attr="pi_heating_demand", config=REPORT_CONFIG_CLIMATE_DEMAND),
     )
     ZCL_INIT_ATTRS: dict[int | str, bool] = {
         "abs_min_heat_setpoint_limit": True,

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -22,7 +22,7 @@ from ..const import (
     REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ZigbeeChannel
 
 AttributeUpdateRecord = namedtuple("AttributeUpdateRecord", "attr_id, attr_name, value")
 REPORT_CONFIG_CLIMATE = (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 25)
@@ -41,7 +41,7 @@ class FanChannel(ZigbeeChannel):
 
     _value_attribute = 0
 
-    REPORT_CONFIG = (ReportConfig(attr="fan_mode", config=REPORT_CONFIG_OP),)
+    REPORT_CONFIG = (AttrReportConfig(attr="fan_mode", config=REPORT_CONFIG_OP),)
     ZCL_INIT_ATTRS = {"fan_mode_sequence": True}
 
     @property
@@ -90,17 +90,25 @@ class ThermostatChannel(ZigbeeChannel):
     """Thermostat channel."""
 
     REPORT_CONFIG = (
-        ReportConfig(attr="local_temperature", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="occupied_cooling_setpoint", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="occupied_heating_setpoint", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="unoccupied_cooling_setpoint", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="unoccupied_heating_setpoint", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="running_mode", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="running_state", config=REPORT_CONFIG_CLIMATE_DEMAND),
-        ReportConfig(attr="system_mode", config=REPORT_CONFIG_CLIMATE),
-        ReportConfig(attr="occupancy", config=REPORT_CONFIG_CLIMATE_DISCRETE),
-        ReportConfig(attr="pi_cooling_demand", config=REPORT_CONFIG_CLIMATE_DEMAND),
-        ReportConfig(attr="pi_heating_demand", config=REPORT_CONFIG_CLIMATE_DEMAND),
+        AttrReportConfig(attr="local_temperature", config=REPORT_CONFIG_CLIMATE),
+        AttrReportConfig(
+            attr="occupied_cooling_setpoint", config=REPORT_CONFIG_CLIMATE
+        ),
+        AttrReportConfig(
+            attr="occupied_heating_setpoint", config=REPORT_CONFIG_CLIMATE
+        ),
+        AttrReportConfig(
+            attr="unoccupied_cooling_setpoint", config=REPORT_CONFIG_CLIMATE
+        ),
+        AttrReportConfig(
+            attr="unoccupied_heating_setpoint", config=REPORT_CONFIG_CLIMATE
+        ),
+        AttrReportConfig(attr="running_mode", config=REPORT_CONFIG_CLIMATE),
+        AttrReportConfig(attr="running_state", config=REPORT_CONFIG_CLIMATE_DEMAND),
+        AttrReportConfig(attr="system_mode", config=REPORT_CONFIG_CLIMATE),
+        AttrReportConfig(attr="occupancy", config=REPORT_CONFIG_CLIMATE_DISCRETE),
+        AttrReportConfig(attr="pi_cooling_demand", config=REPORT_CONFIG_CLIMATE_DEMAND),
+        AttrReportConfig(attr="pi_heating_demand", config=REPORT_CONFIG_CLIMATE_DEMAND),
     )
     ZCL_INIT_ATTRS: dict[int | str, bool] = {
         "abs_min_heat_setpoint_limit": True,

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -7,7 +7,7 @@ from zigpy.zcl.clusters import lighting
 
 from .. import registries
 from ..const import REPORT_CONFIG_DEFAULT
-from .base import ClientChannel, ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ClientChannel, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(lighting.Ballast.cluster_id)
@@ -29,9 +29,9 @@ class ColorChannel(ZigbeeChannel):
     CAPABILITIES_COLOR_TEMP = 0x10
     UNSUPPORTED_ATTRIBUTE = 0x86
     REPORT_CONFIG = (
-        ReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
-        ReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
-        ReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
     )
     MAX_MIREDS: int = 500
     MIN_MIREDS: int = 153

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -7,7 +7,7 @@ from zigpy.zcl.clusters import lighting
 
 from .. import registries
 from ..const import REPORT_CONFIG_DEFAULT
-from .base import ClientChannel, ZigbeeChannel
+from .base import ClientChannel, ReportConfig, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(lighting.Ballast.cluster_id)
@@ -29,9 +29,9 @@ class ColorChannel(ZigbeeChannel):
     CAPABILITIES_COLOR_TEMP = 0x10
     UNSUPPORTED_ATTRIBUTE = 0x86
     REPORT_CONFIG = (
-        {"attr": "current_x", "config": REPORT_CONFIG_DEFAULT},
-        {"attr": "current_y", "config": REPORT_CONFIG_DEFAULT},
-        {"attr": "color_temperature", "config": REPORT_CONFIG_DEFAULT},
+        ReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
+        ReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
+        ReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
     )
     MAX_MIREDS: int = 500
     MIN_MIREDS: int = 153

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -31,12 +31,12 @@ _LOGGER = logging.getLogger(__name__)
 class SmartThingsHumidity(ZigbeeChannel):
     """Smart Things Humidity channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 50),
-        }
-    ]
+        },
+    )
 
 
 @registries.CHANNEL_ONLY_CLUSTERS.register(0xFD00)
@@ -87,12 +87,12 @@ class OppleRemote(ZigbeeChannel):
 class SmartThingsAcceleration(ZigbeeChannel):
     """Smart Things Acceleration channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         ReportConfig(attr="acceleration", config=REPORT_CONFIG_ASAP),
         ReportConfig(attr="x_axis", config=REPORT_CONFIG_ASAP),
         ReportConfig(attr="y_axis", config=REPORT_CONFIG_ASAP),
         ReportConfig(attr="z_axis", config=REPORT_CONFIG_ASAP),
-    ]
+    )
 
     @callback
     def attribute_updated(self, attrid, value):

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -19,7 +19,7 @@ from ..const import (
     SIGNAL_ATTR_UPDATED,
     UNKNOWN,
 )
-from .base import ClientChannel, ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ClientChannel, ZigbeeChannel
 
 if TYPE_CHECKING:
     from . import ChannelPool
@@ -88,10 +88,10 @@ class SmartThingsAcceleration(ZigbeeChannel):
     """Smart Things Acceleration channel."""
 
     REPORT_CONFIG = (
-        ReportConfig(attr="acceleration", config=REPORT_CONFIG_ASAP),
-        ReportConfig(attr="x_axis", config=REPORT_CONFIG_ASAP),
-        ReportConfig(attr="y_axis", config=REPORT_CONFIG_ASAP),
-        ReportConfig(attr="z_axis", config=REPORT_CONFIG_ASAP),
+        AttrReportConfig(attr="acceleration", config=REPORT_CONFIG_ASAP),
+        AttrReportConfig(attr="x_axis", config=REPORT_CONFIG_ASAP),
+        AttrReportConfig(attr="y_axis", config=REPORT_CONFIG_ASAP),
+        AttrReportConfig(attr="z_axis", config=REPORT_CONFIG_ASAP),
     )
 
     @callback

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -44,7 +44,7 @@ class SmartThingsHumidity(ZigbeeChannel):
 class OsramButton(ZigbeeChannel):
     """Osram button channel."""
 
-    REPORT_CONFIG: list[ReportConfig] = []
+    REPORT_CONFIG = ()
 
 
 @registries.CHANNEL_ONLY_CLUSTERS.register(registries.PHILLIPS_REMOTE_CLUSTER)
@@ -52,7 +52,7 @@ class OsramButton(ZigbeeChannel):
 class PhillipsRemote(ZigbeeChannel):
     """Phillips remote channel."""
 
-    REPORT_CONFIG: list[ReportConfig] = []
+    REPORT_CONFIG = ()
 
 
 @registries.CHANNEL_ONLY_CLUSTERS.register(0xFCC0)
@@ -60,7 +60,7 @@ class PhillipsRemote(ZigbeeChannel):
 class OppleRemote(ZigbeeChannel):
     """Opple button channel."""
 
-    REPORT_CONFIG: list[ReportConfig] = []
+    REPORT_CONFIG = ()
 
     def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Opple channel."""
@@ -121,4 +121,4 @@ class SmartThingsAcceleration(ZigbeeChannel):
 class InovelliCluster(ClientChannel):
     """Inovelli Button Press Event channel."""
 
-    REPORT_CONFIG: list[ReportConfig] = []
+    REPORT_CONFIG = ()

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -19,7 +19,7 @@ from ..const import (
     SIGNAL_ATTR_UPDATED,
     UNKNOWN,
 )
-from .base import ClientChannel, ZigbeeChannel
+from .base import ClientChannel, ReportConfig, ZigbeeChannel
 
 if TYPE_CHECKING:
     from . import ChannelPool
@@ -44,7 +44,7 @@ class SmartThingsHumidity(ZigbeeChannel):
 class OsramButton(ZigbeeChannel):
     """Osram button channel."""
 
-    REPORT_CONFIG = []
+    REPORT_CONFIG: list[ReportConfig] = []
 
 
 @registries.CHANNEL_ONLY_CLUSTERS.register(registries.PHILLIPS_REMOTE_CLUSTER)
@@ -52,7 +52,7 @@ class OsramButton(ZigbeeChannel):
 class PhillipsRemote(ZigbeeChannel):
     """Phillips remote channel."""
 
-    REPORT_CONFIG = []
+    REPORT_CONFIG: list[ReportConfig] = []
 
 
 @registries.CHANNEL_ONLY_CLUSTERS.register(0xFCC0)
@@ -60,7 +60,7 @@ class PhillipsRemote(ZigbeeChannel):
 class OppleRemote(ZigbeeChannel):
     """Opple button channel."""
 
-    REPORT_CONFIG = []
+    REPORT_CONFIG: list[ReportConfig] = []
 
     def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Opple channel."""
@@ -88,10 +88,10 @@ class SmartThingsAcceleration(ZigbeeChannel):
     """Smart Things Acceleration channel."""
 
     REPORT_CONFIG = [
-        {"attr": "acceleration", "config": REPORT_CONFIG_ASAP},
-        {"attr": "x_axis", "config": REPORT_CONFIG_ASAP},
-        {"attr": "y_axis", "config": REPORT_CONFIG_ASAP},
-        {"attr": "z_axis", "config": REPORT_CONFIG_ASAP},
+        ReportConfig(attr="acceleration", config=REPORT_CONFIG_ASAP),
+        ReportConfig(attr="x_axis", config=REPORT_CONFIG_ASAP),
+        ReportConfig(attr="y_axis", config=REPORT_CONFIG_ASAP),
+        ReportConfig(attr="z_axis", config=REPORT_CONFIG_ASAP),
     ]
 
     @callback
@@ -121,4 +121,4 @@ class SmartThingsAcceleration(ZigbeeChannel):
 class InovelliCluster(ClientChannel):
     """Inovelli Button Press Event channel."""
 
-    REPORT_CONFIG = []
+    REPORT_CONFIG: list[ReportConfig] = []

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -15,7 +15,7 @@ from .base import ReportConfig, ZigbeeChannel
 class FlowMeasurement(ZigbeeChannel):
     """Flow Measurement channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -24,7 +24,7 @@ class FlowMeasurement(ZigbeeChannel):
 class IlluminanceLevelSensing(ZigbeeChannel):
     """Illuminance Level Sensing channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="level_status", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="level_status", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -33,57 +33,57 @@ class IlluminanceLevelSensing(ZigbeeChannel):
 class IlluminanceMeasurement(ZigbeeChannel):
     """Illuminance Measurement channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.OccupancySensing.cluster_id)
 class OccupancySensing(ZigbeeChannel):
     """Occupancy Sensing channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="occupancy", config=REPORT_CONFIG_IMMEDIATE)]
+    REPORT_CONFIG = (ReportConfig(attr="occupancy", config=REPORT_CONFIG_IMMEDIATE),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.PressureMeasurement.cluster_id)
 class PressureMeasurement(ZigbeeChannel):
     """Pressure measurement channel."""
 
-    REPORT_CONFIG = [ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT)]
+    REPORT_CONFIG = (ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.RelativeHumidity.cluster_id)
 class RelativeHumidity(ZigbeeChannel):
     """Relative Humidity measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.SoilMoisture.cluster_id)
 class SoilMoisture(ZigbeeChannel):
     """Soil Moisture measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.LeafWetness.cluster_id)
 class LeafWetness(ZigbeeChannel):
     """Leaf Wetness measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -92,12 +92,12 @@ class LeafWetness(ZigbeeChannel):
 class TemperatureMeasurement(ZigbeeChannel):
     """Temperature measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 50),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -106,12 +106,12 @@ class TemperatureMeasurement(ZigbeeChannel):
 class CarbonMonoxideConcentration(ZigbeeChannel):
     """Carbon Monoxide measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -120,24 +120,24 @@ class CarbonMonoxideConcentration(ZigbeeChannel):
 class CarbonDioxideConcentration(ZigbeeChannel):
     """Carbon Dioxide measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.PM25.cluster_id)
 class PM25(ZigbeeChannel):
     """Particulate Matter 2.5 microns or less measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.1),
-        }
-    ]
+        },
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -146,9 +146,9 @@ class PM25(ZigbeeChannel):
 class FormaldehydeConcentration(ZigbeeChannel):
     """Formaldehyde measurement channel."""
 
-    REPORT_CONFIG = [
+    REPORT_CONFIG = (
         {
             "attr": "measured_value",
             "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
-        }
-    ]
+        },
+    )

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -8,14 +8,16 @@ from ..const import (
     REPORT_CONFIG_MAX_INT,
     REPORT_CONFIG_MIN_INT,
 )
-from .base import ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.FlowMeasurement.cluster_id)
 class FlowMeasurement(ZigbeeChannel):
     """Flow Measurement channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -24,7 +26,9 @@ class FlowMeasurement(ZigbeeChannel):
 class IlluminanceLevelSensing(ZigbeeChannel):
     """Illuminance Level Sensing channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="level_status", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="level_status", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -33,21 +37,27 @@ class IlluminanceLevelSensing(ZigbeeChannel):
 class IlluminanceMeasurement(ZigbeeChannel):
     """Illuminance Measurement channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.OccupancySensing.cluster_id)
 class OccupancySensing(ZigbeeChannel):
     """Occupancy Sensing channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="occupancy", config=REPORT_CONFIG_IMMEDIATE),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="occupancy", config=REPORT_CONFIG_IMMEDIATE),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.PressureMeasurement.cluster_id)
 class PressureMeasurement(ZigbeeChannel):
     """Pressure measurement channel."""
 
-    REPORT_CONFIG = (ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),)
+    REPORT_CONFIG = (
+        AttrReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT),
+    )
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.RelativeHumidity.cluster_id)

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -8,14 +8,14 @@ from ..const import (
     REPORT_CONFIG_MAX_INT,
     REPORT_CONFIG_MIN_INT,
 )
-from .base import ZigbeeChannel
+from .base import ReportConfig, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.FlowMeasurement.cluster_id)
 class FlowMeasurement(ZigbeeChannel):
     """Flow Measurement channel."""
 
-    REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -24,7 +24,7 @@ class FlowMeasurement(ZigbeeChannel):
 class IlluminanceLevelSensing(ZigbeeChannel):
     """Illuminance Level Sensing channel."""
 
-    REPORT_CONFIG = [{"attr": "level_status", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="level_status", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
@@ -33,21 +33,21 @@ class IlluminanceLevelSensing(ZigbeeChannel):
 class IlluminanceMeasurement(ZigbeeChannel):
     """Illuminance Measurement channel."""
 
-    REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.OccupancySensing.cluster_id)
 class OccupancySensing(ZigbeeChannel):
     """Occupancy Sensing channel."""
 
-    REPORT_CONFIG = [{"attr": "occupancy", "config": REPORT_CONFIG_IMMEDIATE}]
+    REPORT_CONFIG = [ReportConfig(attr="occupancy", config=REPORT_CONFIG_IMMEDIATE)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.PressureMeasurement.cluster_id)
 class PressureMeasurement(ZigbeeChannel):
     """Pressure measurement channel."""
 
-    REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [ReportConfig(attr="measured_value", config=REPORT_CONFIG_DEFAULT)]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.RelativeHumidity.cluster_id)

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -65,10 +65,10 @@ class RelativeHumidity(ZigbeeChannel):
     """Relative Humidity measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
+        ),
     )
 
 
@@ -77,10 +77,10 @@ class SoilMoisture(ZigbeeChannel):
     """Soil Moisture measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
+        ),
     )
 
 
@@ -89,10 +89,10 @@ class LeafWetness(ZigbeeChannel):
     """Leaf Wetness measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 100),
+        ),
     )
 
 
@@ -103,10 +103,10 @@ class TemperatureMeasurement(ZigbeeChannel):
     """Temperature measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 50),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 50),
+        ),
     )
 
 
@@ -117,10 +117,10 @@ class CarbonMonoxideConcentration(ZigbeeChannel):
     """Carbon Monoxide measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
+        ),
     )
 
 
@@ -131,10 +131,10 @@ class CarbonDioxideConcentration(ZigbeeChannel):
     """Carbon Dioxide measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
+        ),
     )
 
 
@@ -143,10 +143,10 @@ class PM25(ZigbeeChannel):
     """Particulate Matter 2.5 microns or less measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.1),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.1),
+        ),
     )
 
 
@@ -157,8 +157,8 @@ class FormaldehydeConcentration(ZigbeeChannel):
     """Formaldehyde measurement channel."""
 
     REPORT_CONFIG = (
-        {
-            "attr": "measured_value",
-            "config": (REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
-        },
+        AttrReportConfig(
+            attr="measured_value",
+            config=(REPORT_CONFIG_MIN_INT, REPORT_CONFIG_MAX_INT, 0.000001),
+        ),
     )

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -15,7 +15,7 @@ from ..const import (
     REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import ReportConfig, ZigbeeChannel
+from .base import AttrReportConfig, ZigbeeChannel
 
 if TYPE_CHECKING:
     from . import ChannelPool
@@ -66,9 +66,9 @@ class Metering(ZigbeeChannel):
     """Metering channel."""
 
     REPORT_CONFIG = (
-        ReportConfig(attr="instantaneous_demand", config=REPORT_CONFIG_OP),
-        ReportConfig(attr="current_summ_delivered", config=REPORT_CONFIG_DEFAULT),
-        ReportConfig(attr="status", config=REPORT_CONFIG_ASAP),
+        AttrReportConfig(attr="instantaneous_demand", config=REPORT_CONFIG_OP),
+        AttrReportConfig(attr="current_summ_delivered", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="status", config=REPORT_CONFIG_ASAP),
     )
     ZCL_INIT_ATTRS = {
         "demand_formatting": True,

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -15,7 +15,7 @@ from ..const import (
     REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import ZigbeeChannel
+from .base import ReportConfig, ZigbeeChannel
 
 if TYPE_CHECKING:
     from . import ChannelPool
@@ -66,9 +66,9 @@ class Metering(ZigbeeChannel):
     """Metering channel."""
 
     REPORT_CONFIG = (
-        {"attr": "instantaneous_demand", "config": REPORT_CONFIG_OP},
-        {"attr": "current_summ_delivered", "config": REPORT_CONFIG_DEFAULT},
-        {"attr": "status", "config": REPORT_CONFIG_ASAP},
+        ReportConfig(attr="instantaneous_demand", config=REPORT_CONFIG_OP),
+        ReportConfig(attr="current_summ_delivered", config=REPORT_CONFIG_DEFAULT),
+        ReportConfig(attr="status", config=REPORT_CONFIG_ASAP),
     )
     ZCL_INIT_ATTRS = {
         "demand_formatting": True,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current type hint for `REPORT_CONFIG` isn't valid and causes all sort of issues for `mypy`.

Linked to #73603

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
