### PR TITLE
Add Hive device configuration to config flow

### DIFF
--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -103,11 +103,12 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input:
+            if self.device_registration:
+                self.device_name = user_input["device_name"]
+                await self.hive_auth.device_registration(user_input["device_name"])
+                self.data["device_data"] = await self.hive_auth.get_device_data()
+
             try:
-                if self.device_registration:
-                    self.device_name = user_input["device_name"]
-                    await self.hive_auth.device_registration(user_input["device_name"])
-                    self.data["device_data"] = await self.hive_auth.get_device_data()
                 return await self.async_setup_hive_entry()
             except UnknownHiveError:
                 errors["base"] = "unknown"

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -61,9 +61,12 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 # Configure the entry.
-                if self.context["source"] == config_entries.SOURCE_REAUTH:
-                    return await self.async_setup_hive_entry()
-                return await self.async_step_configuration()
+                try:
+                    if self.context["source"] == config_entries.SOURCE_REAUTH:
+                        return await self.async_setup_hive_entry()
+                    return await self.async_step_configuration()
+                except UnknownHiveError:
+                    errors["base"] = "unknown"
 
         # Show User Input form.
         schema = vol.Schema(
@@ -88,10 +91,13 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_internet_available"
 
             if not errors:
-                if self.context["source"] == config_entries.SOURCE_REAUTH:
-                    return await self.async_setup_hive_entry()
-                self.device_registration = True
-                return await self.async_step_configuration()
+                try:
+                    if self.context["source"] == config_entries.SOURCE_REAUTH:
+                        return await self.async_setup_hive_entry()
+                    self.device_registration = True
+                    return await self.async_step_configuration()
+                except UnknownHiveError:
+                    errors["base"] = "unknown"
 
         schema = vol.Schema({vol.Required(CONF_CODE): str})
         return self.async_show_form(step_id="2fa", data_schema=schema, errors=errors)

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -90,13 +90,10 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_internet_available"
 
             if not errors:
-                try:
-                    if self.context["source"] == config_entries.SOURCE_REAUTH:
-                        return await self.async_setup_hive_entry()
-                    self.device_registration = True
-                    return await self.async_step_configuration()
-                except UnknownHiveError:
-                    errors["base"] = "unknown"
+                if self.context["source"] == config_entries.SOURCE_REAUTH:
+                    return await self.async_setup_hive_entry()
+                self.device_registration = True
+                return await self.async_step_configuration()
 
         schema = vol.Schema({vol.Required(CONF_CODE): str})
         return self.async_show_form(step_id="2fa", data_schema=schema, errors=errors)

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import CONF_CODE, CONFIG_ENTRY_VERSION, DOMAIN
+from .const import CONF_CODE, CONF_DEVICE_NAME, CONFIG_ENTRY_VERSION, DOMAIN
 
 
 class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -91,12 +91,37 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 try:
                     self.device_registration = True
-                    return await self.async_setup_hive_entry()
+                    return await self.async_step_configuration()
                 except UnknownHiveError:
                     errors["base"] = "unknown"
 
         schema = vol.Schema({vol.Required(CONF_CODE): str})
         return self.async_show_form(step_id="2fa", data_schema=schema, errors=errors)
+
+    async def async_step_configuration(self, user_input=None):
+        """Handle hive configuration step."""
+        errors = {}
+
+        if user_input:
+            if not errors:
+                try:
+                    if self.device_registration:
+                        await self.hive_auth.device_registration(
+                            user_input["device_name"]
+                        )
+                        self.data[
+                            "device_data"
+                        ] = await self.hive_auth.get_device_data()
+                    return await self.async_setup_hive_entry()
+                except UnknownHiveError:
+                    errors["base"] = "unknown"
+
+        schema = vol.Schema(
+            {vol.Optional(CONF_DEVICE_NAME, default="Home Assistant"): str}
+        )
+        return self.async_show_form(
+            step_id="configuration", data_schema=schema, errors=errors
+        )
 
     async def async_setup_hive_entry(self):
         """Finish setup and create the config entry."""
@@ -105,9 +130,6 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             raise UnknownHiveError
 
         # Setup the config entry
-        if self.device_registration:
-            await self.hive_auth.device_registration("Home Assistant")
-            self.data["device_data"] = await self.hive_auth.getDeviceData()
         self.data["tokens"] = self.tokens
         if self.context["source"] == config_entries.SOURCE_REAUTH:
             self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -60,11 +60,10 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_2fa()
 
             if not errors:
-                # Complete the entry setup.
-                try:
+                # Configure the entry.
+                if self.context["source"] == config_entries.SOURCE_REAUTH:
                     return await self.async_setup_hive_entry()
-                except UnknownHiveError:
-                    errors["base"] = "unknown"
+                return await self.async_step_configuration()
 
         # Show User Input form.
         schema = vol.Schema(
@@ -89,11 +88,10 @@ class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_internet_available"
 
             if not errors:
-                try:
-                    self.device_registration = True
-                    return await self.async_step_configuration()
-                except UnknownHiveError:
-                    errors["base"] = "unknown"
+                if self.context["source"] == config_entries.SOURCE_REAUTH:
+                    return await self.async_setup_hive_entry()
+                self.device_registration = True
+                return await self.async_step_configuration()
 
         schema = vol.Schema({vol.Required(CONF_CODE): str})
         return self.async_show_form(step_id="2fa", data_schema=schema, errors=errors)

--- a/homeassistant/components/hive/const.py
+++ b/homeassistant/components/hive/const.py
@@ -5,6 +5,7 @@ ATTR_MODE = "mode"
 ATTR_TIME_PERIOD = "time_period"
 ATTR_ONOFF = "on_off"
 CONF_CODE = "2fa"
+CONF_DEVICE_NAME = "device_name"
 CONFIG_ENTRY_VERSION = 1
 DEFAULT_NAME = "Hive"
 DOMAIN = "hive"

--- a/homeassistant/components/hive/manifest.json
+++ b/homeassistant/components/hive/manifest.json
@@ -6,7 +6,7 @@
     "models": ["HHKBridge*"]
   },
   "documentation": "https://www.home-assistant.io/integrations/hive",
-  "requirements": ["pyhiveapi==0.5.12"],
+  "requirements": ["pyhiveapi==0.5.13"],
   "codeowners": ["@Rendili", "@KJonline"],
   "iot_class": "cloud_polling",
   "loggers": ["apyhiveapi"]

--- a/homeassistant/components/hive/manifest.json
+++ b/homeassistant/components/hive/manifest.json
@@ -6,7 +6,7 @@
     "models": ["HHKBridge*"]
   },
   "documentation": "https://www.home-assistant.io/integrations/hive",
