### PR TITLE
Remove unnecessary type definitions in zha

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import zigpy.exceptions
+import zigpy.zcl
 from zigpy.zcl.foundation import (
     CommandSchema,
     ConfigureReportingResponseRecord,
@@ -19,7 +20,6 @@ from homeassistant.const import ATTR_COMMAND
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .. import typing as zha_typing
 from ..const import (
     ATTR_ARGS,
     ATTR_ATTRIBUTE_ID,
@@ -107,9 +107,7 @@ class ZigbeeChannel(LogMixin):
     # attribute read is acceptable.
     ZCL_INIT_ATTRS: dict[int | str, bool] = {}
 
-    def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: ChannelPool
-    ) -> None:
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize ZigbeeChannel."""
         self._generic_id = f"channel_0x{cluster.cluster_id:04x}"
         self._ch_pool = ch_pool

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 import zigpy.exceptions
 import zigpy.types as t
+import zigpy.zcl
 from zigpy.zcl.clusters import general
 from zigpy.zcl.foundation import Status
 
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_call_later
 
-from .. import registries, typing as zha_typing
+from .. import registries
 from ..const import (
     REPORT_CONFIG_ASAP,
     REPORT_CONFIG_BATTERY_SAVE,
@@ -307,9 +308,7 @@ class OnOffChannel(ZigbeeChannel):
         "start_up_on_off": True,
     }
 
-    def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: ChannelPool
-    ) -> None:
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize OnOffChannel."""
         super().__init__(cluster, ch_pool)
         self._off_listener = None

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import zigpy.zcl
+
 from homeassistant.core import callback
 
-from .. import registries, typing as zha_typing
+from .. import registries
 from ..const import (
     ATTR_ATTRIBUTE_ID,
     ATTR_ATTRIBUTE_NAME,
@@ -60,9 +62,7 @@ class OppleRemote(ZigbeeChannel):
 
     REPORT_CONFIG = []
 
-    def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: ChannelPool
-    ) -> None:
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Opple channel."""
         super().__init__(cluster, ch_pool)
         if self.cluster.endpoint.model == "lumi.motion.ac02":

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -10,12 +10,13 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from zigpy.exceptions import ZigbeeException
+import zigpy.zcl
 from zigpy.zcl.clusters import security
 from zigpy.zcl.clusters.security import IasAce as AceCluster
 
 from homeassistant.core import callback
 
-from .. import registries, typing as zha_typing
+from .. import registries
 from ..const import (
     SIGNAL_ATTR_UPDATED,
     WARNING_DEVICE_MODE_EMERGENCY,
@@ -51,9 +52,7 @@ SIGNAL_ALARM_TRIGGERED = "zha_armed_triggered"
 class IasAce(ZigbeeChannel):
     """IAS Ancillary Control Equipment channel."""
 
-    def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: ChannelPool
-    ) -> None:
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize IAS Ancillary Control Equipment channel."""
         super().__init__(cluster, ch_pool)
         self.command_map: dict[int, CALLABLE_T] = {

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -5,9 +5,10 @@ import enum
 from functools import partialmethod
 from typing import TYPE_CHECKING
 
+import zigpy.zcl
 from zigpy.zcl.clusters import smartenergy
 
-from .. import registries, typing as zha_typing
+from .. import registries
 from ..const import (
     REPORT_CONFIG_ASAP,
     REPORT_CONFIG_DEFAULT,
@@ -118,9 +119,7 @@ class Metering(ZigbeeChannel):
         DEMAND = 0
         SUMMATION = 1
 
-    def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: ChannelPool
-    ) -> None:
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Metering."""
         super().__init__(cluster, ch_pool)
         self._format_spec = None

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -12,6 +12,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from zigpy import types
+import zigpy.device
 import zigpy.exceptions
 from zigpy.profiles import PROFILES
 import zigpy.quirks
@@ -27,7 +28,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.event import async_track_time_interval
 
-from . import channels, typing as zha_typing
+from . import channels
 from .const import (
     ATTR_ARGS,
     ATTR_ATTRIBUTE,
@@ -100,7 +101,7 @@ class ZHADevice(LogMixin):
     def __init__(
         self,
         hass: HomeAssistant,
-        zigpy_device: zha_typing.ZigpyDeviceType,
+        zigpy_device: zigpy.device.Device,
         zha_gateway: ZHAGateway,
     ) -> None:
         """Initialize the gateway."""
@@ -151,7 +152,7 @@ class ZHADevice(LogMixin):
         self._ha_device_id = device_id
 
     @property
-    def device(self) -> zha_typing.ZigpyDeviceType:
+    def device(self) -> zigpy.device.Device:
         """Return underlying Zigpy device."""
         return self._zigpy_device
 
@@ -332,7 +333,7 @@ class ZHADevice(LogMixin):
     def new(
         cls,
         hass: HomeAssistant,
-        zigpy_dev: zha_typing.ZigpyDeviceType,
+        zigpy_dev: zigpy.device.Device,
         gateway: ZHAGateway,
         restored: bool = False,
     ):

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -21,6 +21,7 @@ import voluptuous as vol
 import zigpy.exceptions
 import zigpy.types
 import zigpy.util
+import zigpy.zcl
 import zigpy.zdo.types as zdo_types
 
 from homeassistant.config_entries import ConfigEntry
@@ -35,7 +36,6 @@ from .const import (
     DATA_ZHA_GATEWAY,
 )
 from .registries import BINDABLE_CLUSTERS
-from .typing import ZigpyClusterType
 
 if TYPE_CHECKING:
     from .device import ZHADevice
@@ -48,7 +48,7 @@ _T = TypeVar("_T")
 class BindingPair:
     """Information for binding."""
 
-    source_cluster: ZigpyClusterType
+    source_cluster: zigpy.zcl.Cluster
     target_ieee: zigpy.types.EUI64
     target_ep_id: int
 

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -2,14 +2,12 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-import zigpy.device
 import zigpy.endpoint
 import zigpy.group
 import zigpy.zdo
 
 # pylint: disable=invalid-name
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)
-ZigpyDeviceType = zigpy.device.Device
 ZigpyEndpointType = zigpy.endpoint.Endpoint
 ZigpyGroupType = zigpy.group.Group
 ZigpyZdoType = zigpy.zdo.ZDO

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -2,12 +2,10 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-import zigpy.endpoint
 import zigpy.group
 import zigpy.zdo
 
 # pylint: disable=invalid-name
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)
-ZigpyEndpointType = zigpy.endpoint.Endpoint
 ZigpyGroupType = zigpy.group.Group
 ZigpyZdoType = zigpy.zdo.ZDO

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -2,8 +2,5 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-import zigpy.zdo
-
 # pylint: disable=invalid-name
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)
-ZigpyZdoType = zigpy.zdo.ZDO

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -5,12 +5,10 @@ from typing import TypeVar
 import zigpy.device
 import zigpy.endpoint
 import zigpy.group
-import zigpy.zcl
 import zigpy.zdo
 
 # pylint: disable=invalid-name
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)
-ZigpyClusterType = zigpy.zcl.Cluster
 ZigpyDeviceType = zigpy.device.Device
 ZigpyEndpointType = zigpy.endpoint.Endpoint
 ZigpyGroupType = zigpy.group.Group

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -2,10 +2,8 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-import zigpy.group
 import zigpy.zdo
 
 # pylint: disable=invalid-name
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)
-ZigpyGroupType = zigpy.group.Group
 ZigpyZdoType = zigpy.zdo.ZDO


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove unnecessary type definitions in zha
Linked to #73603, and as follow-up to #73596

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
