### PR TITLE
Use ha-av instead of av and bump to v10.0.0b3

### DIFF
--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -2,7 +2,7 @@
   "domain": "generic",
   "name": "Generic Camera",
   "config_flow": true,
-  "requirements": ["av==9.2.0", "pillow==9.1.1"],
+  "requirements": ["ha-av==10.0.0b1", "pillow==9.1.1"],
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "codeowners": ["@davet2001"],
   "iot_class": "local_push"

--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -2,7 +2,7 @@
   "domain": "generic",
   "name": "Generic Camera",
   "config_flow": true,
-  "requirements": ["ha-av==10.0.0b2", "pillow==9.1.1"],
+  "requirements": ["ha-av==10.0.0b3", "pillow==9.1.1"],
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "codeowners": ["@davet2001"],
   "iot_class": "local_push"

--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -2,7 +2,7 @@
   "domain": "generic",
   "name": "Generic Camera",
   "config_flow": true,
-  "requirements": ["ha-av==10.0.0b1", "pillow==9.1.1"],
+  "requirements": ["ha-av==10.0.0b2", "pillow==9.1.1"],
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "codeowners": ["@davet2001"],
   "iot_class": "local_push"

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -2,7 +2,7 @@
   "domain": "stream",
   "name": "Stream",
   "documentation": "https://www.home-assistant.io/integrations/stream",
-  "requirements": ["PyTurboJPEG==1.6.6", "av==9.2.0"],
+  "requirements": ["PyTurboJPEG==1.6.6", "ha-av==10.0.0b1"],
   "dependencies": ["http"],
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
   "quality_scale": "internal",

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -2,7 +2,7 @@
   "domain": "stream",
   "name": "Stream",
   "documentation": "https://www.home-assistant.io/integrations/stream",
-  "requirements": ["PyTurboJPEG==1.6.6", "ha-av==10.0.0b2"],
+  "requirements": ["PyTurboJPEG==1.6.6", "ha-av==10.0.0b3"],
   "dependencies": ["http"],
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
   "quality_scale": "internal",

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -2,7 +2,7 @@
   "domain": "stream",
   "name": "Stream",
   "documentation": "https://www.home-assistant.io/integrations/stream",
-  "requirements": ["PyTurboJPEG==1.6.6", "ha-av==10.0.0b1"],
+  "requirements": ["PyTurboJPEG==1.6.6", "ha-av==10.0.0b2"],
   "dependencies": ["http"],
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
   "quality_scale": "internal",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ guppy3==3.1.2
 
 # homeassistant.components.generic
 # homeassistant.components.stream
-ha-av==10.0.0b2
+ha-av==10.0.0b3
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -356,9 +356,6 @@ auroranoaa==0.0.2
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.7
 
-# homeassistant.components.generic
-av==9.2.0
-
 # homeassistant.components.avea
 # avea==1.5.1
 
@@ -778,6 +775,7 @@ gstreamer-player==1.1.2
 # homeassistant.components.profiler
 guppy3==3.1.2
 
+# homeassistant.components.generic
 # homeassistant.components.stream
 ha-av==10.0.0b1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -357,7 +357,6 @@ auroranoaa==0.0.2
 aurorapy==0.2.7
 
 # homeassistant.components.generic
-# homeassistant.components.stream
 av==9.2.0
 
 # homeassistant.components.avea
@@ -778,6 +777,9 @@ gstreamer-player==1.1.2
 
 # homeassistant.components.profiler
 guppy3==3.1.2
+
+# homeassistant.components.stream
+ha-av==10.0.0b1
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ guppy3==3.1.2
 
 # homeassistant.components.generic
 # homeassistant.components.stream
-ha-av==10.0.0b1
+ha-av==10.0.0b2
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -293,7 +293,6 @@ auroranoaa==0.0.2
 aurorapy==0.2.7
 
 # homeassistant.components.generic
-# homeassistant.components.stream
 av==9.2.0
 
 # homeassistant.components.axis
@@ -557,6 +556,9 @@ growattServer==1.2.2
 
 # homeassistant.components.profiler
 guppy3==3.1.2
+
+# homeassistant.components.stream
+ha-av==10.0.0b1
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -556,7 +556,7 @@ guppy3==3.1.2
 
 # homeassistant.components.generic
 # homeassistant.components.stream
-ha-av==10.0.0b1
+ha-av==10.0.0b2
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -556,7 +556,7 @@ guppy3==3.1.2
 
 # homeassistant.components.generic
 # homeassistant.components.stream
-ha-av==10.0.0b2
+ha-av==10.0.0b3
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -292,9 +292,6 @@ auroranoaa==0.0.2
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.7
 
-# homeassistant.components.generic
-av==9.2.0
-
 # homeassistant.components.axis
 axis==44
 
@@ -557,6 +554,7 @@ growattServer==1.2.2
 # homeassistant.components.profiler
 guppy3==3.1.2
 
+# homeassistant.components.generic
 # homeassistant.components.stream
 ha-av==10.0.0b1
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
av version 9.x.x doesn't support ffmpeg 5.x which keeps us from moving to alpine 3.16.
There is a PR on the av repo that looks good for ffmpeg 5.x support, but it probably won't be merged until after 2022.7 is out.
ha-av version 10.0.0b3 is based on the main branch of pyav, adding on the PR that allows 5.x support and few other PRs to fix some tests.
Due to build issues, windows binary wheels are not yet available.
https://github.com/PyAV-Org/PyAV/compare/v9.2.0...uvjustin:v10.0.0-beta.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71384
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
