### PR TITLE
More enums in deCONZ Alarm Control Panel

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -1,20 +1,11 @@
 """Support for deCONZ alarm control panel devices."""
 from __future__ import annotations
 
-from pydeconz.interfaces.alarm_systems import ArmAction
+from pydeconz.models.alarm_system import AlarmSystemArmAction
 from pydeconz.models.event import EventType
 from pydeconz.models.sensor.ancillary_control import (
-    ANCILLARY_CONTROL_ARMED_AWAY,
-    ANCILLARY_CONTROL_ARMED_NIGHT,
-    ANCILLARY_CONTROL_ARMED_STAY,
-    ANCILLARY_CONTROL_ARMING_AWAY,
-    ANCILLARY_CONTROL_ARMING_NIGHT,
-    ANCILLARY_CONTROL_ARMING_STAY,
-    ANCILLARY_CONTROL_DISARMED,
-    ANCILLARY_CONTROL_ENTRY_DELAY,
-    ANCILLARY_CONTROL_EXIT_DELAY,
-    ANCILLARY_CONTROL_IN_ALARM,
     AncillaryControl,
+    AncillaryControlPanel,
 )
 
 from homeassistant.components.alarm_control_panel import (
@@ -40,16 +31,16 @@ from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 DECONZ_TO_ALARM_STATE = {
-    ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
-    ANCILLARY_CONTROL_ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
-    ANCILLARY_CONTROL_ARMED_STAY: STATE_ALARM_ARMED_HOME,
-    ANCILLARY_CONTROL_ARMING_AWAY: STATE_ALARM_ARMING,
-    ANCILLARY_CONTROL_ARMING_NIGHT: STATE_ALARM_ARMING,
-    ANCILLARY_CONTROL_ARMING_STAY: STATE_ALARM_ARMING,
-    ANCILLARY_CONTROL_DISARMED: STATE_ALARM_DISARMED,
-    ANCILLARY_CONTROL_ENTRY_DELAY: STATE_ALARM_PENDING,
-    ANCILLARY_CONTROL_EXIT_DELAY: STATE_ALARM_PENDING,
-    ANCILLARY_CONTROL_IN_ALARM: STATE_ALARM_TRIGGERED,
+    AncillaryControlPanel.ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
+    AncillaryControlPanel.ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
+    AncillaryControlPanel.ARMED_STAY: STATE_ALARM_ARMED_HOME,
+    AncillaryControlPanel.ARMING_AWAY: STATE_ALARM_ARMING,
+    AncillaryControlPanel.ARMING_NIGHT: STATE_ALARM_ARMING,
+    AncillaryControlPanel.ARMING_STAY: STATE_ALARM_ARMING,
+    AncillaryControlPanel.DISARMED: STATE_ALARM_DISARMED,
+    AncillaryControlPanel.ENTRY_DELAY: STATE_ALARM_PENDING,
+    AncillaryControlPanel.EXIT_DELAY: STATE_ALARM_PENDING,
+    AncillaryControlPanel.IN_ALARM: STATE_ALARM_TRIGGERED,
 }
 
 
@@ -133,26 +124,26 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
         """Send arm away command."""
         if code:
             await self.gateway.api.alarmsystems.arm(
-                self.alarm_system_id, ArmAction.AWAY, code
+                self.alarm_system_id, AlarmSystemArmAction.AWAY, code
             )
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         if code:
             await self.gateway.api.alarmsystems.arm(
-                self.alarm_system_id, ArmAction.STAY, code
+                self.alarm_system_id, AlarmSystemArmAction.STAY, code
             )
 
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         if code:
             await self.gateway.api.alarmsystems.arm(
-                self.alarm_system_id, ArmAction.NIGHT, code
+                self.alarm_system_id, AlarmSystemArmAction.NIGHT, code
             )
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if code:
             await self.gateway.api.alarmsystems.arm(
-                self.alarm_system_id, ArmAction.DISARM, code
+                self.alarm_system_id, AlarmSystemArmAction.DISARM, code
             )

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -6,11 +6,8 @@ from typing import Any
 
 from pydeconz.models.event import EventType
 from pydeconz.models.sensor.ancillary_control import (
-    ANCILLARY_CONTROL_EMERGENCY,
-    ANCILLARY_CONTROL_FIRE,
-    ANCILLARY_CONTROL_INVALID_CODE,
-    ANCILLARY_CONTROL_PANIC,
     AncillaryControl,
+    AncillaryControlAction,
 )
 from pydeconz.models.sensor.switch import Switch
 
@@ -33,10 +30,10 @@ CONF_DECONZ_EVENT = "deconz_event"
 CONF_DECONZ_ALARM_EVENT = "deconz_alarm_event"
 
 SUPPORTED_DECONZ_ALARM_EVENTS = {
-    ANCILLARY_CONTROL_EMERGENCY,
-    ANCILLARY_CONTROL_FIRE,
-    ANCILLARY_CONTROL_INVALID_CODE,
-    ANCILLARY_CONTROL_PANIC,
+    AncillaryControlAction.EMERGENCY,
+    AncillaryControlAction.FIRE,
+    AncillaryControlAction.INVALID_CODE,
+    AncillaryControlAction.PANIC,
 }
 
 
@@ -183,7 +180,7 @@ class DeconzAlarmEvent(DeconzEventBase):
             CONF_ID: self.event_id,
             CONF_UNIQUE_ID: self.serial,
             CONF_DEVICE_ID: self.device_id,
-            CONF_EVENT: self._device.action,
+            CONF_EVENT: self._device.action.value,
         }
 
         self.gateway.hass.bus.async_fire(CONF_DECONZ_ALARM_EVENT, data)

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==93"],
+  "requirements": ["pydeconz==94"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1441,7 +1441,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==93
+pydeconz==94
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -968,7 +968,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==93
+pydeconz==94
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -2,19 +2,7 @@
 
 from unittest.mock import patch
 
-from pydeconz.models.sensor.ancillary_control import (
-    ANCILLARY_CONTROL_ARMED_AWAY,
-    ANCILLARY_CONTROL_ARMED_NIGHT,
-    ANCILLARY_CONTROL_ARMED_STAY,
-    ANCILLARY_CONTROL_ARMING_AWAY,
-    ANCILLARY_CONTROL_ARMING_NIGHT,
-    ANCILLARY_CONTROL_ARMING_STAY,
-    ANCILLARY_CONTROL_DISARMED,
-    ANCILLARY_CONTROL_ENTRY_DELAY,
-    ANCILLARY_CONTROL_EXIT_DELAY,
-    ANCILLARY_CONTROL_IN_ALARM,
-    ANCILLARY_CONTROL_NOT_READY,
-)
+from pydeconz.models.sensor.ancillary_control import AncillaryControlPanel
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
@@ -123,7 +111,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_AWAY},
+        "state": {"panel": AncillaryControlPanel.ARMED_AWAY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -137,7 +125,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_NIGHT},
+        "state": {"panel": AncillaryControlPanel.ARMED_NIGHT},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -153,7 +141,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_STAY},
+        "state": {"panel": AncillaryControlPanel.ARMED_STAY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -167,7 +155,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_DISARMED},
+        "state": {"panel": AncillaryControlPanel.DISARMED},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -177,9 +165,9 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
     # Event signals alarm control panel arming
 
     for arming_event in {
-        ANCILLARY_CONTROL_ARMING_AWAY,
-        ANCILLARY_CONTROL_ARMING_NIGHT,
-        ANCILLARY_CONTROL_ARMING_STAY,
+        AncillaryControlPanel.ARMING_AWAY,
+        AncillaryControlPanel.ARMING_NIGHT,
+        AncillaryControlPanel.ARMING_STAY,
     }:
 
         event_changed_sensor = {
@@ -196,7 +184,10 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
 
     # Event signals alarm control panel pending
 
-    for pending_event in {ANCILLARY_CONTROL_ENTRY_DELAY, ANCILLARY_CONTROL_EXIT_DELAY}:
+    for pending_event in {
+        AncillaryControlPanel.ENTRY_DELAY,
+        AncillaryControlPanel.EXIT_DELAY,
+    }:
 
         event_changed_sensor = {
             "t": "event",
@@ -219,7 +210,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_IN_ALARM},
+        "state": {"panel": AncillaryControlPanel.IN_ALARM},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -233,7 +224,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_NOT_READY},
+        "state": {"panel": AncillaryControlPanel.NOT_READY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -3,11 +3,8 @@
 from unittest.mock import patch
 
 from pydeconz.models.sensor.ancillary_control import (
-    ANCILLARY_CONTROL_ARMED_AWAY,
-    ANCILLARY_CONTROL_EMERGENCY,
-    ANCILLARY_CONTROL_FIRE,
-    ANCILLARY_CONTROL_INVALID_CODE,
-    ANCILLARY_CONTROL_PANIC,
+    AncillaryControlAction,
+    AncillaryControlPanel,
 )
 
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
@@ -286,7 +283,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"action": ANCILLARY_CONTROL_EMERGENCY},
+        "state": {"action": AncillaryControlAction.EMERGENCY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -300,7 +297,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         CONF_ID: "keypad",
         CONF_UNIQUE_ID: "00:00:00:00:00:00:00:01",
         CONF_DEVICE_ID: device.id,
-        CONF_EVENT: ANCILLARY_CONTROL_EMERGENCY,
+        CONF_EVENT: AncillaryControlAction.EMERGENCY.value,
     }
 
     # Fire event
