### PR TITLE
Drop custom type (CALLABLE_T) from zha

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1516,7 +1516,6 @@ omit =
     homeassistant/components/zha/core/gateway.py
     homeassistant/components/zha/core/helpers.py
     homeassistant/components/zha/core/registries.py
-    homeassistant/components/zha/core/typing.py
     homeassistant/components/zha/entity.py
     homeassistant/components/zha/light.py
     homeassistant/components/zha/sensor.py

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -7,7 +7,8 @@ https://home-assistant.io/integrations/zha/
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from zigpy.exceptions import ZigbeeException
 import zigpy.zcl
@@ -25,7 +26,6 @@ from ..const import (
     WARNING_DEVICE_STROBE_HIGH,
     WARNING_DEVICE_STROBE_YES,
 )
-from ..typing import CALLABLE_T
 from .base import ChannelStatus, ZigbeeChannel
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class IasAce(ZigbeeChannel):
     def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize IAS Ancillary Control Equipment channel."""
         super().__init__(cluster, ch_pool)
-        self.command_map: dict[int, CALLABLE_T] = {
+        self.command_map: dict[int, Callable[..., Any]] = {
             IAS_ACE_ARM: self.arm,
             IAS_ACE_BYPASS: self._bypass,
             IAS_ACE_EMERGENCY: self._emergency,
@@ -67,7 +67,7 @@ class IasAce(ZigbeeChannel):
             IAS_ACE_GET_BYPASSED_ZONE_LIST: self._get_bypassed_zone_list,
             IAS_ACE_GET_ZONE_STATUS: self._get_zone_status,
         }
-        self.arm_map: dict[AceCluster.ArmMode, CALLABLE_T] = {
+        self.arm_map: dict[AceCluster.ArmMode, Callable[..., Any]] = {
             AceCluster.ArmMode.Disarm: self._disarm,
             AceCluster.ArmMode.Arm_All_Zones: self._arm_away,
             AceCluster.ArmMode.Arm_Day_Home_Only: self._arm_day,

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -16,6 +16,7 @@ from homeassistant.const import Platform
 
 # importing channels updates registries
 from . import channels as zha_channels  # noqa: F401 pylint: disable=unused-import
+from ..entity import ZhaEntity, ZhaGroupEntity
 from .decorators import DictRegistry, SetRegistry
 
 if TYPE_CHECKING:
@@ -214,7 +215,7 @@ class MatchRule:
 class EntityClassAndChannels:
     """Container for entity class and corresponding channels."""
 
-    entity_class: Callable[..., Any]
+    entity_class: type[ZhaEntity]
     claimed_channel: list[ZigbeeChannel]
 
 
@@ -224,19 +225,19 @@ class ZHAEntityRegistry:
     def __init__(self):
         """Initialize Registry instance."""
         self._strict_registry: dict[
-            str, dict[MatchRule, Callable[..., Any]]
+            str, dict[MatchRule, type[ZhaEntity]]
         ] = collections.defaultdict(dict)
         self._multi_entity_registry: dict[
-            str, dict[int | str | None, dict[MatchRule, list[Callable[..., Any]]]]
+            str, dict[int | str | None, dict[MatchRule, list[type[ZhaEntity]]]]
         ] = collections.defaultdict(
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
         )
         self._config_diagnostic_entity_registry: dict[
-            str, dict[int | str | None, dict[MatchRule, list[Callable[..., Any]]]]
+            str, dict[int | str | None, dict[MatchRule, list[type[ZhaEntity]]]]
         ] = collections.defaultdict(
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
         )
-        self._group_registry: dict[str, Callable[..., Any]] = {}
+        self._group_registry: dict[str, type[ZhaGroupEntity]] = {}
         self.single_device_matches: dict[
             Platform, dict[EUI64, list[str]]
         ] = collections.defaultdict(lambda: collections.defaultdict(list))
@@ -247,8 +248,8 @@ class ZHAEntityRegistry:
         manufacturer: str,
         model: str,
         channels: list[ZigbeeChannel],
-        default: Callable[..., Any] = None,
-    ) -> tuple[Callable[..., Any], list[ZigbeeChannel]]:
+        default: type[ZhaEntity] | None = None,
+    ) -> tuple[type[ZhaEntity] | None, list[ZigbeeChannel]]:
         """Match a ZHA Channels to a ZHA Entity class."""
         matches = self._strict_registry[component]
         for match in sorted(matches, key=lambda x: x.weight, reverse=True):
@@ -309,7 +310,7 @@ class ZHAEntityRegistry:
 
         return result, list(all_claimed)
 
-    def get_group_entity(self, component: str) -> Callable[..., Any]:
+    def get_group_entity(self, component: str) -> type[ZhaGroupEntity] | None:
         """Match a ZHA group to a ZHA Entity class."""
         return self._group_registry.get(component)
 

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -396,7 +396,7 @@ class ZHAEntityRegistry:
             aux_channels,
         )
 
-        def decorator(zha_entity: Callable[..., Any]) -> Callable[..., Any]:
+        def decorator(zha_entity: _ZhaEntityT) -> _ZhaEntityT:
             """Register a loose match rule.
 
             All non empty fields of a match rule must match.

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import collections
 from collections.abc import Callable
 import dataclasses
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import attr
 from zigpy import zcl
