### PR TITLE
Fix type hints in zha smartenergy channel

### DIFF
--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -122,8 +122,8 @@ class Metering(ZigbeeChannel):
     def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Metering."""
         super().__init__(cluster, ch_pool)
-        self._format_spec = None
-        self._summa_format = None
+        self._format_spec: str | None = None
+        self._summa_format: str | None = None
 
     @property
     def divisor(self) -> int:
@@ -131,7 +131,7 @@ class Metering(ZigbeeChannel):
         return self.cluster.get("divisor") or 1
 
     @property
-    def device_type(self) -> int | None:
+    def device_type(self) -> str | int | None:
         """Return metering device type."""
         dev_type = self.cluster.get("metering_device_type")
         if dev_type is None:
@@ -154,7 +154,7 @@ class Metering(ZigbeeChannel):
         return self.DeviceStatusDefault(status)
 
     @property
-    def unit_of_measurement(self) -> str:
+    def unit_of_measurement(self) -> str | int:
         """Return unit of measurement."""
         return self.cluster.get("unit_of_measure")
 
@@ -210,18 +210,22 @@ class Metering(ZigbeeChannel):
 
         return f"{{:0{width}.{r_digits}f}}"
 
-    def _formatter_function(self, selector: FormatSelector, value: int) -> int | float:
+    def _formatter_function(
+        self, selector: FormatSelector, value: int
+    ) -> int | float | str:
         """Return formatted value for display."""
-        value = value * self.multiplier / self.divisor
+        value_float = value * self.multiplier / self.divisor
         if self.unit_of_measurement == 0:
             # Zigbee spec power unit is kW, but we show the value in W
-            value_watt = value * 1000
+            value_watt = value_float * 1000
             if value_watt < 100:
                 return round(value_watt, 1)
             return round(value_watt)
         if selector == self.FormatSelector.SUMMATION:
-            return self._summa_format.format(value).lstrip()
-        return self._format_spec.format(value).lstrip()
+            assert self._summa_format
+            return self._summa_format.format(value_float).lstrip()
+        assert self._format_spec
+        return self._format_spec.format(value_float).lstrip()
 
     demand_formatter = partialmethod(_formatter_function, FormatSelector.DEMAND)
     summa_formatter = partialmethod(_formatter_function, FormatSelector.SUMMATION)

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -154,7 +154,7 @@ class Metering(ZigbeeChannel):
         return self.DeviceStatusDefault(status)
 
     @property
-    def unit_of_measurement(self) -> str | int:
+    def unit_of_measurement(self) -> int:
         """Return unit of measurement."""
         return self.cluster.get("unit_of_measure")
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3009,9 +3009,6 @@ ignore_errors = true
 [mypy-homeassistant.components.zha.core.channels.security]
 ignore_errors = true
 
-[mypy-homeassistant.components.zha.core.channels.smartenergy]
-ignore_errors = true
-
 [mypy-homeassistant.components.zha.core.device]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -152,7 +152,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.zha.core.channels.homeautomation",
     "homeassistant.components.zha.core.channels.hvac",
     "homeassistant.components.zha.core.channels.security",
-    "homeassistant.components.zha.core.channels.smartenergy",
     "homeassistant.components.zha.core.device",
     "homeassistant.components.zha.core.discovery",
     "homeassistant.components.zha.core.gateway",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix type hints in zha smartenergy channel
Linked to #73603

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
