### PR TITLE
Fix unexpected exception in Google Calendar OAuth exchange

### DIFF
--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -138,7 +138,7 @@ class DeviceFlow:
 
     @callback
     def _async_timeout(self, now: datetime.datetime) -> None:
-        _LOGGER.debug("OAuth token exchange timeout.")
+        _LOGGER.debug("OAuth token exchange timeout")
         self._finish()
 
     @callback

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 import datetime
 import logging
 from typing import Any, cast
@@ -19,9 +18,12 @@ from oauth2client.client import (
 
 from homeassistant.components.application_credentials import AuthImplementation
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time,
+    async_track_time_interval,
+)
 from homeassistant.util import dt
 
 from .const import (
@@ -76,6 +78,16 @@ class DeviceFlow:
         self._oauth_flow = oauth_flow
         self._device_flow_info: DeviceFlowInfo = device_flow_info
         self._exchange_task_unsub: CALLBACK_TYPE | None = None
+        self._timeout_unsub: CALLBACK_TYPE | None = None
+        max_timeout = dt.utcnow() + datetime.timedelta(seconds=EXCHANGE_TIMEOUT_SECONDS)
+        # For some reason, oauth.step1_get_device_and_user_codes() returns a datetime
+        # object without tzinfo. For the comparison below to work, it needs one.
+        user_code_expiry = device_flow_info.user_code_expiry.replace(
+            tzinfo=datetime.timezone.utc
+        )
+        self._expiration_time = min(user_code_expiry, max_timeout)
+        self._listener: CALLBACK_TYPE | None = None
+        self._creds: Credentials | None = None
 
     @property
     def verification_url(self) -> str:
@@ -87,48 +99,56 @@ class DeviceFlow:
         """Return the code that the user should enter at the verification url."""
         return self._device_flow_info.user_code  # type: ignore[no-any-return]
 
-    async def start_exchange_task(
-        self, finished_cb: Callable[[Credentials | None], Awaitable[None]]
+    @callback
+    def async_set_listener(
+        self,
+        update_callback: CALLBACK_TYPE,
     ) -> None:
-        """Start the device auth exchange flow polling.
+        """Invoke the update callback when the exchange finishes or on timeout."""
+        self._listener = update_callback
 
-        The callback is invoked with the valid credentials or with None on timeout.
-        """
+    @property
+    def creds(self) -> Credentials | None:
+        """Return result of exchange step or None on timeout."""
+        return self._creds
+
+    def async_start_exchange(self) -> None:
+        """Start the device auth exchange flow polling."""
         _LOGGER.debug("Starting exchange flow")
-        assert not self._exchange_task_unsub
-        max_timeout = dt.utcnow() + datetime.timedelta(seconds=EXCHANGE_TIMEOUT_SECONDS)
-        # For some reason, oauth.step1_get_device_and_user_codes() returns a datetime
-        # object without tzinfo. For the comparison below to work, it needs one.
-        user_code_expiry = self._device_flow_info.user_code_expiry.replace(
-            tzinfo=datetime.timezone.utc
-        )
-        expiration_time = min(user_code_expiry, max_timeout)
-
-        def _exchange() -> Credentials:
-            return self._oauth_flow.step2_exchange(
-                device_flow_info=self._device_flow_info
-            )
-
-        async def _poll_attempt(now: datetime.datetime) -> None:
-            assert self._exchange_task_unsub
-            _LOGGER.debug("Attempting OAuth code exchange")
-            # Note: The callback is invoked with None when the device code has expired
-            creds: Credentials | None = None
-            if now < expiration_time:
-                try:
-                    creds = await self._hass.async_add_executor_job(_exchange)
-                except FlowExchangeError:
-                    _LOGGER.debug("Token not yet ready; trying again later")
-                    return
-            self._exchange_task_unsub()
-            self._exchange_task_unsub = None
-            await finished_cb(creds)
-
         self._exchange_task_unsub = async_track_time_interval(
             self._hass,
-            _poll_attempt,
+            self._async_poll_attempt,
             datetime.timedelta(seconds=self._device_flow_info.interval),
         )
+        self._timeout_unsub = async_track_point_in_utc_time(
+            self._hass, self._async_timeout, self._expiration_time
+        )
+
+    async def _async_poll_attempt(self, now: datetime.datetime) -> None:
+        _LOGGER.debug("Attempting OAuth code exchange")
+        try:
+            self._creds = await self._hass.async_add_executor_job(self._exchange)
+        except FlowExchangeError:
+            _LOGGER.debug("Token not yet ready; trying again later")
+            return
+        self._finish()
+
+    def _exchange(self) -> Credentials:
+        return self._oauth_flow.step2_exchange(device_flow_info=self._device_flow_info)
+
+    @callback
+    def _async_timeout(self, now: datetime.datetime) -> None:
+        _LOGGER.debug("OAuth token exchange timeout.")
+        self._finish()
+
+    @callback
+    def _finish(self) -> None:
+        if self._exchange_task_unsub:
+            self._exchange_task_unsub()
+        if self._timeout_unsub:
+            self._timeout_unsub()
+        if self._listener:
+            self._listener()
 
 
 def get_feature_access(

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from gcal_sync.api import GoogleCalendarService
 from gcal_sync.exceptions import ApiException
-from oauth2client.client import Credentials
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -96,9 +95,9 @@ class OAuth2FlowHandler(
                 return self.async_abort(reason="oauth_error")
             self._device_flow = device_flow
 
-            async def _exchange_finished(creds: Credentials | None) -> None:
+            def _exchange_finished() -> None:
                 self.external_data = {
-                    DEVICE_AUTH_CREDS: creds
+                    DEVICE_AUTH_CREDS: device_flow.creds
                 }  # is None on timeout/expiration
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_configure(
@@ -106,7 +105,8 @@ class OAuth2FlowHandler(
                     )
                 )
 
-            await device_flow.start_exchange_task(_exchange_finished)
+            device_flow.async_set_listener(_exchange_finished)
+            device_flow.async_start_exchange()
 
         return self.async_show_progress(
             step_id="auth",

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -248,13 +248,13 @@ async def test_code_error(
         assert result.get("reason") == "oauth_error"
 
 
-@pytest.mark.parametrize("code_expiration_delta", [datetime.timedelta(seconds=5)])
+@pytest.mark.parametrize("code_expiration_delta", [datetime.timedelta(seconds=50)])
 async def test_expired_after_exchange(
     hass: HomeAssistant,
     mock_code_flow: Mock,
     component_setup: ComponentSetup,
 ) -> None:
-    """Test credential exchange expires immediately."""
+    """Test credential exchange expires."""
     assert await component_setup()
 
     result = await hass.config_entries.flow.async_init(
@@ -265,6 +265,7 @@ async def test_expired_after_exchange(
     assert "description_placeholders" in result
     assert "url" in result["description_placeholders"]
 
+    # Fail first attempt then advance clock past exchange timeout
     with patch(
         "oauth2client.client.OAuth2WebServerFlow.step2_exchange",
         side_effect=FlowExchangeError(),

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 from aiohttp.client_exceptions import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from oauth2client.client import (
+    DeviceFlowInfo,
     FlowExchangeError,
     OAuth2Credentials,
     OAuth2DeviceCodeError,
@@ -59,10 +60,17 @@ async def mock_code_flow(
 ) -> YieldFixture[Mock]:
     """Fixture for initiating OAuth flow."""
     with patch(
-        "oauth2client.client.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step1_get_device_and_user_codes",
     ) as mock_flow:
-        mock_flow.return_value.user_code_expiry = utcnow() + code_expiration_delta
-        mock_flow.return_value.interval = CODE_CHECK_INTERVAL
+        mock_flow.return_value = DeviceFlowInfo.FromResponse(
+            {
+                "device_code": "4/4-GMMhmHCXhWEzkobqIHGG_EnNYYsAkukHspeYUk9E8",
+                "user_code": "GQVQ-JKEC",
+                "verification_url": "https://www.google.com/device",
+                "expires_in": code_expiration_delta.total_seconds(),
+                "interval": CODE_CHECK_INTERVAL,
+            }
+        )
         yield mock_flow
 
 
@@ -70,7 +78,8 @@ async def mock_code_flow(
 async def mock_exchange(creds: OAuth2Credentials) -> YieldFixture[Mock]:
     """Fixture for mocking out the exchange for credentials."""
     with patch(
-        "oauth2client.client.OAuth2WebServerFlow.step2_exchange", return_value=creds
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step2_exchange",
+        return_value=creds,
     ) as mock:
         yield mock
 
@@ -108,7 +117,6 @@ async def fire_alarm(hass, point_in_time):
         await hass.async_block_till_done()
 
 
-@pytest.mark.freeze_time("2022-06-03 15:19:59-00:00")
 async def test_full_flow_yaml_creds(
     hass: HomeAssistant,
     mock_code_flow: Mock,
@@ -131,9 +139,8 @@ async def test_full_flow_yaml_creds(
         "homeassistant.components.google.async_setup_entry", return_value=True
     ) as mock_setup:
         # Run one tick to invoke the credential exchange check
-        freezer.tick(CODE_CHECK_ALARM_TIMEDELTA)
-        await fire_alarm(hass, datetime.datetime.utcnow())
-        await hass.async_block_till_done()
+        now = utcnow()
+        await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
         result = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"]
         )
@@ -143,11 +150,12 @@ async def test_full_flow_yaml_creds(
     assert "data" in result
     data = result["data"]
     assert "token" in data
+    assert 0 < data["token"]["expires_in"] <= 60 * 60
     assert (
-        data["token"]["expires_in"]
-        == 60 * 60 - CODE_CHECK_ALARM_TIMEDELTA.total_seconds()
+        datetime.datetime.now().timestamp()
+        <= data["token"]["expires_at"]
+        < (datetime.datetime.now() + datetime.timedelta(days=8)).timestamp()
     )
-    assert data["token"]["expires_at"] == 1654273199.0
     data["token"].pop("expires_at")
     data["token"].pop("expires_in")
     assert data == {
@@ -238,7 +246,7 @@ async def test_code_error(
     assert await component_setup()
 
     with patch(
-        "oauth2client.client.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step1_get_device_and_user_codes",
         side_effect=OAuth2DeviceCodeError("Test Failure"),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -267,7 +275,7 @@ async def test_expired_after_exchange(
 
     # Fail first attempt then advance clock past exchange timeout
     with patch(
-        "oauth2client.client.OAuth2WebServerFlow.step2_exchange",
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step2_exchange",
         side_effect=FlowExchangeError(),
     ):
         now = utcnow()
@@ -299,7 +307,7 @@ async def test_exchange_error(
     # Run one tick to invoke the credential exchange check
     now = utcnow()
     with patch(
-        "oauth2client.client.OAuth2WebServerFlow.step2_exchange",
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step2_exchange",
         side_effect=FlowExchangeError(),
     ):
         now += CODE_CHECK_ALARM_TIMEDELTA


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Rewrite google calendar oauth exchange callbacks. The goal is to prevent this error:

```
2022-06-14 17:04:39 INFO (SyncWorker_10) [oauth2client.client] Successfully retrieved access token
2022-06-14 17:04:39 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/components/google/api.py", line 123, in _poll_attempt
self._exchange_task_unsub()
TypeError: 'NoneType' object is not callable
```

I am not totally positive how it gets into this state, but it seemed worth trying to simplify anyway. The asserts have been replaced with explicit checks before running the unsub calls.

This replaces the asserts with some other rewrite of the logic to match more common patterns seen in other code in home assistant. Instead of having a single callback for updates and a timeout, the timeout is split into a separate listener. The new code is more lines of code, but seems like it could be a bit more straight forward avoiding passing callback parameters around.

The tests that use freezetime needed to be reverted because of https://github.com/spulec/freezegun/issues/89 -- not sure if that was exposed because of moving patches around or specific callbacks around.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #73484
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