@@ -16,11 +16,15 @@ from homeassistant.const import Platform
 
 # importing channels updates registries
 from . import channels as zha_channels  # noqa: F401 pylint: disable=unused-import
-from ..entity import ZhaEntity, ZhaGroupEntity
 from .decorators import DictRegistry, SetRegistry
 
 if TYPE_CHECKING:
+    from ..entity import ZhaEntity, ZhaGroupEntity
     from .channels.base import ClientChannel, ZigbeeChannel
+
+
+_ZhaEntityT = TypeVar("_ZhaEntityT", bound=type["ZhaEntity"])
+_ZhaGroupEntityT = TypeVar("_ZhaGroupEntityT", bound=type["ZhaGroupEntity"])
 
 GROUP_ENTITY_DOMAINS = [Platform.LIGHT, Platform.SWITCH, Platform.FAN]
 
@@ -322,14 +326,14 @@ class ZHAEntityRegistry:
         manufacturers: Callable | set[str] | str = None,
         models: Callable | set[str] | str = None,
         aux_channels: Callable | set[str] | str = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ) -> Callable[[_ZhaEntityT], _ZhaEntityT]:
         """Decorate a strict match rule."""
 
         rule = MatchRule(
             channel_names, generic_ids, manufacturers, models, aux_channels
         )
 
-        def decorator(zha_ent: Callable[..., Any]) -> Callable[..., Any]:
+        def decorator(zha_ent: _ZhaEntityT) -> _ZhaEntityT:
             """Register a strict match rule.
 
             All non empty fields of a match rule must match.
@@ -348,7 +352,7 @@ class ZHAEntityRegistry:
         models: Callable | set[str] | str = None,
         aux_channels: Callable | set[str] | str = None,
         stop_on_match_group: int | str | None = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ) -> Callable[[_ZhaEntityT], _ZhaEntityT]:
         """Decorate a loose match rule."""
 
         rule = MatchRule(
@@ -359,7 +363,7 @@ class ZHAEntityRegistry:
             aux_channels,
         )
 
-        def decorator(zha_entity: Callable[..., Any]) -> Callable[..., Any]:
+        def decorator(zha_entity: _ZhaEntityT) -> _ZhaEntityT:
             """Register a loose match rule.
 
             All non empty fields of a match rule must match.
