### PR TITLE
Implemented RestoreEntity for Dynalite

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,9 +37,14 @@ WORKDIR /workspaces
 COPY requirements.txt ./
 COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
 RUN pip3 install -r requirements.txt --use-deprecated=legacy-resolver
-COPY requirements_test.txt requirements_test_pre_commit.txt ./
+COPY requirements_test.txt requirements_test_pre_commit.txt requirements_test_all.txt ./
 RUN pip3 install -r requirements_test.txt --use-deprecated=legacy-resolver
-RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
+
+# my addition
+RUN pip3 install --use-deprecated=legacy-resolver -r requirements_test_all.txt -c homeassistant/package_constraints.txt
+
+RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt requirements_test_all.txt homeassistant/
+
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,14 +37,9 @@ WORKDIR /workspaces
 COPY requirements.txt ./
 COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
 RUN pip3 install -r requirements.txt --use-deprecated=legacy-resolver
-COPY requirements_test.txt requirements_test_pre_commit.txt requirements_test_all.txt ./
+COPY requirements_test.txt requirements_test_pre_commit.txt ./
 RUN pip3 install -r requirements_test.txt --use-deprecated=legacy-resolver
-
-# my addition
-RUN pip3 install --use-deprecated=legacy-resolver -r requirements_test_all.txt -c homeassistant/package_constraints.txt
-
-RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt requirements_test_all.txt homeassistant/
-
+RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/homeassistant/components/dynalite/cover.py
+++ b/homeassistant/components/dynalite/cover.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from homeassistant.components.cover import DEVICE_CLASSES, CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    DEVICE_CLASSES,
+    CoverDeviceClass,
+    CoverEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -77,6 +82,12 @@ class DynaliteCover(DynaliteBase, CoverEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._device.async_stop_cover(**kwargs)
+
+    def initialize_state(self, state):
+        """Initialize the state from cache."""
+        target_level = state.attributes.get(ATTR_CURRENT_POSITION)
+        if target_level is not None:
+            self._device.init_level(target_level)
 
 
 class DynaliteCoverWithTilt(DynaliteCover):

--- a/homeassistant/components/dynalite/dynalitebase.py
+++ b/homeassistant/components/dynalite/dynalitebase.py
@@ -101,7 +101,7 @@ class DynaliteBase(RestoreEntity, ABC):
 
     @abstractmethod
     def initialize_state(self, state):
-        """Leaving a stub for the inner classes to implement."""
+        """Initialize the state from cache."""
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister signal dispatch listeners when being removed."""

--- a/homeassistant/components/dynalite/dynalitebase.py
+++ b/homeassistant/components/dynalite/dynalitebase.py
@@ -1,14 +1,16 @@
 """Support for the Dynalite devices as entities."""
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .bridge import DynaliteBridge
 from .const import DOMAIN, LOGGER
@@ -37,7 +39,7 @@ def async_setup_entry_base(
     bridge.register_add_devices(platform, async_add_entities_platform)
 
 
-class DynaliteBase(Entity):
+class DynaliteBase(RestoreEntity, ABC):
     """Base class for the Dynalite entities."""
 
     def __init__(self, device: Any, bridge: DynaliteBridge) -> None:
@@ -71,8 +73,16 @@ class DynaliteBase(Entity):
         )
 
     async def async_added_to_hass(self) -> None:
-        """Added to hass so need to register to dispatch."""
+        """Added to hass so need to restore state and register to dispatch."""
         # register for device specific update
+        await super().async_added_to_hass()
+
+        cur_state = await self.async_get_last_state()
+        if cur_state:
+            self.initialize_state(cur_state)
+        else:
+            LOGGER.info("Restore state not available for %s", self.entity_id)
+
         self._unsub_dispatchers.append(
             async_dispatcher_connect(
                 self.hass,
@@ -88,6 +98,10 @@ class DynaliteBase(Entity):
                 self.async_schedule_update_ha_state,
             )
         )
+
+    @abstractmethod
+    def initialize_state(self, state):
+        """Leaving a stub for the inner classes to implement."""
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister signal dispatch listeners when being removed."""

--- a/homeassistant/components/dynalite/light.py
+++ b/homeassistant/components/dynalite/light.py
@@ -1,8 +1,7 @@
 """Support for Dynalite channels as lights."""
 
 from typing import Any
-
-from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -44,3 +43,9 @@ class DynaliteLight(DynaliteBase, LightEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self._device.async_turn_off(**kwargs)
+
+    def initialize_state(self, state):
+        """Initialize the state from cache."""
+        target_level = state.attributes.get(ATTR_BRIGHTNESS)
+        if target_level is not None:
+            self._device.init_level(target_level)

--- a/homeassistant/components/dynalite/light.py
+++ b/homeassistant/components/dynalite/light.py
@@ -1,6 +1,7 @@
 """Support for Dynalite channels as lights."""
 
 from typing import Any
+
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dynalite",
   "codeowners": ["@ziv1234"],
-  "requirements": ["dynalite_devices==0.1.46"],
+  "requirements": ["dynalite_devices==0.1.47"],
   "iot_class": "local_push",
   "loggers": ["dynalite_devices_lib"]
 }

--- a/homeassistant/components/dynalite/switch.py
+++ b/homeassistant/components/dynalite/switch.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -34,3 +35,8 @@ class DynaliteSwitch(DynaliteBase, SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self._device.async_turn_off()
+
+    def initialize_state(self, state):
+        """Initialize the state from cache."""
+        target_level = 1 if state.state == STATE_ON else 0
+        self._device.init_level(target_level)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -573,7 +573,7 @@ dwdwfsapi==1.0.5
 dweepy==0.3.0
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.46
+dynalite_devices==0.1.47
 
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -432,7 +432,7 @@ doorbirdpy==2.1.0
 dsmr_parser==0.33
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.46
+dynalite_devices==0.1.47
 
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1

--- a/tests/components/dynalite/test_bridge.py
+++ b/tests/components/dynalite/test_bridge.py
@@ -70,10 +70,12 @@ async def test_add_devices_then_register(hass):
     device1.category = "light"
     device1.name = "NAME"
     device1.unique_id = "unique1"
+    device1.brightness = 1
     device2 = Mock()
     device2.category = "switch"
     device2.name = "NAME2"
     device2.unique_id = "unique2"
+    device2.brightness = 1
     new_device_func([device1, device2])
     device3 = Mock()
     device3.category = "switch"
@@ -103,10 +105,12 @@ async def test_register_then_add_devices(hass):
     device1.category = "light"
     device1.name = "NAME"
     device1.unique_id = "unique1"
+    device1.brightness = 1
     device2 = Mock()
     device2.category = "switch"
     device2.name = "NAME2"
     device2.unique_id = "unique2"
+    device2.brightness = 1
     new_device_func([device1, device2])
     await hass.async_block_till_done()
     assert hass.states.get("light.name")

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -9,7 +9,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
-    DEVICE_CLASS_BLIND,
+    CoverDeviceClass,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -38,7 +38,7 @@ from tests.common import mock_restore_cache
 def mock_device():
     """Mock a Dynalite device."""
     mock_dev = create_mock_device("cover", DynaliteTimeCoverWithTiltDevice)
-    mock_dev.device_class = DEVICE_CLASS_BLIND
+    mock_dev.device_class = CoverDeviceClass.BLIND.value
     mock_dev.current_cover_position = 0
     mock_dev.current_cover_tilt_position = 0
     mock_dev.is_opening = False

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -9,6 +9,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    DEVICE_CLASS_BLIND,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -37,7 +38,7 @@ from tests.common import mock_restore_cache
 def mock_device():
     """Mock a Dynalite device."""
     mock_dev = create_mock_device("cover", DynaliteTimeCoverWithTiltDevice)
-    mock_dev.device_class = "blind"
+    mock_dev.device_class = DEVICE_CLASS_BLIND
     mock_dev.current_cover_position = 0
     mock_dev.current_cover_tilt_position = 0
     mock_dev.is_opening = False

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -26,6 +26,9 @@ def mock_device():
     mock_dev.device_class = "blind"
     mock_dev.current_cover_position = 0
     mock_dev.current_cover_tilt_position = 0
+    mock_dev.is_opening = False
+    mock_dev.is_closing = False
+    mock_dev.is_closed = True
     return mock_dev
 
 
@@ -118,6 +121,8 @@ async def test_cover_restore_state(hass, mock_device):
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_called_once_with(77)
+    entity_state = hass.states.get("cover.name")
+    assert entity_state.state == "closed"
 
 
 async def test_cover_restore_state_bad_cache(hass, mock_device):
@@ -128,3 +133,5 @@ async def test_cover_restore_state_bad_cache(hass, mock_device):
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_not_called()
+    entity_state = hass.states.get("cover.name")
+    assert entity_state.state == "closed"

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -1,9 +1,23 @@
 """Test Dynalite cover."""
+from unittest.mock import Mock
+
 from dynalite_devices_lib.cover import DynaliteTimeCoverWithTiltDevice
 import pytest
 
-from homeassistant.components.cover import ATTR_CURRENT_POSITION
-from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+)
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 
@@ -29,6 +43,12 @@ def mock_device():
     mock_dev.is_opening = False
     mock_dev.is_closing = False
     mock_dev.is_closed = True
+
+    def mock_init_level(target):
+        mock_dev.is_closed = target == 0
+
+    type(mock_dev).init_level = Mock(side_effect=mock_init_level)
+
     return mock_dev
 
 
@@ -38,11 +58,11 @@ async def test_cover_setup(hass, mock_device):
     entity_state = hass.states.get("cover.name")
     assert entity_state.attributes[ATTR_FRIENDLY_NAME] == mock_device.name
     assert (
-        entity_state.attributes["current_position"]
+        entity_state.attributes[ATTR_CURRENT_POSITION]
         == mock_device.current_cover_position
     )
     assert (
-        entity_state.attributes["current_tilt_position"]
+        entity_state.attributes[ATTR_CURRENT_TILT_POSITION]
         == mock_device.current_cover_tilt_position
     )
     assert entity_state.attributes[ATTR_DEVICE_CLASS] == mock_device.device_class
@@ -57,7 +77,7 @@ async def test_cover_setup(hass, mock_device):
             {
                 ATTR_SERVICE: "set_cover_position",
                 ATTR_METHOD: "async_set_cover_position",
-                ATTR_ARGS: {"position": 50},
+                ATTR_ARGS: {ATTR_POSITION: 50},
             },
             {ATTR_SERVICE: "open_cover_tilt", ATTR_METHOD: "async_open_cover_tilt"},
             {ATTR_SERVICE: "close_cover_tilt", ATTR_METHOD: "async_close_cover_tilt"},
@@ -65,7 +85,7 @@ async def test_cover_setup(hass, mock_device):
             {
                 ATTR_SERVICE: "set_cover_tilt_position",
                 ATTR_METHOD: "async_set_cover_tilt_position",
-                ATTR_ARGS: {"tilt_position": 50},
+                ATTR_ARGS: {ATTR_TILT_POSITION: 50},
             },
         ],
     )
