### PR TITLE
Handle non-str keys when storing json data

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -45,7 +45,7 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
     return {} if default is None else default
 
 
-def _orjson_encoder(data: Any) -> Any:
+def _orjson_encoder(data: Any) -> str:
     """JSON encoder that uses orjson."""
     return orjson.dumps(
         data, option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -45,6 +45,13 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
     return {} if default is None else default
 
 
+def _orjson_encoder(data: Any) -> Any:
+    """JSON encoder that uses orjson."""
+    return orjson.dumps(
+        data, option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS
+    ).decode("utf-8")
+
+
 def save_json(
     filename: str,
     data: list | dict,
@@ -62,8 +69,8 @@ def save_json(
         if encoder:
             json_data = json.dumps(data, indent=2, cls=encoder)
         else:
-            dump = orjson.dumps
-            json_data = orjson.dumps(data, option=orjson.OPT_INDENT_2).decode("utf-8")
+            dump = _orjson_encoder
+            json_data = _orjson_encoder(data)
     except TypeError as error:
         msg = f"Failed to serialize to JSON: {filename}. Bad data at {format_unserializable_data(find_paths_unserializable_data(data, dump=dump))}"
         _LOGGER.error(msg)

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -52,6 +52,14 @@ def test_save_and_load():
     assert data == TEST_JSON_A
 
 
+def test_save_and_load_int_keys():
+    """Test saving and loading back stringifies the keys."""
+    fname = _path_for("test1")
+    save_json(fname, {1: "a", 2: "b"})
+    data = load_json(fname)
+    assert data == {"1": "a", "2": "b"}
+
+
 def test_save_and_load_private():
     """Test we can load private files and that they are protected."""
     fname = _path_for("test2")


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle non-str keys when storing json data.

We need to set `OPT_NON_STR_KEYS` here as well to allow `int` to be coerced into strings since json doesn't allow `int` keys

Fixes #73882

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
