### PR TITLE
Split timer service for Sensibo

### DIFF
--- a/homeassistant/components/sensibo/binary_sensor.py
+++ b/homeassistant/components/sensibo/binary_sensor.py
@@ -1,9 +1,9 @@
 """Binary Sensor platform for Sensibo integration."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pysensibo.model import MotionSensor, SensiboDevice
 
@@ -36,7 +36,6 @@ class DeviceBaseEntityDescriptionMixin:
     """Mixin for required Sensibo base description keys."""
 
     value_fn: Callable[[SensiboDevice], bool | None]
-    extra_fn: Callable[[SensiboDevice], dict[str, str | bool | None] | None] | None
 
 
 @dataclass
@@ -85,7 +84,6 @@ MOTION_DEVICE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ..
         name="Room Occupied",
         icon="mdi:motion-sensor",
         value_fn=lambda data: data.room_occupied,
-        extra_fn=None,
     ),
 )
 
@@ -96,7 +94,6 @@ PURE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
         name="Pure Boost Enabled",
         icon="mdi:wind-power-outline",
         value_fn=lambda data: data.pure_boost_enabled,
-        extra_fn=None,
     ),
     SensiboDeviceBinarySensorEntityDescription(
         key="pure_ac_integration",
@@ -105,7 +102,6 @@ PURE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
         name="Pure Boost linked with AC",
         icon="mdi:connection",
         value_fn=lambda data: data.pure_ac_integration,
-        extra_fn=None,
     ),
     SensiboDeviceBinarySensorEntityDescription(
         key="pure_geo_integration",
@@ -114,7 +110,6 @@ PURE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
         name="Pure Boost linked with Presence",
         icon="mdi:connection",
         value_fn=lambda data: data.pure_geo_integration,
-        extra_fn=None,
     ),
     SensiboDeviceBinarySensorEntityDescription(
         key="pure_measure_integration",
@@ -123,7 +118,6 @@ PURE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
         name="Pure Boost linked with Indoor Air Quality",
         icon="mdi:connection",
         value_fn=lambda data: data.pure_measure_integration,
-        extra_fn=None,
     ),
     SensiboDeviceBinarySensorEntityDescription(
         key="pure_prime_integration",
@@ -132,7 +126,6 @@ PURE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
         name="Pure Boost linked with Outdoor Air Quality",
         icon="mdi:connection",
         value_fn=lambda data: data.pure_prime_integration,
-        extra_fn=None,
     ),
 )
 
@@ -230,10 +223,3 @@ class SensiboDeviceSensor(SensiboDeviceBaseEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self.device_data)
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return additional attributes."""
-        if self.entity_description.extra_fn is not None:
-            return self.entity_description.extra_fn(self.device_data)
-        return None

--- a/homeassistant/components/sensibo/binary_sensor.py
+++ b/homeassistant/components/sensibo/binary_sensor.py
@@ -89,17 +89,6 @@ MOTION_DEVICE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ..
     ),
 )
 
