### PR TITLE
Add missing type hints in fans

### DIFF
--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -118,7 +118,7 @@ class ComfoConnectFan(FanEntity):
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
         if percentage is None:

--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -1,6 +1,8 @@
 """Demo fan platform that has a fake fan."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -192,9 +194,9 @@ class DemoPercentageFan(BaseDemoFan, FanEntity):
 
     def turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the entity."""
         if preset_mode:
@@ -262,9 +264,9 @@ class AsyncDemoPercentageFan(BaseDemoFan, FanEntity):
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the entity."""
         if preset_mode:

--- a/homeassistant/components/fjaraskupan/fan.py
+++ b/homeassistant/components/fjaraskupan/fan.py
@@ -1,6 +1,8 @@
 """Support for Fjäråskupan fans."""
 from __future__ import annotations
 
+from typing import Any
+
 from fjaraskupan import (
     COMMAND_AFTERCOOKINGTIMERAUTO,
     COMMAND_AFTERCOOKINGTIMERMANUAL,
@@ -93,9 +95,9 @@ class Fan(CoordinatorEntity[Coordinator], FanEntity):
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
 

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -60,7 +60,7 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
         return self._attr_is_on
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current speed percentage."""
         return self._attr_percentage
 
@@ -111,7 +111,7 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
         )
         await self.coordinator.async_request_refresh()
 
-    async def async_set_percentage(self, percentage: int):
+    async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         rotation_speed = {"rotationSpeed": percentage}
         payload = json.dumps(rotation_speed)

--- a/homeassistant/components/insteon/fan.py
+++ b/homeassistant/components/insteon/fan.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+from typing import Any
 
 from homeassistant.components.fan import (
     DOMAIN as FAN_DOMAIN,
@@ -62,9 +63,9 @@ class InsteonFanEntity(InsteonEntity, FanEntity):
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
         await self.async_set_percentage(percentage or 67)

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -1,6 +1,8 @@
 """Support for Lutron Caseta fans."""
 from __future__ import annotations
 
+from typing import Any
+
 from pylutron_caseta import FAN_HIGH, FAN_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_OFF
 
 from homeassistant.components.fan import DOMAIN, FanEntity, FanEntityFeature
@@ -58,10 +60,10 @@ class LutronCasetaFan(LutronCasetaDeviceUpdatableEntity, FanEntity):
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
-    ):
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn the fan on."""
         if percentage is None:
             percentage = DEFAULT_ON_PERCENTAGE

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -127,7 +127,7 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
     async def async_turn_on(
         self,
         percentage: int | None = None,
-        preset_mode: int | None = None,
+        preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import functools
 import logging
 import math
+from typing import Any
 
 import voluptuous as vol
 
@@ -511,17 +512,17 @@ class MqttFan(MqttEntity, FanEntity):
         return self._state
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current percentage."""
         return self._percentage
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Return the current preset _mode."""
         return self._preset_mode
 
     @property
-    def preset_modes(self) -> list:
+    def preset_modes(self) -> list[str]:
         """Get the list of available preset modes."""
         return self._preset_modes
 
@@ -536,16 +537,16 @@ class MqttFan(MqttEntity, FanEntity):
         return self._speed_count
 
     @property
-    def oscillating(self):
+    def oscillating(self) -> bool | None:
         """Return the oscillation state."""
         return self._oscillation
 
     # The speed attribute deprecated in the schema, support will be removed after a quarter (2021.7)
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the entity.
 

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import math
+from typing import Any
 
 from pysmartthings import Capability
 
@@ -69,7 +70,7 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Turn the fan on."""
         await self.async_set_percentage(percentage)

--- a/homeassistant/components/smarty/fan.py
+++ b/homeassistant/components/smarty/fan.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import math
+from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant, callback
@@ -64,7 +65,7 @@ class SmartyFan(FanEntity):
         return "mdi:air-conditioner"
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return state of the fan."""
         return bool(self._smarty_fan_speed)
 
@@ -96,7 +97,12 @@ class SmartyFan(FanEntity):
         self._smarty_fan_speed = fan_speed
         self.schedule_update_ha_state()
 
-    def turn_on(self, percentage=None, preset_mode=None, **kwargs):
+    def turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn on the fan."""
         _LOGGER.debug("Turning on fan. percentage is %s", percentage)
         self.set_percentage(percentage or DEFAULT_ON_PERCENTAGE)

