### PR TITLE
UniFi Protect cleanup and enable unadopted devices

### DIFF
--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -103,7 +103,7 @@ class ProtectButton(ProtectDeviceEntity, ButtonEntity):
     ) -> None:
         """Initialize an UniFi camera."""
         super().__init__(data, device, description)
-        self._attr_name = f"{self.device.name} {self.entity_description.name}"
+        self._attr_name = f"{self.device.display_name} {self.entity_description.name}"
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -36,9 +36,14 @@ def get_camera_channels(
 ) -> Generator[tuple[UFPCamera, CameraChannel, bool], None, None]:
     """Get all the camera channels."""
     for camera in protect.bootstrap.cameras.values():
+        if not camera.is_adopted_by_us:
+            continue
+
         if not camera.channels:
             _LOGGER.warning(
-                "Camera does not have any channels: %s (id: %s)", camera.name, camera.id
+                "Camera does not have any channels: %s (id: %s)",
+                camera.display_name,
+                camera.id,
             )
             continue
 
@@ -116,10 +121,10 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
 
         if self._secure:
             self._attr_unique_id = f"{self.device.mac}_{self.channel.id}"
-            self._attr_name = f"{self.device.name} {self.channel.name}"
+            self._attr_name = f"{self.device.display_name} {self.channel.name}"
         else:
             self._attr_unique_id = f"{self.device.mac}_{self.channel.id}_insecure"
-            self._attr_name = f"{self.device.name} {self.channel.name} Insecure"
+            self._attr_name = f"{self.device.display_name} {self.channel.name} Insecure"
         # only the default (first) channel is enabled by default
         self._attr_entity_registry_enabled_default = is_default and secure
 

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -175,9 +175,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_VERIFY_SSL] = False
                 nvr_data, errors = await self._async_get_nvr_data(user_input)
             if nvr_data and not errors:
