### PR TITLE
Revert "Fix auth_sign_path with query params (#73240)"

### DIFF
--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -17,7 +17,6 @@ from homeassistant.components import websocket_api
 from homeassistant.components.http.auth import (
     CONTENT_USER_NAME,
     DATA_SIGN_SECRET,
-    SIGN_QUERY_PARAM,
     STORAGE_KEY,
     async_setup_auth,
     async_sign_path,
@@ -292,83 +291,6 @@ async def test_auth_access_signed_path_with_refresh_token(
     # refresh token gone should also invalidate signature
     await hass.auth.async_remove_refresh_token(refresh_token)
     req = await client.get(signed_path)
-    assert req.status == HTTPStatus.UNAUTHORIZED
-
-
-async def test_auth_access_signed_path_with_query_param(
-    hass, app, aiohttp_client, hass_access_token
-):
-    """Test access with signed url and query params."""
-    app.router.add_post("/", mock_handler)
-    app.router.add_get("/another_path", mock_handler)
-    await async_setup_auth(hass, app)
-    client = await aiohttp_client(app)
-
-    refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
-
-    signed_path = async_sign_path(
-        hass, "/?test=test", timedelta(seconds=5), refresh_token_id=refresh_token.id
-    )
-
-    req = await client.get(signed_path)
-    assert req.status == HTTPStatus.OK
-    data = await req.json()
-    assert data["user_id"] == refresh_token.user.id
-
-
-async def test_auth_access_signed_path_with_query_param_order(
-    hass, app, aiohttp_client, hass_access_token
-):
-    """Test access with signed url and query params different order."""
-    app.router.add_post("/", mock_handler)
-    app.router.add_get("/another_path", mock_handler)
-    await async_setup_auth(hass, app)
-    client = await aiohttp_client(app)
-
-    refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
-
-    signed_path = async_sign_path(
-        hass,
-        "/?test=test&foo=bar",
-        timedelta(seconds=5),
-        refresh_token_id=refresh_token.id,
-    )
-    url = yarl.URL(signed_path)
-    signed_path = f"{url.path}?{SIGN_QUERY_PARAM}={url.query.get(SIGN_QUERY_PARAM)}&foo=bar&test=test"
-
-    req = await client.get(signed_path)
-    assert req.status == HTTPStatus.OK
-    data = await req.json()
-    assert data["user_id"] == refresh_token.user.id
-
-
-@pytest.mark.parametrize(
-    "base_url,test_url",
-    [
-        ("/?test=test", "/?test=test&foo=bar"),
-        ("/", "/?test=test"),
-        ("/?test=test&foo=bar", "/?test=test&foo=baz"),
-        ("/?test=test&foo=bar", "/?test=test"),
-    ],
-)
-async def test_auth_access_signed_path_with_query_param_tamper(
-    hass, app, aiohttp_client, hass_access_token, base_url: str, test_url: str
-):
-    """Test access with signed url and query params that have been tampered with."""
-    app.router.add_post("/", mock_handler)
-    app.router.add_get("/another_path", mock_handler)
-    await async_setup_auth(hass, app)
-    client = await aiohttp_client(app)
-
-    refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
-
-    signed_path = async_sign_path(
-        hass, base_url, timedelta(seconds=5), refresh_token_id=refresh_token.id
-    )
-    url = yarl.URL(signed_path)
-    token = url.query.get(SIGN_QUERY_PARAM)
-
-    req = await client.get(f"{test_url}&{SIGN_QUERY_PARAM}={token}")
     assert req.status == HTTPStatus.UNAUTHORIZED
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->



Requiring the query params to be signed in #73240 broke the frontend so
we need to revert this and try another approach.

This reverts commit 67618311fa0a400daeef10f8e7256c24f21f9dd0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