@@ -381,7 +385,7 @@ class ZHAEntityRegistry:
         models: Callable | set[str] | str = None,
         aux_channels: Callable | set[str] | str = None,
         stop_on_match_group: int | str | None = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ) -> Callable[[_ZhaEntityT], _ZhaEntityT]:
         """Decorate a loose match rule."""
 
         rule = MatchRule(
@@ -407,10 +411,10 @@ class ZHAEntityRegistry:
 
     def group_match(
         self, component: str
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ) -> Callable[[_ZhaGroupEntityT], _ZhaGroupEntityT]:
         """Decorate a group match rule."""
 
-        def decorator(zha_ent: Callable[..., Any]) -> Callable[..., Any]:
+        def decorator(zha_ent: _ZhaGroupEntityT) -> _ZhaGroupEntityT:
             """Register a group match rule."""
             self._group_registry[component] = zha_ent
             return zha_ent

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import collections
 from collections.abc import Callable
 import dataclasses
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import attr
 from zigpy import zcl
@@ -17,7 +17,6 @@ from homeassistant.const import Platform
 # importing channels updates registries
 from . import channels as zha_channels  # noqa: F401 pylint: disable=unused-import
 from .decorators import DictRegistry, SetRegistry
-from .typing import CALLABLE_T
 
 if TYPE_CHECKING:
     from .channels.base import ClientChannel, ZigbeeChannel
@@ -215,7 +214,7 @@ class MatchRule:
 class EntityClassAndChannels:
     """Container for entity class and corresponding channels."""
 
-    entity_class: CALLABLE_T
+    entity_class: Callable[..., Any]
     claimed_channel: list[ZigbeeChannel]
 
 
@@ -225,19 +224,19 @@ class ZHAEntityRegistry:
     def __init__(self):
         """Initialize Registry instance."""
         self._strict_registry: dict[
-            str, dict[MatchRule, CALLABLE_T]
+            str, dict[MatchRule, Callable[..., Any]]
         ] = collections.defaultdict(dict)
         self._multi_entity_registry: dict[
-            str, dict[int | str | None, dict[MatchRule, list[CALLABLE_T]]]
+            str, dict[int | str | None, dict[MatchRule, list[Callable[..., Any]]]]
         ] = collections.defaultdict(
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
         )
         self._config_diagnostic_entity_registry: dict[
-            str, dict[int | str | None, dict[MatchRule, list[CALLABLE_T]]]
+            str, dict[int | str | None, dict[MatchRule, list[Callable[..., Any]]]]
         ] = collections.defaultdict(
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
         )
-        self._group_registry: dict[str, CALLABLE_T] = {}
+        self._group_registry: dict[str, Callable[..., Any]] = {}
         self.single_device_matches: dict[
             Platform, dict[EUI64, list[str]]
         ] = collections.defaultdict(lambda: collections.defaultdict(list))
@@ -248,8 +247,8 @@ class ZHAEntityRegistry:
         manufacturer: str,
         model: str,
         channels: list[ZigbeeChannel],
-        default: CALLABLE_T = None,
-    ) -> tuple[CALLABLE_T, list[ZigbeeChannel]]:
+        default: Callable[..., Any] = None,
+    ) -> tuple[Callable[..., Any], list[ZigbeeChannel]]:
         """Match a ZHA Channels to a ZHA Entity class."""
         matches = self._strict_registry[component]
         for match in sorted(matches, key=lambda x: x.weight, reverse=True):
@@ -310,7 +309,7 @@ class ZHAEntityRegistry:
 
         return result, list(all_claimed)
 
-    def get_group_entity(self, component: str) -> CALLABLE_T:
+    def get_group_entity(self, component: str) -> Callable[..., Any]:
         """Match a ZHA group to a ZHA Entity class."""
         return self._group_registry.get(component)
 
@@ -322,14 +321,14 @@ class ZHAEntityRegistry:
         manufacturers: Callable | set[str] | str = None,
         models: Callable | set[str] | str = None,
         aux_channels: Callable | set[str] | str = None,
-    ) -> Callable[[CALLABLE_T], CALLABLE_T]:
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorate a strict match rule."""
 
         rule = MatchRule(
             channel_names, generic_ids, manufacturers, models, aux_channels
         )
 
-        def decorator(zha_ent: CALLABLE_T) -> CALLABLE_T:
+        def decorator(zha_ent: Callable[..., Any]) -> Callable[..., Any]:
             """Register a strict match rule.
 
             All non empty fields of a match rule must match.
@@ -348,7 +347,7 @@ class ZHAEntityRegistry:
         models: Callable | set[str] | str = None,
         aux_channels: Callable | set[str] | str = None,
         stop_on_match_group: int | str | None = None,
