### PR TITLE
Cache Canary camera image

### DIFF
--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -133,7 +133,6 @@ class CanaryCamera(CoordinatorEntity[CanaryDataUpdateCoordinator], Camera):
         await self._check_for_image_expiration()
 
         if self._image is None:
-            # if we still don't have an image, grab the live view
             _LOGGER.debug("Grabbing a live view image from %s", self.name)
             await self.hass.async_add_executor_job(self.renew_live_stream_session)
 
@@ -143,20 +142,19 @@ class CanaryCamera(CoordinatorEntity[CanaryDataUpdateCoordinator], Camera):
             if not (live_stream_url := live_stream_session.live_stream_url):
                 return None
 
-            if self._image is None and live_stream_url:
-                image = await ffmpeg.async_get_image(
-                    self.hass,
-                    live_stream_url,
-                    extra_cmd=self._ffmpeg_arguments,
-                    width=width,
-                    height=height,
-                )
+            image = await ffmpeg.async_get_image(
+                self.hass,
+                live_stream_url,
+                extra_cmd=self._ffmpeg_arguments,
+                width=width,
+                height=height,
+            )
 
-                if image:
-                    self._image = image
-                    _LOGGER.debug("Grabbed a live view image from %s", self.name)
-                await self.hass.async_add_executor_job(live_stream_session.stop_session)
-                _LOGGER.debug("Stopped live session from %s", self.name)
+            if image:
+                self._image = image
+                _LOGGER.debug("Grabbed a live view image from %s", self.name)
+            await self.hass.async_add_executor_job(live_stream_session.stop_session)
+            _LOGGER.debug("Stopped live session from %s", self.name)
 
         return self._image
 

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -151,9 +151,7 @@ class CanaryCamera(CoordinatorEntity[CanaryDataUpdateCoordinator], Camera):
                 if image:
                     self._image = image
                     _LOGGER.debug("Grabbed a live view image from %s", self.name)
-                await self.hass.async_add_executor_job(
-                    self._live_stream_session.stop_session
-                )
+                await self.hass.async_add_executor_job(live_stream_session.stop_session)
                 _LOGGER.debug("Stopped live session from %s", self.name)
 
         return self._image

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -133,11 +133,10 @@ class CanaryCamera(CoordinatorEntity[CanaryDataUpdateCoordinator], Camera):
             _LOGGER.debug("Grabbing a live view image from %s", self.name)
             await self.hass.async_add_executor_job(self.renew_live_stream_session)
 
-            if self._live_stream_session is None:
+            if (live_stream_session := self._live_stream_session) is None:
                 return None
 
-            live_stream_url = self._live_stream_session.live_stream_url
-            if not live_stream_url:
+            if not (live_stream_url := live_stream_session.live_stream_url):
                 return None
 
             if self._image is None and live_stream_url:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add cached image for camera so a new image is not retrieved upon every refresh

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [PR 73922](https://github.com/home-assistant/core/pull/73922)
- Link to documentation pull request: 

with py-canary 0.5.3 the updated image will refresh every time an image is requested flooding the Canary servers to get a new image every 10 or so seconds.  This will grab an image and hold it until the next reload (next pull request will use canary entries api to update the image cache when a new entry is updated)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