-DEVICE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
-    SensiboDeviceBinarySensorEntityDescription(
-        key="timer_on",
-        device_class=BinarySensorDeviceClass.RUNNING,
-        name="Timer Running",
-        icon="mdi:timer",
-        value_fn=lambda data: data.timer_on,
-        extra_fn=lambda data: {"id": data.timer_id, "turn_on": data.timer_state_on},
-    ),
-)
-
 PURE_SENSOR_TYPES: tuple[SensiboDeviceBinarySensorEntityDescription, ...] = (
     SensiboDeviceBinarySensorEntityDescription(
         key="pure_boost_enabled",
@@ -171,12 +160,6 @@ async def async_setup_entry(
         for description in MOTION_DEVICE_SENSOR_TYPES
         for device_id, device_data in coordinator.data.parsed.items()
         if device_data.motion_sensors is not None
-    )
-    entities.extend(
-        SensiboDeviceSensor(coordinator, device_id, description)
-        for description in DEVICE_SENSOR_TYPES
-        for device_id, device_data in coordinator.data.parsed.items()
-        if device_data.model != "pure"
     )
     entities.extend(
         SensiboDeviceSensor(coordinator, device_id, description)

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -28,7 +28,6 @@ from .entity import SensiboDeviceBaseEntity
 
 SERVICE_ASSUME_STATE = "assume_state"
 SERVICE_ENABLE_TIMER = "enable_timer"
-SERVICE_DISABLE_TIMER = "disable_timer"
 ATTR_MINUTES = "minutes"
 SERVICE_ENABLE_PURE_BOOST = "enable_pure_boost"
 SERVICE_DISABLE_PURE_BOOST = "disable_pure_boost"
@@ -104,11 +103,6 @@ async def async_setup_entry(
             vol.Required(ATTR_MINUTES): cv.positive_int,
         },
         "async_enable_timer",
-    )
-    platform.async_register_entity_service(
-        SERVICE_DISABLE_TIMER,
-        {},
-        "async_disable_timer",
     )
     platform.async_register_entity_service(
         SERVICE_ENABLE_PURE_BOOST,
@@ -332,15 +326,6 @@ class SensiboClimate(SensiboDeviceBaseEntity, ClimateEntity):
         if result["status"] == "success":
             return await self.coordinator.async_request_refresh()
         raise HomeAssistantError(f"Could not enable timer for device {self.name}")
-
-    async def async_disable_timer(self) -> None:
-        """Delete the timer."""
-
-        result = await self.async_send_command("del_timer")
-
-        if result["status"] == "success":
-            return await self.coordinator.async_request_refresh()
-        raise HomeAssistantError(f"Could not disable timer for device {self.name}")
 
     async def async_enable_pure_boost(
         self,

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -27,7 +27,8 @@ from .coordinator import SensiboDataUpdateCoordinator
 from .entity import SensiboDeviceBaseEntity
 
 SERVICE_ASSUME_STATE = "assume_state"
-SERVICE_TIMER = "timer"
+SERVICE_ENABLE_TIMER = "enable_timer"
+SERVICE_DISABLE_TIMER = "disable_timer"
 ATTR_MINUTES = "minutes"
 SERVICE_ENABLE_PURE_BOOST = "enable_pure_boost"
 SERVICE_DISABLE_PURE_BOOST = "disable_pure_boost"
@@ -98,12 +99,16 @@ async def async_setup_entry(
         "async_assume_state",
     )
     platform.async_register_entity_service(
-        SERVICE_TIMER,
+        SERVICE_ENABLE_TIMER,
         {
-            vol.Required(ATTR_STATE): vol.In(["on", "off"]),
-            vol.Optional(ATTR_MINUTES): cv.positive_int,
+            vol.Required(ATTR_MINUTES): cv.positive_int,
         },
-        "async_set_timer",
+        "async_enable_timer",
+    )
+    platform.async_register_entity_service(
+        SERVICE_DISABLE_TIMER,
+        {},
+        "async_disable_timer",
     )
     platform.async_register_entity_service(
         SERVICE_ENABLE_PURE_BOOST,
@@ -315,27 +320,27 @@ class SensiboClimate(SensiboDeviceBaseEntity, ClimateEntity):
         await self._async_set_ac_state_property("on", state != HVACMode.OFF, True)
         await self.coordinator.async_refresh()
 
-    async def async_set_timer(self, state: str, minutes: int | None = None) -> None:
-        """Set or delete timer."""
-        if state == "off" and self.device_data.timer_id is None:
-            raise HomeAssistantError("No timer to delete")
-
-        if state == "on" and minutes is None:
-            raise ValueError("No value provided for timer")
-
-        if state == "off":
-            result = await self.async_send_command("del_timer")
-        else:
-            new_state = bool(self.device_data.ac_states["on"] is False)
-            params = {
-                "minutesFromNow": minutes,
-                "acState": {**self.device_data.ac_states, "on": new_state},
-            }
-            result = await self.async_send_command("set_timer", params)
+    async def async_enable_timer(self, minutes: int) -> None:
+        """Enable the timer."""
+        new_state = bool(self.device_data.ac_states["on"] is False)
+        params = {
+            "minutesFromNow": minutes,
+            "acState": {**self.device_data.ac_states, "on": new_state},
+        }
+        result = await self.async_send_command("set_timer", params)
 
         if result["status"] == "success":
             return await self.coordinator.async_request_refresh()
-        raise HomeAssistantError(f"Could not set timer for device {self.name}")
+        raise HomeAssistantError(f"Could not enable timer for device {self.name}")
+
+    async def async_disable_timer(self) -> None:
+        """Delete the timer."""
+
+        result = await self.async_send_command("del_timer")
+
+        if result["status"] == "success":
+            return await self.coordinator.async_request_refresh()
+        raise HomeAssistantError(f"Could not disable timer for device {self.name}")
 
     async def async_enable_pure_boost(
         self,

--- a/homeassistant/components/sensibo/const.py
+++ b/homeassistant/components/sensibo/const.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.UPDATE,
 ]
 DEFAULT_NAME = "Sensibo"

--- a/homeassistant/components/sensibo/services.yaml
+++ b/homeassistant/components/sensibo/services.yaml
@@ -16,24 +16,14 @@ assume_state:
           options:
             - "on"
             - "off"
-timer:
-  name: Timer
-  description: Set or delete timer for device.
+enable_timer:
+  name: Enable Timer
+  description: Enable the timer.
   target:
     entity:
       integration: sensibo
       domain: climate
   fields:
-    state:
-      name: State
-      description: Timer on or off.
-      required: true
-      example: "on"
-      selector:
-        select:
-          options:
-            - "on"
-            - "off"
     minutes:
       name: Minutes
       description: Countdown for timer (for timer state on)
@@ -44,6 +34,13 @@ timer:
           min: 0
           step: 1
           mode: box
+disable_timer:
+  name: Disable Timer
+  description: Disable the timer.
+  target:
+    entity:
+      integration: sensibo
+      domain: climate
 enable_pure_boost:
   name: Enable Pure Boost
   description: Enable and configure Pure Boost settings.

--- a/homeassistant/components/sensibo/services.yaml
+++ b/homeassistant/components/sensibo/services.yaml
@@ -18,7 +18,7 @@ assume_state:
             - "off"
 enable_timer:
   name: Enable Timer
-  description: Enable the timer.
+  description: Enable the timer with custom time.
   target:
     entity:
       integration: sensibo
@@ -34,13 +34,6 @@ enable_timer:
           min: 0
           step: 1
           mode: box
-disable_timer:
-  name: Disable Timer
-  description: Disable the timer.
-  target:
-    entity:
-      integration: sensibo
-      domain: climate
 enable_pure_boost:
   name: Enable Pure Boost
   description: Enable and configure Pure Boost settings.

--- a/homeassistant/components/sensibo/switch.py
+++ b/homeassistant/components/sensibo/switch.py
@@ -1,0 +1,122 @@
+"""Switch platform for Sensibo integration."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pysensibo.model import SensiboDevice
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SensiboDataUpdateCoordinator
+from .entity import SensiboDeviceBaseEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass
+class DeviceBaseEntityDescriptionMixin:
+    """Mixin for required Sensibo base description keys."""
+
+    value_fn: Callable[[SensiboDevice], bool | None]
+    extra_fn: Callable[[SensiboDevice], dict[str, str | bool | None]]
+
+
+@dataclass
+class SensiboDeviceSwitchEntityDescription(
+    SwitchEntityDescription, DeviceBaseEntityDescriptionMixin
+):
+    """Describes Sensibo Switch entity."""
+
+
+DEVICE_SWITCH_TYPES: tuple[SensiboDeviceSwitchEntityDescription, ...] = (
+    SensiboDeviceSwitchEntityDescription(
+        key="timer_on_switch",
+        device_class=SwitchDeviceClass.SWITCH,
+        name="Timer",
+        icon="mdi:timer",
+        value_fn=lambda data: data.timer_on,
+        extra_fn=lambda data: {"id": data.timer_id, "turn_on": data.timer_state_on},
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Sensibo binary sensor platform."""
+
+    coordinator: SensiboDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[SensiboDeviceSwitch] = []
+
+    entities.extend(
+        SensiboDeviceSwitch(coordinator, device_id, description)
+        for description in DEVICE_SWITCH_TYPES
+        for device_id, device_data in coordinator.data.parsed.items()
+        if device_data.model != "pure"
+    )
+
+    async_add_entities(entities)
+
+
+class SensiboDeviceSwitch(SensiboDeviceBaseEntity, SwitchEntity):
+    """Representation of a Sensibo Device Switch."""
+
+    entity_description: SensiboDeviceSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: SensiboDataUpdateCoordinator,
+        device_id: str,
+        entity_description: SensiboDeviceSwitchEntityDescription,
+    ) -> None:
+        """Initiate Sensibo Device Switch."""
+        super().__init__(
+            coordinator,
+            device_id,
+        )
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{device_id}-{entity_description.key}"
+        self._attr_name = f"{self.device_data.name} {entity_description.name}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if entity is on."""
+        return self.entity_description.value_fn(self.device_data)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        new_state = bool(self.device_data.ac_states["on"] is False)
+        params = {
+            "minutesFromNow": 60,
+            "acState": {**self.device_data.ac_states, "on": new_state},
+        }
+        result = await self.async_send_command("set_timer", params)
+
+        if result["status"] == "success":
+            return await self.coordinator.async_request_refresh()
+        raise HomeAssistantError(f"Could not enable timer for device {self.name}")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        result = await self.async_send_command("del_timer")
+
+        if result["status"] == "success":
+            return await self.coordinator.async_request_refresh()
+        raise HomeAssistantError(f"Could not disable timer for device {self.name}")
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any]:
+        """Return additional attributes."""
+        return self.entity_description.extra_fn(self.device_data)

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -29,7 +29,6 @@ from homeassistant.components.sensibo.climate import (
     ATTR_SENSITIVITY,
     SERVICE_ASSUME_STATE,
     SERVICE_DISABLE_PURE_BOOST,
-    SERVICE_DISABLE_TIMER,
     SERVICE_ENABLE_PURE_BOOST,
     SERVICE_ENABLE_TIMER,
     _find_valid_target_temp,
@@ -707,9 +706,45 @@ async def test_climate_set_timer(
         )
         await hass.async_block_till_done()
 
-    state1 = hass.states.get("climate.hallway")
+    state_climate = hass.states.get("climate.hallway")
     assert hass.states.get("sensor.hallway_timer_end_time").state == STATE_UNKNOWN
-    assert hass.states.get("binary_sensor.hallway_timer_running").state == "off"
+
+    with patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ), patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
+        return_value={"status": "failure"},
+    ):
+        with pytest.raises(MultipleInvalid):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_ENABLE_TIMER,
+                {
+                    ATTR_ENTITY_ID: state_climate.entity_id,
+                },
+                blocking=True,
+            )
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ), patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
+        return_value={"status": "failure"},
+    ):
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_ENABLE_TIMER,
+                {
+                    ATTR_ENTITY_ID: state_climate.entity_id,
+                    ATTR_MINUTES: 30,
+                },
+                blocking=True,
+            )
+    await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
@@ -722,7 +757,7 @@ async def test_climate_set_timer(
             DOMAIN,
             SERVICE_ENABLE_TIMER,
             {
-                ATTR_ENTITY_ID: state1.entity_id,
+                ATTR_ENTITY_ID: state_climate.entity_id,
                 ATTR_MINUTES: 30,
             },
             blocking=True,
@@ -752,165 +787,6 @@ async def test_climate_set_timer(
         hass.states.get("sensor.hallway_timer_end_time").state
         == "2022-06-06T12:00:00+00:00"
     )
-    assert hass.states.get("binary_sensor.hallway_timer_running").state == "on"
-    assert hass.states.get("binary_sensor.hallway_timer_running").attributes == {
-        "device_class": "running",
-        "friendly_name": "Hallway Timer Running",
-        "icon": "mdi:timer",
-        "id": "SzTGE4oZ4D",
-        "turn_on": False,
-    }
-
-    with patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ), patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_del_timer",
-        return_value={"status": "success"},
-    ):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_DISABLE_TIMER,
-            {
-                ATTR_ENTITY_ID: state1.entity_id,
-            },
-            blocking=True,
-        )
-    await hass.async_block_till_done()
-
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_on", False)
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_id", None)
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_state_on", None)
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_time", None)
-
-    with patch(
-        "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ):
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(minutes=5),
-        )
-        await hass.async_block_till_done()
-
-    assert hass.states.get("sensor.hallway_timer_end_time").state == STATE_UNKNOWN
-    assert hass.states.get("binary_sensor.hallway_timer_running").state == "off"
-
-
-async def test_climate_set_timer_failures(
-    hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
-    load_int: ConfigEntry,
-    monkeypatch: pytest.MonkeyPatch,
-    get_data: SensiboData,
-) -> None:
-    """Test the Sensibo climate Set Timer service failures."""
-
-    with patch(
-        "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ):
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(minutes=5),
-        )
-        await hass.async_block_till_done()
-
-    state1 = hass.states.get("climate.hallway")
-    assert hass.states.get("sensor.hallway_timer_end_time").state == STATE_UNKNOWN
-    assert hass.states.get("binary_sensor.hallway_timer_running").state == "off"
-
-    with pytest.raises(MultipleInvalid):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_ENABLE_TIMER,
-            {
-                ATTR_ENTITY_ID: state1.entity_id,
-            },
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-    with patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ), patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
-        return_value={"status": "success", "result": {"id": ""}},
-    ):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_ENABLE_TIMER,
-            {
-                ATTR_ENTITY_ID: state1.entity_id,
-                ATTR_MINUTES: 30,
-            },
-            blocking=True,
-        )
-    await hass.async_block_till_done()
-
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_on", True)
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_id", None)
-    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_state_on", False)
-    monkeypatch.setattr(
-        get_data.parsed["ABC999111"],
-        "timer_time",
-        datetime(2022, 6, 6, 12, 00, 00, tzinfo=dt.UTC),
-    )
-
-    with patch(
-        "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ):
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(minutes=5),
-        )
-        await hass.async_block_till_done()
-
-    with patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_del_timer",
-        return_value={"status": "failure"},
-    ):
-        with pytest.raises(HomeAssistantError):
-            await hass.services.async_call(
-                DOMAIN,
-                SERVICE_DISABLE_TIMER,
-                {
-                    ATTR_ENTITY_ID: state1.entity_id,
-                },
-                blocking=True,
-            )
-        await hass.async_block_till_done()
-
-    with patch(
-        "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ):
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(minutes=5),
-        )
-        await hass.async_block_till_done()
-
-    with patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
-        return_value=get_data,
-    ), patch(
-        "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
-        return_value={"status": "failure"},
-    ):
-        with pytest.raises(HomeAssistantError):
-            await hass.services.async_call(
-                DOMAIN,
-                SERVICE_ENABLE_TIMER,
-                {
-                    ATTR_ENTITY_ID: state1.entity_id,
-                    ATTR_MINUTES: 30,
-                },
-                blocking=True,
-            )
-    await hass.async_block_till_done()
 
 
 async def test_climate_pure_boost(

--- a/tests/components/sensibo/test_switch.py
+++ b/tests/components/sensibo/test_switch.py
@@ -8,6 +8,7 @@ from pysensibo.model import SensiboData
 import pytest
 from pytest import MonkeyPatch
 
+from homeassistant.components.sensibo.switch import build_params
 from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -147,3 +148,18 @@ async def test_switch_command_failure(
                 },
                 blocking=True,
             )
