### PR TITLE
Fix color transition when turning on a ZHA light

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -228,25 +228,11 @@ class BaseLight(LogMixin, light.LightEntity):
         effect = kwargs.get(light.ATTR_EFFECT)
         flash = kwargs.get(light.ATTR_FLASH)
 
-        if (
-            brightness is None
-            and self._off_with_transition
-            and self._off_brightness is not None
-        ):
-            brightness = self._off_brightness
-
-        # TODO: Move this block somewhere else?
-        if brightness is not None:
-            level = min(254, brightness)
-        else:
-            level = self._brightness or 254
-
         # If the light is currently off but a turn_on call with a color/temperature is sent,
         # the light needs to be turned on first at a low brightness level where the light is immediately transitioned
         # to the correct color. Afterwards, the transition is only from the low brightness to the new brightness.
         # Otherwise, the transition is from the color the light had before being turned on to the new color.
         # This can look especially bad with transitions longer than a second.
-        # TODO: Name this differently?
         color_provided_from_off = (
             not self._state
             and brightness_supported(self._attr_supported_color_modes)
@@ -256,6 +242,18 @@ class BaseLight(LogMixin, light.LightEntity):
         if color_provided_from_off:
             # Set the duration for the color changing commands to 0.
             duration = 0
+
+        if (
+            brightness is None
+            and (self._off_with_transition or color_provided_from_off)
+            and self._off_brightness is not None
+        ):
+            brightness = self._off_brightness
+
+        if brightness is not None:
+            level = min(254, brightness)
+        else:
+            level = self._brightness or 254
 
         t_log = {}
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -74,6 +74,7 @@ CAPABILITIES_COLOR_XY = 0x08
 CAPABILITIES_COLOR_TEMP = 0x10
 
 DEFAULT_TRANSITION = 1
+DEFAULT_MIN_BRIGHTNESS = 2
 
 UPDATE_COLORLOOP_ACTION = 0x1
 UPDATE_COLORLOOP_DIRECTION = 0x2
@@ -260,7 +261,9 @@ class BaseLight(LogMixin, light.LightEntity):
         if color_provided_from_off:
             # If the light is currently off, we first need to turn it on at a low brightness level with no transition.
             # After that, we set it to the desired color/temperature with no transition.
-            result = await self._level_channel.move_to_level_with_on_off(2, 0)
+            result = await self._level_channel.move_to_level_with_on_off(
+                DEFAULT_MIN_BRIGHTNESS, DEFAULT_TRANSITION
+            )
             t_log["move_to_level_with_on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -119,6 +119,7 @@ class BaseLight(LogMixin, light.LightEntity):
     """Operations common to all light entities."""
 
     _FORCE_ON = False
+    _DEFAULT_COLOR_FROM_OFF_TRANSITION = 0
 
     def __init__(self, *args, **kwargs):
         """Initialize the light."""
@@ -262,7 +263,7 @@ class BaseLight(LogMixin, light.LightEntity):
             # If the light is currently off, we first need to turn it on at a low brightness level with no transition.
             # After that, we set it to the desired color/temperature with no transition.
             result = await self._level_channel.move_to_level_with_on_off(
-                DEFAULT_MIN_BRIGHTNESS, DEFAULT_TRANSITION
+                DEFAULT_MIN_BRIGHTNESS, self._DEFAULT_COLOR_FROM_OFF_TRANSITION
             )
             t_log["move_to_level_with_on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -615,6 +616,17 @@ class ForceOnLight(Light):
     """Representation of a light which does not respect move_to_level_with_on_off."""
 
     _FORCE_ON = True
+
+
+@STRICT_MATCH(
+    channel_names=CHANNEL_ON_OFF,
+    aux_channels={CHANNEL_COLOR, CHANNEL_LEVEL},
+    manufacturers={"Sengled"},
+)
+class SengledLight(Light):
+    """Representation of a Sengled light which does not react to move_to_color_temp with 0 as a transition."""
+
+    _DEFAULT_COLOR_FROM_OFF_TRANSITION = 1
 
 
 @GROUP_MATCH()


### PR DESCRIPTION
## Proposed change
Currently, turning on a ZHA light from an off-state with a new color makes the light transition from the old color to the new color.
This is due to Zigbee lights only accepting color changes when the light is actually in an on-state ([for reference](https://github.com/home-assistant/core/issues/42249#issuecomment-715330422)).

Expected:
If a light is off and then gets a call to turn on with a new color, the light should fade up its brightness level to the desired one. It should not fade from an old color if the light was previously off.

Philips Hue (and thus the Hue integration in Home Assistant) works around this limitation in an interesting way.
If the light is turned on from an off-state, it does the following:
1. Immediately set brightness level to 2 with a no transition
2. Immediately set color to the new desired color with no transition
3. Transition to the (new) brightness level with the correct transition

This PR tries to somewhat mirror what Philips/Signify did to bring ZHA's behavior more in line with the Philips Hue integration.

Here's a short video showing the differences between the current implementation in ZHA and the one with the proposed changes:
https://user-images.githubusercontent.com/6409465/175836822-c94352bd-2e49-4a9c-bd38-d26829f28460.mp4
The "flash" from the old color (red) to the new color (blue) is barely noticeable (one frame in the video) with the new changes (which is good). The current implementation has the light fading from the "before the light was turned off"-color to the new color (thus the mixed magenta color).
During the ~4 second transition in the video, the left side only fades the brightness level up (which isn't that noticeable due the camera auto-adjusting exposure and pointing directly into the bulb).
(I should have probably chosen another color than blue but I think the video still makes the changes clear)
​

During longer transitions (> 10 seconds), the current implementation is really noticeable unpleasant. An example is:
1. Turn on lights to a very bright day scene (daylight color)
2. Turn off lights
3. Turn on lights to a night scene (red color)
4. Experience briefly getting blinded from the daylight color during the transition phase
​

Another case where it's annoying and where the transition cannot really be turned off is for activating a scene with a really long transition time:
1. Turn on lights to a warm scene
2. Turn off lights
3. (Wait a night)
4. Turn on lights to a day scene with a 30 minute transition time
5. Watch the lights slowly transition from a warm color to a daylight color

(For step 5, it's expected that the lights only slowly dim up their brightness in those 30 minutes)
This scenario can't easily be worked around with the current implementation. If the day scene has multiple lights at different colors, Home Assistant cannot turn on the scene at a low brightness with no transition and then turn on the scene at the normal (high) brightness with a 30 minute transition time. A second scene with low brightness would be needed.
Either way, this is not really something the end-user should have to work around. (The integration should deal with this issue -> hence my proposed changes)
​

My changes are not finished whatsoever and the code is very messy as of right now. So far, it's basically only to prove that it works correctly. I welcome any feedback/changes.

The changes will/should not change the current behavior for transitioning lights if they are already on and get set to a new color.

I've also thought about adding a config option for this. I don't think it's needed but if it's decided that one is to be implemented, it should probably be on by default, so ZHA's light behavior matches basically every other integration's behavior.

Also, "level 2" as a brightness value for the initial turn-on is the lowest possible brightness for Zigbee lights and it's also what Philips used.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
This issue is the "old issue" from here: https://github.com/home-assistant/core/issues/42249#issue-727906834
(That thread is about two different issues which I thought to be the same at that time.)

This PR will need to be rebased once https://github.com/home-assistant/core/pull/74018 gets merged

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
