### PR TITLE
Add checks for lock properties in type-hint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -690,7 +690,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         ):
             return
 
-        # Check that all arguments are correctly annotated.
+        # Check that all positional arguments are correctly annotated.
         if match.arg_types:
             for key, expected_type in match.arg_types.items():
                 if not _is_valid_type(expected_type, annotations[key]):

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -441,6 +441,8 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             ],
         ),
     ],
+}
+_PROPERTY_MATCH: dict[str, list[ClassTypeHintMatch]] = {
     "lock": [
         ClassTypeHintMatch(
             base_class="LockEntity",
@@ -652,7 +654,12 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
             self._function_matchers.extend(function_matches)
 
         if class_matches := _CLASS_MATCH.get(module_platform):
-            self._class_matchers = class_matches
+            self._class_matchers.extend(class_matches)
+
+        if not self.linter.config.ignore_missing_annotations and (
+            property_matches := _PROPERTY_MATCH.get(module_platform)
+        ):
+            self._class_matchers.extend(property_matches)
 
     def visit_classdef(self, node: nodes.ClassDef) -> None:
         """Called when a ClassDef node is visited."""

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -20,8 +20,8 @@ class TypeHintMatch:
     """Class for pattern matching."""
 
     function_name: str
-    arg_types: dict[int, str]
     return_type: list[str] | str | None | object
+    arg_types: dict[int, str] | None = None
     check_return_type_inheritance: bool = False
 
 
@@ -440,7 +440,38 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                 ),
             ],
         ),
-    ]
+    ],
+    "lock": [
+        ClassTypeHintMatch(
+            base_class="LockEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="changed_by",
+                    return_type=["str", "str | None"],
+                ),
+                TypeHintMatch(
+                    function_name="code_format",
+                    return_type=["str", "str | None"],
+                ),
+                TypeHintMatch(
+                    function_name="is_locked",
+                    return_type=["bool", "bool | None"],
+                ),
+                TypeHintMatch(
+                    function_name="is_locking",
+                    return_type=["bool", "bool | None"],
+                ),
+                TypeHintMatch(
+                    function_name="is_unlocking",
+                    return_type=["bool", "bool | None"],
+                ),
+                TypeHintMatch(
+                    function_name="is_jammed",
+                    return_type=["bool", "bool | None"],
+                ),
+            ],
+        ),
+    ],
 }
 
 
@@ -660,13 +691,14 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
             return
 
         # Check that all arguments are correctly annotated.
-        for key, expected_type in match.arg_types.items():
-            if not _is_valid_type(expected_type, annotations[key]):
-                self.add_message(
-                    "hass-argument-type",
-                    node=node.args.args[key],
-                    args=(key + 1, expected_type),
-                )
+        if match.arg_types:
+            for key, expected_type in match.arg_types.items():
+                if not _is_valid_type(expected_type, annotations[key]):
+                    self.add_message(
+                        "hass-argument-type",
+                        node=node.args.args[key],
+                        args=(key + 1, expected_type),
+                    )
 
         # Check the return type.
         if not _is_valid_return_type(match, node.returns):

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -447,27 +447,27 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             matches=[
                 TypeHintMatch(
                     function_name="changed_by",
-                    return_type=["str", "str | None"],
+                    return_type=["str", None],
                 ),
                 TypeHintMatch(
                     function_name="code_format",
-                    return_type=["str", "str | None"],
+                    return_type=["str", None],
                 ),
                 TypeHintMatch(
                     function_name="is_locked",
-                    return_type=["bool", "bool | None"],
+                    return_type=["bool", None],
                 ),
                 TypeHintMatch(
                     function_name="is_locking",
-                    return_type=["bool", "bool | None"],
+                    return_type=["bool", None],
                 ),
                 TypeHintMatch(
                     function_name="is_unlocking",
-                    return_type=["bool", "bool | None"],
+                    return_type=["bool", None],
                 ),
                 TypeHintMatch(
                     function_name="is_jammed",
-                    return_type=["bool", "bool | None"],
+                    return_type=["bool", None],
                 ),
             ],
         ),

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -442,6 +442,8 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
         ),
     ],
 }
+# Properties are normally checked by mypy, and will only be checked
+# by pylint when --ignore-missing-annotations is False
 _PROPERTY_MATCH: dict[str, list[ClassTypeHintMatch]] = {
     "lock": [
         ClassTypeHintMatch(

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -471,10 +471,10 @@ def test_valid_config_flow_async_get_options_flow(
         type_hint_checker.visit_classdef(class_node)
 
 
-def test_invalid_lock_entity(
+def test_invalid_entity_properties(
     linter: UnittestLinter, type_hint_checker: BaseChecker
 ) -> None:
-    """Ensure invalid hints are rejected for LockEntity properties."""
+    """Check missing entity properties are rejected ignore_missing_annotations=no."""
     # Set bypass option
     type_hint_checker.config.ignore_missing_annotations = False
 
@@ -508,4 +508,30 @@ def test_invalid_lock_entity(
             end_col_offset=18,
         ),
     ):
+        type_hint_checker.visit_classdef(class_node)
+
+
+def test_ignore_invalid_entity_properties(
+    linter: UnittestLinter, type_hint_checker: BaseChecker
+) -> None:
+    """Check invalid entity properties are ignored by default."""
+    class_node = astroid.extract_node(
+        """
+    class LockEntity():
+        pass
+
+    class DoorLock( #@
+        LockEntity
+    ):
+        @property
+        def changed_by(
+            self
+        ):
+            pass
+    """,
+        "homeassistant.components.pylint_test.lock",
+    )
+    type_hint_checker.visit_module(class_node.parent)
+
+    with assert_no_messages(linter):
         type_hint_checker.visit_classdef(class_node)

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -474,7 +474,7 @@ def test_valid_config_flow_async_get_options_flow(
 def test_invalid_entity_properties(
     linter: UnittestLinter, type_hint_checker: BaseChecker
 ) -> None:
-    """Check missing entity properties are rejected ignore_missing_annotations=no."""
+    """Check missing entity properties when ignore_missing_annotations is False."""
     # Set bypass option
     type_hint_checker.config.ignore_missing_annotations = False
 

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -498,7 +498,7 @@ def test_invalid_lock_entity(
         pylint.testutils.MessageTest(
             msg_id="hass-return-type",
             node=prop_node,
-            args=["str", "str | None"],
+            args=["str", None],
             line=9,
             col_offset=4,
             end_line=9,

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -474,7 +474,10 @@ def test_valid_config_flow_async_get_options_flow(
 def test_invalid_lock_entity(
     linter: UnittestLinter, type_hint_checker: BaseChecker
 ) -> None:
-    """Ensure invalid hints are rejected for LockEntity methods/properties."""
+    """Ensure invalid hints are rejected for LockEntity properties."""
+    # Set bypass option
+    type_hint_checker.config.ignore_missing_annotations = False
+
     class_node, prop_node = astroid.extract_node(
         """
     class LockEntity():
@@ -486,7 +489,7 @@ def test_invalid_lock_entity(
         @property
         def changed_by( #@
             self
-        ) -> int:
+        ):
             pass
     """,
         "homeassistant.components.pylint_test.lock",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add checks for lock properties in type-hint plugin

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
