### PR TITLE
Add FanEntity type hint checks to pylint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -730,13 +730,13 @@ def _get_named_annotation(
     node: nodes.FunctionDef, key: str
 ) -> tuple[nodes.NodeNG | None, nodes.NodeNG | None]:
     args = node.args
-    for index, arg_name in enumerate(args.args):
-        if key == arg_name.name:
-            return arg_name, args.annotations[index]
+    for index, arg_node in enumerate(args.args):
+        if key == arg_node.name:
+            return arg_node, args.annotations[index]
 
-    for index, arg_name in enumerate(args.kwonlyargs):
-        if key == arg_name.name:
-            return arg_name, args.kwonlyargs_annotations[index]
+    for index, arg_node in enumerate(args.kwonlyargs):
+        if key == arg_node.name:
+            return arg_node, args.kwonlyargs_annotations[index]
 
     return None, None
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -728,7 +728,7 @@ def _get_all_annotations(node: nodes.FunctionDef) -> list[nodes.NodeNG | None]:
 
 def _get_named_annotation(
     node: nodes.FunctionDef, key: str
-) -> tuple[nodes.NodeNG | None, nodes.NodeNG | None]:
+) -> tuple[nodes.NodeNG, nodes.NodeNG] | tuple[None, None]:
     args = node.args
     for index, arg_node in enumerate(args.args):
         if key == arg_node.name:

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -21,12 +21,12 @@ class TypeHintMatch:
 
     function_name: str
     return_type: list[str] | str | None | object
-    # arg_types is for positional arguments
     arg_types: dict[int, str] | None = None
-    # named_arg_types is for named or keyword arguments
+    """arg_types is for positional arguments"""
     named_arg_types: dict[str, str] | None = None
-    # kwargs_type is for the special case `**kwargs`
+    """named_arg_types is for named or keyword arguments"""
     kwargs_type: str | None = None
+    """kwargs_type is for the special case `**kwargs`"""
     check_return_type_inheritance: bool = False
 
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -23,6 +23,8 @@ class TypeHintMatch:
     return_type: list[str] | str | None | object
     # arg_types is for positional arguments
     arg_types: dict[int, str] | None = None
+    # kwarg_types is for named or keyword arguments
+    kwarg_types: dict[str, str] | None = None
     # kwarg_types is for the special case `**kwargs`
     kwargs_type: str | None = None
     check_return_type_inheritance: bool = False
@@ -448,6 +450,111 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
 # Overriding properties and functions are normally checked by mypy, and will only
 # be checked by pylint when --ignore-missing-annotations is False
 _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
