### PR TITLE
Add websocket command recorder/import_statistics

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -73,7 +73,7 @@ from .tasks import (
     CommitTask,
     DatabaseLockTask,
     EventTask,
-    ExternalStatisticsTask,
+    ImportStatisticsTask,
     KeepAliveTask,
     PerodicCleanupTask,
     PurgeTask,
@@ -479,11 +479,11 @@ class Recorder(threading.Thread):
         )
 
     @callback
-    def async_external_statistics(
+    def async_import_statistics(
         self, metadata: StatisticMetaData, stats: Iterable[StatisticData]
     ) -> None:
-        """Schedule external statistics."""
-        self.queue_task(ExternalStatisticsTask(metadata, stats))
+        """Schedule import of statistics."""
+        self.queue_task(ImportStatisticsTask(metadata, stats))
 
     @callback
     def _async_setup_periodic_tasks(self) -> None:

--- a/homeassistant/components/recorder/tasks.py
+++ b/homeassistant/components/recorder/tasks.py
@@ -124,18 +124,18 @@ class StatisticsTask(RecorderTask):
 
 
 @dataclass
-class ExternalStatisticsTask(RecorderTask):
-    """An object to insert into the recorder queue to run an external statistics task."""
+class ImportStatisticsTask(RecorderTask):
+    """An object to insert into the recorder queue to run an import statistics task."""
 
     metadata: StatisticMetaData
     statistics: Iterable[StatisticData]
 
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
-        if statistics.add_external_statistics(instance, self.metadata, self.statistics):
+        if statistics.import_statistics(instance, self.metadata, self.statistics):
             return
         # Schedule a new statistics task if this one didn't finish
-        instance.queue_task(ExternalStatisticsTask(self.metadata, self.statistics))
+        instance.queue_task(ImportStatisticsTask(self.metadata, self.statistics))
 
 
 @dataclass

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -17,6 +17,7 @@ from homeassistant.components.recorder.db_schema import StatisticsShortTerm
 from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
+    async_import_statistics,
     delete_statistics_duplicates,
     delete_statistics_meta_duplicates,
     get_last_short_term_statistics,
@@ -437,26 +438,45 @@ def test_statistics_duplicated(hass_recorder, caplog):
         caplog.clear()
 
 
-async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
-    """Test inserting external statistics."""
+@pytest.mark.parametrize("last_reset_str", ("2022-01-01T00:00:00+02:00", None))
+@pytest.mark.parametrize(
+    "source, statistic_id, import_fn",
+    (
+        ("test", "test:total_energy_import", async_add_external_statistics),
+        ("recorder", "sensor.total_energy_import", async_import_statistics),
+    ),
+)
+async def test_import_statistics(
+    hass,
+    hass_ws_client,
+    recorder_mock,
+    caplog,
+    source,
+    statistic_id,
+    import_fn,
+    last_reset_str,
+):
+    """Test importing statistics and inserting external statistics."""
     client = await hass_ws_client()
 
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
 
     zero = dt_util.utcnow()
+    last_reset = dt_util.parse_datetime(last_reset_str) if last_reset_str else None
+    last_reset_utc_str = dt_util.as_utc(last_reset).isoformat() if last_reset else None
     period1 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
     period2 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=2)
 
     external_statistics1 = {
         "start": period1,
-        "last_reset": None,
+        "last_reset": last_reset,
         "state": 0,
         "sum": 2,
     }
     external_statistics2 = {
         "start": period2,
-        "last_reset": None,
+        "last_reset": last_reset,
         "state": 1,
         "sum": 3,
     }
@@ -465,37 +485,35 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
         "has_mean": False,
         "has_sum": True,
         "name": "Total imported energy",
-        "source": "test",
-        "statistic_id": "test:total_energy_import",
+        "source": source,
+        "statistic_id": statistic_id,
         "unit_of_measurement": "kWh",
     }
 
-    async_add_external_statistics(
-        hass, external_metadata, (external_statistics1, external_statistics2)
-    )
+    import_fn(hass, external_metadata, (external_statistics1, external_statistics2))
     await async_wait_recording_done(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
-        "test:total_energy_import": [
+        statistic_id: [
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
                 "max": None,
                 "mean": None,
                 "min": None,
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(0.0),
                 "sum": approx(2.0),
             },
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period2.isoformat(),
                 "end": (period2 + timedelta(hours=1)).isoformat(),
                 "max": None,
                 "mean": None,
                 "min": None,
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(1.0),
                 "sum": approx(3.0),
             },
@@ -506,37 +524,37 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
         {
             "has_mean": False,
             "has_sum": True,
-            "statistic_id": "test:total_energy_import",
+            "statistic_id": statistic_id,
             "name": "Total imported energy",
-            "source": "test",
+            "source": source,
             "unit_of_measurement": "kWh",
         }
     ]
