### PR TITLE
Allow multiple google calendar config entries

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -273,7 +273,9 @@ def async_entry_has_scopes(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -220,6 +220,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Google from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {}
+
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
             hass, entry
@@ -249,7 +251,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     calendar_service = GoogleCalendarService(
         ApiAuthImpl(async_get_clientsession(hass), session)
     )
-    hass.data[DOMAIN][DATA_SERVICE] = calendar_service
+    hass.data[DOMAIN][entry.entry_id][DATA_SERVICE] = calendar_service
 
     # Only expose the add event service if we have the correct permissions
     if get_feature_access(hass, entry) is FeatureAccess.read_write:

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import aiohttp
 from gcal_sync.api import GoogleCalendarService
-from gcal_sync.exceptions import ApiException
+from gcal_sync.exceptions import ApiException, AuthException
 from gcal_sync.model import DateOrDatetime, Event
 from oauth2client.file import Storage
 import voluptuous as vol
@@ -257,8 +257,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry.unique_id is None:
         try:
             primary_calendar = await calendar_service.async_get_calendar("primary")
+        except AuthException as err:
+            raise ConfigEntryAuthFailed from err
         except ApiException as err:
-            _LOGGER.debug("Error reading calendar primary calendar: %s", err)
+            raise ConfigEntryNotReady from err
         else:
             hass.config_entries.async_update_entry(entry, unique_id=primary_calendar.id)
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -227,6 +227,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass, entry
         )
     )