+    "fan": [
+        ClassTypeHintMatch(
+            base_class="FanEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="is_on",
+                    return_type=["bool", None],
+                ),
+                TypeHintMatch(
+                    function_name="percentage",
+                    return_type=["int", None],
+                ),
+                TypeHintMatch(
+                    function_name="speed_count",
+                    return_type="int",
+                ),
+                TypeHintMatch(
+                    function_name="percentage_step",
+                    return_type="float",
+                ),
+                TypeHintMatch(
+                    function_name="current_direction",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="oscillating",
+                    return_type=["bool", None],
+                ),
+                TypeHintMatch(
+                    function_name="capability_attributes",
+                    return_type="dict[str]",
+                ),
+                TypeHintMatch(
+                    function_name="supported_features",
+                    return_type="int",
+                ),
+                TypeHintMatch(
+                    function_name="preset_mode",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="preset_modes",
+                    return_type=["list[str]", None],
+                ),
+                TypeHintMatch(
+                    function_name="set_percentage",
+                    arg_types={1: "int"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="async_set_percentage",
+                    arg_types={1: "int"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="set_preset_mode",
+                    arg_types={1: "str"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="async_set_preset_mode",
+                    arg_types={1: "str"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="set_direction",
+                    arg_types={1: "str"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="async_set_direction",
+                    arg_types={1: "str"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="turn_on",
+                    kwarg_types={
+                        "percentage": "int | None",
+                        "preset_mode": "str | None",
+                    },
+                    kwargs_type="Any",
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="async_turn_on",
+                    kwarg_types={
+                        "percentage": "int | None",
+                        "preset_mode": "str | None",
+                    },
+                    kwargs_type="Any",
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="oscillate",
+                    arg_types={1: "bool"},
+                    return_type=None,
+                ),
+                TypeHintMatch(
+                    function_name="async_oscillate",
+                    arg_types={1: "bool"},
+                    return_type=None,
+                ),
+            ],
+        ),
+    ],
     "lock": [
         ClassTypeHintMatch(
             base_class="LockEntity",
@@ -619,6 +726,25 @@ def _get_all_annotations(node: nodes.FunctionDef) -> list[nodes.NodeNG | None]:
     return annotations
 
 
+def _get_kw_annotation(
+    node: nodes.FunctionDef, key: str
+) -> tuple[nodes.NodeNG | None, nodes.NodeNG | None]:
+    args = node.args
+    for index, arg_name in enumerate(args.posonlyargs):
+        if key == arg_name.name:
+            return arg_name, args.posonlyargs_annotations[index]
+
+    for index, arg_name in enumerate(args.args):
+        if key == arg_name.name:
+            return arg_name, args.annotations[index]
+
+    for index, arg_name in enumerate(args.kwonlyargs):
+        if key == arg_name.name:
+            return arg_name, args.kwonlyargs_annotations[index]
+
+    return None, None
+
+
 def _has_valid_annotations(
     annotations: list[nodes.NodeNG | None],
 ) -> bool:
@@ -740,6 +866,17 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
                         "hass-argument-type",
                         node=node.args.args[key],
                         args=(key + 1, expected_type),
+                    )
+
+        # Check that all keyword arguments are correctly annotated.
+        if match.kwarg_types is not None:
+            for kwkey, expected_type in match.kwarg_types.items():
+                kw_node, annotation = _get_kw_annotation(node, kwkey)
+                if kw_node and not _is_valid_type(expected_type, annotation):
+                    self.add_message(
+                        "hass-argument-type",
+                        node=kw_node,
+                        args=(kwkey, expected_type),
                     )
 
         # Check that kwargs is correctly annotated.

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -565,3 +565,63 @@ def test_ignore_invalid_entity_properties(
 
     with assert_no_messages(linter):
         type_hint_checker.visit_classdef(class_node)
+
+
+def test_named_arguments(
+    linter: UnittestLinter, type_hint_checker: BaseChecker
+) -> None:
+    """Check missing entity properties when ignore_missing_annotations is False."""
+    # Set bypass option
+    type_hint_checker.config.ignore_missing_annotations = False
+
+    class_node, prop_node, func_node = astroid.extract_node(
+        """
+    class FanEntity():
+        pass
+
+    class MyFan( #@
+        FanEntity
+    ):
+        async def async_turn_on( #@
+            self,
+            percentage,
+            preset_mode: str,
+            **kwargs
+        ) -> bool:
+            pass
+    """,
+        "homeassistant.components.pylint_test.fan",
+    )
+    type_hint_checker.visit_module(class_node.parent)
+
+    with assert_adds_messages(
+        linter,
+        pylint.testutils.MessageTest(
+            msg_id="hass-return-type",
+            node=prop_node,
+            args=["str", None],
+            line=9,
+            col_offset=4,
+            end_line=9,
+            end_col_offset=18,
+        ),
+        pylint.testutils.MessageTest(
+            msg_id="hass-argument-type",
+            node=func_node,
+            args=("kwargs", "Any"),
+            line=14,
+            col_offset=4,
+            end_line=14,
+            end_col_offset=24,
+        ),
+        pylint.testutils.MessageTest(
+            msg_id="hass-return-type",
+            node=func_node,
+            args="None",
+            line=14,
+            col_offset=4,
+            end_line=14,
+            end_col_offset=24,
+        ),
+    ):
+        type_hint_checker.visit_classdef(class_node)

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -585,6 +585,7 @@ def test_named_arguments(
         async def async_turn_on( #@
             self,
             percentage, #@
+            *,
             preset_mode: str, #@
             **kwargs
         ) -> bool:

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -610,9 +610,9 @@ def test_named_arguments(
             msg_id="hass-argument-type",
             node=preset_mode_node,
             args=("preset_mode", "str | None"),
-            line=11,
+            line=12,
             col_offset=8,
-            end_line=11,
+            end_line=12,
             end_col_offset=24,
         ),
         pylint.testutils.MessageTest(

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -574,7 +574,7 @@ def test_named_arguments(
     # Set bypass option
     type_hint_checker.config.ignore_missing_annotations = False
 
-    class_node, func_node, arg1_node, arg2_node = astroid.extract_node(
+    class_node, func_node, percentage_node, preset_mode_node = astroid.extract_node(
         """
     class FanEntity():
         pass
@@ -597,31 +597,40 @@ def test_named_arguments(
     with assert_adds_messages(
         linter,
         pylint.testutils.MessageTest(
-            msg_id="hass-return-type",
-            node=func_node,
-            args=None,
-            line=9,
-            col_offset=4,
-            end_line=9,
+            msg_id="hass-argument-type",
+            node=percentage_node,
+            args=("percentage", "int | None"),
+            line=10,
+            col_offset=8,
+            end_line=10,
             end_col_offset=18,
+        ),
+        pylint.testutils.MessageTest(
+            msg_id="hass-argument-type",
+            node=preset_mode_node,
+            args=("preset_mode", "str | None"),
+            line=11,
+            col_offset=8,
+            end_line=11,
+            end_col_offset=24,
         ),
         pylint.testutils.MessageTest(
             msg_id="hass-argument-type",
             node=func_node,
             args=("kwargs", "Any"),
-            line=14,
+            line=8,
             col_offset=4,
-            end_line=14,
-            end_col_offset=24,
+            end_line=8,
+            end_col_offset=27,
         ),
         pylint.testutils.MessageTest(
             msg_id="hass-return-type",
             node=func_node,
             args="None",
-            line=14,
+            line=8,
             col_offset=4,
-            end_line=14,
-            end_col_offset=24,
+            end_line=8,
+            end_col_offset=27,
         ),
     ):
         type_hint_checker.visit_classdef(class_node)

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -574,7 +574,7 @@ def test_named_arguments(
     # Set bypass option
     type_hint_checker.config.ignore_missing_annotations = False
 
-    class_node, prop_node, func_node = astroid.extract_node(
+    class_node, func_node, arg1_node, arg2_node = astroid.extract_node(
         """
     class FanEntity():
         pass
@@ -584,8 +584,8 @@ def test_named_arguments(
     ):
         async def async_turn_on( #@
             self,
-            percentage,
-            preset_mode: str,
+            percentage, #@
+            preset_mode: str, #@
             **kwargs
         ) -> bool:
             pass
@@ -598,8 +598,8 @@ def test_named_arguments(
         linter,
         pylint.testutils.MessageTest(
             msg_id="hass-return-type",
-            node=prop_node,
-            args=["str", None],
+            node=func_node,
+            args=None,
             line=9,
             col_offset=4,
             end_line=9,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add FanEntity type hint checks to pylint plugin

Can be tested with `pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/**/fan.py`

```console
************* Module homeassistant.components.switch_as_x.fan
homeassistant/components/switch_as_x/fan.py:52:4: W7431: Argument kwargs should be of type Any (hass-argument-type)
************* Module homeassistant.components.template.fan
homeassistant/components/template/fan.py:218:4: W7432: Return type should be ['bool', None] (hass-return-type)
homeassistant/components/template/fan.py:228:4: W7432: Return type should be ['int', None] (hass-return-type)
homeassistant/components/template/fan.py:238:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/template/fan.py:233:4: W7432: Return type should be ['bool', None] (hass-return-type)
homeassistant/components/template/fan.py:223:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/template/fan.py:244:8: W7431: Argument percentage should be of type int | None (hass-argument-type)
homeassistant/components/template/fan.py:245:8: W7431: Argument preset_mode should be of type str | None (hass-argument-type)
homeassistant/components/template/fan.py:242:4: W7431: Argument kwargs should be of type Any (hass-argument-type)
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
