### PR TITLE
BMW Connected Drive: Handle HTTP 429 issues better

### DIFF
--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -60,19 +60,13 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator):
                 self.update_interval = timedelta(
                     seconds=DEFAULT_SCAN_INTERVAL_SECONDS * 3
                 )
-
-                _LOGGER.warning(
-                    "Too many requests when communicating with BMW API, API allows retry in %s seconds",
-                    err.response.headers.get("Retry-After") or "UNKNOWN",
-                )
-            else:
-                if isinstance(err, HTTPStatusError) and err.response.status_code in (
-                    401,
-                    403,
-                ):
-                    # Clear refresh token only on issues with authorization
-                    self._update_config_entry_refresh_token(None)
-                raise UpdateFailed(f"Error communicating with BMW API: {err}") from err
+            if isinstance(err, HTTPStatusError) and err.response.status_code in (
+                401,
+                403,
+            ):
+                # Clear refresh token only on issues with authorization
+                self._update_config_entry_refresh_token(None)
+            raise UpdateFailed(f"Error communicating with BMW API: {err}") from err
 
         if self.account.refresh_token != old_refresh_token:
             self._update_config_entry_refresh_token(self.account.refresh_token)

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the for the BMW Connected Drive config flow."""
 from unittest.mock import patch
 
+from bimmer_connected.api.authentication import MyBMWAuthentication
 from httpx import HTTPError
 
 from homeassistant import config_entries, data_entry_flow
@@ -15,8 +16,17 @@ from . import FIXTURE_CONFIG_ENTRY, FIXTURE_USER_INPUT
 
 from tests.common import MockConfigEntry
 
-FIXTURE_COMPLETE_ENTRY = {**FIXTURE_USER_INPUT, CONF_REFRESH_TOKEN: None}
+FIXTURE_REFRESH_TOKEN = "SOME_REFRESH_TOKEN"
+FIXTURE_COMPLETE_ENTRY = {
+    **FIXTURE_USER_INPUT,
+    CONF_REFRESH_TOKEN: FIXTURE_REFRESH_TOKEN,
+}
 FIXTURE_IMPORT_ENTRY = {**FIXTURE_USER_INPUT, CONF_REFRESH_TOKEN: None}
+
+
+def login_sideeffect(self: MyBMWAuthentication):
+    """Mock logging in and setting a refresh token."""
+    self.refresh_token = FIXTURE_REFRESH_TOKEN
 
 
 async def test_show_form(hass):
@@ -54,7 +64,8 @@ async def test_full_user_flow_implementation(hass):
     """Test registering an integration and finishing flow works."""
     with patch(
         "bimmer_connected.api.authentication.MyBMWAuthentication.login",
-        return_value=None,
+        side_effect=login_sideeffect,
+        autospec=True,
     ), patch(
         "homeassistant.components.bmw_connected_drive.async_setup_entry",
         return_value=True,

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -5,15 +5,18 @@ from httpx import HTTPError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.bmw_connected_drive.config_flow import DOMAIN
-from homeassistant.components.bmw_connected_drive.const import CONF_READ_ONLY
+from homeassistant.components.bmw_connected_drive.const import (
+    CONF_READ_ONLY,
+    CONF_REFRESH_TOKEN,
+)
 from homeassistant.const import CONF_USERNAME
 
 from . import FIXTURE_CONFIG_ENTRY, FIXTURE_USER_INPUT
 
 from tests.common import MockConfigEntry
 
-FIXTURE_COMPLETE_ENTRY = FIXTURE_USER_INPUT.copy()
-FIXTURE_IMPORT_ENTRY = FIXTURE_USER_INPUT.copy()
+FIXTURE_COMPLETE_ENTRY = {**FIXTURE_USER_INPUT, CONF_REFRESH_TOKEN: None}
+FIXTURE_IMPORT_ENTRY = {**FIXTURE_USER_INPUT, CONF_REFRESH_TOKEN: None}
 
 
 async def test_show_form(hass):
@@ -50,8 +53,8 @@ async def test_connection_error(hass):
 async def test_full_user_flow_implementation(hass):
     """Test registering an integration and finishing flow works."""
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
-        return_value=[],
+        "bimmer_connected.api.authentication.MyBMWAuthentication.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.bmw_connected_drive.async_setup_entry",
         return_value=True,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Recently, some users reported a lot of HTTP 429 Too Many Requests errors by the BMW API when calling the `vehicle` endpoint. The API seems to allow between 4 to 8 requests shortly after each other before throwing a 429 with `Retry-At` times of ~250 seconds (this has been changed recently).

This PR doesn't fix the problem fully, but mitigates some of the effects by:
- Only `login` instead of `get_vehicles` to check the credentials during the config flow
- Re-use `refresh_token` retrieved from checking the credentials
- Clear `refresh_token` from the config entry only on authentication HTTP codes
- Fail silently on HTTP 429, don't throw `UpdateFailed`, but only log a warning (the `UpdateFailed` somehow seemed to throw some people in a never ending 429 loop which I was unable to replicate).
- 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/73370, https://github.com/bimmerconnected/bimmer_connected/discussions/456
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