-  "requirements": ["pyhiveapi==0.5.11"],
+  "requirements": ["pyhiveapi==0.5.12"],
   "codeowners": ["@Rendili", "@KJonline"],
   "iot_class": "cloud_polling",
   "loggers": ["apyhiveapi"]

--- a/homeassistant/components/hive/strings.json
+++ b/homeassistant/components/hive/strings.json
@@ -17,6 +17,13 @@
           "2fa": "Two-factor code"
         }
       },
+      "configuration": {
+        "data": {
+          "device_name": "Device Name"
+        },
+        "description": "Enter your Hive configuration ",
+        "title": "Hive Configuration."
+      },
       "reauth": {
         "title": "Hive Login",
         "description": "Re-enter your Hive login information.",

--- a/homeassistant/components/hive/strings.json
+++ b/homeassistant/components/hive/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Hive Login",
-        "description": "Enter your Hive login information and configuration.",
+        "description": "Enter your Hive login information.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",

--- a/homeassistant/components/hive/translations/en.json
+++ b/homeassistant/components/hive/translations/en.json
@@ -20,6 +20,13 @@
                 "description": "Enter your Hive authentication code. \n \n Please enter code 0000 to request another code.",
                 "title": "Hive Two-factor Authentication."
             },
+            "configuration": {
+                "data": {
+                    "device_name": "Device Name"
+                },
+                "description": "Enter your Hive configuration ",
+                "title": "Hive Configuration."
+            },
             "reauth": {
                 "data": {
                     "password": "Password",
@@ -34,7 +41,7 @@
                     "scan_interval": "Scan Interval (seconds)",
                     "username": "Username"
                 },
-                "description": "Enter your Hive login information and configuration.",
+                "description": "Enter your Hive login information.",
                 "title": "Hive Login"
             }
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1541,7 +1541,7 @@ pyheos==0.7.2
 pyhik==0.3.0
 
 # homeassistant.components.hive
-pyhiveapi==0.5.11
+pyhiveapi==0.5.12
 
 # homeassistant.components.homematic
 pyhomematic==0.1.77

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1541,7 +1541,7 @@ pyheos==0.7.2
 pyhik==0.3.0
 
 # homeassistant.components.hive
