### PR TITLE
Allow multiple configuration entries for nest integration

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -187,6 +187,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if config_mode == config_flow.ConfigMode.SDM:
         await async_import_config(hass, entry)
+    elif entry.unique_id != entry.data[CONF_PROJECT_ID]:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=entry.data[CONF_PROJECT_ID]
+        )
 
     subscriber = await api.new_subscriber(hass, entry)
     if not subscriber:
@@ -254,7 +258,9 @@ async def async_import_config(hass: HomeAssistant, entry: ConfigEntry) -> None:
                 CONF_SUBSCRIBER_ID_IMPORTED: True,  # Don't delete user managed subscriber
             }
         )
-    hass.config_entries.async_update_entry(entry, data=new_data)
+    hass.config_entries.async_update_entry(
+        entry, data=new_data, unique_id=new_data[CONF_PROJECT_ID]
+    )
 
     if entry.data["auth_implementation"] == INSTALLED_AUTH_DOMAIN:
         # App Auth credentials have been deprecated and must be re-created

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -45,7 +45,9 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the cameras."""
 
-    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][entry.entry_id][
+        DATA_DEVICE_MANAGER
+    ]
     entities = []
     for device in device_manager.devices.values():
         if (

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -82,7 +82,9 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the client entities."""
 
-    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][entry.entry_id][
+        DATA_DEVICE_MANAGER
+    ]
     entities = []
     for device in device_manager.devices.values():
         if ThermostatHvacTrait.NAME in device.traits:

