### PR TITLE
Add support for unavailable and unknown to fan groups

### DIFF
--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -32,6 +32,8 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_UNIQUE_ID,
     STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -98,6 +100,7 @@ async def async_setup_entry(
 class FanGroup(GroupEntity, FanEntity):
     """Representation of a FanGroup."""
 
+    _attr_available: bool = False
     _attr_assumed_state: bool = True
 
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
@@ -109,7 +112,7 @@ class FanGroup(GroupEntity, FanEntity):
         self._direction = None
         self._supported_features = 0
         self._speed_count = 100
-        self._is_on = False
+        self._is_on: bool | None = False
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entities}
         self._attr_unique_id = unique_id
@@ -125,7 +128,7 @@ class FanGroup(GroupEntity, FanEntity):
         return self._speed_count
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if the entity is on."""
         return self._is_on
 
@@ -270,11 +273,25 @@ class FanGroup(GroupEntity, FanEntity):
         """Update state and attributes."""
         self._attr_assumed_state = False
 
-        on_states: list[State] = list(
-            filter(None, [self.hass.states.get(x) for x in self._entities])
+        states = [
+            state
+            for entity_id in self._entities
+            if (state := self.hass.states.get(entity_id)) is not None
+        ]
+        self._attr_assumed_state |= not states_equal(states)
+
+        # Set group as unavailable if all members are unavailable or missing
+        self._attr_available = any(state.state != STATE_UNAVAILABLE for state in states)
+
+        valid_state = any(
+            state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE) for state in states
         )
-        self._is_on = any(state.state == STATE_ON for state in on_states)
-        self._attr_assumed_state |= not states_equal(on_states)
+        if not valid_state:
+            # Set as unknown if all members are unknown or unavailable
+            self._is_on = None
+        else:
+            # Set as ON if any member is ON
+            self._is_on = any(state.state == STATE_ON for state in states)
 
         percentage_states = self._async_states_by_support_flag(
             FanEntityFeature.SET_SPEED
@@ -306,5 +323,5 @@ class FanGroup(GroupEntity, FanEntity):
             ior, [feature for feature in SUPPORTED_FLAGS if self._fans[feature]], 0
         )
         self._attr_assumed_state |= any(
-            state.attributes.get(ATTR_ASSUMED_STATE) for state in on_states
+            state.attributes.get(ATTR_ASSUMED_STATE) for state in states
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for unavailable and unknown to fan groups

With this change, the behavior of fan groups is:
- The group state is unavailable if all group members are unavailable.
- Otherwise, the group state is unknown if all group members are unknown or unavailable.
- Otherwise, the group state is on if at least one group member is on.
- Otherwise, the group state is off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
