### PR TITLE
Speed up generation of template states

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1065,6 +1065,7 @@ class State:
     """
 
     __slots__ = [
+        "__weakref__",
         "entity_id",
         "state",
         "attributes",

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1115,7 +1115,7 @@ class State:
 
         State objects are effectively immutable.
         """
-        return hash(id(self))
+        return hash((id(self), self.last_updated))
 
     @property
     def name(self) -> str:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1110,6 +1110,13 @@ class State:
         self.domain, self.object_id = split_entity_id(self.entity_id)
         self._as_dict: ReadOnlyDict[str, Collection[Any]] | None = None
 
+    def __hash__(self) -> int:
+        """Make the state hashable.
+
+        State objects are effectively immutable.
+        """
+        return hash(id(self))
+
     @property
     def name(self) -> str:
         """Name of this state."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1065,7 +1065,6 @@ class State:
     """
 
     __slots__ = [
-        "__weakref__",
         "entity_id",
         "state",
         "attributes",

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -225,7 +225,7 @@ def _false(arg: str) -> bool:
 
 
 @lru_cache(maxsize=EVAL_CACHE_SIZE)
-def _cached_literal_eval(result: Any) -> Any:
+def _cached_literal_eval(result: str) -> Any:
     return literal_eval(result)
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -322,6 +322,7 @@ class Template:
         "_exc_info",
         "_limited",
         "_strict",
+        "_hash_cache",
     )
 
     def __init__(self, template, hass=None):
@@ -337,6 +338,7 @@ class Template:
         self._exc_info = None
         self._limited = None
         self._strict = None
+        self._hash_cache: int = hash(self.template)
 
     @property
     def _env(self) -> TemplateEnvironment:
@@ -622,7 +624,7 @@ class Template:
 
     def __hash__(self) -> int:
         """Hash code for template."""
-        return hash(self.template)
+        return self._hash_cache
 
     def __repr__(self) -> str:
         """Representation of Template."""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -98,6 +98,7 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
 )
 
 CACHED_TEMPLATE_STATES = 256
+EVAL_CACHE_SIZE = 256
 
 
 @bind_hass
@@ -223,7 +224,7 @@ def _false(arg: str) -> bool:
     return False
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=EVAL_CACHE_SIZE)
 def _cached_literal_eval(result: Any) -> Any:
     return literal_eval(result)
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -97,6 +97,8 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
     "template_cv", default=None
 )
 
+CACHED_TEMPLATE_STATES = 256
+
 
 @bind_hass
 def attach(hass: HomeAssistant, obj: Any) -> None:
@@ -893,7 +895,7 @@ def _collect_state(hass: HomeAssistant, entity_id: str) -> None:
         entity_collect.entities.add(entity_id)
 
 
-@lru_cache(maxsize=4096)
+@lru_cache(maxsize=CACHED_TEMPLATE_STATES)
 def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
     return TemplateState(hass, state, collect=False)
 