@@ -100,16 +120,16 @@ async def test_cover_positions(hass, mock_device):
     """Test that the state updates in the various positions."""
     update_func = await create_entity_from_device(hass, mock_device)
     await check_cover_position(
-        hass, update_func, mock_device, True, False, False, "closing"
+        hass, update_func, mock_device, True, False, False, STATE_CLOSING
     )
     await check_cover_position(
-        hass, update_func, mock_device, False, True, False, "opening"
+        hass, update_func, mock_device, False, True, False, STATE_OPENING
     )
     await check_cover_position(
-        hass, update_func, mock_device, False, False, True, "closed"
+        hass, update_func, mock_device, False, False, True, STATE_CLOSED
     )
     await check_cover_position(
-        hass, update_func, mock_device, False, False, False, "open"
+        hass, update_func, mock_device, False, False, False, STATE_OPEN
     )
 
 
@@ -117,21 +137,21 @@ async def test_cover_restore_state(hass, mock_device):
     """Test restore from cache."""
     mock_restore_cache(
         hass,
-        [State("cover.name", "open", attributes={ATTR_CURRENT_POSITION: 77})],
+        [State("cover.name", STATE_OPEN, attributes={ATTR_CURRENT_POSITION: 77})],
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_called_once_with(77)
     entity_state = hass.states.get("cover.name")
-    assert entity_state.state == "closed"
+    assert entity_state.state == STATE_OPEN
 
 
 async def test_cover_restore_state_bad_cache(hass, mock_device):
     """Test restore from a cache without the attribute."""
     mock_restore_cache(
         hass,
-        [State("cover.name", "open", attributes={"bla bla": 77})],
+        [State("cover.name", STATE_OPEN, attributes={"bla bla": 77})],
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_not_called()
     entity_state = hass.states.get("cover.name")
-    assert entity_state.state == "closed"
+    assert entity_state.state == STATE_CLOSED

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -49,7 +49,6 @@ def mock_device():
         mock_dev.is_closed = target == 0
 
     type(mock_dev).init_level = Mock(side_effect=mock_init_level)
-
     return mock_dev
 
 

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -49,6 +49,7 @@ def mock_device():
         mock_dev.is_closed = target == 0
 
     type(mock_dev).init_level = Mock(side_effect=mock_init_level)
+
     return mock_dev
 
 

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -13,6 +13,8 @@ from homeassistant.components.light import (
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_SUPPORTED_FEATURES,
+    STATE_OFF,
+    STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import State
@@ -54,7 +56,7 @@ async def test_light_setup(hass, mock_device):
     assert entity_state.attributes[ATTR_FRIENDLY_NAME] == mock_device.name
     assert entity_state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.BRIGHTNESS]
     assert entity_state.attributes[ATTR_SUPPORTED_FEATURES] == 0
-    assert entity_state.state == "off"
+    assert entity_state.state == STATE_OFF
     await run_service_tests(
         hass,
         mock_device,
@@ -90,13 +92,13 @@ async def test_light_restore_state(hass, mock_device):
     """Test restore from cache."""
     mock_restore_cache(
         hass,
-        [State("light.name", "on", attributes={ATTR_BRIGHTNESS: 77})],
+        [State("light.name", STATE_ON, attributes={ATTR_BRIGHTNESS: 77})],
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_called_once_with(77)
     entity_state = hass.states.get("light.name")
-    assert entity_state.state == "on"
-    assert entity_state.attributes["brightness"] == 77
+    assert entity_state.state == STATE_ON
+    assert entity_state.attributes[ATTR_BRIGHTNESS] == 77
     assert entity_state.attributes[ATTR_COLOR_MODE] == ColorMode.BRIGHTNESS
 
 
@@ -109,4 +111,4 @@ async def test_light_restore_state_bad_cache(hass, mock_device):
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_not_called()
     entity_state = hass.states.get("light.name")
-    assert entity_state.state == "off"
+    assert entity_state.state == STATE_OFF

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -44,7 +44,6 @@ def mock_device():
         mock_dev.brightness = target
 
     type(mock_dev).init_level = Mock(side_effect=mock_init_level)
-
     return mock_dev
 
 

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -36,6 +36,7 @@ def mock_device():
     """Mock a Dynalite device."""
     mock_dev = create_mock_device("light", DynaliteChannelLightDevice)
     mock_dev.brightness = 0
+<<<<<<< HEAD
 
     def mock_is_on():
         return mock_dev.brightness != 0
@@ -46,6 +47,8 @@ def mock_device():
         mock_dev.brightness = target
 
     type(mock_dev).init_level = Mock(side_effect=mock_init_level)
+=======
+>>>>>>> c456737520 (Implemented RestoreEntity)
     return mock_dev
 
 

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -46,7 +46,6 @@ def mock_device():
         mock_dev.brightness = target
 
     type(mock_dev).init_level = Mock(side_effect=mock_init_level)
-
     return mock_dev
 
 

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -1,4 +1,6 @@
 """Test Dynalite light."""
+from unittest.mock import Mock, PropertyMock
+
 from dynalite_devices_lib.light import DynaliteChannelLightDevice
 import pytest
 
@@ -32,6 +34,17 @@ def mock_device():
     """Mock a Dynalite device."""
     mock_dev = create_mock_device("light", DynaliteChannelLightDevice)
     mock_dev.brightness = 0
+
+    def mock_is_on():
+        return mock_dev.brightness != 0
+
+    type(mock_dev).is_on = PropertyMock(side_effect=mock_is_on)
+
+    def mock_init_level(target):
+        mock_dev.brightness = target
+
+    type(mock_dev).init_level = Mock(side_effect=mock_init_level)
+
     return mock_dev
 
 
@@ -40,10 +53,9 @@ async def test_light_setup(hass, mock_device):
     await create_entity_from_device(hass, mock_device)
     entity_state = hass.states.get("light.name")
     assert entity_state.attributes[ATTR_FRIENDLY_NAME] == mock_device.name
-    assert entity_state.attributes["brightness"] == mock_device.brightness
-    assert entity_state.attributes[ATTR_COLOR_MODE] == ColorMode.BRIGHTNESS
     assert entity_state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.BRIGHTNESS]
     assert entity_state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+    assert entity_state.state == "off"
     await run_service_tests(
         hass,
         mock_device,
@@ -83,13 +95,19 @@ async def test_light_restore_state(hass, mock_device):
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_called_once_with(77)
+    entity_state = hass.states.get("light.name")
+    assert entity_state.state == "on"
+    assert entity_state.attributes["brightness"] == 77
+    assert entity_state.attributes[ATTR_COLOR_MODE] == ColorMode.BRIGHTNESS
 
 
 async def test_light_restore_state_bad_cache(hass, mock_device):
     """Test restore from a cache without the attribute."""
     mock_restore_cache(
         hass,
-        [State("light.name", "on", attributes={"blabla": 77})],
+        [State("light.name", "abc", attributes={"blabla": 77})],
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_not_called()
+    entity_state = hass.states.get("light.name")
+    assert entity_state.state == "off"

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -36,7 +36,6 @@ def mock_device():
     """Mock a Dynalite device."""
     mock_dev = create_mock_device("light", DynaliteChannelLightDevice)
     mock_dev.brightness = 0
-<<<<<<< HEAD
 
     def mock_is_on():
         return mock_dev.brightness != 0
@@ -47,8 +46,7 @@ def mock_device():
         mock_dev.brightness = target
 
     type(mock_dev).init_level = Mock(side_effect=mock_init_level)
-=======
->>>>>>> c456737520 (Implemented RestoreEntity)
+
     return mock_dev
 
 

--- a/tests/components/dynalite/test_switch.py
+++ b/tests/components/dynalite/test_switch.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from dynalite_devices_lib.switch import DynalitePresetSwitchDevice
 import pytest
 
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import State
 
 from .common import (
@@ -37,7 +37,7 @@ async def test_switch_setup(hass, mock_device):
     await create_entity_from_device(hass, mock_device)
     entity_state = hass.states.get("switch.name")
     assert entity_state.attributes[ATTR_FRIENDLY_NAME] == mock_device.name
-    assert entity_state.state == "off"
+    assert entity_state.state == STATE_OFF
     await run_service_tests(
         hass,
         mock_device,
@@ -49,7 +49,7 @@ async def test_switch_setup(hass, mock_device):
     )
 
 
-@pytest.mark.parametrize("saved_state, level", [("on", 1), ("off", 0)])
+@pytest.mark.parametrize("saved_state, level", [(STATE_ON, 1), (STATE_OFF, 0)])
 async def test_switch_restore_state(hass, mock_device, saved_state, level):
     """Test restore from cache."""
     mock_restore_cache(

--- a/tests/components/dynalite/test_switch.py
+++ b/tests/components/dynalite/test_switch.py
@@ -4,6 +4,7 @@ from dynalite_devices_lib.switch import DynalitePresetSwitchDevice
 import pytest
 
 from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import State
 
 from .common import (
     ATTR_METHOD,
@@ -12,6 +13,8 @@ from .common import (
     create_mock_device,
     run_service_tests,
 )
+
+from tests.common import mock_restore_cache
 
 
 @pytest.fixture
@@ -34,3 +37,19 @@ async def test_switch_setup(hass, mock_device):
             {ATTR_SERVICE: "turn_off", ATTR_METHOD: "async_turn_off"},
         ],
     )
+
+
+@pytest.mark.parametrize("saved_state, level", [("on", 1), ("off", 0)])
+async def test_switch_restore_state(hass, mock_device, saved_state, level):
+    """Test restore from cache."""
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                "switch.name",
+                saved_state,
+            )
+        ],
+    )
+    await create_entity_from_device(hass, mock_device)
+    mock_device.init_level.assert_called_once_with(level)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changing the Dynalite entities to derive from RestoreEntity instead of Entity. This is especially important since Dynalite systems are quite "weak" in reporting states as it has to be actively pulled creating network load and not always 100% results. RestoreEntity improves this.

The changes required an updated dependency from 0.46 to 0.47 (https://github.com/ziv1234/python-dynalite-devices/releases/tag/v0.47)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
