### PR TITLE
Add bool template filter and function

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -969,7 +969,7 @@ def forgiving_boolean(
         return cv.boolean(value)
     except vol.Invalid:
         if default is _SENTINEL:
-            raise_no_default("boolean", value)
+            raise_no_default("bool", value)
         return default
 
 
@@ -2002,7 +2002,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["relative_time"] = relative_time
         self.filters["slugify"] = slugify
         self.filters["iif"] = iif
-        self.filters["boolean"] = forgiving_boolean
+        self.filters["bool"] = forgiving_boolean
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -2034,7 +2034,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["unpack"] = struct_unpack
         self.globals["slugify"] = slugify
         self.globals["iif"] = iif
-        self.globals["boolean"] = forgiving_boolean
+        self.globals["bool"] = forgiving_boolean
         self.tests["is_number"] = is_number
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -296,6 +296,34 @@ def test_int_function(hass):
     assert render(hass, "{{ int('bad', default=1) }}") == 1
 
 
+def test_boolean_function(hass):
+    """Test boolean function."""
+    assert render(hass, "{{ boolean(true) }}") is True
+    assert render(hass, "{{ boolean(false) }}") is False
+    assert render(hass, "{{ boolean('on') }}") is True
+    assert render(hass, "{{ boolean('off') }}") is False
+    with pytest.raises(TemplateError):
+        render(hass, "{{ boolean('unknown') }}")
+    with pytest.raises(TemplateError):
+        render(hass, "{{ boolean(none) }}")
+    assert render(hass, "{{ boolean('unavailable', none) }}") is None
+    assert render(hass, "{{ boolean('unavailable', default=none) }}") is None
+
+
+def test_boolean_filter(hass):
+    """Test boolean filter."""
+    assert render(hass, "{{ true | boolean }}") is True
+    assert render(hass, "{{ false | boolean }}") is False
+    assert render(hass, "{{ 'on' | boolean }}") is True
+    assert render(hass, "{{ 'off' | boolean }}") is False
+    with pytest.raises(TemplateError):
+        render(hass, "{{ 'unknown' | boolean }}")
+    with pytest.raises(TemplateError):
+        render(hass, "{{ none | boolean }}")
+    assert render(hass, "{{ 'unavailable' | boolean(none) }}") is None
+    assert render(hass, "{{ 'unavailable' | boolean(default=none) }}") is None
+
+
 @pytest.mark.parametrize(
     "value, expected",
     [

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -296,32 +296,32 @@ def test_int_function(hass):
     assert render(hass, "{{ int('bad', default=1) }}") == 1
 
 
-def test_boolean_function(hass):
-    """Test boolean function."""
-    assert render(hass, "{{ boolean(true) }}") is True
-    assert render(hass, "{{ boolean(false) }}") is False
-    assert render(hass, "{{ boolean('on') }}") is True
-    assert render(hass, "{{ boolean('off') }}") is False
+def test_bool_function(hass):
+    """Test bool function."""
+    assert render(hass, "{{ bool(true) }}") is True
+    assert render(hass, "{{ bool(false) }}") is False
+    assert render(hass, "{{ bool('on') }}") is True
+    assert render(hass, "{{ bool('off') }}") is False
     with pytest.raises(TemplateError):
-        render(hass, "{{ boolean('unknown') }}")
+        render(hass, "{{ bool('unknown') }}")
     with pytest.raises(TemplateError):
-        render(hass, "{{ boolean(none) }}")
-    assert render(hass, "{{ boolean('unavailable', none) }}") is None
-    assert render(hass, "{{ boolean('unavailable', default=none) }}") is None
+        render(hass, "{{ bool(none) }}")
+    assert render(hass, "{{ bool('unavailable', none) }}") is None
+    assert render(hass, "{{ bool('unavailable', default=none) }}") is None
 
 
-def test_boolean_filter(hass):
-    """Test boolean filter."""
-    assert render(hass, "{{ true | boolean }}") is True
-    assert render(hass, "{{ false | boolean }}") is False
-    assert render(hass, "{{ 'on' | boolean }}") is True
-    assert render(hass, "{{ 'off' | boolean }}") is False
+def test_bool_filter(hass):
+    """Test bool filter."""
+    assert render(hass, "{{ true | bool }}") is True
+    assert render(hass, "{{ false | bool }}") is False
+    assert render(hass, "{{ 'on' | bool }}") is True
+    assert render(hass, "{{ 'off' | bool }}") is False
     with pytest.raises(TemplateError):
-        render(hass, "{{ 'unknown' | boolean }}")
+        render(hass, "{{ 'unknown' | bool }}")
     with pytest.raises(TemplateError):
-        render(hass, "{{ none | boolean }}")
-    assert render(hass, "{{ 'unavailable' | boolean(none) }}") is None
-    assert render(hass, "{{ 'unavailable' | boolean(default=none) }}") is None
+        render(hass, "{{ none | bool }}")
+    assert render(hass, "{{ 'unavailable' | bool(none) }}") is None
+    assert render(hass, "{{ 'unavailable' | bool(default=none) }}") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

Add a new template filter (and a matching function) `bool`, analogous to the existing `float`, `int`, `as_timestamp`, etc. The filter returns true for "true", "yes", "on", "enable", "1", boolean true, and non-zero numbers; and false for "false", "no", "off", "disable", "0", boolean false, and zero. In other cases an error is thrown or a default is returned, if specified.

The motivation for this are binary sensors and similar entities. If they were only on or off, an `is_state(..., "on")` would be sufficient; however, they could also be unknown or unavailable, and handling that currently requires long if-else chains. For numeric sensors we can do `states("sensor.temperature") | int(none)` to get either the value or none, and this PR makes something like `states("binary_sensor.door") | bool(none)` possible as well. This synergizes with the existing `iif` filter: `states("binary_sensor.door") | bool(none) | iif("open", "closed", "sensor died")`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: home-assistant/home-assistant.io#23221

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