@@ -915,7 +917,7 @@ def _get_state(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
     return _get_template_state_from_state(hass, entity_id, hass.states.get(entity_id))
 
 
-@lru_cache(maxsize=4096)
+@lru_cache(maxsize=CACHED_TEMPLATE_STATES)
 def _template_state(hass: HomeAssistant, state: State) -> TemplateState:
     return TemplateState(hass, state)
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from datetime import datetime, timedelta
-from functools import partial, wraps
+from functools import cache, lru_cache, partial, wraps
 import json
 import logging
 import math
@@ -624,8 +624,26 @@ class Template:
         return 'Template("' + self.template + '")'
 
 
+@cache
+def _domain_states(hass: HomeAssistant, name: str) -> DomainStates:
+    return DomainStates(hass, name)
+
+
+def _readonly(*args: Any, **kwargs: Any) -> Any:
+    """Raise an exception when a states object is modified."""
+    raise RuntimeError("Cannot modify template States object")
+
+
 class AllStates:
     """Class to expose all HA states as attributes."""
+
+    __setitem__ = _readonly
+    __delitem__ = _readonly
+    pop = _readonly
+    popitem = _readonly
+    clear = _readonly
+    update = _readonly
+    setdefault = _readonly
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize all states."""
@@ -642,7 +660,7 @@ class AllStates:
         if not valid_entity_id(f"{name}.entity"):
             raise TemplateError(f"Invalid domain name '{name}'")
 
-        return DomainStates(self._hass, name)
+        return _domain_states(self._hass, name)
 
     # Jinja will try __getitem__ first and it avoids the need
     # to call is_safe_attribute
@@ -680,6 +698,14 @@ class AllStates:
 
 class DomainStates:
     """Class to expose a specific HA domain as attributes."""
+
+    __setitem__ = _readonly
+    __delitem__ = _readonly
+    pop = _readonly
+    popitem = _readonly
+    clear = _readonly
+    update = _readonly
+    setdefault = _readonly
 
     def __init__(self, hass: HomeAssistant, domain: str) -> None:
         """Initialize the domain states."""
@@ -725,6 +751,14 @@ class TemplateStateBase(State):
     __slots__ = ("_hass", "_collect", "_entity_id")
 
     _state: State
+
+    __setitem__ = _readonly
+    __delitem__ = _readonly
+    pop = _readonly
+    popitem = _readonly
+    clear = _readonly
+    update = _readonly
+    setdefault = _readonly
 
     # Inheritance is done so functions that check against State keep working
     # pylint: disable=super-init-not-called
@@ -864,10 +898,15 @@ def _collect_state(hass: HomeAssistant, entity_id: str) -> None:
         entity_collect.entities.add(entity_id)
 
 
+@lru_cache(maxsize=4096)
+def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
+    return TemplateState(hass, state, collect=False)
+
+
 def _state_generator(hass: HomeAssistant, domain: str | None) -> Generator:
     """State generator for a domain or all states."""
     for state in sorted(hass.states.async_all(domain), key=attrgetter("entity_id")):
-        yield TemplateState(hass, state, collect=False)
+        yield _template_state_no_collect(hass, state)
 
 
 def _get_state_if_valid(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
@@ -881,6 +920,11 @@ def _get_state(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
     return _get_template_state_from_state(hass, entity_id, hass.states.get(entity_id))
 
 
+@lru_cache(maxsize=4096)
+def _template_state(hass: HomeAssistant, state: State) -> TemplateState:
+    return TemplateState(hass, state)
+
+
 def _get_template_state_from_state(
     hass: HomeAssistant, entity_id: str, state: State | None
 ) -> TemplateState | None:
@@ -889,7 +933,7 @@ def _get_template_state_from_state(
         # access to the state properties in the state wrapper.
         _collect_state(hass, entity_id)
         return None
-    return TemplateState(hass, state)
+    return _template_state(hass, state)
 
 
 def _resolve_state(

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -97,8 +97,8 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
     "template_cv", default=None
 )
 
-CACHED_TEMPLATE_STATES = 256
-EVAL_CACHE_SIZE = 256
+CACHED_TEMPLATE_STATES = 512
+EVAL_CACHE_SIZE = 512
 
 
 @bind_hass

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -224,9 +224,7 @@ def _false(arg: str) -> bool:
     return False
 
 
-@lru_cache(maxsize=EVAL_CACHE_SIZE)
-def _cached_literal_eval(result: str) -> Any:
-    return literal_eval(result)
+_cached_literal_eval = lru_cache(maxsize=EVAL_CACHE_SIZE)(literal_eval)
 
 
 class RenderInfo:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -631,7 +631,7 @@ def _domain_states(hass: HomeAssistant, name: str) -> DomainStates:
 
 def _readonly(*args: Any, **kwargs: Any) -> Any:
     """Raise an exception when a states object is modified."""
-    raise RuntimeError("Cannot modify template States object")
+    raise RuntimeError(f"Cannot modify template States object: {args} {kwargs}")
 
 
 class AllStates:
@@ -639,11 +639,7 @@ class AllStates:
 
     __setitem__ = _readonly
     __delitem__ = _readonly
-    pop = _readonly
-    popitem = _readonly
-    clear = _readonly
-    update = _readonly
-    setdefault = _readonly
+    __slots__ = ("_hass",)
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize all states."""
@@ -699,13 +695,10 @@ class AllStates:
 class DomainStates:
     """Class to expose a specific HA domain as attributes."""
 
+    __slots__ = ("_hass", "_domain")
+
     __setitem__ = _readonly
     __delitem__ = _readonly
-    pop = _readonly
-    popitem = _readonly
-    clear = _readonly
-    update = _readonly
-    setdefault = _readonly
 
     def __init__(self, hass: HomeAssistant, domain: str) -> None:
         """Initialize the domain states."""
@@ -754,11 +747,6 @@ class TemplateStateBase(State):
 
     __setitem__ = _readonly
     __delitem__ = _readonly
-    pop = _readonly
-    popitem = _readonly
-    clear = _readonly
-    update = _readonly
-    setdefault = _readonly
 
     # Inheritance is done so functions that check against State keep working
     # pylint: disable=super-init-not-called

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -221,6 +221,11 @@ def _false(arg: str) -> bool:
     return False
 
 
+@lru_cache(maxsize=256)
+def _cached_literal_eval(result: Any) -> Any:
+    return literal_eval(result)
+
+
 class RenderInfo:
     """Holds information about a template render."""
 
@@ -420,7 +425,7 @@ class Template:
     def _parse_result(self, render_result: str) -> Any:
         """Parse the result."""
         try:
-            result = literal_eval(render_result)
+            result = _cached_literal_eval(render_result)
 
             if type(result) in RESULT_WRAPPERS:
                 result = RESULT_WRAPPERS[type(result)](

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -21,7 +21,7 @@ from struct import error as StructError, pack, unpack_from
 import sys
 from typing import Any, cast
 from urllib.parse import urlencode as urllib_urlencode
-import weakref
+from weakref import WeakKeyDictionary, WeakValueDictionary
 
 import jinja2
 from jinja2 import pass_context, pass_environment
@@ -92,6 +92,11 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
 
 ALL_STATES_RATE_LIMIT = timedelta(minutes=1)
 DOMAIN_STATES_RATE_LIMIT = timedelta(seconds=1)
+
+TEMPLATE_STATES_COLLECT: WeakKeyDictionary[State, TemplateState] = WeakKeyDictionary({})
+TEMPLATE_STATES_NO_COLLECT: WeakKeyDictionary[State, TemplateState] = WeakKeyDictionary(
+    {}
+)
 
 template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
     "template_cv", default=None
@@ -893,9 +898,13 @@ def _collect_state(hass: HomeAssistant, entity_id: str) -> None:
         entity_collect.entities.add(entity_id)
 
 
-@lru_cache(maxsize=4096)
 def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
-    return TemplateState(hass, state, collect=False)
+    if temlate_state := TEMPLATE_STATES_NO_COLLECT.get(state):
+        return temlate_state
+    template_state = TEMPLATE_STATES_NO_COLLECT[state] = TemplateState(
+        hass, state, collect=False
+    )
+    return template_state
 
 
 def _state_generator(hass: HomeAssistant, domain: str | None) -> Generator:
@@ -915,9 +924,11 @@ def _get_state(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
     return _get_template_state_from_state(hass, entity_id, hass.states.get(entity_id))
 
 
-@lru_cache(maxsize=4096)
 def _template_state(hass: HomeAssistant, state: State) -> TemplateState:
-    return TemplateState(hass, state)
+    if temlate_state := TEMPLATE_STATES_COLLECT.get(state):
+        return temlate_state
+    template_state = TEMPLATE_STATES_COLLECT[state] = TemplateState(hass, state)
+    return template_state
 
 
 def _get_template_state_from_state(
@@ -1933,7 +1944,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             undefined = jinja2.StrictUndefined
         super().__init__(undefined=undefined)
         self.hass = hass
-        self.template_cache = weakref.WeakValueDictionary()
+        self.template_cache = WeakValueDictionary()
         self.filters["round"] = forgiving_round
         self.filters["multiply"] = multiply
         self.filters["log"] = logarithm

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     MASS_GRAMS,
     PRESSURE_PA,
     SPEED_KILOMETERS_PER_HOUR,
+    STATE_ON,
     TEMP_CELSIUS,
     VOLUME_LITERS,
 )
@@ -3831,3 +3832,12 @@ async def test_undefined_variable(hass, caplog):
         "Template variable warning: 'no_such_variable' is undefined when rendering '{{ no_such_variable }}'"
         in caplog.text
     )
+
+
+async def test_template_states_blocks_setitem(hass):
+    """Test we cannot setitem on TemplateStates."""
+    hass.states.async_set("light.new", STATE_ON)
+    state = hass.states.get("light.new")
+    template_state = template.TemplateState(hass, state, True)
+    with pytest.raises(RuntimeError):
+        template_state["any"] = "any"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up generation of template states.

Found this while analyzing the data provided by @Mariusthvdb in https://community.home-assistant.io/t/how-to-install-py-spy-on-a-ha-os-instance-please-instruct/430822/31

I'm expecting about a 19% speed up based on the before and after py_spys.  Creating the TemplateStates is cached most of the time now so at this point 90% of the overhead is jinja which we really can't optimize much more (famous last words) since most of it is actually python overhead.  Hopefully python 3.11 will make quite a difference here (I expect it will)

<img width="1276" alt="Screen Shot 2022-06-20 at 15 24 22" src="https://user-images.githubusercontent.com/663432/174673329-ebd09c00-b930-450e-8aed-fc2343419240.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
