### PR TITLE
Remove entities from Alexa when disabling Alexa

### DIFF
--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -1,5 +1,8 @@
 """Alexa configuration for Home Assistant Cloud."""
+from __future__ import annotations
+
 import asyncio
+from collections.abc import Callable
 from contextlib import suppress
 from datetime import timedelta
 from http import HTTPStatus
@@ -24,7 +27,15 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from .const import CONF_ENTITY_CONFIG, CONF_FILTER, PREF_SHOULD_EXPOSE
+from .const import (
+    CONF_ENTITY_CONFIG,
+    CONF_FILTER,
+    PREF_ALEXA_DEFAULT_EXPOSE,
+    PREF_ALEXA_ENTITY_CONFIGS,
+    PREF_ALEXA_REPORT_STATE,
+    PREF_ENABLE_ALEXA,
+    PREF_SHOULD_EXPOSE,
+)
 from .prefs import CloudPreferences
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,8 +65,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         self._token = None
         self._token_valid = None
         self._cur_entity_prefs = prefs.alexa_entity_configs
-        self._cur_default_expose = prefs.alexa_default_expose
-        self._alexa_sync_unsub = None
+        self._alexa_sync_unsub: Callable[[], None] | None = None
         self._endpoint = None
 
     @property
@@ -75,7 +85,11 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
     @property
     def should_report_state(self):
         """Return if states should be proactively reported."""
-        return self._prefs.alexa_report_state and self.authorized
+        return (
+            self._prefs.alexa_enabled
+            and self._prefs.alexa_report_state
+            and self.authorized
+        )
 
     @property
     def endpoint(self):
@@ -179,7 +193,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         self._token_valid = utcnow() + timedelta(seconds=body["expires_in"])
         return self._token
 
-    async def _async_prefs_updated(self, prefs):
+    async def _async_prefs_updated(self, prefs: CloudPreferences):
         """Handle updated preferences."""
         if not self._cloud.is_logged_in:
             if self.is_reporting_states:
@@ -189,6 +203,8 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
                 self._alexa_sync_unsub()
                 self._alexa_sync_unsub = None
             return
+
+        updated_prefs = prefs.last_updated
 
         if (
             ALEXA_DOMAIN not in self.hass.config.components
@@ -211,28 +227,30 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
             await self.async_sync_entities()
             return
 
-        # If user has filter in config.yaml, don't sync.
-        if not self._config[CONF_FILTER].empty_filter:
-            return
-
-        # If entity prefs are the same, don't sync.
-        if (
-            self._cur_entity_prefs is prefs.alexa_entity_configs
-            and self._cur_default_expose is prefs.alexa_default_expose
+        # Nothing to do if no Alexa related things have changed
+        if not any(
+            key in updated_prefs
+            for key in (
+                PREF_ALEXA_DEFAULT_EXPOSE,
+                PREF_ALEXA_ENTITY_CONFIGS,
+                PREF_ALEXA_REPORT_STATE,
+                PREF_ENABLE_ALEXA,
+            )
         ):
             return
 
-        if self._alexa_sync_unsub:
-            self._alexa_sync_unsub()
-            self._alexa_sync_unsub = None
+        # If we update just entity preferences, delay updating
+        # as we might update more
+        if updated_prefs == {PREF_ALEXA_ENTITY_CONFIGS}:
+            if self._alexa_sync_unsub:
+                self._alexa_sync_unsub()
 
-        if self._cur_default_expose is not prefs.alexa_default_expose:
-            await self.async_sync_entities()
+            self._alexa_sync_unsub = async_call_later(
+                self.hass, SYNC_DELAY, self._sync_prefs
+            )
             return
 
-        self._alexa_sync_unsub = async_call_later(
-            self.hass, SYNC_DELAY, self._sync_prefs
-        )
+        await self.async_sync_entities()
 
     async def _sync_prefs(self, _now):
         """Sync the updated preferences to Alexa."""
@@ -243,9 +261,14 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         seen = set()
         to_update = []
         to_remove = []
+        is_enabled = self.enabled
 
         for entity_id, info in old_prefs.items():
             seen.add(entity_id)
+
+            if not is_enabled:
+                to_remove.append(entity_id)
+
             old_expose = info.get(PREF_SHOULD_EXPOSE)
 
             if entity_id in new_prefs:
@@ -291,8 +314,10 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         to_update = []
         to_remove = []
 
+        is_enabled = self.enabled
+
         for entity in alexa_entities.async_get_entities(self.hass, self):
-            if self.should_expose(entity.entity_id):
+            if is_enabled and self.should_expose(entity.entity_id):
                 to_update.append(entity.entity_id)
             else:
                 to_remove.append(entity.entity_id)

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -193,7 +193,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         self._token_valid = utcnow() + timedelta(seconds=body["expires_in"])
         return self._token
 
-    async def _async_prefs_updated(self, prefs: CloudPreferences):
+    async def _async_prefs_updated(self, prefs: CloudPreferences) -> None:
         """Handle updated preferences."""
         if not self._cloud.is_logged_in:
             if self.is_reporting_states:

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -50,6 +50,7 @@ class CloudPreferences:
         self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._prefs = None
         self._listeners = []
+        self.last_updated: set[str] = set()
 
     async def async_initialize(self):
         """Finish initializing the preferences."""
@@ -308,6 +309,9 @@ class CloudPreferences:
 
     async def _save_prefs(self, prefs):
         """Save preferences to disk."""
+        self.last_updated = {
+            key for key, value in prefs.items() if value != self._prefs.get(key)
+        }
         self._prefs = prefs
         await self._store.async_save(self._prefs)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a user enables/disables Alexa via Home Assistant Cloud, trigger a sync so the entities are up to date.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