--- a/homeassistant/components/switch_as_x/fan.py
+++ b/homeassistant/components/switch_as_x/fan.py
@@ -1,6 +1,8 @@
 """Fan support for switch entities."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.fan import FanEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENTITY_ID
@@ -53,7 +55,7 @@ class FanSwitch(BaseToggleEntity, FanEntity):
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan.
 

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -215,35 +215,35 @@ class TemplateFan(TemplateEntity, FanEntity):
         return self._preset_modes
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if device is on."""
         return self._state == STATE_ON
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         return self._preset_mode
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current speed percentage."""
         return self._percentage
 
     @property
-    def oscillating(self):
+    def oscillating(self) -> bool | None:
         """Return the oscillation state."""
         return self._oscillating
 
     @property
-    def current_direction(self):
+    def current_direction(self) -> str | None:
         """Return the oscillation state."""
         return self._direction
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
         await self.async_run_script(

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -158,8 +158,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
 
     def turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -1,6 +1,9 @@
 """Support for VeSync fans."""
+from __future__ import annotations
+
 import logging
 import math
+from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -91,7 +94,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         self.smartfan = fan
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current speed."""
         if (
             self.smartfan.mode == "manual"
@@ -115,7 +118,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         return PRESET_MODES[SKU_TO_BASE_DEVICE.get(self.device.device_type)]
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Get the current preset mode."""
         if self.smartfan.mode in (FAN_MODE_AUTO, FAN_MODE_SLEEP):
             return self.smartfan.mode
@@ -148,7 +151,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
         return attr
 
-    def set_percentage(self, percentage):
+    def set_percentage(self, percentage: int) -> None:
         """Set the speed of the device."""
         if percentage == 0:
             self.smartfan.turn_off()
@@ -167,7 +170,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         )
         self.schedule_update_ha_state()
 
-    def set_preset_mode(self, preset_mode):
+    def set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of device."""
         if preset_mode not in self.preset_modes:
             raise ValueError(
@@ -187,9 +190,9 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
     def turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn the device on."""
         if preset_mode:

--- a/homeassistant/components/wilight/fan.py
+++ b/homeassistant/components/wilight/fan.py
@@ -1,6 +1,8 @@
 """Support for WiLight Fan."""
 from __future__ import annotations
 
+from typing import Any
+
 from pywilight.const import (
     FAN_V1,
     ITEM_FAN,
@@ -64,7 +66,7 @@ class WiLightFan(WiLightDevice, FanEntity):
         return "mdi:fan"
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if device is on."""
         return self._status.get("direction", WL_DIRECTION_OFF) != WL_DIRECTION_OFF
 
@@ -98,9 +100,9 @@ class WiLightFan(WiLightDevice, FanEntity):
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
         if percentage is None:
@@ -108,7 +110,7 @@ class WiLightFan(WiLightDevice, FanEntity):
         else:
             await self.async_set_percentage(percentage)
 
-    async def async_set_percentage(self, percentage: int):
+    async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan."""
         if percentage == 0:
             await self._client.set_fan_direction(self._index, WL_DIRECTION_OFF)
@@ -121,7 +123,7 @@ class WiLightFan(WiLightDevice, FanEntity):
         wl_speed = percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
         await self._client.set_fan_speed(self._index, wl_speed)
 
-    async def async_set_direction(self, direction: str):
+    async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         wl_direction = WL_DIRECTION_REVERSE
         if direction == DIRECTION_FORWARD:

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -1,8 +1,11 @@
 """Support for Xiaomi Mi Air Purifier and Xiaomi Mi Air Humidifier."""
+from __future__ import annotations
+
 from abc import abstractmethod
 import asyncio
 import logging
 import math
+from typing import Any
 
 from miio.airfresh import OperationMode as AirfreshOperationMode
 from miio.airfresh_t2017 import OperationMode as AirfreshOperationModeT2017
@@ -291,12 +294,12 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
         """Hold operation mode class."""
 
     @property
-    def preset_modes(self) -> list:
+    def preset_modes(self) -> list[str]:
         """Get the list of available preset modes."""
         return self._preset_modes
 
     @property
-    def percentage(self):
+    def percentage(self) -> None:
         """Return the percentage based speed of the fan."""
         return None
 
@@ -306,15 +309,15 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
         return self._state_attrs
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return true if device is on."""
         return self._state
 
     async def async_turn_on(
         self,
-        percentage: int = None,
-        preset_mode: str = None,
-        **kwargs,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn the device on."""
         result = await self._try_command(
@@ -352,12 +355,12 @@ class XiaomiGenericAirPurifier(XiaomiGenericDevice):
         self._speed_count = 100
 
     @property
-    def speed_count(self):
+    def speed_count(self) -> int:
         """Return the number of speeds of the fan supported."""
         return self._speed_count
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Get the active preset mode."""
         if self._state:
             preset_mode = self.operation_mode_class(self._mode).name
@@ -451,7 +454,7 @@ class XiaomiAirPurifier(XiaomiGenericAirPurifier):
         return AirpurifierOperationMode
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current percentage based speed."""
         if self._state:
             mode = self.operation_mode_class(self._mode)
@@ -528,7 +531,7 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
         return AirpurifierMiotOperationMode
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current percentage based speed."""
         if self._fan_level is None:
             return None
@@ -642,7 +645,7 @@ class XiaomiAirFresh(XiaomiGenericAirPurifier):
         return AirfreshOperationMode
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current percentage based speed."""
         if self._state:
             mode = AirfreshOperationMode(self._mode)
@@ -733,7 +736,7 @@ class XiaomiAirFreshA1(XiaomiGenericAirPurifier):
         return AirfreshOperationModeT2017
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current percentage based speed."""
         if self._favorite_speed is None:
             return None
@@ -826,17 +829,17 @@ class XiaomiGenericFan(XiaomiGenericDevice):
         self._percentage = None
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Get the active preset mode."""
         return self._preset_mode
 
     @property
-    def preset_modes(self) -> list:
+    def preset_modes(self) -> list[str]:
         """Get the list of available preset modes."""
         return [mode.name for mode in self.operation_mode_class]
 
     @property
-    def percentage(self):
+    def percentage(self) -> int | None:
         """Return the current speed as a percentage."""
         if self._state:
             return self._percentage
@@ -844,7 +847,7 @@ class XiaomiGenericFan(XiaomiGenericDevice):
         return None
 
     @property
-    def oscillating(self):
+    def oscillating(self) -> bool | None:
         """Return whether or not the fan is currently oscillating."""
         return self._oscillating
 
@@ -890,12 +893,12 @@ class XiaomiFan(XiaomiGenericFan):
         """Hold operation mode class."""
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str:
         """Get the active preset mode."""
         return ATTR_MODE_NATURE if self._nature_mode else ATTR_MODE_NORMAL
 
     @property
-    def preset_modes(self) -> list:
+    def preset_modes(self) -> list[str]:
         """Get the list of available preset modes."""
         return [ATTR_MODE_NATURE, ATTR_MODE_NORMAL]
 
@@ -1030,7 +1033,7 @@ class XiaomiFanMiot(XiaomiGenericFan):
         return FanOperationMode
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Get the active preset mode."""
         return self._preset_mode
 

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from abc import abstractmethod
 import functools
 import math
+from typing import Any
 
 from zigpy.exceptions import ZigbeeException
 from zigpy.zcl.clusters import hvac
@@ -87,7 +88,12 @@ class BaseFan(FanEntity):
         """Return the number of speeds the fan supports."""
         return int_states_in_range(SPEED_RANGE)
 
-    async def async_turn_on(self, percentage=None, preset_mode=None, **kwargs) -> None:
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn the entity on."""
         if percentage is None:
             percentage = DEFAULT_ON_PERCENTAGE

--- a/homeassistant/components/zwave_me/fan.py
+++ b/homeassistant/components/zwave_me/fan.py
@@ -66,7 +66,7 @@ class ZWaveMeFan(ZWaveMeEntity, FanEntity):
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
         self.set_percentage(percentage if percentage is not None else 99)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #73801

This PR is 100% type hints. There are a few extra components that need manual adjustment, and those will be adjusted separately.

```console
pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/**/fan.py

************* Module homeassistant.components.mqtt.fan
homeassistant/components/mqtt/fan.py:515:4: W7432: Return type should be ['int', None] (hass-return-type)
homeassistant/components/mqtt/fan.py:540:4: W7432: Return type should be ['bool', None] (hass-return-type)
homeassistant/components/mqtt/fan.py:520:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/mqtt/fan.py:525:4: W7432: Return type should be ['list[str]', None] (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
