### PR TITLE
Move add/remove logic of deCONZ groups to gateway class

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 import async_timeout
 from pydeconz import DeconzSession, errors
 from pydeconz.interfaces.api import APIItems, GroupedAPIItems
+from pydeconz.interfaces.groups import Groups
 from pydeconz.models.event import EventType
 
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
@@ -59,18 +60,18 @@ class DeconzGateway:
         self.ignore_state_updates = False
 
         self.signal_reachable = f"deconz-reachable-{config_entry.entry_id}"
-        self.signal_reload_groups = f"deconz_reload_group_{config_entry.entry_id}"
         self.signal_reload_clip_sensors = f"deconz_reload_clip_{config_entry.entry_id}"
 
         self.deconz_ids: dict[str, str] = {}
         self.entities: dict[str, set[str]] = {}
         self.events: list[DeconzAlarmEvent | DeconzEvent] = []
         self.ignored_devices: set[tuple[Callable[[EventType, str], None], str]] = set()
+        self.deconz_groups: set[tuple[Callable[[EventType, str], None], str]] = set()
 
-        self._option_allow_deconz_groups = self.config_entry.options.get(
+        self.option_allow_deconz_groups = config_entry.options.get(
             CONF_ALLOW_DECONZ_GROUPS, DEFAULT_ALLOW_DECONZ_GROUPS
         )
-        self.option_allow_new_devices = self.config_entry.options.get(
+        self.option_allow_new_devices = config_entry.options.get(
             CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES
         )
 
@@ -98,13 +99,6 @@ class DeconzGateway:
             CONF_ALLOW_CLIP_SENSOR, DEFAULT_ALLOW_CLIP_SENSOR
         )
 
-    @property
-    def option_allow_deconz_groups(self) -> bool:
-        """Allow loading deCONZ groups from gateway."""
-        return self.config_entry.options.get(
-            CONF_ALLOW_DECONZ_GROUPS, DEFAULT_ALLOW_DECONZ_GROUPS
-        )
-
     @callback
     def register_platform_add_device_callback(
         self,
@@ -113,16 +107,28 @@ class DeconzGateway:
     ) -> None:
         """Wrap add_device_callback to check allow_new_devices option."""
 
-        def async_add_device(event: EventType, device_id: str) -> None:
+        initializing = True
+
+        def async_add_device(_: EventType, device_id: str) -> None:
             """Add device or add it to ignored_devices set.
 
             If ignore_state_updates is True means device_refresh service is used.
             Device_refresh is expected to load new devices.
             """
-            if not self.option_allow_new_devices and not self.ignore_state_updates:
+            if (
+                not initializing
+                and not self.option_allow_new_devices
+                and not self.ignore_state_updates
+            ):
                 self.ignored_devices.add((async_add_device, device_id))
                 return
-            add_device_callback(event, device_id)
+
+            if isinstance(deconz_device_interface, Groups):
+                self.deconz_groups.add((async_add_device, device_id))
+                if not self.option_allow_deconz_groups:
+                    return
+
+            add_device_callback(EventType.ADDED, device_id)
 
         self.config_entry.async_on_unload(
             deconz_device_interface.subscribe(
@@ -132,7 +138,9 @@ class DeconzGateway:
         )
 
         for device_id in deconz_device_interface:
-            add_device_callback(EventType.ADDED, device_id)
+            async_add_device(EventType.ADDED, device_id)
+
+        initializing = False
 
     @callback
     def load_ignored_devices(self) -> None:
@@ -216,13 +224,16 @@ class DeconzGateway:
 
         # Allow Groups
 
-        if self.option_allow_deconz_groups:
-            if not self._option_allow_deconz_groups:
-                async_dispatcher_send(self.hass, self.signal_reload_groups)
-        else:
-            deconz_ids += [group.deconz_id for group in self.api.groups.values()]
-
-        self._option_allow_deconz_groups = self.option_allow_deconz_groups
+        option_allow_deconz_groups = self.config_entry.options.get(
+            CONF_ALLOW_DECONZ_GROUPS, DEFAULT_ALLOW_DECONZ_GROUPS
+        )
+        if option_allow_deconz_groups != self.option_allow_deconz_groups:
+            self.option_allow_deconz_groups = option_allow_deconz_groups
+            if option_allow_deconz_groups:
+                for add_device, device_id in self.deconz_groups:
+                    add_device(EventType.ADDED, device_id)
+            else:
+                deconz_ids += [group.deconz_id for group in self.api.groups.values()]
 
         # Allow adding new devices
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move more load/remove logic to gateway class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