-                return self._async_create_entry(
-                    nvr_data.name or nvr_data.type, user_input
-                )
+                return self._async_create_entry(nvr_data.display_name, user_input)
 
         placeholders = {
             "name": discovery_info["hostname"]
@@ -323,9 +321,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(nvr_data.mac)
                 self._abort_if_unique_id_configured()
 
-                return self._async_create_entry(
-                    nvr_data.name or nvr_data.type, user_input
-                )
+                return self._async_create_entry(nvr_data.display_name, user_input)
 
         user_input = user_input or {}
         return self.async_show_form(

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -120,7 +120,9 @@ class ProtectData:
     @callback
     def _async_process_ws_message(self, message: WSSubscriptionMessage) -> None:
         # removed packets are not processed yet
-        if message.new_obj is None:  # pragma: no cover
+        if message.new_obj is None or not getattr(
+            message.new_obj, "is_adopted_by_us", True
+        ):
             return
 
         if message.new_obj.model in DEVICES_WITH_ENTITIES:

--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -27,11 +27,11 @@ async def async_setup_entry(
     data: ProtectData = hass.data[DOMAIN][entry.entry_id]
     entities = []
     for device in data.api.bootstrap.lights.values():
+        if not device.is_adopted_by_us:
+            continue
+
         if device.can_write(data.api.bootstrap.auth_user):
             entities.append(ProtectLight(data, device))
-
-    if not entities:
-        return
 
     async_add_entities(entities)
 

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -14,8 +14,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 
-from .utils import async_device_by_id
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -69,7 +67,7 @@ async def async_migrate_buttons(
     bootstrap = await async_get_bootstrap(protect)
     count = 0
     for button in to_migrate:
-        device = async_device_by_id(bootstrap, button.unique_id)
+        device = bootstrap.get_device_from_id(button.unique_id)
         if device is None:
             continue
 
@@ -130,7 +128,7 @@ async def async_migrate_device_ids(
         if parts[0] == bootstrap.nvr.id:
             device: NVR | ProtectAdoptableDeviceModel | None = bootstrap.nvr
         else:
-            device = async_device_by_id(bootstrap, parts[0])
+            device = bootstrap.get_device_from_id(parts[0])
 
         if device is None:
             continue

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -5,9 +5,9 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import Enum
 import logging
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, Union
 
-from pyunifiprotect.data import ProtectDeviceModel
+from pyunifiprotect.data import NVR, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 
@@ -15,7 +15,7 @@ from .utils import get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
 
-T = TypeVar("T", bound=ProtectDeviceModel)
+T = TypeVar("T", bound=Union[ProtectAdoptableDeviceModel, NVR])
 
 
 class PermRequired(int, Enum):
@@ -63,7 +63,7 @@ class ProtectSetableKeysMixin(ProtectRequiredKeysMixin[T]):
 
     async def ufp_set(self, obj: T, value: Any) -> None:
         """Set value for UniFi Protect device."""
-        _LOGGER.debug("Setting %s to %s for %s", self.name, value, obj.name)
+        _LOGGER.debug("Setting %s to %s for %s", self.name, value, obj.display_name)
         if self.ufp_set_method is not None:
             await getattr(obj, self.ufp_set_method)(value)
         elif self.ufp_set_method_fn is not None:

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -143,7 +143,7 @@ def _get_doorbell_options(api: ProtectApiClient) -> list[dict[str, Any]]:
 def _get_paired_camera_options(api: ProtectApiClient) -> list[dict[str, Any]]:
     options = [{"id": TYPE_EMPTY_VALUE, "name": "Not Paired"}]
     for camera in api.bootstrap.cameras.values():
-        options.append({"id": camera.id, "name": camera.name or camera.type})
+        options.append({"id": camera.id, "name": camera.display_name or camera.type})
 
     return options
 
@@ -353,7 +353,7 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
     ) -> None:
         """Initialize the unifi protect select entity."""
         super().__init__(data, device, description)
-        self._attr_name = f"{self.device.name} {self.entity_description.name}"
+        self._attr_name = f"{self.device.display_name} {self.entity_description.name}"
         self._async_set_options()
 
     @callback
@@ -421,7 +421,10 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
             timeout_msg = f" with timeout of {duration} minute(s)"
 
         _LOGGER.debug(
-            'Setting message for %s to "%s"%s', self.device.name, message, timeout_msg
+            'Setting message for %s to "%s"%s',
+            self.device.display_name,
+            message,
+            timeout_msg,
         )
         await self.device.set_lcd_text(
             DoorbellMessageType.CUSTOM_MESSAGE, message, reset_at=reset_at

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -108,7 +108,7 @@ def _get_alarm_sound(obj: Sensor) -> str:
 
 
 ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
-    ProtectSensorEntityDescription[ProtectDeviceModel](
+    ProtectSensorEntityDescription(
         key="uptime",
         name="Uptime",
         icon="mdi:clock",
@@ -353,7 +353,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         name="Paired Camera",
         icon="mdi:cctv",
         entity_category=EntityCategory.DIAGNOSTIC,
-        ufp_value="camera.name",
+        ufp_value="camera.display_name",
         ufp_perm=PermRequired.NO_WRITE,
     ),
 )
@@ -373,13 +373,13 @@ DOORLOCK_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         name="Paired Camera",
         icon="mdi:cctv",
         entity_category=EntityCategory.DIAGNOSTIC,
-        ufp_value="camera.name",
+        ufp_value="camera.display_name",
         ufp_perm=PermRequired.NO_WRITE,
     ),
 )
 
 NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
-    ProtectSensorEntityDescription[ProtectDeviceModel](
+    ProtectSensorEntityDescription(
         key="uptime",
         name="Uptime",
         icon="mdi:clock",
@@ -541,7 +541,7 @@ LIGHT_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         name="Paired Camera",
         icon="mdi:cctv",
         entity_category=EntityCategory.DIAGNOSTIC,
-        ufp_value="camera.name",
+        ufp_value="camera.display_name",
         ufp_perm=PermRequired.NO_WRITE,
     ),
 )
@@ -618,11 +618,14 @@ def _async_motion_entities(
     entities: list[ProtectDeviceEntity] = []
     for device in data.api.bootstrap.cameras.values():
         for description in MOTION_TRIP_SENSORS:
+            if not device.is_adopted_by_us:
+                continue
+
             entities.append(ProtectDeviceSensor(data, device, description))
             _LOGGER.debug(
                 "Adding trip sensor entity %s for %s",
                 description.name,
-                device.name,
+                device.display_name,
             )
 
         if not device.feature_flags.has_smart_detect:
@@ -633,7 +636,7 @@ def _async_motion_entities(
             _LOGGER.debug(
                 "Adding sensor entity %s for %s",
                 description.name,
-                device.name,
+                device.display_name,
             )
 
     return entities

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -22,7 +22,6 @@ from .const import DOMAIN
 from .data import ProtectData
 from .entity import ProtectDeviceEntity, async_all_device_entities
 from .models import PermRequired, ProtectSetableKeysMixin, T
-from .utils import async_get_is_highfps
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,7 +80,7 @@ CAMERA_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
         icon="mdi:video-high-definition",
         entity_category=EntityCategory.CONFIG,
         ufp_required_field="feature_flags.has_highfps",
-        ufp_value_fn=async_get_is_highfps,
+        ufp_value="is_high_fps_enabled",
         ufp_set_method_fn=_set_highfps,
         ufp_perm=PermRequired.WRITE,
     ),
@@ -328,7 +327,7 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
     ) -> None:
         """Initialize an UniFi Protect Switch."""
         super().__init__(data, device, description)
-        self._attr_name = f"{self.device.name} {self.entity_description.name}"
+        self._attr_name = f"{self.device.display_name} {self.entity_description.name}"
         self._switch_type = self.entity_description.key
 
         if not isinstance(self.device, Camera):
@@ -362,7 +361,9 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
 
         if self._switch_type == _KEY_PRIVACY_MODE:
             assert isinstance(self.device, Camera)
-            _LOGGER.debug("Setting Privacy Mode to false for %s", self.device.name)
+            _LOGGER.debug(
+                "Setting Privacy Mode to false for %s", self.device.display_name
+            )
             await self.device.set_privacy(
                 False, self._previous_mic_level, self._previous_record_mode
             )

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -9,18 +9,15 @@ from typing import Any
 
 from pyunifiprotect.data import (
     Bootstrap,
-    Camera,
     Light,
     LightModeEnableType,
     LightModeType,
     ProtectAdoptableDeviceModel,
-    ProtectDeviceModel,
-    VideoMode,
 )
 
 from homeassistant.core import HomeAssistant, callback
 
-from .const import DEVICES_THAT_ADOPT, ModelType
+from .const import ModelType
 
 
 def get_nested_attr(obj: Any, attr: str) -> Any:
@@ -80,42 +77,15 @@ def async_get_devices_by_type(
 
 
 @callback
-def async_device_by_id(
-    bootstrap: Bootstrap,
-    device_id: str,
-    device_type: ModelType | None = None,
-) -> ProtectAdoptableDeviceModel | None:
-    """Get devices by type."""
-
-    device_types = DEVICES_THAT_ADOPT
-    if device_type is not None:
-        device_types = {device_type}
-
-    device = None
-    for model in device_types:
-        device = async_get_devices_by_type(bootstrap, model).get(device_id)
-        if device is not None:
-            break
-    return device
-
-
-@callback
 def async_get_devices(
     bootstrap: Bootstrap, model_type: Iterable[ModelType]
-) -> Generator[ProtectDeviceModel, None, None]:
+) -> Generator[ProtectAdoptableDeviceModel, None, None]:
     """Return all device by type."""
     return (
         device
         for device_type in model_type
         for device in async_get_devices_by_type(bootstrap, device_type).values()
     )
-
-
-@callback
-def async_get_is_highfps(obj: Camera) -> bool:
-    """Return if camera has High FPS mode enabled."""
-
-    return bool(obj.video_mode == VideoMode.HIGH_FPS)
 
 
 @callback

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -284,7 +284,7 @@ def ids_from_device_description(
 def generate_random_ids() -> tuple[str, str]:
     """Generate random IDs for device."""
 
-    return random_hex(24).upper(), random_hex(12).upper()
+    return random_hex(24).lower(), random_hex(12).upper()
 
 
 def regenerate_device_ids(device: ProtectAdoptableDeviceModel) -> None:

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -529,13 +529,22 @@ async def test_camera_ws_update(
     new_camera = camera[0].copy()
     new_camera.is_recording = True
 
-    mock_msg = Mock()
-    mock_msg.changed_data = {}
-    mock_msg.new_obj = new_camera
+    no_camera = camera[0].copy()
+    no_camera.is_adopted = False
 
     new_bootstrap.cameras = {new_camera.id: new_camera}
     mock_entry.api.bootstrap = new_bootstrap
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = new_camera
     mock_entry.api.ws_subscription(mock_msg)
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = no_camera
+    mock_entry.api.ws_subscription(mock_msg)
+
     await hass.async_block_till_done()
 
     state = hass.states.get(camera[1])

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -242,3 +242,27 @@ async def test_device_remove_devices(
         await remove_device(await hass_ws_client(hass), dead_device_entry.id, entry_id)
         is True
     )
+
+
+async def test_device_remove_devices_nvr(
+    hass: HomeAssistant,
+    mock_entry: MockEntityFixture,
+    hass_ws_client: Callable[
+        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
+    ],
+) -> None:
+    """Test we can only remove a NVR device that no longer exists."""
+    assert await async_setup_component(hass, "config", {})
+
+    mock_entry.api.get_bootstrap = AsyncMock(return_value=mock_entry.api.bootstrap)
+    await hass.config_entries.async_setup(mock_entry.entry.entry_id)
+    await hass.async_block_till_done()
+    entry_id = mock_entry.entry.entry_id
+
+    device_registry = dr.async_get(hass)
+
+    live_device_entry = list(device_registry.devices.values())[0]
+    assert (
+        await remove_device(await hass_ws_client(hass), live_device_entry.id, entry_id)
+        is False
+    )

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockEntityFixture, assert_entity_counts
+from .conftest import MockEntityFixture, assert_entity_counts, regenerate_device_ids
 
 
 @pytest.fixture(name="light")
@@ -36,9 +36,17 @@ async def light_fixture(
     light_obj._api = mock_entry.api
     light_obj.name = "Test Light"
     light_obj.is_light_on = False
+    regenerate_device_ids(light_obj)
+
+    no_light_obj = mock_light.copy()
+    no_light_obj._api = mock_entry.api
+    no_light_obj.name = "Unadopted Light"
+    no_light_obj.is_adopted = False
+    regenerate_device_ids(no_light_obj)
 
     mock_entry.api.bootstrap.lights = {
         light_obj.id: light_obj,
+        no_light_obj.id: no_light_obj,
     }
 
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockEntityFixture, assert_entity_counts
+from .conftest import MockEntityFixture, assert_entity_counts, regenerate_device_ids
 
 
 @pytest.fixture(name="doorlock")
@@ -39,9 +39,17 @@ async def doorlock_fixture(
     lock_obj._api = mock_entry.api
     lock_obj.name = "Test Lock"
     lock_obj.lock_status = LockStatusType.OPEN
+    regenerate_device_ids(lock_obj)
+
+    no_lock_obj = mock_doorlock.copy()
+    no_lock_obj._api = mock_entry.api
+    no_lock_obj.name = "Unadopted Lock"
+    no_lock_obj.is_adopted = False
+    regenerate_device_ids(no_lock_obj)
 
     mock_entry.api.bootstrap.doorlocks = {
         lock_obj.id: lock_obj,
+        no_lock_obj.id: no_lock_obj,
     }
 
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -26,7 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockEntityFixture, assert_entity_counts
+from .conftest import MockEntityFixture, assert_entity_counts, regenerate_device_ids
 
 
 @pytest.fixture(name="camera")
@@ -45,9 +45,20 @@ async def camera_fixture(
     camera_obj.channels[2]._api = mock_entry.api
     camera_obj.name = "Test Camera"
     camera_obj.feature_flags.has_speaker = True
+    regenerate_device_ids(camera_obj)
+
+    no_camera_obj = mock_camera.copy()
+    no_camera_obj._api = mock_entry.api
+    no_camera_obj.channels[0]._api = mock_entry.api
+    no_camera_obj.channels[1]._api = mock_entry.api
+    no_camera_obj.channels[2]._api = mock_entry.api
+    no_camera_obj.name = "Unadopted Camera"
+    no_camera_obj.is_adopted = False
+    regenerate_device_ids(no_camera_obj)
 
     mock_entry.api.bootstrap.cameras = {
         camera_obj.id: camera_obj,
+        no_camera_obj.id: no_camera_obj,
     }
 
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A few cleanup operations to get rid of tech debt from recent PRs. Could be split into two PRs since there are two minor widespread changes in the PR, but I decided not to split them since both essentially require a test of everything to verify it is working.

* Removes `ignore_unadopted` flag from ProtectAPIClient (and ignores unadopted devices manually everywhere)
* Use newest helpers from UniFi Protect to clean up/remove code
* More tests to fill in most of the gaps in test coverage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