+    if not isinstance(
+        implementation, config_entry_oauth2_flow.LocalOAuth2Implementation
+    ):
+        raise ValueError(f"Unexpected auth implementation {implementation}")
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=implementation.client_id
+        )
+
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
     # Force a token refresh to fix a bug where tokens were persisted with
     # expires_in (relative time delta) and expires_at (absolute time) swapped.

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -105,7 +105,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the google calendar platform."""
-    calendar_service = hass.data[DOMAIN][DATA_SERVICE]
+    calendar_service = hass.data[DOMAIN][entry.entry_id][DATA_SERVICE]
     try:
         result = await calendar_service.async_list_calendars()
     except ApiException as err:

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from gcal_sync.api import GoogleCalendarService
 from gcal_sync.exceptions import ApiException
@@ -135,8 +135,6 @@ class OAuth2FlowHandler(
                 self._reauth_config_entry.entry_id
             )
             return self.async_abort(reason="reauth_successful")
-        await self.async_set_unique_id(cast(DeviceAuth, self.flow_impl).client_id)
-        self._abort_if_unique_id_configured()
         calendar_service = GoogleCalendarService(
             AccessTokenAuthImpl(
                 async_get_clientsession(self.hass), data["token"]["access_token"]
@@ -147,6 +145,9 @@ class OAuth2FlowHandler(
         except ApiException as err:
             _LOGGER.debug("Error reading calendar primary calendar: %s", err)
             primary_calendar = None
+        else:
+            await self.async_set_unique_id(primary_calendar.id)
+            self._abort_if_unique_id_configured()
         title = primary_calendar.id if primary_calendar else self.flow_impl.name
         return self.async_create_entry(
             title=title,

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from gcal_sync.api import GoogleCalendarService
 from gcal_sync.exceptions import ApiException
@@ -79,10 +79,6 @@ class OAuth2FlowHandler(
                     self.flow_impl,
                 )
                 return self.async_abort(reason="oauth_error")
-
-            await self.async_set_unique_id(self.flow_impl.client_id)
-            self._abort_if_unique_id_configured()
-
             calendar_access = get_feature_access(self.hass)
             if self._reauth_config_entry and self._reauth_config_entry.options:
                 calendar_access = FeatureAccess[
@@ -139,7 +135,8 @@ class OAuth2FlowHandler(
                 self._reauth_config_entry.entry_id
             )
             return self.async_abort(reason="reauth_successful")
-
+        await self.async_set_unique_id(cast(DeviceAuth, self.flow_impl).client_id)
+        self._abort_if_unique_id_configured()
         calendar_service = GoogleCalendarService(
             AccessTokenAuthImpl(
                 async_get_clientsession(self.hass), data["token"]["access_token"]

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -143,14 +143,12 @@ class OAuth2FlowHandler(
         try:
             primary_calendar = await calendar_service.async_get_calendar("primary")
         except ApiException as err:
-            _LOGGER.debug("Error reading calendar primary calendar: %s", err)
-            primary_calendar = None
-        if primary_calendar:
-            await self.async_set_unique_id(primary_calendar.id)
-            self._abort_if_unique_id_configured()
-        title = primary_calendar.id if primary_calendar else self.flow_impl.name
+            _LOGGER.error("Error reading primary calendar: %s", err)
+            return self.async_abort(reason="cannot_connect")
+        await self.async_set_unique_id(primary_calendar.id)
+        self._abort_if_unique_id_configured()
         return self.async_create_entry(
-            title=title,
+            title=primary_calendar.id,
             data=data,
             options={
                 CONF_CALENDAR_ACCESS: get_feature_access(self.hass).name,

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -59,14 +59,6 @@ class OAuth2FlowHandler(
         self.external_data = info
         return await super().async_step_creation(info)
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle external yaml configuration."""
-        if not self._reauth_config_entry and self._async_current_entries():
-            return self.async_abort(reason="already_configured")
-        return await super().async_step_user(user_input)
-
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -135,12 +127,13 @@ class OAuth2FlowHandler(
 
     async def async_oauth_create_entry(self, data: dict) -> FlowResult:
         """Create an entry for the flow, or update existing entry."""
-        existing_entries = self._async_current_entries()
-        if existing_entries:
-            assert len(existing_entries) == 1
-            entry = existing_entries[0]
-            self.hass.config_entries.async_update_entry(entry, data=data)
-            await self.hass.config_entries.async_reload(entry.entry_id)
+        if self._reauth_config_entry:
+            self.hass.config_entries.async_update_entry(
+                self._reauth_config_entry, data=data
+            )
+            await self.hass.config_entries.async_reload(
+                self._reauth_config_entry.entry_id
+            )
             return self.async_abort(reason="reauth_successful")
 
         calendar_service = GoogleCalendarService(

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -145,7 +145,7 @@ class OAuth2FlowHandler(
         except ApiException as err:
             _LOGGER.debug("Error reading calendar primary calendar: %s", err)
             primary_calendar = None
-        else:
+        if primary_calendar:
             await self.async_set_unique_id(primary_calendar.id)
             self._abort_if_unique_id_configured()
         title = primary_calendar.id if primary_calendar else self.flow_impl.name

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -79,6 +79,10 @@ class OAuth2FlowHandler(
                     self.flow_impl,
                 )
                 return self.async_abort(reason="oauth_error")
+
+            await self.async_set_unique_id(self.flow_impl.client_id)
+            self._abort_if_unique_id_configured()
+
             calendar_access = get_feature_access(self.hass)
             if self._reauth_config_entry and self._reauth_config_entry.options:
                 calendar_access = FeatureAccess[

--- a/homeassistant/components/google/strings.json
+++ b/homeassistant/components/google/strings.json
@@ -15,6 +15,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "code_expired": "Authentication code expired or credential setup is invalid, please try again.",

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -53,6 +53,9 @@ TEST_API_CALENDAR = {
     "defaultReminders": [],
 }
 
+CLIENT_ID = "client-id"
+CLIENT_SECRET = "client-secret"
+
 
 @pytest.fixture
 def test_api_calendar():
@@ -148,8 +151,8 @@ def creds(
     """Fixture that defines creds used in the test."""
     return OAuth2Credentials(
         access_token="ACCESS_TOKEN",
-        client_id="client-id",
-        client_secret="client-secret",
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
         refresh_token="REFRESH_TOKEN",
         token_expiry=token_expiry,
         token_uri="http://example.com",
@@ -187,6 +190,7 @@ def config_entry(
     """Fixture to create a config entry for the integration."""
     return MockConfigEntry(
         domain=DOMAIN,
+        unique_id=CLIENT_ID,
         data={
             "auth_implementation": "device_auth",
             "token": {
@@ -315,7 +319,7 @@ def google_config_track_new() -> None:
 @pytest.fixture
 def google_config(google_config_track_new: bool | None) -> dict[str, Any]:
     """Fixture for overriding component config."""
-    google_config = {CONF_CLIENT_ID: "client-id", CONF_CLIENT_SECRET: "client-secret"}
+    google_config = {CONF_CLIENT_ID: CLIENT_ID, CONF_CLIENT_SECRET: CLIENT_SECRET}
     if google_config_track_new is not None:
         google_config[CONF_TRACK_NEW] = google_config_track_new
     return google_config

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import datetime
+import http
 from typing import Any, Generator, TypeVar
 from unittest.mock import Mock, mock_open, patch
 
@@ -283,12 +284,16 @@ def mock_calendar_get(
     """Fixture for returning a calendar get response."""
 
     def _result(
-        calendar_id: str, response: dict[str, Any], exc: ClientError | None = None
+        calendar_id: str,
+        response: dict[str, Any],
+        exc: ClientError | None = None,
+        status: http.HTTPStatus = http.HTTPStatus.OK,
     ) -> None:
         aioclient_mock.get(
             f"{API_BASE_URL}/calendars/{calendar_id}",
             json=response,
             exc=exc,
+            status=status,
         )
         return
 

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -182,7 +182,14 @@ def config_entry_options() -> dict[str, Any] | None:
 
 
 @pytest.fixture
+def config_entry_unique_id() -> str:
+    """Fixture that returns the default config entry unique id."""
+    return CLIENT_ID
+
+
+@pytest.fixture
 def config_entry(
+    config_entry_unique_id: str,
     token_scopes: list[str],
     config_entry_token_expiry: float,
     config_entry_options: dict[str, Any] | None,
@@ -190,7 +197,7 @@ def config_entry(
     """Fixture to create a config entry for the integration."""
     return MockConfigEntry(
         domain=DOMAIN,
-        unique_id=CLIENT_ID,
+        unique_id=config_entry_unique_id,
         data={
             "auth_implementation": "device_auth",
             "token": {

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -27,6 +27,7 @@ YieldFixture = Generator[_T, None, None]
 
 
 CALENDAR_ID = "qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com"
+EMAIL_ADDRESS = "user@gmail.com"
 
 # Entities can either be created based on data directly from the API, or from
 # the yaml config that overrides the entity name and other settings. A test
@@ -184,7 +185,7 @@ def config_entry_options() -> dict[str, Any] | None:
 @pytest.fixture
 def config_entry_unique_id() -> str:
     """Fixture that returns the default config entry unique id."""
-    return CLIENT_ID
+    return EMAIL_ADDRESS
 
 
 @pytest.fixture

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -21,7 +21,6 @@ import homeassistant.util.dt as dt_util
 
 from .conftest import (
     CALENDAR_ID,
-    CLIENT_ID,
     TEST_API_ENTITY,
     TEST_API_ENTITY_NAME,
     TEST_YAML_ENTITY,
@@ -703,5 +702,5 @@ async def test_unique_id_migration(
         entity_registry, config_entry.entry_id
     )
     assert {entry.unique_id for entry in registry_entries} == {
-        f"{CLIENT_ID}-{CALENDAR_ID}-we_are_we_are_a_test_calendar"
+        f"{config_entry.unique_id}-{CALENDAR_ID}-we_are_we_are_a_test_calendar"
     }

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -358,6 +358,16 @@ async def test_duplicate_config_entries(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert result.get("type") == "progress"
+    assert result.get("step_id") == "auth"
+    assert "description_placeholders" in result
+    assert "url" in result["description_placeholders"]
+
+    # Run one tick to invoke the credential exchange check
+    now = utcnow()
+    await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(flow_id=result["flow_id"])
     assert result.get("type") == "abort"
     assert result.get("reason") == "already_configured"
 

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -593,7 +593,7 @@ async def test_reauth_flow(
 
 
 @pytest.mark.parametrize("primary_calendar_error", [ClientError()])
-async def test_title_lookup_failure(
+async def test_calendar_lookup_failure(
     hass: HomeAssistant,
     mock_code_flow: Mock,
     mock_exchange: Mock,
@@ -610,9 +610,7 @@ async def test_title_lookup_failure(
     assert "description_placeholders" in result
     assert "url" in result["description_placeholders"]
 
-    with patch(
-        "homeassistant.components.google.async_setup_entry", return_value=True
-    ) as mock_setup:
+    with patch("homeassistant.components.google.async_setup_entry", return_value=True):
         # Run one tick to invoke the credential exchange check
         now = utcnow()
         await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
@@ -621,12 +619,8 @@ async def test_title_lookup_failure(
             flow_id=result["flow_id"]
         )
 
-    assert result.get("type") == "create_entry"
-    assert result.get("title") == "Import from configuration.yaml"
-
-    assert len(mock_setup.mock_calls) == 1
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
+    assert result.get("type") == "abort"
+    assert result.get("reason") == "cannot_connect"
 
 
 async def test_options_flow_triggers_reauth(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Google Calendar no longer supports entity customizations in the UI when `google_calendars.yaml` specifies the same entity multiple times. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow multiple google calendar config entries at the same time, possible now that we have a path away from yaml.

Config entries are assigned a unique id based on the OAuth client id used with the account. Existing config entries are updated with the unique id (oauth client id) if it is not already set. Additionally, entities have been migrated to use a new unique id format since accounts may share generic calendar id names for contacts, holidays, family, etc. Entity ids use the config entry unique id (oauth client id) as a prefix.

Note that `google_calendars.yaml` if it exists, is still applied to each account, which is possibly odd but is discouraged generally anyway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
