### PR TITLE
Additional surround controls for Sonos

### DIFF
--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -20,6 +20,8 @@ LEVEL_TYPES = {
     "bass": (-10, 10),
     "treble": (-10, 10),
     "sub_gain": (-15, 15),
+    "surround_level": (-15, 15),
+    "music_surround_level": (-15, 15),
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -146,6 +146,9 @@ class SonosSpeaker:
         self.sub_enabled: bool | None = None
         self.sub_gain: int | None = None
         self.surround_enabled: bool | None = None
+        self.surround_mode: bool | None = None
+        self.surround_level: int | None = None
+        self.music_surround_level: int | None = None
 
         # Misc features
         self.buttons_enabled: bool | None = None
@@ -515,11 +518,19 @@ class SonosSpeaker:
             "night_mode",
             "sub_enabled",
             "surround_enabled",
+            "surround_mode",
         ):
             if bool_var in variables:
                 setattr(self, bool_var, variables[bool_var] == "1")
 
-        for int_var in ("audio_delay", "bass", "treble", "sub_gain"):
+        for int_var in (
+            "audio_delay",
+            "bass",
+            "treble",
+            "sub_gain",
+            "surround_level",
+            "music_surround_level",
+        ):
             if int_var in variables:
                 setattr(self, int_var, variables[int_var])
 

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -39,6 +39,7 @@ ATTR_INCLUDE_LINKED_ZONES = "include_linked_zones"
 
 ATTR_CROSSFADE = "cross_fade"
 ATTR_LOUDNESS = "loudness"
+ATTR_MUSIC_PLAYBACK_FULL_VOLUME = "surround_mode"
 ATTR_NIGHT_SOUND = "night_mode"
 ATTR_SPEECH_ENHANCEMENT = "dialog_level"
 ATTR_STATUS_LIGHT = "status_light"
@@ -50,6 +51,7 @@ ALL_FEATURES = (
     ATTR_TOUCH_CONTROLS,
     ATTR_CROSSFADE,
     ATTR_LOUDNESS,
+    ATTR_MUSIC_PLAYBACK_FULL_VOLUME,
     ATTR_NIGHT_SOUND,
     ATTR_SPEECH_ENHANCEMENT,
     ATTR_SUB_ENABLED,
@@ -67,6 +69,7 @@ POLL_REQUIRED = (
 FRIENDLY_NAMES = {
     ATTR_CROSSFADE: "Crossfade",
     ATTR_LOUDNESS: "Loudness",
+    ATTR_MUSIC_PLAYBACK_FULL_VOLUME: "Surround Music Full Volume",
     ATTR_NIGHT_SOUND: "Night Sound",
     ATTR_SPEECH_ENHANCEMENT: "Speech Enhancement",
     ATTR_STATUS_LIGHT: "Status Light",
@@ -77,6 +80,7 @@ FRIENDLY_NAMES = {
 
 FEATURE_ICONS = {
     ATTR_LOUDNESS: "mdi:bullhorn-variant",
+    ATTR_MUSIC_PLAYBACK_FULL_VOLUME: "mdi:music-note-plus",
     ATTR_NIGHT_SOUND: "mdi:chat-sleep",
     ATTR_SPEECH_ENHANCEMENT: "mdi:ear-hearing",
     ATTR_CROSSFADE: "mdi:swap-horizontal",

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -117,6 +117,9 @@ def soco_fixture(
         mock_soco.sub_enabled = False
         mock_soco.sub_gain = 5
         mock_soco.surround_enabled = True
+        mock_soco.surround_mode = True
+        mock_soco.surround_level = 3
+        mock_soco.music_surround_level = 4
         mock_soco.soundbar_audio_input_format = "Dolby 5.1"
         mock_soco.get_battery_info.return_value = battery_info
         mock_soco.all_zones = {mock_soco}

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -22,6 +22,16 @@ async def test_number_entities(hass, async_autosetup_sonos, soco):
     audio_delay_state = hass.states.get(audio_delay_number.entity_id)
     assert audio_delay_state.state == "2"
 
+    surround_level_number = entity_registry.entities["number.zone_a_surround_level"]
+    surround_level_state = hass.states.get(surround_level_number.entity_id)
+    assert surround_level_state.state == "3"
+
+    music_surround_level_number = entity_registry.entities[
+        "number.zone_a_music_surround_level"
+    ]
+    music_surround_level_state = hass.states.get(music_surround_level_number.entity_id)
+    assert music_surround_level_state.state == "4"
+
     with patch("soco.SoCo.audio_delay") as mock_audio_delay:
         await hass.services.async_call(
             NUMBER_DOMAIN,

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -52,6 +52,14 @@ async def test_switch_attributes(hass, async_autosetup_sonos, soco):
     assert alarm_state.attributes.get(ATTR_PLAY_MODE) == "SHUFFLE_NOREPEAT"
     assert not alarm_state.attributes.get(ATTR_INCLUDE_LINKED_ZONES)
 
+    surround_music_full_volume = entity_registry.entities[
+        "switch.zone_a_surround_music_full_volume"
+    ]
+    surround_music_full_volume_state = hass.states.get(
+        surround_music_full_volume.entity_id
+    )
+    assert surround_music_full_volume_state.state == STATE_ON
+
     night_sound = entity_registry.entities["switch.zone_a_night_sound"]
     night_sound_state = hass.states.get(night_sound.entity_id)
     assert night_sound_state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the following new entities for surround setups:

* "Surround Music Full Volume" switch
* "Surround Level" for TV/movie playback surround volume adjustment [-15, 15]
* "Music Surround Level" for music surround volume adjustment [-15, 15]

This is a different approach at #66962 which relies on new convenience methods in soco-0.28.0 to make the implementation a bit simpler.

cc: @rytilahti 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