--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -276,10 +276,6 @@ class NestFlowHandler(
         if self.config_mode == ConfigMode.LEGACY:
             return await self.async_step_init(user_input)
         self._data[DATA_SDM] = {}
-        # Reauth will update an existing entry
-        entries = self._async_current_entries()
-        if entries and self.source != SOURCE_REAUTH:
-            return self.async_abort(reason="single_instance_allowed")
         if self.source == SOURCE_REAUTH:
             return await super().async_step_user(user_input)
         # Application Credentials setup needs information from the user
@@ -466,9 +462,7 @@ class NestFlowHandler(
         """Create an entry for the SDM flow."""
         assert self.config_mode != ConfigMode.LEGACY, "Step only supported for SDM API"
         await self.async_set_unique_id(DOMAIN)
-        # Update existing config entry when in the reauth flow.  This
-        # integration only supports one config entry so remove any prior entries
-        # added before the "single_instance_allowed" check was added
+        # Update existing config entry when in the reauth flow.
         if entry := self._async_reauth_entry():
             self.hass.config_entries.async_update_entry(
                 entry, data=self._data, unique_id=DOMAIN

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import logging
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import InfoTrait
@@ -13,8 +12,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DATA_DEVICE_MANAGER, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 DEVICE_TYPE_MAP: dict[str, str] = {
     "sdm.devices.types.CAMERA": "Camera",
@@ -85,7 +82,6 @@ def async_nest_devices(hass: HomeAssistant) -> Mapping[str, Device]:
         devices.update(
             {device.name: device for device in device_manager.devices.values()}
         )
-    _LOGGER.info(devices)
     return devices
 
 
@@ -97,5 +93,4 @@ def async_nest_devices_by_device_id(hass: HomeAssistant) -> Mapping[str, Device]
     for nest_device_id, device in async_nest_devices(hass).items():
         if device_entry := device_registry.async_get_device({(DOMAIN, nest_device_id)}):
             devices[device_entry.id] = device
-    _LOGGER.info(devices)
     return devices

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -80,8 +80,6 @@ def async_nest_devices(hass: HomeAssistant) -> Mapping[str, Device]:
     """Return a mapping of all nest devices for all config entries."""
     devices = {}
     for entry_id in hass.data[DOMAIN]:
-        if DATA_DEVICE_MANAGER not in hass.data[DOMAIN][entry_id]:
-            continue
         if not (device_manager := hass.data[DOMAIN][entry_id].get(DATA_DEVICE_MANAGER)):
             continue
         devices.update(

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+import logging
+
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import InfoTrait
 
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import DOMAIN
+from .const import DATA_DEVICE_MANAGER, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 DEVICE_TYPE_MAP: dict[str, str] = {
     "sdm.devices.types.CAMERA": "Camera",
@@ -66,3 +73,31 @@ class NestDeviceInfo:
             names = [name for id, name in items]
             return " ".join(names)
         return None
+
+
+@callback
+def async_nest_devices(hass: HomeAssistant) -> Mapping[str, Device]:
+    """Return a mapping of all nest devices for all config entries."""
+    devices = {}
+    for entry_id in hass.data[DOMAIN]:
+        if DATA_DEVICE_MANAGER not in hass.data[DOMAIN][entry_id]:
+            continue
+        if not (device_manager := hass.data[DOMAIN][entry_id].get(DATA_DEVICE_MANAGER)):
+            continue
+        devices.update(
+            {device.name: device for device in device_manager.devices.values()}
+        )
+    _LOGGER.info(devices)
+    return devices
+
+
+@callback
+def async_nest_devices_by_device_id(hass: HomeAssistant) -> Mapping[str, Device]:
+    """Return a mapping of all nest devices by home assistant device id, for all config entries."""
+    device_registry = dr.async_get(hass)
+    devices = {}
+    for nest_device_id, device in async_nest_devices(hass).items():
+        if device_entry := device_registry.async_get_device({(DOMAIN, nest_device_id)}):
+            devices[device_entry.id] = device
+    _LOGGER.info(devices)
+    return devices

--- a/homeassistant/components/nest/device_trigger.py
+++ b/homeassistant/components/nest/device_trigger.py
@@ -1,7 +1,6 @@
 """Provides device automations for Nest."""
 from __future__ import annotations
 
-from google_nest_sdm.device_manager import DeviceManager
 import voluptuous as vol
 
 from homeassistant.components.automation import (
@@ -14,11 +13,11 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_DEVICE_MANAGER, DOMAIN
+from .const import DOMAIN
+from .device_info import async_nest_devices_by_device_id
 from .events import DEVICE_TRAIT_TRIGGER_MAP, NEST_EVENT
 
 DEVICE = "device"
@@ -32,43 +31,18 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-@callback
-def async_get_nest_device_id(hass: HomeAssistant, device_id: str) -> str | None:
-    """Get the nest API device_id from the HomeAssistant device_id."""
-    device_registry = dr.async_get(hass)
-    if device := device_registry.async_get(device_id):
-        for (domain, unique_id) in device.identifiers:
-            if domain == DOMAIN:
-                return unique_id
-    return None
-
-
-@callback
-def async_get_device_trigger_types(
-    hass: HomeAssistant, nest_device_id: str
-) -> list[str]:
-    """List event triggers supported for a Nest device."""
-    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
-    if not (nest_device := device_manager.devices.get(nest_device_id)):
-        raise InvalidDeviceAutomationConfig(f"Nest device not found {nest_device_id}")
-
-    # Determine the set of event types based on the supported device traits
-    trigger_types = [
-        trigger_type
-        for trait in nest_device.traits
-        if (trigger_type := DEVICE_TRAIT_TRIGGER_MAP.get(trait))
-    ]
-    return trigger_types
-
-
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
     """List device triggers for a Nest device."""
-    nest_device_id = async_get_nest_device_id(hass, device_id)
-    if not nest_device_id:
+    devices = async_nest_devices_by_device_id(hass)
+    if not (device := devices.get(device_id)):
         raise InvalidDeviceAutomationConfig(f"Device not found {device_id}")
-    trigger_types = async_get_device_trigger_types(hass, nest_device_id)
+    trigger_types = [
+        trigger_type
+        for trait in device.traits
+        if (trigger_type := DEVICE_TRAIT_TRIGGER_MAP.get(trait))
+    ]
     return [
         {
             CONF_PLATFORM: DEVICE,

--- a/homeassistant/components/nest/diagnostics.py
+++ b/homeassistant/components/nest/diagnostics.py
@@ -27,10 +27,15 @@ def _async_get_nest_devices(
     if DATA_SDM not in config_entry.data:
         return {}
 
-    if DATA_DEVICE_MANAGER not in hass.data[DOMAIN]:
+    if (
+        config_entry.entry_id not in hass.data[DOMAIN]
+        or DATA_DEVICE_MANAGER not in hass.data[DOMAIN][config_entry.entry_id]
+    ):
         return {}
 
-    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][config_entry.entry_id][
+        DATA_DEVICE_MANAGER
+    ]
     return device_manager.devices
 
 

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -25,7 +25,6 @@ import os
 
 from google_nest_sdm.camera_traits import CameraClipPreviewTrait, CameraEventImageTrait
 from google_nest_sdm.device import Device
-from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.event import EventImageType, ImageEventBase
 from google_nest_sdm.event_media import (
     ClipPreviewSession,
@@ -57,8 +56,8 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import dt as dt_util
 
-from .const import DATA_DEVICE_MANAGER, DOMAIN
-from .device_info import NestDeviceInfo
+from .const import DOMAIN
+from .device_info import NestDeviceInfo, async_nest_devices_by_device_id
 from .events import EVENT_NAME_MAP, MEDIA_SOURCE_EVENT_TITLE_MAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -271,21 +270,13 @@ async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
 @callback
 def async_get_media_source_devices(hass: HomeAssistant) -> Mapping[str, Device]:
     """Return a mapping of device id to eligible Nest event media devices."""
-    if DATA_DEVICE_MANAGER not in hass.data[DOMAIN]:
-        # Integration unloaded, or is legacy nest integration
-        return {}
-    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
-    device_registry = dr.async_get(hass)
-    devices = {}
-    for device in device_manager.devices.values():
-        if not (
-            CameraEventImageTrait.NAME in device.traits
-            or CameraClipPreviewTrait.NAME in device.traits
-        ):
-            continue
-        if device_entry := device_registry.async_get_device({(DOMAIN, device.name)}):
-            devices[device_entry.id] = device
-    return devices
+    devices = async_nest_devices_by_device_id(hass)
+    return {
+        device_id: device
+        for device_id, device in devices.items()
+        if CameraEventImageTrait.NAME in device.traits
+        or CameraClipPreviewTrait.NAME in device.traits
+    }
 
 
 @dataclass

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -36,7 +36,9 @@ async def async_setup_sdm_entry(
 ) -> None:
     """Set up the sensors."""
 
-    device_manager: DeviceManager = hass.data[DOMAIN][DATA_DEVICE_MANAGER]
+    device_manager: DeviceManager = hass.data[DOMAIN][entry.entry_id][
+        DATA_DEVICE_MANAGER
+    ]
     entities: list[SensorEntity] = []
     for device in device_manager.devices.values():
         if TemperatureTrait.NAME in device.traits:

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -70,7 +70,6 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "unknown_authorize_url_generation": "[%key:common::config_flow::abort::unknown_authorize_url_generation%]",

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -69,6 +69,7 @@
       "subscriber_error": "Unknown subscriber error, see logs"
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -24,6 +24,7 @@ from homeassistant.setup import async_setup_component
 
 from .common import (
     DEVICE_ID,
+    PROJECT_ID,
     SUBSCRIBER_ID,
     TEST_CONFIG_APP_CREDS,
     TEST_CONFIG_YAML_ONLY,
@@ -214,10 +215,17 @@ def config(
 
 
 @pytest.fixture
+def config_entry_unique_id() -> str:
+    """Fixture to set ConfigEntry unique id."""
+    return PROJECT_ID
+
+
+@pytest.fixture
 def config_entry(
     subscriber_id: str | None,
     auth_implementation: str | None,
     nest_test_config: NestTestConfig,
+    config_entry_unique_id: str,
 ) -> MockConfigEntry | None:
     """Fixture that sets up the ConfigEntry for the test."""
     if nest_test_config.config_entry_data is None:
@@ -229,7 +237,7 @@ def config_entry(
         else:
             del data[CONF_SUBSCRIBER_ID]
     data["auth_implementation"] = auth_implementation
-    return MockConfigEntry(domain=DOMAIN, data=data)
+    return MockConfigEntry(domain=DOMAIN, data=data, unique_id=config_entry_unique_id)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -76,8 +76,8 @@ class OAuthFixture:
         assert result.get("type") == "form"
         assert result.get("step_id") == "device_project"
 
-        result = await self.async_configure(result, {"project_id": PROJECT_ID})
-        await self.async_oauth_web_flow(result)
+        result = await self.async_configure(result, {"project_id": project_id})
+        await self.async_oauth_web_flow(result, project_id=project_id)
 
     async def async_oauth_web_flow(self, result: dict, project_id=PROJECT_ID) -> None:
         """Invoke the oauth flow for Web Auth with fake responses."""
@@ -404,7 +404,7 @@ async def test_web_reauth(hass, oauth, setup_platform, config_entry):
     entry = await oauth.async_finish_setup(result)
     # Verify existing tokens are replaced
     entry.data["token"].pop("expires_at")
-    assert entry.unique_id == DOMAIN
+    assert entry.unique_id == PROJECT_ID
     assert entry.data["token"] == {
         "refresh_token": "mock-refresh-token",
         "access_token": "mock-access-token",
@@ -415,7 +415,7 @@ async def test_web_reauth(hass, oauth, setup_platform, config_entry):
     assert entry.data.get("subscriber_id") == orig_subscriber_id  # Not updated
 
 
-async def test_multiple_config_entrties(hass, oauth, setup_platform):
+async def test_multiple_config_entries(hass, oauth, setup_platform):
     """Verify config flow can be started when existing config entry exists."""
     await setup_platform()
 
@@ -425,7 +425,7 @@ async def test_multiple_config_entrties(hass, oauth, setup_platform):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    await oauth.async_app_creds_flow(result)
+    await oauth.async_app_creds_flow(result, project_id="project-id-2")
     entry = await oauth.async_finish_setup(result)
     assert entry.title == "Mock Title"
     assert "token" in entry.data
@@ -434,14 +434,32 @@ async def test_multiple_config_entrties(hass, oauth, setup_platform):
     assert len(entries) == 2
 
 
-async def test_unexpected_existing_config_entries(
+async def test_duplicate_config_entries(hass, oauth, setup_platform):
+    """Verify that config entries must be for unique projects."""
+    await setup_platform()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "cloud_project"
+
+    result = await oauth.async_configure(result, {"cloud_project_id": CLOUD_PROJECT_ID})
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "device_project"
+
+    result = await oauth.async_configure(result, {"project_id": PROJECT_ID})
+    assert result.get("type") == "abort"
+    assert result.get("reason") == "already_configured"
+
+
+async def test_reauth_multiple_config_entries(
     hass, oauth, setup_platform, config_entry
 ):
     """Test Nest reauthentication with multiple existing config entries."""
-    # Note that this case will not happen in the future since only a single
-    # instance is now allowed, but this may have been allowed in the past.
-    # On reauth, only one entry is kept and the others are deleted.
-
     await setup_platform()
 
     old_entry = MockConfigEntry(
@@ -469,7 +487,7 @@ async def test_unexpected_existing_config_entries(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2
     entry = entries[0]
-    assert entry.unique_id == DOMAIN
+    assert entry.unique_id == PROJECT_ID
     entry.data["token"].pop("expires_at")
     assert entry.data["token"] == {
         "refresh_token": "mock-refresh-token",
@@ -548,7 +566,7 @@ async def test_app_auth_yaml_reauth(hass, oauth, setup_platform, config_entry):
     # Verify existing tokens are replaced
     entry = await oauth.async_finish_setup(result, {"code": "1234"})
     entry.data["token"].pop("expires_at")
-    assert entry.unique_id == DOMAIN
+    assert entry.unique_id == PROJECT_ID
     assert entry.data["token"] == {
         "refresh_token": "mock-refresh-token",
         "access_token": "mock-access-token",
@@ -578,7 +596,7 @@ async def test_web_auth_yaml_reauth(hass, oauth, setup_platform, config_entry):
     # Verify existing tokens are replaced
     entry = await oauth.async_finish_setup(result, {"code": "1234"})
     entry.data["token"].pop("expires_at")
-    assert entry.unique_id == DOMAIN
+    assert entry.unique_id == PROJECT_ID
     assert entry.data["token"] == {
         "refresh_token": "mock-refresh-token",
         "access_token": "mock-access-token",
@@ -607,7 +625,7 @@ async def test_pubsub_subscription_strip_whitespace(
     assert entry.title == "Import from configuration.yaml"
     assert "token" in entry.data
     entry.data["token"].pop("expires_at")
-    assert entry.unique_id == DOMAIN
+    assert entry.unique_id == PROJECT_ID
     assert entry.data["token"] == {
         "refresh_token": "mock-refresh-token",
         "access_token": "mock-access-token",
@@ -651,7 +669,7 @@ async def test_pubsub_subscriber_config_entry_reauth(
     # Entering an updated access token refreshs the config entry.
     entry = await oauth.async_finish_setup(result, {"code": "1234"})
     entry.data["token"].pop("expires_at")
-    assert entry.unique_id == DOMAIN
+    assert entry.unique_id == PROJECT_ID
     assert entry.data["token"] == {
         "refresh_token": "mock-refresh-token",
         "access_token": "mock-access-token",

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -273,3 +273,18 @@ async def test_remove_entry_delete_subscriber_failure(
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert not entries
+
+
+@pytest.mark.parametrize("config_entry_unique_id", [DOMAIN, None])
+async def test_migrate_unique_id(
+    hass, error_caplog, setup_platform, config_entry, config_entry_unique_id
+):
+    """Test successful setup."""
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry.unique_id == config_entry_unique_id
+
+    await setup_platform()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.unique_id == PROJECT_ID

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -103,18 +103,18 @@ async def test_setup_configuration_failure(
 
 @pytest.mark.parametrize("subscriber_side_effect", [SubscriberException()])
 async def test_setup_susbcriber_failure(
-    hass, error_caplog, failing_subscriber, setup_base_platform
+    hass, warning_caplog, failing_subscriber, setup_base_platform
 ):
     """Test configuration error."""
     await setup_base_platform()
-    assert "Subscriber error:" in error_caplog.text
+    assert "Subscriber error:" in warning_caplog.text
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_device_manager_failure(hass, error_caplog, setup_base_platform):
+async def test_setup_device_manager_failure(hass, warning_caplog, setup_base_platform):
     """Test device manager api failure."""
     with patch(
         "homeassistant.components.nest.api.GoogleNestSubscriber.start_async"
@@ -124,8 +124,7 @@ async def test_setup_device_manager_failure(hass, error_caplog, setup_base_platf
     ):
         await setup_base_platform()
 
-    assert len(error_caplog.messages) == 1
-    assert "Device manager error:" in error_caplog.text
+    assert "Device manager error:" in warning_caplog.text
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow multiple configuration entries for Nest, now that yaml is no longer required given application credentials. Each entry now has a unique id based on the device access project id, and the config flow has been updated to set that as well as migration for existing config entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
