### PR TITLE
Set Google Cast audio devices as speakers

### DIFF
--- a/homeassistant/components/cast/const.py
+++ b/homeassistant/components/cast/const.py
@@ -26,3 +26,10 @@ SIGNAL_HASS_CAST_SHOW_VIEW = "cast_show_view"
 CONF_IGNORE_CEC = "ignore_cec"
 CONF_KNOWN_HOSTS = "known_hosts"
 CONF_UUID = "uuid"
+
+# Regular chromecast, supports video/audio
+CAST_TYPE_CHROMECAST = "cast"
+# Cast Audio device, supports only audio
+CAST_TYPE_AUDIO = "audio"
+# Cast Audio group device, supports only audio
+CAST_TYPE_GROUP = "group"

--- a/homeassistant/components/cast/const.py
+++ b/homeassistant/components/cast/const.py
@@ -26,10 +26,3 @@ SIGNAL_HASS_CAST_SHOW_VIEW = "cast_show_view"
 CONF_IGNORE_CEC = "ignore_cec"
 CONF_KNOWN_HOSTS = "known_hosts"
 CONF_UUID = "uuid"
-
-# Regular chromecast, supports video/audio
-CAST_TYPE_CHROMECAST = "cast"
-# Cast Audio device, supports only audio
-CAST_TYPE_AUDIO = "audio"
-# Cast Audio group device, supports only audio
-CAST_TYPE_GROUP = "group"

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -63,6 +63,8 @@ from homeassistant.util.logging import async_create_catching_coro
 from .const import (
     ADDED_CAST_DEVICES_KEY,
     CAST_MULTIZONE_MANAGER_KEY,
+    CAST_TYPE_AUDIO,
+    CAST_TYPE_GROUP,
     CONF_IGNORE_CEC,
     CONF_UUID,
     DOMAIN as CAST_DOMAIN,
@@ -299,6 +301,11 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
             model=cast_info.cast_info.model_name,
             name=str(cast_info.friendly_name),
         )
+
+        if cast_info.cast_info.cast_type == CAST_TYPE_AUDIO:
+            self._attr_icon = "mdi:speaker"
+        elif cast_info.cast_info.cast_type == CAST_TYPE_GROUP:
+            self._attr_icon = "mdi:speaker-multiple"
 
     async def async_added_to_hass(self):
         """Create chromecast object when added to hass."""

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -64,8 +64,6 @@ from homeassistant.util.logging import async_create_catching_coro
 from .const import (
     ADDED_CAST_DEVICES_KEY,
     CAST_MULTIZONE_MANAGER_KEY,
-    CAST_TYPE_AUDIO,
-    CAST_TYPE_GROUP,
     CONF_IGNORE_CEC,
     CONF_UUID,
     DOMAIN as CAST_DOMAIN,
@@ -303,14 +301,11 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
             name=str(cast_info.friendly_name),
         )
 
-        if cast_info.cast_info.cast_type == CAST_TYPE_AUDIO:
+        if cast_info.cast_info.cast_type in [
+            pychromecast.const.CAST_TYPE_AUDIO,
+            pychromecast.const.CAST_TYPE_GROUP,
+        ]:
             self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
-            self._attr_icon = "mdi:speaker"
-        elif cast_info.cast_info.cast_type == CAST_TYPE_GROUP:
-            self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
-            self._attr_icon = "mdi:speaker-multiple"
-        else:
-            self._attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     async def async_added_to_hass(self):
         """Create chromecast object when added to hass."""

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -30,6 +30,7 @@ from homeassistant.components import media_source, zeroconf
 from homeassistant.components.media_player import (
     BrowseError,
     BrowseMedia,
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     async_process_play_media_url,
@@ -303,9 +304,13 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
         )
 
         if cast_info.cast_info.cast_type == CAST_TYPE_AUDIO:
+            self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
             self._attr_icon = "mdi:speaker"
         elif cast_info.cast_info.cast_type == CAST_TYPE_GROUP:
+            self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
             self._attr_icon = "mdi:speaker-multiple"
+        else:
+            self._attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     async def async_added_to_hass(self):
         """Create chromecast object when added to hass."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will set proper icons to Google Cast audio-only devices, making it easier to distinguish TVs from Nest Minis for example.

As in YouTube Music app:

![image](https://user-images.githubusercontent.com/29582865/175058011-f9bf24b3-36e1-4936-9e05-06ce9c20f49e.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant-libs/pychromecast/issues/632
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
