### PR TITLE
Fix logbook state query with postgresql

### DIFF
--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -377,9 +377,9 @@ def _rows_match(row: Row | EventAsRow, other_row: Row | EventAsRow) -> bool:
     """Check of rows match by using the same method as Events __hash__."""
     if (
         row is other_row
-        or (state_id := row.state_id) is not None
+        or (state_id := row.state_id)
         and state_id == other_row.state_id
-        or (event_id := row.event_id) is not None
+        or (event_id := row.event_id)
         and event_id == other_row.event_id
     ):
         return True

--- a/homeassistant/components/logbook/queries/common.py
+++ b/homeassistant/components/logbook/queries/common.py
@@ -87,7 +87,7 @@ EVENT_COLUMNS_FOR_STATE_SELECT = [
 ]
 
 EMPTY_STATE_COLUMNS = (
-    literal(value=None, type_=sqlalchemy.String).label("state_id"),
+    literal(value=0, type_=sqlalchemy.Integer).label("state_id"),
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
     literal(value=None, type_=sqlalchemy.String).label("icon"),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We need to type this to a number as postgresql will complain
  about trying to union it with a text field since it assumed
  the null as text

Found while testing #73554
```
Traceback (most recent call last):                                                                                         
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
    await func(hass, connection, msg)                                                                                      
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 387, in ws_event_stream
    last_event_time = await _async_send_historical_events(                                                                 
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 117, in _async_send_historical_events
    message, last_event_time = await _async_get_ws_stream_events(                                                                                                                                                                               
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 182, in _async_get_ws_stream_events                                                                                                                     
    return await get_instance(hass).async_add_executor_job(                                                                                                                                                                                     
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run                                                                                                                                                                 
    result = self.fn(*self.args, **self.kwargs)                                                                                                                                                                                                 
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 213, in _ws_stream_get_events                                                                                                                          
    events = event_processor.get_events(start_day, end_day)                                                                                                                                                                                     
  File "/usr/src/homeassistant/homeassistant/components/logbook/processor.py", line 164, in get_events                                                                                                                                         
    return self.humanify(yield_rows(session.execute(stmt)))                                                                                                                                                                                     
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 1712, in execute                                                                                                                                                
    result = conn._execute_20(statement, params or {}, execution_options)                                                                                                                                                                       
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1631, in _execute_20                                                                                                                                            
    return meth(self, args_10style, kwargs_10style, execution_options)                                                                               
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/sql/lambdas.py", line 516, in _execute_on_connection                                                              
    return connection._execute_clauseelement(                                                              
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1498, in _execute_clauseelement                                                                                       
    ret = self._execute_context(                                                                                                                                                         
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1862, in _execute_context                                            
    self._handle_dbapi_exception(                                                                                                                             
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 2043, in _handle_dbapi_exception                                     
    util.raise_(                                                                                                                                              
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 208, in raise_                       
    raise exception                                                                                                                                           
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1819, in _execute_context            
    self.dialect.do_execute(                                                                                                                                
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute                
    cursor.execute(statement, parameters)                                                                                                                    
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.DatatypeMismatch) UNION types text and integer cannot be matched                                                                                                                      
LINE 9: ...ent_id AS context_parent_id, NULL AS shared_data, states.sta...                                           
                                                             ^                                                                         
                                                                                               
[SQL: WITH anon_1 AS                                                                                                                                                                                                                            
(SELECT anon_2.context_id AS context_id                                                             
FROM (SELECT events.context_id AS context_id                                                                                                                                                                                                    
FROM events LEFT OUTER JOIN event_data ON events.data_id = event_data.data_id                                                                                                                                                                   
WHERE events.time_fired > %(start_day_1)s AND events.time_fired < %(end_day_1)s AND events.event_type IN (%(event_types_1_1)s, %(event_types_1_2)s, %(event_types_1_3)s, %(event_types_1_4)s) AND (CAST(event_data.shared_data AS JSONB) -> %(pa
 SELECT events.event_id AS event_id, events.event_type AS event_type, events.event_data AS event_data, events.time_fired AS time_fired, events.context_id AS context_id, events.context_user_id AS context_user_id, events.context_parent_id AS
FROM events LEFT OUTER JOIN event_data ON events.data_id = event_data.data_id
WHERE events.time_fired > %(start_day_1)s AND events.time_fired < %(end_day_1)s AND events.event_type IN (%(event_types_1_1)s, %(event_types_1_2)s, %(event_types_1_3)s, %(event_types_1_4)s) AND (CAST(event_data.shared_data AS JSONB) -> %(pa
FROM anon_1 LEFT OUTER JOIN events ON anon_1.context_id = events.context_id LEFT OUTER JOIN event_data ON events.data_id = event_data.data_id UNION ALL SELECT %(param_9)s AS event_id, %(param_10)s AS event_type, %(param_11)s AS event_data,
FROM anon_1 LEFT OUTER JOIN states ON anon_1.context_id = states.context_id ORDER BY time_fired]
[parameters: {'param_1': None, 'param_2': None, 'param_3': None, 'param_4': None, 'param_5': None, 'param_6': None, 'start_day_1': datetime.datetime(2022, 6, 22, 20, 36, 38, 954000, tzinfo=datetime.timezone.utc), 'end_day_1': datetime.datet
(Background on this error at: https://sqlalche.me/e/14/f405)        
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