+
+
+async def test_build_params(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+    monkeypatch: MonkeyPatch,
+    get_data: SensiboData,
+) -> None:
+    """Test the build params method."""
+
+    assert build_params("set_timer", get_data.parsed["ABC999111"]) == {
+        "minutesFromNow": 60,
+        "acState": {**get_data.parsed["ABC999111"].ac_states, "on": False},
+    }
+    assert build_params("incorrect_command", get_data.parsed["ABC999111"]) is None

--- a/tests/components/sensibo/test_switch.py
+++ b/tests/components/sensibo/test_switch.py
@@ -1,0 +1,149 @@
+"""The test for the sensibo switch platform."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from pysensibo.model import SensiboData
+import pytest
+from pytest import MonkeyPatch
+
+from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt
+
+from tests.common import async_fire_time_changed
+
+
+async def test_switch(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+    monkeypatch: MonkeyPatch,
+    get_data: SensiboData,
+) -> None:
+    """Test the Sensibo switch."""
+
+    state1 = hass.states.get("switch.hallway_timer")
+    assert state1.state == STATE_OFF
+    assert state1.attributes["id"] is None
+    assert state1.attributes["turn_on"] is None
+
+    with patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ), patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
+        return_value={"status": "success", "result": {"id": "SzTGE4oZ4D"}},
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: state1.entity_id,
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_on", True)
+    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_id", "SzTGE4oZ4D")
+    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_state_on", False)
+    with patch(
+        "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ):
+        async_fire_time_changed(
+            hass,
+            dt.utcnow() + timedelta(minutes=5),
+        )
+        await hass.async_block_till_done()
+    state1 = hass.states.get("switch.hallway_timer")
+    assert state1.state == STATE_ON
+    assert state1.attributes["id"] == "SzTGE4oZ4D"
+    assert state1.attributes["turn_on"] is False
+
+    with patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ), patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_del_timer",
+        return_value={"status": "success", "result": {"id": "SzTGE4oZ4D"}},
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {
+                ATTR_ENTITY_ID: state1.entity_id,
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    monkeypatch.setattr(get_data.parsed["ABC999111"], "timer_on", False)
+
+    with patch(
+        "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ):
+        async_fire_time_changed(
+            hass,
+            dt.utcnow() + timedelta(minutes=5),
+        )
+        await hass.async_block_till_done()
+
+    state1 = hass.states.get("switch.hallway_timer")
+    assert state1.state == STATE_OFF
+
+
+async def test_switch_command_failure(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+    monkeypatch: MonkeyPatch,
+    get_data: SensiboData,
+) -> None:
+    """Test the Sensibo switch fails commands."""
+
+    state1 = hass.states.get("switch.hallway_timer")
+
+    with patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ), patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_set_timer",
+        return_value={"status": "failure"},
+    ):
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {
+                    ATTR_ENTITY_ID: state1.entity_id,
+                },
+                blocking=True,
+            )
+
+    with patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_get_devices_data",
+        return_value=get_data,
+    ), patch(
+        "homeassistant.components.sensibo.util.SensiboClient.async_del_timer",
+        return_value={"status": "failure"},
+    ):
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_OFF,
+                {
+                    ATTR_ENTITY_ID: state1.entity_id,
+                },
+                blocking=True,
+            )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split the timer service for sensibo into two services `sensibo.enable_timer` and `sensibo.disable_timer`
Make it a bit more user friendly
Previous PR: https://github.com/home-assistant/core/pull/73072

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23139

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
