### PR TITLE
Modify behavior of lock groups

### DIFF
--- a/homeassistant/components/group/lock.py
+++ b/homeassistant/components/group/lock.py
@@ -166,7 +166,7 @@ class LockGroup(GroupEntity, LockEntity):
             if (state := self.hass.states.get(entity_id)) is not None
         ]
 
-        valid_state = all(
+        valid_state = any(
             state not in (STATE_UNKNOWN, STATE_UNAVAILABLE) for state in states
         )
 

--- a/tests/components/group/test_lock.py
+++ b/tests/components/group/test_lock.py
@@ -90,28 +90,10 @@ async def test_state_reporting(hass):
     await hass.async_block_till_done()
     assert hass.states.get("lock.lock_group").state == STATE_UNAVAILABLE
 
-    # At least one member unknown or unavailable -> group unknown
+    # The group state is unknown if all group members are unknown or unavailable.
     for state_1 in (
-        STATE_JAMMED,
-        STATE_LOCKED,
-        STATE_LOCKING,
-        STATE_UNKNOWN,
-        STATE_UNLOCKED,
-        STATE_UNLOCKING,
-    ):
-        hass.states.async_set("lock.test1", state_1)
-        hass.states.async_set("lock.test2", STATE_UNAVAILABLE)
-        await hass.async_block_till_done()
-        assert hass.states.get("lock.lock_group").state == STATE_UNKNOWN
-
-    for state_1 in (
-        STATE_JAMMED,
-        STATE_LOCKED,
-        STATE_LOCKING,
         STATE_UNAVAILABLE,
         STATE_UNKNOWN,
-        STATE_UNLOCKED,
-        STATE_UNLOCKING,
     ):
         hass.states.async_set("lock.test1", state_1)
         hass.states.async_set("lock.test2", STATE_UNKNOWN)
@@ -123,6 +105,8 @@ async def test_state_reporting(hass):
         STATE_JAMMED,
         STATE_LOCKED,
         STATE_LOCKING,
+        STATE_UNAVAILABLE,
+        STATE_UNKNOWN,
         STATE_UNLOCKED,
         STATE_UNLOCKING,
     ):
@@ -135,6 +119,8 @@ async def test_state_reporting(hass):
     for state_1 in (
         STATE_LOCKED,
         STATE_LOCKING,
+        STATE_UNAVAILABLE,
+        STATE_UNKNOWN,
         STATE_UNLOCKED,
         STATE_UNLOCKING,
     ):
@@ -146,6 +132,8 @@ async def test_state_reporting(hass):
     # At least one member unlocking -> group unlocking
     for state_1 in (
         STATE_LOCKED,
+        STATE_UNAVAILABLE,
+        STATE_UNKNOWN,
         STATE_UNLOCKED,
         STATE_UNLOCKING,
     ):
@@ -157,6 +145,8 @@ async def test_state_reporting(hass):
     # At least one member unlocked -> group unlocked
     for state_1 in (
         STATE_LOCKED,
+        STATE_UNAVAILABLE,
+        STATE_UNKNOWN,
         STATE_UNLOCKED,
     ):
         hass.states.async_set("lock.test1", state_1)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modify behavior of lock groups so it's `unknown` only if all group members are `unknown` or `unavailable`.

With this change, the behavior of lock groups is:
- The group state is unavailable if all group members are unavailable.
- Otherwise, the group state is unknown if all group members are unknown or unavailable.
- Otherwise, the group state is jammed if at least one group member is jammed.
- Otherwise, the group state is locking if at least one group member is locking.
- Otherwise, the group state is unlocking if at least one group member is unlocking.
- Otherwise, the group state is unlocked if at least one group member is unlocked.
- Otherwise, the group state is locked.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