@@ -310,7 +307,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"action": ANCILLARY_CONTROL_FIRE},
+        "state": {"action": AncillaryControlAction.FIRE},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -324,7 +321,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         CONF_ID: "keypad",
         CONF_UNIQUE_ID: "00:00:00:00:00:00:00:01",
         CONF_DEVICE_ID: device.id,
-        CONF_EVENT: ANCILLARY_CONTROL_FIRE,
+        CONF_EVENT: AncillaryControlAction.FIRE.value,
     }
 
     # Invalid code event
@@ -334,7 +331,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"action": ANCILLARY_CONTROL_INVALID_CODE},
+        "state": {"action": AncillaryControlAction.INVALID_CODE},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -348,7 +345,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         CONF_ID: "keypad",
         CONF_UNIQUE_ID: "00:00:00:00:00:00:00:01",
         CONF_DEVICE_ID: device.id,
-        CONF_EVENT: ANCILLARY_CONTROL_INVALID_CODE,
+        CONF_EVENT: AncillaryControlAction.INVALID_CODE.value,
     }
 
     # Panic event
@@ -358,7 +355,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"action": ANCILLARY_CONTROL_PANIC},
+        "state": {"action": AncillaryControlAction.PANIC},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -372,7 +369,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         CONF_ID: "keypad",
         CONF_UNIQUE_ID: "00:00:00:00:00:00:00:01",
         CONF_DEVICE_ID: device.id,
-        CONF_EVENT: ANCILLARY_CONTROL_PANIC,
+        CONF_EVENT: AncillaryControlAction.PANIC.value,
     }
 
     # Only care for changes to specific action events
@@ -382,7 +379,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"action": ANCILLARY_CONTROL_ARMED_AWAY},
+        "state": {"action": AncillaryControlAction.ARMED_AWAY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -396,7 +393,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_AWAY},
+        "state": {"panel": AncillaryControlPanel.ARMED_AWAY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -415,7 +412,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_events_bad_unique_id(hass, aioclient_mock, mock_deconz_websocket):
+async def test_deconz_events_bad_unique_id(hass, aioclient_mock):
     """Verify no devices are created if unique id is bad or missing."""
     data = {
         "sensors": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use some additional enums in Alarm Control Panel rather than constants

A lot of removals in pydeconz based on changes done in previous PRs to the integration
https://github.com/Kane610/deconz/compare/v93...v94


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
