### PR TITLE
Add CoverEntity to pylint checks

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -438,11 +438,6 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
 # be checked by pylint when --ignore-missing-annotations is False
 _ENTITY_MATCH: list[TypeHintMatch] = [
     TypeHintMatch(
-        function_name="device_class",
-        return_type=[DEVICE_CLASS, "str", None],
-        check_return_type_inheritance=True,
-    ),
-    TypeHintMatch(
         function_name="should_poll",
         return_type="bool",
     ),
@@ -574,10 +569,17 @@ _TOGGLE_ENTITY_MATCH: list[TypeHintMatch] = [
 ]
 _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
     "cover": [
-        ClassTypeHintMatch(base_class="Entity", matches=_ENTITY_MATCH),
+        ClassTypeHintMatch(
+            base_class="Entity",
+            matches=_ENTITY_MATCH,
+        ),
         ClassTypeHintMatch(
             base_class="CoverEntity",
             matches=[
+                TypeHintMatch(
+                    function_name="device_class",
+                    return_type=["CoverDeviceClass", "str", None],
+                ),
                 TypeHintMatch(
                     function_name="current_cover_position",
                     return_type=["int", None],
@@ -585,10 +587,6 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                 TypeHintMatch(
                     function_name="current_cover_tilt_position",
                     return_type=["int", None],
-                ),
-                TypeHintMatch(
-                    function_name="device_class",
-                    return_type=["CoverDeviceClass", "str", None],
                 ),
                 TypeHintMatch(
                     function_name="is_opening",
@@ -678,6 +676,10 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             base_class="FanEntity",
             matches=[
                 TypeHintMatch(
+                    function_name="device_class",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
                     function_name="percentage",
                     return_type=["int", None],
                 ),
@@ -750,6 +752,10 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
         ClassTypeHintMatch(
             base_class="LockEntity",
             matches=[
+                TypeHintMatch(
+                    function_name="device_class",
+                    return_type=["str", None],
+                ),
                 TypeHintMatch(
                     function_name="changed_by",
                     return_type=["str", None],

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -817,10 +817,8 @@ def _is_valid_type(
     if expected_type == DEVICE_CLASS and in_return:
         return (
             isinstance(node, nodes.Name)
-            and node.name
             and node.name.endswith("DeviceClass")
             or isinstance(node, nodes.Attribute)
-            and node.attrname
             and node.attrname.endswith("DeviceClass")
         )
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -474,6 +474,10 @@ _ENTITY_MATCH: list[TypeHintMatch] = [
         return_type=["DeviceInfo", None],
     ),
     TypeHintMatch(
+        function_name="device_class",
+        return_type=[DEVICE_CLASS, "str", None],
+    ),
+    TypeHintMatch(
         function_name="unit_of_measurement",
         return_type=["str", None],
     ),

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -571,6 +571,101 @@ _TOGGLE_ENTITY_MATCH: list[TypeHintMatch] = [
     ),
 ]
 _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
+    "cover": [
+        ClassTypeHintMatch(
+            base_class="Entity",
+            matches=_ENTITY_MATCH,
+        ),
+        ClassTypeHintMatch(
+            base_class="CoverEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="current_cover_position",
+                    return_type=["int", None],
+                ),
+                TypeHintMatch(
+                    function_name="current_cover_tilt_position",
+                    return_type=["int", None],
+                ),
+                TypeHintMatch(
+                    function_name="device_class",
+                    return_type=["CoverDeviceClass", "str", None],
+                ),
+                TypeHintMatch(
+                    function_name="is_opening",
+                    return_type=["bool", None],
+                ),
+                TypeHintMatch(
+                    function_name="is_closing",
+                    return_type=["bool", None],
+                ),
+                TypeHintMatch(
+                    function_name="is_closed",
+                    return_type=["bool", None],
+                ),
+                TypeHintMatch(
+                    function_name="open_cover",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="close_cover",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="toggle",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="set_cover_position",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="stop_cover",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="open_cover_tilt",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="close_cover_tilt",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="set_cover_tilt_position",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="stop_cover_tilt",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+                TypeHintMatch(
+                    function_name="toggle_tilt",
+                    kwargs_type="Any",
+                    return_type=None,
+                    has_async_counterpart=True,
+                ),
+            ],
+        ),
+    ],
     "fan": [
         ClassTypeHintMatch(
             base_class="Entity",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -435,6 +435,10 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
 }
 # Overriding properties and functions are normally checked by mypy, and will only
 # be checked by pylint when --ignore-missing-annotations is False
+_BASE_DEVICE_CLASS = TypeHintMatch(
+    function_name="device_class",
+    return_type=["str", None],
+)
 _ENTITY_MATCH: list[TypeHintMatch] = [
     TypeHintMatch(
         function_name="should_poll",
@@ -471,10 +475,6 @@ _ENTITY_MATCH: list[TypeHintMatch] = [
     TypeHintMatch(
         function_name="device_info",
         return_type=["DeviceInfo", None],
-    ),
-    TypeHintMatch(
-        function_name="device_class",
-        return_type=["str", None],
     ),
     TypeHintMatch(
         function_name="unit_of_measurement",
@@ -669,7 +669,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
     "fan": [
         ClassTypeHintMatch(
             base_class="Entity",
-            matches=_ENTITY_MATCH,
+            matches=_ENTITY_MATCH + [_BASE_DEVICE_CLASS],
         ),
         ClassTypeHintMatch(
             base_class="ToggleEntity",
@@ -746,7 +746,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
     "lock": [
         ClassTypeHintMatch(
             base_class="Entity",
-            matches=_ENTITY_MATCH,
+            matches=_ENTITY_MATCH + [_BASE_DEVICE_CLASS],
         ),
         ClassTypeHintMatch(
             base_class="LockEntity",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add CoverEntity to pylint checks

```console
pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/**/cover.py           

************* Module homeassistant.components.garadget.cover
homeassistant/components/garadget/cover.py:236:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.lutron.cover
homeassistant/components/lutron/cover.py:69:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.rflink.cover
homeassistant/components/rflink/cover.py:145:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/rflink/cover.py:155:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/rflink/cover.py:128:4: W7432: Return type should be None (hass-return-type)
homeassistant/components/rflink/cover.py:150:4: W7432: Return type should be ['bool', None] (hass-return-type)
************* Module homeassistant.components.esphome.cover
homeassistant/components/esphome/cover.py:128:4: W7431: Argument kwargs should be of type Any (hass-argument-type)
************* Module homeassistant.components.smartthings.cover
homeassistant/components/smartthings/cover.py:110:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.soma.cover
homeassistant/components/soma/cover.py:105:4: W7432: Return type should be None (hass-return-type)
homeassistant/components/soma/cover.py:175:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.zha.cover
homeassistant/components/zha/cover.py:165:4: W7432: Return type should be None (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
