### PR TITLE
Adjust set_percentage routine in fans

### DIFF
--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -67,8 +67,11 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
         api_version = self._api_version
         return api_version.major == 1 and api_version.minor > 3
 
-    async def async_set_percentage(self, percentage: int | None) -> None:
+    async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
+        await self._async_set_percentage(percentage)
+
+    async def _async_set_percentage(self, percentage: int | None) -> None:
         if percentage == 0:
             await self.async_turn_off()
             return
@@ -95,7 +98,7 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
-        await self.async_set_percentage(percentage)
+        await self._async_set_percentage(percentage)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -52,8 +52,11 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
 
     _attr_supported_features = FanEntityFeature.SET_SPEED
 
-    async def async_set_percentage(self, percentage: int | None) -> None:
+    async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
+        await self._async_set_percentage(percentage)
+
+    async def _async_set_percentage(self, percentage: int | None) -> None:
         if percentage is None:
             await self._device.switch_on(set_status=True)
         elif percentage == 0:
@@ -72,7 +75,7 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
         **kwargs,
     ) -> None:
         """Turn the fan on."""
-        await self.async_set_percentage(percentage)
+        await self._async_set_percentage(percentage)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the fan off."""

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -136,15 +136,18 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the fan on."""
-        self.set_percentage(percentage)
+        self._set_percentage(percentage)
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         with self._wemo_call_wrapper("turn off"):
             self.wemo.set_state(FanMode.Off)
 
-    def set_percentage(self, percentage: int | None) -> None:
+    def set_percentage(self, percentage: int) -> None:
         """Set the fan_mode of the Humidifier."""
+        self._set_percentage(percentage)
+
+    def _set_percentage(self, percentage: int | None) -> None:
         if percentage is None:
             named_speed = self._last_fan_on_mode
         elif percentage == 0:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to https://github.com/home-assistant/core/pull/73801

When called from a service, the `set_percentage` routine will always be called with the first argument being an `int`.
When called internally from `turn_on` or `async_turn_on`, it can be called with `int | None`

In order to clarify, I suggest that we introduce an internal `_set_percentage` in each of the three components to make the distinction.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