-pyhiveapi==0.5.12
+pyhiveapi==0.5.13
 
 # homeassistant.components.homematic
 pyhomematic==0.1.77

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1035,7 +1035,7 @@ pyhaversion==22.4.1
 pyheos==0.7.2
 
 # homeassistant.components.hive
-pyhiveapi==0.5.11
+pyhiveapi==0.5.12
 
 # homeassistant.components.homematic
 pyhomematic==0.1.77

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1035,7 +1035,7 @@ pyhaversion==22.4.1
 pyheos==0.7.2
 
 # homeassistant.components.hive
-pyhiveapi==0.5.12
+pyhiveapi==0.5.13
 
 # homeassistant.components.homematic
 pyhomematic==0.1.77

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -34,31 +34,21 @@ async def test_import_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ):
+    ), patch(
+        "homeassistant.components.hive.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.hive.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "configuration"
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.hive.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.hive.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_DEVICE_NAME: DEVICE_NAME},
-        )
-
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == USERNAME
-    assert result2["data"] == {
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -92,31 +82,21 @@ async def test_user_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
-        )
-
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["step_id"] == "configuration"
-    assert result2["errors"] == {}
-
-    with patch(
+    ), patch(
         "homeassistant.components.hive.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.hive.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result3 = await hass.config_entries.flow.async_configure(
+        result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_DEVICE_NAME: DEVICE_NAME},
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result3["title"] == USERNAME
-    assert result3["data"] == {
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == USERNAME
+    assert result2["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -690,19 +670,10 @@ async def test_user_flow_unknown_error(hass):
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["errors"] == {}
-
-    result3 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {CONF_DEVICE_NAME: DEVICE_NAME},
-    )
-    await hass.async_block_till_done()
-
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result3["step_id"] == "configuration"
-    assert result3["errors"] == {"base": "unknown"}
+    assert result2["errors"] == {"base": "unknown"}
 
 
 async def test_user_flow_2fa_unknown_error(hass):

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -351,7 +351,7 @@ async def test_reauth_2fa_flow(hass):
                 CONF_CODE: MFA_CODE,
             },
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == UPDATED_PASSWORD

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -325,8 +325,6 @@ async def test_reauth_2fa_flow(hass):
             },
         },
     ), patch(
-        "homeassistant.components.hive.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.hive.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -342,7 +340,6 @@ async def test_reauth_2fa_flow(hass):
     assert mock_config.data.get("password") == UPDATED_PASSWORD
     assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result3["reason"] == "reauth_successful"
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from apyhiveapi.helper import hive_exceptions
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.hive.const import CONF_CODE, DOMAIN
+from homeassistant.components.hive.const import CONF_CODE, CONF_DEVICE_NAME, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 
 from tests.common import MockConfigEntry
@@ -16,6 +16,7 @@ UPDATED_PASSWORD = "updated-password"
 INCORRECT_PASSWORD = "incorrect-password"
 SCAN_INTERVAL = 120
 UPDATED_SCAN_INTERVAL = 60
+DEVICE_NAME = "Test Home Assistant"
 MFA_CODE = "1234"
 MFA_RESEND_CODE = "0000"
 MFA_INVALID_CODE = "HIVE"
@@ -33,21 +34,31 @@ async def test_import_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ), patch(
-        "homeassistant.components.hive.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.hive.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == USERNAME
-    assert result["data"] == {
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.hive.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.hive.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_DEVICE_NAME: DEVICE_NAME},
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == USERNAME
+    assert result2["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -81,21 +92,31 @@ async def test_user_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ), patch(
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["step_id"] == "configuration"
+    assert result2["errors"] == {}
+
+    with patch(
         "homeassistant.components.hive.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.hive.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
+        result3 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+            {CONF_DEVICE_NAME: DEVICE_NAME},
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == USERNAME
-    assert result2["data"] == {
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["title"] == USERNAME
+    assert result3["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -148,11 +169,23 @@ async def test_user_flow_2fa(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ), patch(
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_CODE: MFA_CODE,
+            },
+        )
+
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["step_id"] == "configuration"
+    assert result3["errors"] == {}
+
+    with patch(
         "homeassistant.components.hive.config_flow.Auth.device_registration",
         return_value=True,
     ), patch(
-        "homeassistant.components.hive.config_flow.Auth.getDeviceData",
+        "homeassistant.components.hive.config_flow.Auth.get_device_data",
         return_value=[
             "mock-device-group-key",
             "mock-device-key",
@@ -164,14 +197,17 @@ async def test_user_flow_2fa(hass):
         "homeassistant.components.hive.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], {CONF_CODE: MFA_CODE}
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_DEVICE_NAME: DEVICE_NAME,
+            },
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result3["title"] == USERNAME
-    assert result3["data"] == {
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["title"] == USERNAME
+    assert result4["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -235,9 +271,6 @@ async def test_reauth_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ), patch(
-        "homeassistant.components.hive.config_flow.Auth.device_registration",
-        return_value=True,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -252,6 +285,78 @@ async def test_reauth_flow(hass):
     assert mock_config.data.get("password") == UPDATED_PASSWORD
     assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result2["reason"] == "reauth_successful"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_reauth_2fa_flow(hass):
+    """Test the reauth flow."""
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USERNAME,
+        data={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: INCORRECT_PASSWORD,
+            "tokens": {
+                "AccessToken": "mock-access-token",
+                "RefreshToken": "mock-refresh-token",
+            },
+        },
+    )
+    mock_config.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.login",
+        side_effect=hive_exceptions.HiveInvalidPassword(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "unique_id": mock_config.unique_id,
+            },
+            data=mock_config.data,
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "invalid_password"}
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.login",
+        return_value={
+            "ChallengeName": "SMS_MFA",
+        },
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: UPDATED_PASSWORD,
+            },
+        )
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.sms_2fa",
+        return_value={
+            "ChallengeName": "SUCCESS",
+            "AuthenticationResult": {
+                "RefreshToken": "mock-refresh-token",
+                "AccessToken": "mock-access-token",
+            },
+        },
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_CODE: MFA_CODE,
+            },
+        )
+    await hass.async_block_till_done()
+
+    assert mock_config.data.get("username") == USERNAME
+    assert mock_config.data.get("password") == UPDATED_PASSWORD
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
@@ -343,11 +448,23 @@ async def test_user_flow_2fa_send_new_code(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ), patch(
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_CODE: MFA_CODE,
+            },
+        )
+
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["step_id"] == "configuration"
+    assert result4["errors"] == {}
+
+    with patch(
         "homeassistant.components.hive.config_flow.Auth.device_registration",
         return_value=True,
     ), patch(
-        "homeassistant.components.hive.config_flow.Auth.getDeviceData",
+        "homeassistant.components.hive.config_flow.Auth.get_device_data",
         return_value=[
             "mock-device-group-key",
             "mock-device-key",
@@ -359,14 +476,14 @@ async def test_user_flow_2fa_send_new_code(hass):
         "homeassistant.components.hive.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result4 = await hass.config_entries.flow.async_configure(
-            result3["flow_id"], {CONF_CODE: MFA_CODE}
+        result5 = await hass.config_entries.flow.async_configure(
+            result4["flow_id"], {CONF_DEVICE_NAME: DEVICE_NAME}
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result4["title"] == USERNAME
-    assert result4["data"] == {
+    assert result5["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result5["title"] == USERNAME
+    assert result5["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -573,10 +690,19 @@ async def test_user_flow_unknown_error(hass):
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
-        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "unknown"}
+    assert result2["errors"] == {}
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_DEVICE_NAME: DEVICE_NAME},
+    )
+    await hass.async_block_till_done()
+
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["step_id"] == "configuration"
+    assert result3["errors"] == {"base": "unknown"}
 
 
 async def test_user_flow_2fa_unknown_error(hass):
@@ -610,7 +736,28 @@ async def test_user_flow_2fa_unknown_error(hass):
             result2["flow_id"],
             {CONF_CODE: MFA_CODE},
         )
-        await hass.async_block_till_done()
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result3["errors"] == {"base": "unknown"}
+    assert result3["step_id"] == "configuration"
+    assert result3["errors"] == {}
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.device_registration",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.hive.config_flow.Auth.get_device_data",
+        return_value=[
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_DEVICE_NAME: DEVICE_NAME},
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["step_id"] == "configuration"
+    assert result4["errors"] == {"base": "unknown"}

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -324,7 +324,12 @@ async def test_reauth_2fa_flow(hass):
                 "AccessToken": "mock-access-token",
             },
         },
-    ):
+    ), patch(
+        "homeassistant.components.hive.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.hive.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             {
@@ -337,6 +342,8 @@ async def test_reauth_2fa_flow(hass):
     assert mock_config.data.get("password") == UPDATED_PASSWORD
     assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result3["reason"] == "reauth_successful"
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change is to introduce a new form into the Hive config flow to allow the user to set the name of device when registering it after login.

https://github.com/Pyhass/Pyhiveapi/compare/v0.5.11...v0.5.13

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