-    ) -> Callable[[CALLABLE_T], CALLABLE_T]:
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorate a loose match rule."""
 
         rule = MatchRule(
@@ -359,7 +358,7 @@ class ZHAEntityRegistry:
             aux_channels,
         )
 
-        def decorator(zha_entity: CALLABLE_T) -> CALLABLE_T:
+        def decorator(zha_entity: Callable[..., Any]) -> Callable[..., Any]:
             """Register a loose match rule.
 
             All non empty fields of a match rule must match.
@@ -381,7 +380,7 @@ class ZHAEntityRegistry:
         models: Callable | set[str] | str = None,
         aux_channels: Callable | set[str] | str = None,
         stop_on_match_group: int | str | None = None,
-    ) -> Callable[[CALLABLE_T], CALLABLE_T]:
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorate a loose match rule."""
 
         rule = MatchRule(
@@ -392,7 +391,7 @@ class ZHAEntityRegistry:
             aux_channels,
         )
 
-        def decorator(zha_entity: CALLABLE_T) -> CALLABLE_T:
+        def decorator(zha_entity: Callable[..., Any]) -> Callable[..., Any]:
             """Register a loose match rule.
 
             All non empty fields of a match rule must match.
@@ -405,10 +404,12 @@ class ZHAEntityRegistry:
 
         return decorator
 
-    def group_match(self, component: str) -> Callable[[CALLABLE_T], CALLABLE_T]:
+    def group_match(
+        self, component: str
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorate a group match rule."""
 
-        def decorator(zha_ent: CALLABLE_T) -> CALLABLE_T:
+        def decorator(zha_ent: Callable[..., Any]) -> Callable[..., Any]:
             """Register a group match rule."""
             self._group_registry[component] = zha_ent
             return zha_ent

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import collections
 from collections.abc import Callable
 import dataclasses
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import attr
 from zigpy import zcl

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -1,6 +1,0 @@
-"""Typing helpers for ZHA component."""
-from collections.abc import Callable
-from typing import TypeVar
-
-# pylint: disable=invalid-name
-CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -57,7 +57,7 @@ class BaseZhaEntity(LogMixin, entity.Entity):
         self._state: Any = None
         self._extra_state_attributes: dict[str, Any] = {}
         self._zha_device = zha_device
-        self._unsubs: list[Callable[..., Any]] = []
+        self._unsubs: list[Callable[[], None]] = []
         self.remove_future: asyncio.Future[Any] = asyncio.Future()
 
     @property
@@ -130,7 +130,7 @@ class BaseZhaEntity(LogMixin, entity.Entity):
         self,
         channel: ZigbeeChannel,
         signal: str,
-        func: Callable[..., Any],
+        func: Callable[[], Any],
         signal_override=False,
     ):
         """Accept a signal from a channel."""

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import functools
 import logging
 from typing import TYPE_CHECKING, Any
@@ -29,7 +30,6 @@ from .core.const import (
     SIGNAL_REMOVE,
 )
 from .core.helpers import LogMixin
-from .core.typing import CALLABLE_T
 
 if TYPE_CHECKING:
     from .core.channels.base import ZigbeeChannel
@@ -57,7 +57,7 @@ class BaseZhaEntity(LogMixin, entity.Entity):
         self._state: Any = None
         self._extra_state_attributes: dict[str, Any] = {}
         self._zha_device = zha_device
-        self._unsubs: list[CALLABLE_T] = []
+        self._unsubs: list[Callable[..., Any]] = []
         self.remove_future: asyncio.Future[Any] = asyncio.Future()
 
     @property
@@ -130,7 +130,7 @@ class BaseZhaEntity(LogMixin, entity.Entity):
         self,
         channel: ZigbeeChannel,
         signal: str,
-        func: CALLABLE_T,
+        func: Callable[..., Any],
         signal_override=False,
     ):
         """Accept a signal from a channel."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop custom type (`CALLABLE_T`) from zha
Linked to #73603

Needs:
- [ ] #73735

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
