### PR TITLE
Normalize deCONZ binary sensor unique IDs

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -180,47 +180,6 @@ BINARY_SENSOR_DESCRIPTIONS = [
 ]
 
 
-# async def async_update_unique_ids(
-#     hass: HomeAssistant, config_entry: ConfigEntry
-# ) -> None:
-#     """Update unique ID to always have a suffix."""
-
-#     all_descriptions = list(ENTITY_DESCRIPTIONS.values()) + [BINARY_SENSOR_DESCRIPTIONS]
-#     all_keys = [
-#         description.key
-#         for descriptions in all_descriptions
-#         for description in descriptions
-#     ]
-
-#     @callback
-#     def update_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
-#         """Update unique ID of entity entry."""
-#         if (
-#             entity_entry.domain != DOMAIN
-#             or entity_entry.unique_id.rsplit("-", 1)[-1] in all_keys
-#         ):
-#             return None
-#         print(
-#             entity_entry.entity_category,
-#             entity_entry.original_device_class,
-#             entity_entry.unique_id,
-#             entity_entry.unique_id.rsplit("-", 1),
-#         )
-#         for descriptions in all_descriptions:
-#             for description in descriptions:
-#                 if entity_entry.entity_category != description.entity_category:
-#                     continue
-#                 if entity_entry.original_device_class != description.device_class:
-#                     continue
-#                 unique_id = entity_entry.unique_id.split("-")[0]
-#                 print({"new_unique_id": f"{unique_id}-{description.key}"})
-#                 return {"new_unique_id": f"{unique_id}-{description.key}"}
-
-#         return None
-
-#     await er.async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
-
-
 @callback
 def async_update_unique_id(
     hass: HomeAssistant, unique_id: str, description: DeconzBinarySensorDescription

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -27,8 +27,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import homeassistant.helpers.entity_registry as er
 
-from .const import ATTR_DARK, ATTR_ON
+from .const import ATTR_DARK, ATTR_ON, DOMAIN as DECONZ_DOMAIN
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
@@ -179,6 +180,68 @@ BINARY_SENSOR_DESCRIPTIONS = [
 ]
 
 
+# async def async_update_unique_ids(
+#     hass: HomeAssistant, config_entry: ConfigEntry
+# ) -> None:
+#     """Update unique ID to always have a suffix."""
+
+#     all_descriptions = list(ENTITY_DESCRIPTIONS.values()) + [BINARY_SENSOR_DESCRIPTIONS]
+#     all_keys = [
+#         description.key
+#         for descriptions in all_descriptions
+#         for description in descriptions
+#     ]
+
+#     @callback
+#     def update_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+#         """Update unique ID of entity entry."""
+#         if (
+#             entity_entry.domain != DOMAIN
+#             or entity_entry.unique_id.rsplit("-", 1)[-1] in all_keys
+#         ):
+#             return None
+#         print(
+#             entity_entry.entity_category,
+#             entity_entry.original_device_class,
+#             entity_entry.unique_id,
+#             entity_entry.unique_id.rsplit("-", 1),
+#         )
+#         for descriptions in all_descriptions:
+#             for description in descriptions:
+#                 if entity_entry.entity_category != description.entity_category:
+#                     continue
+#                 if entity_entry.original_device_class != description.device_class:
+#                     continue
+#                 unique_id = entity_entry.unique_id.split("-")[0]
+#                 print({"new_unique_id": f"{unique_id}-{description.key}"})
+#                 return {"new_unique_id": f"{unique_id}-{description.key}"}
+
+#         return None
+
+#     await er.async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
+
+
+@callback
+def async_update_unique_id(
+    hass: HomeAssistant, unique_id: str, description: DeconzBinarySensorDescription
+) -> None:
+    """Update unique ID to always have a suffix.
+
+    Introduced with release 2022.7.
+    """
+    ent_reg = er.async_get(hass)
+
+    new_unique_id = f"{unique_id}-{description.key}"
+    if ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, new_unique_id):
+        return
+
+    if description.suffix:
+        unique_id = f'{unique_id.split("-", 1)[0]}-{description.suffix.lower()}'
+
+    if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
+        ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -204,6 +267,8 @@ async def async_setup_entry(
                 or description.value_fn(sensor) is None
             ):
                 continue
+
+            async_update_unique_id(hass, sensor.unique_id, description)
 
             async_add_entities([DeconzBinarySensor(sensor, gateway, description)])
 