-    metadata = get_metadata(hass, statistic_ids=("test:total_energy_import",))
+    metadata = get_metadata(hass, statistic_ids=(statistic_id,))
     assert metadata == {
-        "test:total_energy_import": (
+        statistic_id: (
             1,
             {
                 "has_mean": False,
                 "has_sum": True,
                 "name": "Total imported energy",
-                "source": "test",
-                "statistic_id": "test:total_energy_import",
+                "source": source,
+                "statistic_id": statistic_id,
                 "unit_of_measurement": "kWh",
             },
         )
     }
-    last_stats = get_last_statistics(hass, 1, "test:total_energy_import", True)
+    last_stats = get_last_statistics(hass, 1, statistic_id, True)
     assert last_stats == {
-        "test:total_energy_import": [
+        statistic_id: [
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period2.isoformat(),
                 "end": (period2 + timedelta(hours=1)).isoformat(),
                 "max": None,
                 "mean": None,
                 "min": None,
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(1.0),
                 "sum": approx(3.0),
             },
@@ -550,13 +568,13 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
         "state": 5,
         "sum": 6,
     }
-    async_add_external_statistics(hass, external_metadata, (external_statistics,))
+    import_fn(hass, external_metadata, (external_statistics,))
     await async_wait_recording_done(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
-        "test:total_energy_import": [
+        statistic_id: [
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
                 "max": None,
@@ -567,13 +585,13 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
                 "sum": approx(6.0),
             },
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period2.isoformat(),
                 "end": (period2 + timedelta(hours=1)).isoformat(),
                 "max": None,
                 "mean": None,
                 "min": None,
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(1.0),
                 "sum": approx(3.0),
             },
@@ -586,34 +604,34 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
         "max": 1,
         "mean": 2,
         "min": 3,
-        "last_reset": None,
+        "last_reset": last_reset,
         "state": 4,
         "sum": 5,
     }
-    async_add_external_statistics(hass, external_metadata, (external_statistics,))
+    import_fn(hass, external_metadata, (external_statistics,))
     await async_wait_recording_done(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
-        "test:total_energy_import": [
+        statistic_id: [
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
                 "max": approx(1.0),
                 "mean": approx(2.0),
                 "min": approx(3.0),
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(4.0),
                 "sum": approx(5.0),
             },
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period2.isoformat(),
                 "end": (period2 + timedelta(hours=1)).isoformat(),
                 "max": None,
                 "mean": None,
                 "min": None,
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(1.0),
                 "sum": approx(3.0),
             },
@@ -624,7 +642,7 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
         {
             "id": 1,
             "type": "recorder/adjust_sum_statistics",
-            "statistic_id": "test:total_energy_import",
+            "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
         }
@@ -635,26 +653,26 @@ async def test_external_statistics(hass, hass_ws_client, recorder_mock, caplog):
     await async_wait_recording_done(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
-        "test:total_energy_import": [
+        statistic_id: [
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
                 "max": approx(1.0),
                 "mean": approx(2.0),
                 "min": approx(3.0),
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(4.0),
                 "sum": approx(5.0),
             },
             {
-                "statistic_id": "test:total_energy_import",
+                "statistic_id": statistic_id,
                 "start": period2.isoformat(),
                 "end": (period2 + timedelta(hours=1)).isoformat(),
                 "max": None,
                 "mean": None,
                 "min": None,
-                "last_reset": None,
+                "last_reset": last_reset_utc_str,
                 "state": approx(1.0),
                 "sum": approx(1003.0),
             },
@@ -670,11 +688,12 @@ def test_external_statistics_errors(hass_recorder, caplog):
     assert "Statistics already compiled" not in caplog.text
 
     zero = dt_util.utcnow()
+    last_reset = zero.replace(minute=0, second=0, microsecond=0) - timedelta(days=1)
     period1 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
 
     _external_statistics = {
         "start": period1,
-        "last_reset": None,
+        "last_reset": last_reset,
         "state": 0,
         "sum": 2,
     }
@@ -711,7 +730,7 @@ def test_external_statistics_errors(hass_recorder, caplog):
     assert list_statistic_ids(hass) == []
     assert get_metadata(hass, statistic_ids=("test:total_energy_import",)) == {}
 
-    # Attempt to insert statistics for an naive starting time
+    # Attempt to insert statistics for a naive starting time
     external_metadata = {**_external_metadata}
     external_statistics = {
         **_external_statistics,
@@ -733,6 +752,106 @@ def test_external_statistics_errors(hass_recorder, caplog):
     assert statistics_during_period(hass, zero, period="hour") == {}
     assert list_statistic_ids(hass) == []
     assert get_metadata(hass, statistic_ids=("test:total_energy_import",)) == {}
+
+    # Attempt to insert statistics with a naive last_reset
+    external_metadata = {**_external_metadata}
+    external_statistics = {
+        **_external_statistics,
+        "last_reset": last_reset.replace(tzinfo=None),
+    }
+    with pytest.raises(HomeAssistantError):
+        async_add_external_statistics(hass, external_metadata, (external_statistics,))
+    wait_recording_done(hass)
+    assert statistics_during_period(hass, zero, period="hour") == {}
+    assert list_statistic_ids(hass) == []
+    assert get_metadata(hass, statistic_ids=("test:total_energy_import",)) == {}
+
+
+def test_import_statistics_errors(hass_recorder, caplog):
+    """Test validation of imported statistics."""
+    hass = hass_recorder()
+    wait_recording_done(hass)
+    assert "Compiling statistics for" not in caplog.text
+    assert "Statistics already compiled" not in caplog.text
+
+    zero = dt_util.utcnow()
+    last_reset = zero.replace(minute=0, second=0, microsecond=0) - timedelta(days=1)
+    period1 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+
+    _external_statistics = {
+        "start": period1,
+        "last_reset": last_reset,
+        "state": 0,
+        "sum": 2,
+    }
+
+    _external_metadata = {
+        "has_mean": False,
+        "has_sum": True,
+        "name": "Total imported energy",
+        "source": "recorder",
+        "statistic_id": "sensor.total_energy_import",
+        "unit_of_measurement": "kWh",
+    }
+
+    # Attempt to insert statistics for an external source
+    external_metadata = {
+        **_external_metadata,
+        "statistic_id": "test:total_energy_import",
+    }
+    external_statistics = {**_external_statistics}
+    with pytest.raises(HomeAssistantError):
+        async_import_statistics(hass, external_metadata, (external_statistics,))
+    wait_recording_done(hass)
+    assert statistics_during_period(hass, zero, period="hour") == {}
+    assert list_statistic_ids(hass) == []
+    assert get_metadata(hass, statistic_ids=("test:total_energy_import",)) == {}
+
+    # Attempt to insert statistics for the wrong domain
+    external_metadata = {**_external_metadata, "source": "sensor"}
+    external_statistics = {**_external_statistics}
+    with pytest.raises(HomeAssistantError):
+        async_import_statistics(hass, external_metadata, (external_statistics,))
+    wait_recording_done(hass)
+    assert statistics_during_period(hass, zero, period="hour") == {}
+    assert list_statistic_ids(hass) == []
+    assert get_metadata(hass, statistic_ids=("sensor.total_energy_import",)) == {}
+
+    # Attempt to insert statistics for a naive starting time
+    external_metadata = {**_external_metadata}
+    external_statistics = {
+        **_external_statistics,
+        "start": period1.replace(tzinfo=None),
+    }
+    with pytest.raises(HomeAssistantError):
+        async_import_statistics(hass, external_metadata, (external_statistics,))
+    wait_recording_done(hass)
+    assert statistics_during_period(hass, zero, period="hour") == {}
+    assert list_statistic_ids(hass) == []
+    assert get_metadata(hass, statistic_ids=("sensor.total_energy_import",)) == {}
+
+    # Attempt to insert statistics for an invalid starting time
+    external_metadata = {**_external_metadata}
+    external_statistics = {**_external_statistics, "start": period1.replace(minute=1)}
+    with pytest.raises(HomeAssistantError):
+        async_import_statistics(hass, external_metadata, (external_statistics,))
+    wait_recording_done(hass)
+    assert statistics_during_period(hass, zero, period="hour") == {}
+    assert list_statistic_ids(hass) == []
+    assert get_metadata(hass, statistic_ids=("sensor.total_energy_import",)) == {}
+
+    # Attempt to insert statistics with a naive last_reset
+    external_metadata = {**_external_metadata}
+    external_statistics = {
+        **_external_statistics,
+        "last_reset": last_reset.replace(tzinfo=None),
+    }
+    with pytest.raises(HomeAssistantError):
+        async_import_statistics(hass, external_metadata, (external_statistics,))
+    wait_recording_done(hass)
+    assert statistics_during_period(hass, zero, period="hour") == {}
+    assert list_statistic_ids(hass) == []
+    assert get_metadata(hass, statistic_ids=("sensor.total_energy_import",)) == {}
 
 
 @pytest.mark.parametrize("timezone", ["America/Regina", "Europe/Vienna", "UTC"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a new websocket command `recorder/import_statistics`

The command is very similar to exisingt Python API `recorder.statistics.add_external_statistic`, but also allows injecting statistics for sensors, i.e. non external sources.

I have two use cases:
- Using an external one shot script to import historical data from the electricity provider database (in my case Hydroquebec).
- My Electricity provider (Hydroquebec) doesn't provide "live" data. It provides data only several hours later. So, I will make a script that import statistic data when I can get it. This script will use the new endpoint to push data. I guess there are other electricity providers that have the same kind of limitation.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
