### PR TITLE
Expose ThreeWayWindowHandle direction as sensor in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -118,3 +118,4 @@ class OverkizDeviceClass(StrEnum):
     PRIORITY_LOCK_ORIGINATOR = "overkiz__priority_lock_originator"
     SENSOR_DEFECT = "overkiz__sensor_defect"
     SENSOR_ROOM = "overkiz__sensor_room"
+    THREE_WAY_HANDLE_DIRECTION = "overkiz__three_way_handle_direction"

--- a/homeassistant/components/overkiz/manifest.json
+++ b/homeassistant/components/overkiz/manifest.json
@@ -3,7 +3,7 @@
   "name": "Overkiz (by Somfy)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/overkiz",
-  "requirements": ["pyoverkiz==1.4.1"],
+  "requirements": ["pyoverkiz==1.4.2"],
   "zeroconf": [
     {
       "type": "_kizbox._tcp.local.",

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -366,6 +366,12 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         entity_registry_enabled_default=False,
     ),
+    # ThreeWayWindowHandle/WindowHandle
+    OverkizSensorDescription(
+        key=OverkizState.CORE_THREE_WAY_HANDLE_DIRECTION,
+        name="Three Way Handle Direction",
+        device_class=OverkizDeviceClass.THREE_WAY_HANDLE_DIRECTION,
+    ),
 ]
 
 SUPPORTED_STATES = {description.key: description for description in SENSOR_DESCRIPTIONS}

--- a/homeassistant/components/overkiz/strings.sensor.json
+++ b/homeassistant/components/overkiz/strings.sensor.json
@@ -36,6 +36,11 @@
       "low_battery": "Low battery",
       "maintenance_required": "Maintenance required",
       "no_defect": "No defect"
+    },
+    "overkiz__three_way_handle_direction": {
+      "closed": "Closed",
+      "open": "Open",
+      "tilt": "Tilt"
     }
   }
 }

--- a/homeassistant/components/overkiz/translations/sensor.en.json
+++ b/homeassistant/components/overkiz/translations/sensor.en.json
@@ -36,6 +36,11 @@
         "overkiz__sensor_room": {
             "clean": "Clean",
             "dirty": "Dirty"
+        },
+        "overkiz__three_way_handle_direction": {
+            "closed": "Closed",
+            "open": "Open",
+            "tilt": "Tilt"
         }
     }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1720,7 +1720,7 @@ pyotgw==1.1b1
 pyotp==2.6.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.4.1
+pyoverkiz==1.4.2
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1169,7 +1169,7 @@ pyotgw==1.1b1
 pyotp==2.6.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.4.1
+pyoverkiz==1.4.2
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0


### PR DESCRIPTION
## Proposed change
Adds a sensor for the Enocean ThreeWayWindowHandle to show the direction, including tilt.

Small dependency upgrade required, since we missed a required enum. [compare v1.4.1 ... 1.4.2](https://github.com/iMicknl/python-overkiz-api/compare/v1.4.1...v1.4.2)


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