@@ -255,9 +320,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this device."""
-        if self.entity_description.suffix:
-            return f"{self.serial}-{self.entity_description.suffix.lower()}"
-        return super().unique_id
+        return f"{super().unique_id}-{self.entity_description.key}"
 
     @callback
     def async_update_callback(self) -> None:

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceClass
 from homeassistant.components.deconz.const import (
     CONF_ALLOW_CLIP_SENSOR,
     CONF_ALLOW_NEW_DEVICES,
@@ -63,7 +63,8 @@ TEST_DATA = [
             "entity_count": 3,
             "device_count": 3,
             "entity_id": "binary_sensor.alarm_10",
-            "unique_id": "00:15:8d:00:02:b5:d1:80-01-0500",
+            "unique_id": "00:15:8d:00:02:b5:d1:80-01-0500-alarm",
+            "old_unique_id": "00:15:8d:00:02:b5:d1:80-01-0500",
             "state": STATE_OFF,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.SAFETY,
@@ -104,7 +105,8 @@ TEST_DATA = [
             "entity_count": 4,
             "device_count": 3,
             "entity_id": "binary_sensor.cave_co",
-            "unique_id": "00:15:8d:00:02:a5:21:24-01-0101",
+            "unique_id": "00:15:8d:00:02:a5:21:24-01-0101-carbon_monoxide",
+            "old_unique_id": "00:15:8d:00:02:a5:21:24-01-0101",
             "state": STATE_OFF,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.CO,
@@ -139,7 +141,8 @@ TEST_DATA = [
             "entity_count": 2,
             "device_count": 3,
             "entity_id": "binary_sensor.sensor_kitchen_smoke",
-            "unique_id": "00:15:8d:00:01:d9:3e:7c-01-0500",
+            "unique_id": "00:15:8d:00:01:d9:3e:7c-01-0500-fire",
+            "old_unique_id": "00:15:8d:00:01:d9:3e:7c-01-0500",
             "state": STATE_OFF,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.SMOKE,
@@ -175,7 +178,8 @@ TEST_DATA = [
             "entity_count": 2,
             "device_count": 3,
             "entity_id": "binary_sensor.sensor_kitchen_smoke_test_mode",
-            "unique_id": "00:15:8d:00:01:d9:3e:7c-test mode",
+            "unique_id": "00:15:8d:00:01:d9:3e:7c-01-0500-in_test_mode",
+            "old_unique_id": "00:15:8d:00:01:d9:3e:7c-test mode",
             "state": STATE_OFF,
             "entity_category": EntityCategory.DIAGNOSTIC,
             "device_class": BinarySensorDeviceClass.SMOKE,
@@ -207,7 +211,8 @@ TEST_DATA = [
             "entity_count": 1,
             "device_count": 2,
             "entity_id": "binary_sensor.kitchen_switch",
-            "unique_id": "kitchen-switch",
+            "unique_id": "kitchen-switch-flag",
+            "old_unique_id": "kitchen-switch",
             "state": STATE_ON,
             "entity_category": None,
             "device_class": None,
@@ -244,7 +249,8 @@ TEST_DATA = [
             "entity_count": 3,
             "device_count": 3,
             "entity_id": "binary_sensor.back_door",
-            "unique_id": "00:15:8d:00:02:2b:96:b4-01-0006",
+            "unique_id": "00:15:8d:00:02:2b:96:b4-01-0006-open",
+            "old_unique_id": "00:15:8d:00:02:2b:96:b4-01-0006",
             "state": STATE_OFF,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.OPENING,
@@ -290,7 +296,8 @@ TEST_DATA = [
             "entity_count": 3,
             "device_count": 3,
             "entity_id": "binary_sensor.motion_sensor_4",
-            "unique_id": "00:17:88:01:03:28:8c:9b-02-0406",
+            "unique_id": "00:17:88:01:03:28:8c:9b-02-0406-presence",
+            "old_unique_id": "00:17:88:01:03:28:8c:9b-02-0406",
             "state": STATE_OFF,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.MOTION,
@@ -331,7 +338,8 @@ TEST_DATA = [
             "entity_count": 5,
             "device_count": 3,
             "entity_id": "binary_sensor.water2",
-            "unique_id": "00:15:8d:00:02:2f:07:db-01-0500",
+            "unique_id": "00:15:8d:00:02:2f:07:db-01-0500-water",
+            "old_unique_id": "00:15:8d:00:02:2f:07:db-01-0500",
             "state": STATE_OFF,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.MOISTURE,
@@ -376,7 +384,8 @@ TEST_DATA = [
             "entity_count": 3,
             "device_count": 3,
             "entity_id": "binary_sensor.vibration_1",
-            "unique_id": "00:15:8d:00:02:a5:21:24-01-0101",
+            "unique_id": "00:15:8d:00:02:a5:21:24-01-0101-vibration",
+            "old_unique_id": "00:15:8d:00:02:a5:21:24-01-0101",
             "state": STATE_ON,
             "entity_category": None,
             "device_class": BinarySensorDeviceClass.VIBRATION,
@@ -414,7 +423,8 @@ TEST_DATA = [
             "entity_count": 4,
             "device_count": 3,
             "entity_id": "binary_sensor.presence_sensor_tampered",
-            "unique_id": "00:00:00:00:00:00:00:00-tampered",
+            "unique_id": "00:00:00:00:00:00:00:00-00-tampered",
+            "old_unique_id": "00:00:00:00:00:00:00:00-tampered",
             "state": STATE_OFF,
             "entity_category": EntityCategory.DIAGNOSTIC,
             "device_class": BinarySensorDeviceClass.TAMPER,
@@ -447,7 +457,8 @@ TEST_DATA = [
             "entity_count": 4,
             "device_count": 3,
             "entity_id": "binary_sensor.presence_sensor_low_battery",
-            "unique_id": "00:00:00:00:00:00:00:00-low battery",
+            "unique_id": "00:00:00:00:00:00:00:00-00-low_battery",
+            "old_unique_id": "00:00:00:00:00:00:00:00-low battery",
             "state": STATE_OFF,
             "entity_category": EntityCategory.DIAGNOSTIC,
             "device_class": BinarySensorDeviceClass.BATTERY,
@@ -469,6 +480,14 @@ async def test_binary_sensors(
     """Test successful creation of binary sensor entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
