### PR TITLE
Allow configuring username and password in generic camera config flow

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 import voluptuous as vol
+import yarl
 
 from homeassistant.components.camera import (
     DEFAULT_CONTENT_TYPE,
@@ -146,6 +147,8 @@ class GenericCamera(Camera):
         self.hass = hass
         self._attr_unique_id = identifier
         self._authentication = device_info.get(CONF_AUTHENTICATION)
+        self._username = device_info.get(CONF_USERNAME)
+        self._password = device_info.get(CONF_PASSWORD)
         self._name = device_info.get(CONF_NAME, title)
         self._still_image_url = device_info.get(CONF_STILL_IMAGE_URL)
         if (
@@ -223,7 +226,11 @@ class GenericCamera(Camera):
             return None
 
         try:
-            return self._stream_source.async_render(parse_result=False)
+            stream_url = self._stream_source.async_render(parse_result=False)
+            url = yarl.URL(stream_url)
+            if not url.user and not url.password and self._username and self._password:
+                url = url.with_user(self._username).with_password(self._password)
+            return str(url)
         except TemplateError as err:
             _LOGGER.error("Error parsing template %s: %s", self._stream_source, err)
             return None

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -221,6 +221,14 @@ async def async_test_stream(
         stream_options[CONF_RTSP_TRANSPORT] = rtsp_transport
     if info.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
         stream_options[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = True
+
+    url = yarl.URL(stream_source)
+    if not url.user and not url.password:
+        username = info.get(CONF_USERNAME)
+        password = info.get(CONF_PASSWORD)
+        if username and password:
+            url = url.with_user(username).with_password(password)
+            stream_source = str(url)
     try:
         stream = create_stream(hass, stream_source, stream_options, "test_stream")
         hls_provider = stream.add_provider(HLS_PROVIDER)

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -194,6 +194,8 @@ async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png
                 "still_image_url": "http://example.com",
                 "stream_source": 'http://example.com/{{ states.sensor.temp.state + "a" }}',
                 "limit_refetch_to_url_change": True,
+                "username": "barney",
+                "password": "betty",
             },
         },
     )

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -12,11 +12,20 @@ from homeassistant.components.camera import (
     async_get_mjpeg_stream,
     async_get_stream_source,
 )
+from homeassistant.components.generic.const import (
+    CONF_CONTENT_TYPE,
+    CONF_FRAMERATE,
+    CONF_LIMIT_REFETCH_TO_URL_CHANGE,
+    CONF_STILL_IMAGE_URL,
+    CONF_STREAM_SOURCE,
+    DOMAIN,
+)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.setup import async_setup_component
 
-from tests.common import AsyncMock, Mock
+from tests.common import AsyncMock, Mock, MockConfigEntry
 
 
 @respx.mock
@@ -187,21 +196,23 @@ async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png
     respx.get("http://example.com/0a").respond(stream=fakeimgbytes_png)
 
     hass.states.async_set("sensor.temp", "0")
-    assert await async_setup_component(
-        hass,
-        "camera",
-        {
-            "camera": {
-                "name": "config_test",
-                "platform": "generic",
-                "still_image_url": "http://example.com",
-                "stream_source": 'http://example.com/{{ states.sensor.temp.state + "a" }}',
-                "limit_refetch_to_url_change": True,
-                "username": "barney",
-                "password": "betty",
-            },
+    mock_entry = MockConfigEntry(
+        title="config_test",
+        domain=DOMAIN,
+        data={},
+        options={
+            CONF_STILL_IMAGE_URL: "http://example.com",
+            CONF_STREAM_SOURCE: 'http://example.com/{{ states.sensor.temp.state + "a" }}',
+            CONF_LIMIT_REFETCH_TO_URL_CHANGE: True,
+            CONF_FRAMERATE: 2,
+            CONF_CONTENT_TYPE: "image/png",
+            CONF_VERIFY_SSL: False,
+            CONF_USERNAME: "barney",
+            CONF_PASSWORD: "betty",
         },
     )
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     assert await async_setup_component(hass, "stream", {})
     await hass.async_block_till_done()
 

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -8,7 +8,10 @@ import httpx
 import pytest
 import respx
 
-from homeassistant.components.camera import async_get_mjpeg_stream
+from homeassistant.components.camera import (
+    async_get_mjpeg_stream,
+    async_get_stream_source,
+)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.setup import async_setup_component
@@ -203,6 +206,8 @@ async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png
     await hass.async_block_till_done()
 
     hass.states.async_set("sensor.temp", "5")
+    stream_source = await async_get_stream_source(hass, "camera.config_test")
+    assert stream_source == "http://barney:betty@example.com/5a"
 
     with patch(
         "homeassistant.components.camera.Stream.endpoint_url",

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -10,6 +10,7 @@ import respx
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.camera import async_get_image
+from homeassistant.components.generic.config_flow import slug
 from homeassistant.components.generic.const import (
     CONF_CONTENT_TYPE,
     CONF_FRAMERATE,
@@ -515,6 +516,13 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
         )
     assert result5.get("type") == data_entry_flow.RESULT_TYPE_FORM
     assert result5["errors"] == {"stream_source": "template_error"}
+
+
+async def test_slug(hass, caplog):
+    """Test the slug function."""
+    result = slug(hass, "http://127.0.0.2/testurl/{{1/0}}")
+    assert result is None
+    assert "Syntax error in" in caplog.text
 
 
 @respx.mock

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -522,7 +522,7 @@ async def test_slug(hass, caplog):
     """
     Test that the slug function generates an error in case of invalid template.
 
-    Other paths in the slug function are already tested by the other tests.
+    Other paths in the slug function are already tested by other tests.
     """
     result = slug(hass, "http://127.0.0.2/testurl/{{1/0}}")
     assert result is None

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -519,7 +519,11 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
 
 
 async def test_slug(hass, caplog):
-    """Test the slug function."""
+    """
+    Test that the slug function generates an error in case of invalid template.
+
+    Other paths in the slug function are already tested by the other tests.
+    """
     result = slug(hass, "http://127.0.0.2/testurl/{{1/0}}")
     assert result is None
     assert "Syntax error in" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This PR will change the component to use the same username and password for both the still_image_url and the stream_url. Distinct username/password pairs can still be provided if they are embedded in the urls e.g. `http://username:password@example.com/image`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Username and password no longer has to be in the URL for streams, they can be provided via the username/password UI boxes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
Currently 
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #69684
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23183

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
