### PR TITLE
Partially revert "Switch loader to use json helper (#73872)"

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -7,7 +7,6 @@ from typing import Any, Final
 import orjson
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
-JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 
 
 class JSONEncoder(json.JSONEncoder):

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -7,6 +7,7 @@ from typing import Any, Final
 import orjson
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
+JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 
 
 class JSONEncoder(json.JSONEncoder):

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from contextlib import suppress
 import functools as ft
 import importlib
+import json
 import logging
 import pathlib
 import sys
@@ -29,7 +30,6 @@ from .generated.mqtt import MQTT
 from .generated.ssdp import SSDP
 from .generated.usb import USB
 from .generated.zeroconf import HOMEKIT, ZEROCONF
-from .helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
 from .util.async_ import gather_with_concurrency
 
 # Typing imports that create a circular dependency
@@ -366,8 +366,8 @@ class Integration:
                 continue
 
             try:
-                manifest = json_loads(manifest_path.read_text())
-            except JSON_DECODE_EXCEPTIONS as err:
+                manifest = json.loads(manifest_path.read_text())
+            except ValueError as err:
                 _LOGGER.error(
                     "Error parsing manifest.json file at %s: %s", manifest_path, err
                 )


### PR DESCRIPTION
This reverts commit 164eba7.<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Partially reverts #73872 to address the CI segfault issues we have been running into for the past 5 days.

I've been able to reproduce it locally by creating a fresh venv with a full install of dependencies and running a partial test, like so:

```bash
pytest  --timeout=10 --cov=homeassistant.components.open_meteo --cov-report term-missing --cov-report xml:cov.xml --durations=0 --durations-min=0.5 tests/components/open_meteo
```

```
[1]    210018 segmentation fault (core dumped)  pytest --timeout=10 --cov=homeassistant.components.open_meteo --cov-report   
```

Resulting backtrace from the core dump:

```txt
Reading symbols from /home/frenck/.pyenv/versions/3.9.9/envs/home-assistant-core/bin/python3.9...
[New LWP 210018]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/home/frenck/.pyenv/versions/3.9.9/envs/home-assistant-core/bin/python3.9 /home'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055a2ec81e5d4 in _Py_Dealloc (op=0x55a2eed919c0) at Objects/object.c:2209
2209    Objects/object.c: No such file or directory.
```

I was able to git bisect it, resulting in:

![image](https://user-images.githubusercontent.com/195327/176042998-5a7d7ca7-98c9-4f3a-ab64-335a29f11fbe.png)

Testing it in draft/testing PR #74046 showed it resolved the segfault in our CI too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