+
+    # Create entity entry to migrate to new unique ID
+    ent_reg.async_get_or_create(
+        DOMAIN,
+        DECONZ_DOMAIN,
+        expected["old_unique_id"],
+        suggested_object_id=expected["entity_id"].replace(DOMAIN, ""),
+    )
 
     with patch.dict(DECONZ_WEB_REQUEST, {"sensors": {"1": sensor_data}}):
         config_entry = await setup_deconz_integration(
@@ -734,3 +753,28 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
 
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("binary_sensor.presence_sensor")
+
+
+# async def test_binary_sensor_update_unique_id(hass, aioclient_mock):
+#     """Test successful creation of binary sensor entities."""
+#     ent_reg = er.async_get(hass)
+
+#     with patch.dict(DECONZ_WEB_REQUEST, {"sensors": {"1": sensor_data}}):
+#         config_entry = await setup_deconz_integration(
+#             hass, aioclient_mock, options={CONF_ALLOW_CLIP_SENSOR: True}
+#         )
+
+#     assert len(hass.states.async_all()) == expected["entity_count"]
+
+#     # Verify state data
+
+#     sensor = hass.states.get(expected["entity_id"])
+#     assert sensor.state == expected["state"]
+#     assert sensor.attributes.get(ATTR_DEVICE_CLASS) == expected["device_class"]
+#     assert sensor.attributes == expected["attributes"]
+
+#     # Verify entity registry data
+
+#     ent_reg_entry = ent_reg.async_get(expected["entity_id"])
+#     assert ent_reg_entry.entity_category is expected["entity_category"]
+#     assert ent_reg_entry.unique_id == expected["unique_id"]

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -753,28 +753,3 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
 
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("binary_sensor.presence_sensor")
-
-
-# async def test_binary_sensor_update_unique_id(hass, aioclient_mock):
-#     """Test successful creation of binary sensor entities."""
-#     ent_reg = er.async_get(hass)
-
-#     with patch.dict(DECONZ_WEB_REQUEST, {"sensors": {"1": sensor_data}}):
-#         config_entry = await setup_deconz_integration(
-#             hass, aioclient_mock, options={CONF_ALLOW_CLIP_SENSOR: True}
-#         )
-
-#     assert len(hass.states.async_all()) == expected["entity_count"]
-
-#     # Verify state data
-
-#     sensor = hass.states.get(expected["entity_id"])
-#     assert sensor.state == expected["state"]
-#     assert sensor.attributes.get(ATTR_DEVICE_CLASS) == expected["device_class"]
-#     assert sensor.attributes == expected["attributes"]
-
-#     # Verify entity registry data
-
-#     ent_reg_entry = ent_reg.async_get(expected["entity_id"])
-#     assert ent_reg_entry.entity_category is expected["entity_category"]
-#     assert ent_reg_entry.unique_id == expected["unique_id"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To prepare for better expansion/scalability of more binary sensor entities it is needed to simplify the unique IDs.
This operation needs to be done on more platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
