### PR TITLE
Use pydeconz interface controls for climate platform

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -3,28 +3,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydeconz.models.event import EventType
-from pydeconz.models.sensor.thermostat import (
-    THERMOSTAT_FAN_MODE_AUTO,
-    THERMOSTAT_FAN_MODE_HIGH,
-    THERMOSTAT_FAN_MODE_LOW,
-    THERMOSTAT_FAN_MODE_MEDIUM,
-    THERMOSTAT_FAN_MODE_OFF,
-    THERMOSTAT_FAN_MODE_ON,
-    THERMOSTAT_FAN_MODE_SMART,
-    THERMOSTAT_MODE_AUTO,
-    THERMOSTAT_MODE_COOL,
-    THERMOSTAT_MODE_HEAT,
-    THERMOSTAT_MODE_OFF,
-    THERMOSTAT_PRESET_AUTO,
-    THERMOSTAT_PRESET_BOOST,
-    THERMOSTAT_PRESET_COMFORT,
-    THERMOSTAT_PRESET_COMPLEX,
-    THERMOSTAT_PRESET_ECO,
-    THERMOSTAT_PRESET_HOLIDAY,
-    THERMOSTAT_PRESET_MANUAL,
-    Thermostat,
+from pydeconz.interfaces.sensors import (
+    ThermostatFanMode,
+    ThermostatMode,
+    ThermostatPreset,
 )
+from pydeconz.models.event import EventType
+from pydeconz.models.sensor.thermostat import Thermostat
 
 from homeassistant.components.climate import DOMAIN, ClimateEntity
 from homeassistant.components.climate.const import (
@@ -53,21 +38,21 @@ from .gateway import DeconzGateway, get_gateway_from_config_entry
 DECONZ_FAN_SMART = "smart"
 
 FAN_MODE_TO_DECONZ = {
-    DECONZ_FAN_SMART: THERMOSTAT_FAN_MODE_SMART,
-    FAN_AUTO: THERMOSTAT_FAN_MODE_AUTO,
-    FAN_HIGH: THERMOSTAT_FAN_MODE_HIGH,
-    FAN_MEDIUM: THERMOSTAT_FAN_MODE_MEDIUM,
-    FAN_LOW: THERMOSTAT_FAN_MODE_LOW,
-    FAN_ON: THERMOSTAT_FAN_MODE_ON,
-    FAN_OFF: THERMOSTAT_FAN_MODE_OFF,
+    DECONZ_FAN_SMART: ThermostatFanMode.SMART,
+    FAN_AUTO: ThermostatFanMode.AUTO,
+    FAN_HIGH: ThermostatFanMode.HIGH,
+    FAN_MEDIUM: ThermostatFanMode.MEDIUM,
+    FAN_LOW: ThermostatFanMode.LOW,
+    FAN_ON: ThermostatFanMode.ON,
+    FAN_OFF: ThermostatFanMode.OFF,
 }
 DECONZ_TO_FAN_MODE = {value: key for key, value in FAN_MODE_TO_DECONZ.items()}
 
-HVAC_MODE_TO_DECONZ: dict[HVACMode, str] = {
-    HVACMode.AUTO: THERMOSTAT_MODE_AUTO,
-    HVACMode.COOL: THERMOSTAT_MODE_COOL,
-    HVACMode.HEAT: THERMOSTAT_MODE_HEAT,
-    HVACMode.OFF: THERMOSTAT_MODE_OFF,
+HVAC_MODE_TO_DECONZ = {
+    HVACMode.AUTO: ThermostatMode.AUTO,
+    HVACMode.COOL: ThermostatMode.COOL,
+    HVACMode.HEAT: ThermostatMode.HEAT,
+    HVACMode.OFF: ThermostatMode.OFF,
 }
 
 DECONZ_PRESET_AUTO = "auto"
@@ -76,13 +61,13 @@ DECONZ_PRESET_HOLIDAY = "holiday"
 DECONZ_PRESET_MANUAL = "manual"
 
 PRESET_MODE_TO_DECONZ = {
-    DECONZ_PRESET_AUTO: THERMOSTAT_PRESET_AUTO,
-    PRESET_BOOST: THERMOSTAT_PRESET_BOOST,
-    PRESET_COMFORT: THERMOSTAT_PRESET_COMFORT,
-    DECONZ_PRESET_COMPLEX: THERMOSTAT_PRESET_COMPLEX,
-    PRESET_ECO: THERMOSTAT_PRESET_ECO,
-    DECONZ_PRESET_HOLIDAY: THERMOSTAT_PRESET_HOLIDAY,
-    DECONZ_PRESET_MANUAL: THERMOSTAT_PRESET_MANUAL,
+    DECONZ_PRESET_AUTO: ThermostatPreset.AUTO,
+    PRESET_BOOST: ThermostatPreset.BOOST,
+    PRESET_COMFORT: ThermostatPreset.COMFORT,
+    DECONZ_PRESET_COMPLEX: ThermostatPreset.COMPLEX,
+    PRESET_ECO: ThermostatPreset.ECO,
+    DECONZ_PRESET_HOLIDAY: ThermostatPreset.HOLIDAY,
+    DECONZ_PRESET_MANUAL: ThermostatPreset.MANUAL,
 }
 DECONZ_TO_PRESET_MODE = {value: key for key, value in PRESET_MODE_TO_DECONZ.items()}
 
@@ -166,16 +151,19 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def fan_mode(self) -> str:
         """Return fan operation."""
-        if self._device.fan_mode in DECONZ_TO_FAN_MODE:
-            return DECONZ_TO_FAN_MODE[self._device.fan_mode]
-        return DECONZ_TO_FAN_MODE[FAN_ON if self._device.state_on else FAN_OFF]
+        if self._device.fan_mode:
+            return DECONZ_TO_FAN_MODE[ThermostatFanMode(self._device.fan_mode)]
+        return FAN_ON if self._device.state_on else FAN_OFF
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if fan_mode not in FAN_MODE_TO_DECONZ:
             raise ValueError(f"Unsupported fan mode {fan_mode}")
 
-        await self._device.set_config(fan_mode=FAN_MODE_TO_DECONZ[fan_mode])
+        await self.gateway.api.sensors.thermostat.set_config(
+            id=self._device.resource_id,
+            fan_mode=FAN_MODE_TO_DECONZ[fan_mode],
+        )
 
     # HVAC control
 
@@ -185,8 +173,8 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
 
         Need to be one of HVAC_MODE_*.
         """
-        if self._device.mode in self._deconz_to_hvac_mode:
-            return self._deconz_to_hvac_mode[self._device.mode]
+        if self._device.mode:
+            return self._deconz_to_hvac_mode[ThermostatMode(self._device.mode)]
         return HVACMode.HEAT if self._device.state_on else HVACMode.OFF
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -195,17 +183,23 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
             raise ValueError(f"Unsupported HVAC mode {hvac_mode}")
 
         if len(self._attr_hvac_modes) == 2:  # Only allow turn on and off thermostat
-            await self._device.set_config(on=hvac_mode != HVACMode.OFF)
+            await self.gateway.api.sensors.thermostat.set_config(
+                id=self._device.resource_id,
+                on=hvac_mode != HVACMode.OFF,
+            )
         else:
-            await self._device.set_config(mode=HVAC_MODE_TO_DECONZ[hvac_mode])
+            await self.gateway.api.sensors.thermostat.set_config(
+                id=self._device.resource_id,
+                mode=HVAC_MODE_TO_DECONZ[hvac_mode],
+            )
 
     # Preset control
 
     @property
     def preset_mode(self) -> str | None:
         """Return preset mode."""
-        if self._device.preset in DECONZ_TO_PRESET_MODE:
-            return DECONZ_TO_PRESET_MODE[self._device.preset]
+        if self._device.preset:
+            return DECONZ_TO_PRESET_MODE[ThermostatPreset(self._device.preset)]
         return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -213,7 +207,10 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         if preset_mode not in PRESET_MODE_TO_DECONZ:
             raise ValueError(f"Unsupported preset mode {preset_mode}")
 
-        await self._device.set_config(preset=PRESET_MODE_TO_DECONZ[preset_mode])
+        await self.gateway.api.sensors.thermostat.set_config(
+            id=self._device.resource_id,
+            preset=PRESET_MODE_TO_DECONZ[preset_mode],
+        )
 
     # Temperature control
 
@@ -225,7 +222,11 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
-        if self._device.mode == THERMOSTAT_MODE_COOL and self._device.cooling_setpoint:
+        if (
+            self._device.mode
+            and ThermostatMode(self._device.mode) == ThermostatMode.COOL
+            and self._device.cooling_setpoint
+        ):
             return self._device.cooling_setpoint
 
         if self._device.heating_setpoint:
@@ -238,11 +239,19 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         if ATTR_TEMPERATURE not in kwargs:
             raise ValueError(f"Expected attribute {ATTR_TEMPERATURE}")
 
-        data = {"heating_setpoint": kwargs[ATTR_TEMPERATURE] * 100}
-        if self._device.mode == "cool":
-            data = {"cooling_setpoint": kwargs[ATTR_TEMPERATURE] * 100}
-
-        await self._device.set_config(**data)
+        if (
+            self._device.mode
+            and ThermostatMode(self._device.mode) == ThermostatMode.COOL
+        ):
+            await self.gateway.api.sensors.thermostat.set_config(
+                id=self._device.resource_id,
+                cooling_setpoint=kwargs[ATTR_TEMPERATURE] * 100,
+            )
+        else:
+            await self.gateway.api.sensors.thermostat.set_config(
+                id=self._device.resource_id,
+                heating_setpoint=kwargs[ATTR_TEMPERATURE] * 100,
+            )
 
     @property
     def extra_state_attributes(self) -> dict[str, bool | int]:

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==92"],
+  "requirements": ["pydeconz==93"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1438,7 +1438,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==92
+pydeconz==93
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -965,7 +965,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==92
+pydeconz==93
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -232,7 +232,7 @@ async def test_climate_device_without_cooling_support(
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "config": {"mode": None},
+        "config": {"mode": "other"},
         "state": {"on": True},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
@@ -471,7 +471,7 @@ async def test_climate_device_with_fan_support(
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"fanmode": None},
+        "config": {"fanmode": "unsupported"},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -485,7 +485,7 @@ async def test_climate_device_with_fan_support(
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"fanmode": None},
+        "config": {"fanmode": "unsupported"},
         "state": {"on": True},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
@@ -500,7 +500,7 @@ async def test_climate_device_with_fan_support(
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"fanmode": None},
+        "config": {"fanmode": "unsupported"},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -618,7 +618,7 @@ async def test_climate_device_with_preset(hass, aioclient_mock, mock_deconz_webs
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"preset": None},
+        "config": {"preset": "unsupported"},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -232,7 +232,7 @@ async def test_climate_device_without_cooling_support(
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "config": {"mode": "other"},
+        "config": {"mode": None},
         "state": {"on": True},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
@@ -471,7 +471,7 @@ async def test_climate_device_with_fan_support(
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"fanmode": "unsupported"},
+        "config": {"fanmode": None},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -485,7 +485,7 @@ async def test_climate_device_with_fan_support(
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"fanmode": "unsupported"},
+        "config": {"fanmode": None},
         "state": {"on": True},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
@@ -500,7 +500,7 @@ async def test_climate_device_with_fan_support(
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"fanmode": "unsupported"},
+        "config": {"fanmode": None},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -618,7 +618,7 @@ async def test_climate_device_with_preset(hass, aioclient_mock, mock_deconz_webs
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "config": {"preset": "unsupported"},
+        "config": {"preset": None},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar change as https://github.com/home-assistant/core/pull/72317
Move controls over to the interface class and clean up the data model in pydeconz by utilising more enums where possible
https://github.com/Kane610/deconz/compare/v92...v93

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
