### PR TITLE
Add support for Atlantic Electrical Towel Dryer to Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -1,8 +1,8 @@
 """Climate entities for the Overkiz (by Somfy) integration."""
 from pyoverkiz.enums.ui import UIWidget
 
-from .atlantic_electrical_towel_dryer import AtlanticElectricalTowelDryer
 from .atlantic_electrical_heater import AtlanticElectricalHeater
+from .atlantic_electrical_towel_dryer import AtlanticElectricalTowelDryer
 from .atlantic_pass_apc_zone_control import AtlanticPassAPCZoneControl
 from .somfy_thermostat import SomfyThermostat
 

--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -1,12 +1,14 @@
 """Climate entities for the Overkiz (by Somfy) integration."""
 from pyoverkiz.enums.ui import UIWidget
 
+from .atlantic_electrical_towel_dryer import AtlanticElectricalTowelDryer
 from .atlantic_electrical_heater import AtlanticElectricalHeater
 from .atlantic_pass_apc_zone_control import AtlanticPassAPCZoneControl
 from .somfy_thermostat import SomfyThermostat
 
 WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: AtlanticElectricalHeater,
+    UIWidget.ATLANTIC_ELECTRICAL_TOWEL_DRYER: AtlanticElectricalTowelDryer,
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
     UIWidget.SOMFY_THERMOSTAT: SomfyThermostat,
 }

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
@@ -1,0 +1,127 @@
+"""Support for Atlantic Electrical Towel Dryer."""
+from __future__ import annotations
+
+from typing import Any, cast
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    PRESET_BOOST,
+    PRESET_NONE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
+from homeassistant.components.overkiz.entity import OverkizEntity
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+PRESET_DRYING = "drying"
+
+OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
+    OverkizCommandParam.EXTERNAL: HVAC_MODE_HEAT,  # manu
+    OverkizCommandParam.INTERNAL: HVAC_MODE_AUTO,  # prog
+    OverkizCommandParam.STANDBY: HVAC_MODE_OFF,
+}
+HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+
+OVERKIZ_TO_PRESET_MODE: dict[str, str] = {
+    OverkizCommandParam.PERMANENT_HEATING: PRESET_NONE,
+    OverkizCommandParam.BOOST: PRESET_BOOST,
+    OverkizCommandParam.DRYING: PRESET_DRYING,
+}
+
+PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
+
+
+class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
+    """Representation of Atlantic Electrical Towel Dryer."""
+
+    _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
+    _attr_preset_modes = [*PRESET_MODE_TO_OVERKIZ]
+    _attr_temperature_unit = TEMP_CELSIUS
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Init method."""
+        super().__init__(device_url, coordinator)
+        self.temperature_device = self.executor.linked_device(7)
+
+        self._attr_supported_features = SUPPORT_TARGET_TEMPERATURE
+
+        # Not all AtlanticElectricalTowelDryer models support presets, thus we need to check if the command is available
+        if self.executor.has_command(OverkizCommand.SET_TOWEL_DRYER_TEMPORARY_STATE):
+            self._attr_supported_features += SUPPORT_PRESET_MODE
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+        if OverkizState.CORE_OPERATING_MODE in self.device.states:
+            return OVERKIZ_TO_HVAC_MODE[
+                cast(str, self.executor.select_state(OverkizState.CORE_OPERATING_MODE))
+            ]
+
+        # TODO figure out why we have two options here...
+        if OverkizState.CORE_ON_OFF in self.device.states:
+            return OVERKIZ_TO_HVAC_MODE[
+                cast(str, self.executor.select_state(OverkizState.CORE_ON_OFF))
+            ]
+
+        return HVAC_MODE_OFF
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_TOWER_DRYER_OPERATING_MODE,  # TODO fix typo upstream
+            HVAC_MODE_TO_OVERKIZ[hvac_mode],
+        )
+
+    @property
+    def target_temperature(self) -> None:
+        """Return the temperature."""
+        if self.hvac_mode == HVAC_MODE_AUTO:
+            self.executor.select_state(OverkizState.IO_EFFECTIVE_TEMPERATURE_SETPOINT)
+        else:
+            self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+            return cast(float, temperature.value)
+
+        return None
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new temperature."""
+        temperature = kwargs[ATTR_TEMPERATURE]
+
+        if self.hvac_mode == HVAC_MODE_AUTO:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_DEROGATED_TARGET_TEMPERATURE, temperature
+            )
+        else:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_TARGET_TEMPERATURE, temperature
+            )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return OVERKIZ_TO_PRESET_MODE[
+            cast(
+                str,
+                self.executor.select_state(OverkizState.IO_TOWEL_DRYER_TEMPORARY_STATE),
+            )
+        ]
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_TOWEL_DRYER_TEMPORARY_STATE,
+            PRESET_MODE_TO_OVERKIZ[preset_mode],
+        )

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
@@ -33,6 +33,8 @@ OVERKIZ_TO_PRESET_MODE: dict[str, str] = {
 
 PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
 
+TEMPERATURE_SENSOR_DEVICE_INDEX = 7
+
 
 class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
     """Representation of Atlantic Electrical Towel Dryer."""
@@ -46,7 +48,9 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
     ) -> None:
         """Init method."""
         super().__init__(device_url, coordinator)
-        self.temperature_device = self.executor.linked_device(7)
+        self.temperature_device = self.executor.linked_device(
+            TEMPERATURE_SENSOR_DEVICE_INDEX
+        )
 
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -62,6 +62,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIClass.WINDOW: Platform.COVER,
     UIWidget.ALARM_PANEL_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.ATLANTIC_ELECTRICAL_HEATER: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
+    UIWidget.ATLANTIC_ELECTRICAL_TOWEL_DRYER: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIWidget.MY_FOX_ALARM_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)


### PR DESCRIPTION
## Proposed change
Part of the efforts to support all Overkiz climate devices. This time the Atlantic Electrical Towel Dryer, ported from the custom component to core.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
