### PR TITLE
Adjust entity filters to make includes stronger than excludes

### DIFF
--- a/homeassistant/components/recorder/filters.py
+++ b/homeassistant/components/recorder/filters.py
@@ -139,47 +139,52 @@ class Filters:
         have_exclude = self._have_exclude
         have_include = self._have_include
 
-        # Case 1 - no includes or excludes - pass all entities
+        # Case 1 - No filter
+        # - All entities included
         if not have_include and not have_exclude:
             return None
 
-        # Case 2 - includes, no excludes - only include specified entities
+        # Case 2 - Only includes
+        # - Entity listed in entities include: include
+        # - Otherwise, entity matches domain include: include
+        # - Otherwise, entity matches glob include: include
+        # - Otherwise: exclude
         if have_include and not have_exclude:
             return or_(*includes).self_group()
 
-        # Case 3 - excludes, no includes - only exclude specified entities
+        # Case 3 - Only excludes
+        # - Entity listed in exclude: exclude
+        # - Otherwise, entity matches domain exclude: exclude
+        # - Otherwise, entity matches glob exclude: exclude
+        # - Otherwise: include
         if not have_include and have_exclude:
             return not_(or_(*excludes).self_group())
 
-        # Case 4 - both includes and excludes specified
-        # Case 4a - include domain or glob specified
-        #  - if entity_id is included, accept
-        #  - if entity_id is excluded, reject
-        #  - if included by glob, accept
-        #  - if excluded by glob, reject
-        #  - if domain matches, accept
-        #  - reject
+        # Case 4 - Domain and/or glob includes (may also have excludes)
+        # - Entity listed in entities include: include
+        # - Otherwise, entity listed in entities exclude: exclude
+        # - Otherwise, entity matches glob include: include
+        # - Otherwise, entity matches glob exclude: exclude
+        # - Otherwise, entity matches domain include: include
+        # - Otherwise: exclude
         if self.included_domains or self.included_entity_globs:
             return or_(
                 i_entities,
                 (~e_entities & (i_entity_globs | (~e_entity_globs & i_domains))),
             ).self_group()
 
-        # Case 4b - exclude domain or glob specified, include has no domain or glob
-        # In this one case the traditional include logic is inverted. Even though an
-        # include is specified since its only a list of entity IDs its used only to
-        # expose specific entities excluded by domain or glob. Any entities not
-        # excluded are then presumed included. Logic is as follows
-        #  - if entity_id is included, accept
-        #  - if entity_id is excluded, reject
-        #  - if domain is excluded, reject
-        #  - if excluded by glob, reject
-        #  - accept
+        # Case 5 - Domain and/or glob excludes (no domain and/or glob includes)
+        # - Entity listed in entities include: include
+        # - Otherwise, entity listed in exclude: exclude
+        # - Otherwise, entity matches glob exclude: exclude
+        # - Otherwise, entity matches domain exclude: exclude
+        # - Otherwise: include
         if self.excluded_domains or self.excluded_entity_globs:
             return (not_(or_(*excludes)) | i_entities).self_group()
 
-        # Case 4c - neither include or exclude domain specified
-        #  - Only pass if entity is included.  Ignore entity excludes.
+        # Case 6 - No Domain and/or glob includes or excludes
+        # - Entity listed in entities include: include
+        # - Otherwise: exclude
         return i_entities
 
     def states_entity_filter(self) -> ClauseList:

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -145,11 +145,7 @@ def _glob_to_re(glob: str) -> re.Pattern[str]:
 
 def _test_against_patterns(patterns: list[re.Pattern[str]], entity_id: str) -> bool:
     """Test entity against list of patterns, true if any match."""
-    for pattern in patterns:
-        if pattern.match(entity_id):
-            return True
-
-    return False
+    return any(pattern.match(entity_id) for pattern in patterns)
 
 
 def _convert_globs_to_pattern_list(globs: list[str] | None) -> list[re.Pattern[str]]:
@@ -193,7 +189,7 @@ def _generate_filter_from_sets_and_pattern_lists(
         return (
             entity_id in include_e
             or domain in include_d
-            or bool(include_eg and _test_against_patterns(include_eg, entity_id))
+            or _test_against_patterns(include_eg, entity_id)
         )
 
     def entity_excluded(domain: str, entity_id: str) -> bool:
@@ -201,10 +197,10 @@ def _generate_filter_from_sets_and_pattern_lists(
         return (
             entity_id in exclude_e
             or domain in exclude_d
-            or bool(exclude_eg and _test_against_patterns(exclude_eg, entity_id))
+            or _test_against_patterns(exclude_eg, entity_id)
         )
 
-    # Case 1 - no includes or excludes - pass all entities
+    # Case 1 - no includes or excludes - accept all entities
     if not have_include and not have_exclude:
         return lambda entity_id: True
 
@@ -230,26 +226,26 @@ def _generate_filter_from_sets_and_pattern_lists(
 
     # Case 4 - both includes and excludes specified
     # Case 4a - include domain or glob specified
-    #  - if domain is included, pass if entity not excluded
-    #  - if glob is included, pass if entity and domain not excluded
-    #  - if domain and glob are not included, pass if entity is included
-    # note: if both include domain matches then exclude domains ignored.
-    #   If glob matches then exclude domains and glob checked
+    #  - if entity_id is included, accept
+    #  - if entity_id is excluded, reject
+    #  - if included by glob, accept
+    #  - if excluded by glob, reject
+    #  - if domain matches, accept
+    #  - reject
     if include_d or include_eg:
 
         def entity_filter_4a(entity_id: str) -> bool:
             """Return filter function for case 4a."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in include_d:
-                return not (
-                    entity_id in exclude_e
-                    or bool(
-                        exclude_eg and _test_against_patterns(exclude_eg, entity_id)
+            return entity_id in include_e or (
+                entity_id not in exclude_e
+                and (
+                    _test_against_patterns(include_eg, entity_id)
+                    or (
+                        split_entity_id(entity_id)[0] in include_d
+                        and not _test_against_patterns(exclude_eg, entity_id)
                     )
                 )
-            if _test_against_patterns(include_eg, entity_id):
-                return not entity_excluded(domain, entity_id)
-            return entity_id in include_e
+            )
 
         return entity_filter_4a
 
@@ -258,8 +254,11 @@ def _generate_filter_from_sets_and_pattern_lists(
     # include is specified since its only a list of entity IDs its used only to
     # expose specific entities excluded by domain or glob. Any entities not
     # excluded are then presumed included. Logic is as follows
-    #  - if domain or glob is excluded, pass if entity is included
-    #  - if domain is not excluded, pass if entity not excluded by ID
+    #  - if entity_id is included, accept
+    #  - if entity_id is excluded, reject
+    #  - if domain is excluded, reject
+    #  - if excluded by glob, reject
+    #  - accept
     if exclude_d or exclude_eg:
 
         def entity_filter_4b(entity_id: str) -> bool:
@@ -274,5 +273,5 @@ def _generate_filter_from_sets_and_pattern_lists(
         return entity_filter_4b
 
     # Case 4c - neither include or exclude domain specified
-    #  - Only pass if entity is included.  Ignore entity excludes.
+    #  - Only accept if entity is included.  Ignore entity excludes.
     return lambda entity_id: entity_id in include_e

--- a/tests/components/apache_kafka/test_init.py
+++ b/tests/components/apache_kafka/test_init.py
@@ -169,7 +169,7 @@ async def test_filtered_allowlist(hass, mock_client):
         FilterTest("light.excluded_test", False),
         FilterTest("light.excluded", False),
         FilterTest("sensor.included_test", True),
-        FilterTest("climate.included_test", False),
+        FilterTest("climate.included_test", True),
     ]
 
     await _run_filter_tests(hass, tests, mock_client)

--- a/tests/components/azure_event_hub/test_init.py
+++ b/tests/components/azure_event_hub/test_init.py
@@ -176,7 +176,7 @@ async def test_full_batch(hass, entry_with_one_event, mock_create_batch):
                 FilterTest("light.excluded_test", 0),
                 FilterTest("light.excluded", 0),
                 FilterTest("sensor.included_test", 1),
-                FilterTest("climate.included_test", 0),
+                FilterTest("climate.included_test", 1),
             ],
         ),
         (

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -222,7 +222,7 @@ async def test_filtered_allowlist(hass, mock_client):
         FilterTest("light.excluded_test", False),
         FilterTest("light.excluded", False),
         FilterTest("sensor.included_test", True),
-        FilterTest("climate.included_test", False),
+        FilterTest("climate.included_test", True),
     ]
 
     for test in tests:

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -753,7 +753,7 @@ async def test_fetch_period_api_with_entity_glob_include_and_exclude(
         {
             "history": {
                 "exclude": {
-                    "entity_globs": ["light.many*"],
+                    "entity_globs": ["light.many*", "binary_sensor.*"],
                 },
                 "include": {
                     "entity_globs": ["light.m*"],
@@ -769,6 +769,7 @@ async def test_fetch_period_api_with_entity_glob_include_and_exclude(
     hass.states.async_set("light.many_state_changes", "on")
     hass.states.async_set("switch.match", "on")
     hass.states.async_set("media_player.test", "on")
+    hass.states.async_set("binary_sensor.exclude", "on")
 
     await async_wait_recording_done(hass)
 
@@ -778,10 +779,11 @@ async def test_fetch_period_api_with_entity_glob_include_and_exclude(
     )
     assert response.status == HTTPStatus.OK
     response_json = await response.json()
-    assert len(response_json) == 3
-    assert response_json[0][0]["entity_id"] == "light.match"
-    assert response_json[1][0]["entity_id"] == "media_player.test"
-    assert response_json[2][0]["entity_id"] == "switch.match"
+    assert len(response_json) == 4
+    assert response_json[0][0]["entity_id"] == "light.many_state_changes"
+    assert response_json[1][0]["entity_id"] == "light.match"
+    assert response_json[2][0]["entity_id"] == "media_player.test"
+    assert response_json[3][0]["entity_id"] == "switch.match"
 
 
 async def test_entity_ids_limit_via_api(hass, hass_client, recorder_mock):

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -866,7 +866,7 @@ async def test_event_listener_filtered_allowlist(
         FilterTest("fake.excluded", False),
         FilterTest("another_fake.denied", False),
         FilterTest("fake.excluded_entity", False),
-        FilterTest("another_fake.included_entity", False),
+        FilterTest("another_fake.included_entity", True),
     ]
     execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
 

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -2153,7 +2153,7 @@ async def test_include_exclude_events_with_glob_filters(
     client = await hass_client()
     entries = await _async_fetch_logbook(client)
 
-    assert len(entries) == 6
+    assert len(entries) == 7
     _assert_entry(
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
@@ -2162,6 +2162,7 @@ async def test_include_exclude_events_with_glob_filters(
     _assert_entry(entries[3], name="bla", entity_id=entity_id, state="20")
     _assert_entry(entries[4], name="blu", entity_id=entity_id2, state="20")
     _assert_entry(entries[5], name="included", entity_id=entity_id4, state="30")
+    _assert_entry(entries[6], name="included", entity_id=entity_id5, state="30")
 
 
 async def test_empty_config(hass, hass_client, recorder_mock):

--- a/tests/components/recorder/test_filters_with_entityfilter.py
+++ b/tests/components/recorder/test_filters_with_entityfilter.py
@@ -514,3 +514,128 @@ async def test_same_entity_included_excluded_include_domain_wins(hass, recorder_
 
     assert filtered_events_entity_ids == filter_accept
     assert not filtered_events_entity_ids.intersection(filter_reject)
+
+
+async def test_specificly_included_entity_always_wins(hass, recorder_mock):
+    """Test specificlly included entity always wins."""
+    filter_accept = {
+        "media_player.test2",
+        "media_player.test3",
+        "thermostat.test",
+        "binary_sensor.specific_include",
+    }
+    filter_reject = {
+        "binary_sensor.test2",
+        "binary_sensor.home",
+        "binary_sensor.can_cancel_this_one",
+    }
+    conf = {
+        CONF_INCLUDE: {
+            CONF_ENTITIES: ["binary_sensor.specific_include"],
+        },
+        CONF_EXCLUDE: {
+            CONF_DOMAINS: ["binary_sensor"],
+            CONF_ENTITY_GLOBS: ["binary_sensor.*"],
+        },
+    }
+
+    extracted_filter = extract_include_exclude_filter_conf(conf)
+    entity_filter = convert_include_exclude_filter(extracted_filter)
+    sqlalchemy_filter = sqlalchemy_filter_from_include_exclude_conf(extracted_filter)
+    assert sqlalchemy_filter is not None
+
+    for entity_id in filter_accept:
+        assert entity_filter(entity_id) is True
+
+    for entity_id in filter_reject:
+        assert entity_filter(entity_id) is False
+
+    (
+        filtered_states_entity_ids,
+        filtered_events_entity_ids,
+    ) = await _async_get_states_and_events_with_filter(
+        hass, sqlalchemy_filter, filter_accept | filter_reject
+    )
+
+    assert filtered_states_entity_ids == filter_accept
+    assert not filtered_states_entity_ids.intersection(filter_reject)
+
+    assert filtered_events_entity_ids == filter_accept
+    assert not filtered_events_entity_ids.intersection(filter_reject)
+
+
+async def test_specificly_included_entity_always_wins_over_glob(hass, recorder_mock):
+    """Test specificlly included entity always wins over a glob."""
+    filter_accept = {
+        "sensor.apc900va_status",
+        "sensor.apc900va_battery_charge",
+        "sensor.apc900va_battery_runtime",
+        "sensor.apc900va_load",
+        "sensor.energy_x",
+    }
+    filter_reject = {
+        "sensor.apc900va_not_included",
+    }
+    conf = {
+        CONF_EXCLUDE: {
+            CONF_DOMAINS: [
+                "updater",
+                "camera",
+                "group",
+                "media_player",
+                "script",
+                "sun",
+                "automation",
+                "zone",
+                "weblink",
+                "scene",
+                "calendar",
+                "weather",
+                "remote",
+                "notify",
+                "switch",
+                "shell_command",
+                "media_player",
+            ],
+            CONF_ENTITY_GLOBS: ["sensor.apc900va_*"],
+        },
+        CONF_INCLUDE: {
+            CONF_DOMAINS: [
+                "binary_sensor",
+                "climate",
+                "device_tracker",
+                "input_boolean",
+                "sensor",
+            ],
+            CONF_ENTITY_GLOBS: ["sensor.energy_*"],
+            CONF_ENTITIES: [
+                "sensor.apc900va_status",
+                "sensor.apc900va_battery_charge",
+                "sensor.apc900va_battery_runtime",
+                "sensor.apc900va_load",
+            ],
+        },
+    }
+    extracted_filter = extract_include_exclude_filter_conf(conf)
+    entity_filter = convert_include_exclude_filter(extracted_filter)
+    sqlalchemy_filter = sqlalchemy_filter_from_include_exclude_conf(extracted_filter)
+    assert sqlalchemy_filter is not None
+
+    for entity_id in filter_accept:
+        assert entity_filter(entity_id) is True
+
+    for entity_id in filter_reject:
+        assert entity_filter(entity_id) is False
+
+    (
+        filtered_states_entity_ids,
+        filtered_events_entity_ids,
+    ) = await _async_get_states_and_events_with_filter(
+        hass, sqlalchemy_filter, filter_accept | filter_reject
+    )
+
+    assert filtered_states_entity_ids == filter_accept
+    assert not filtered_states_entity_ids.intersection(filter_reject)
+
+    assert filtered_events_entity_ids == filter_accept
+    assert not filtered_events_entity_ids.intersection(filter_reject)

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -108,6 +108,28 @@ def test_with_include_domain_case4a():
     assert testfilter("sun.sun") is False
 
 
+def test_with_include_domain_exclude_glob_case4a():
+    """Test case 4a - include and exclude specified, with included domain but excluded by glob."""
+    incl_dom = {"light", "sensor"}
+    incl_ent = {"binary_sensor.working"}
+    incl_glob = {}
+    excl_dom = {}
+    excl_ent = {"light.ignoreme", "sensor.notworking"}
+    excl_glob = {"sensor.busted"}
+    testfilter = generate_filter(
+        incl_dom, incl_ent, excl_dom, excl_ent, incl_glob, excl_glob
+    )
+
+    assert testfilter("sensor.test")
+    assert testfilter("sensor.busted") is False
+    assert testfilter("sensor.notworking") is False
+    assert testfilter("light.test")
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.working")
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("sun.sun") is False
+
+
 def test_with_include_glob_case4a():
     """Test case 4a - include and exclude specified, with included glob."""
     incl_dom = {}
@@ -142,12 +164,59 @@ def test_with_include_domain_glob_filtering_case4a():
     )
 
     assert testfilter("sensor.working")
-    assert testfilter("sensor.notworking") is False
+    assert testfilter("sensor.notworking") is True  # include is stronger
     assert testfilter("light.test")
-    assert testfilter("light.notworking") is False
+    assert testfilter("light.notworking") is True  # include is stronger
     assert testfilter("light.ignoreme") is False
-    assert testfilter("binary_sensor.not_working") is False
+    assert testfilter("binary_sensor.not_working") is True  # include is stronger
     assert testfilter("binary_sensor.another") is False
+    assert testfilter("sun.sun") is False
+
+
+def test_with_include_domain_glob_filtering_case4a_include_strong():
+    """Test case 4a - include and exclude specified, both have domains and globs, and a specifically included entity."""
+    incl_dom = {"light"}
+    incl_glob = {"*working"}
+    incl_ent = {"binary_sensor.specificly_included"}
+    excl_dom = {"binary_sensor"}
+    excl_glob = {"*notworking"}
+    excl_ent = {"light.ignoreme"}
+    testfilter = generate_filter(
+        incl_dom, incl_ent, excl_dom, excl_ent, incl_glob, excl_glob
+    )
+
+    assert testfilter("sensor.working")
+    assert testfilter("sensor.notworking") is True  # iclude is stronger
+    assert testfilter("light.test")
+    assert testfilter("light.notworking") is True  # iclude is stronger
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.not_working") is True  # iclude is stronger
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("binary_sensor.specificly_included") is True
+    assert testfilter("sun.sun") is False
+
+
+def test_with_include_glob_filtering_case4a_include_strong():
+    """Test case 4a - include and exclude specified, both have globs, and a specifically included entity."""
+    incl_dom = {}
+    incl_glob = {"*working"}
+    incl_ent = {"binary_sensor.specificly_included"}
+    excl_dom = {}
+    excl_glob = {"*broken", "*notworking", "binary_sensor.*"}
+    excl_ent = {"light.ignoreme"}
+    testfilter = generate_filter(
+        incl_dom, incl_ent, excl_dom, excl_ent, incl_glob, excl_glob
+    )
+
+    assert testfilter("sensor.working") is True
+    assert testfilter("sensor.notworking") is True  # include is stronger
+    assert testfilter("sensor.broken") is False
+    assert testfilter("light.test") is False
+    assert testfilter("light.notworking") is True  # include is stronger
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.not_working") is True  # include is stronger
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("binary_sensor.specificly_included") is True
     assert testfilter("sun.sun") is False
 
 
@@ -174,6 +243,27 @@ def test_exclude_glob_case4b():
     incl_glob = {}
     incl_ent = {"binary_sensor.working"}
     excl_dom = {}
+    excl_glob = {"binary_sensor.*"}
+    excl_ent = {"light.ignoreme", "sensor.notworking"}
+    testfilter = generate_filter(
+        incl_dom, incl_ent, excl_dom, excl_ent, incl_glob, excl_glob
+    )
+
+    assert testfilter("sensor.test")
+    assert testfilter("sensor.notworking") is False
+    assert testfilter("light.test")
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.working")
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("sun.sun") is True
+
+
+def test_exclude_glob_case4b_include_strong():
+    """Test case 4b - include and exclude specified, with excluded glob, and a specifically included entity."""
+    incl_dom = {}
+    incl_glob = {}
+    incl_ent = {"binary_sensor.working"}
+    excl_dom = {"binary_sensor"}
     excl_glob = {"binary_sensor.*"}
     excl_ent = {"light.ignoreme", "sensor.notworking"}
     testfilter = generate_filter(

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -91,8 +91,8 @@ def test_excludes_only_with_glob_case_3():
     assert testfilter("cover.garage_door")
 
 
-def test_with_include_domain_case4a():
-    """Test case 4a - include and exclude specified, with included domain."""
+def test_with_include_domain_case4():
+    """Test case 4 - include and exclude specified, with included domain."""
     incl_dom = {"light", "sensor"}
     incl_ent = {"binary_sensor.working"}
     excl_dom = {}
@@ -108,8 +108,8 @@ def test_with_include_domain_case4a():
     assert testfilter("sun.sun") is False
 
 
-def test_with_include_domain_exclude_glob_case4a():
-    """Test case 4a - include and exclude specified, with included domain but excluded by glob."""
+def test_with_include_domain_exclude_glob_case4():
+    """Test case 4 - include and exclude specified, with included domain but excluded by glob."""
     incl_dom = {"light", "sensor"}
     incl_ent = {"binary_sensor.working"}
     incl_glob = {}
@@ -130,8 +130,8 @@ def test_with_include_domain_exclude_glob_case4a():
     assert testfilter("sun.sun") is False
 
 
-def test_with_include_glob_case4a():
-    """Test case 4a - include and exclude specified, with included glob."""
+def test_with_include_glob_case4():
+    """Test case 4 - include and exclude specified, with included glob."""
     incl_dom = {}
     incl_glob = {"light.*", "sensor.*"}
     incl_ent = {"binary_sensor.working"}
@@ -151,8 +151,8 @@ def test_with_include_glob_case4a():
     assert testfilter("sun.sun") is False
 
 
-def test_with_include_domain_glob_filtering_case4a():
-    """Test case 4a - include and exclude specified, both have domains and globs."""
+def test_with_include_domain_glob_filtering_case4():
+    """Test case 4 - include and exclude specified, both have domains and globs."""
     incl_dom = {"light"}
     incl_glob = {"*working"}
     incl_ent = {}
@@ -174,7 +174,7 @@ def test_with_include_domain_glob_filtering_case4a():
 
 
 def test_with_include_domain_glob_filtering_case4a_include_strong():
-    """Test case 4a - include and exclude specified, both have domains and globs, and a specifically included entity."""
+    """Test case 4 - include and exclude specified, both have domains and globs, and a specifically included entity."""
     incl_dom = {"light"}
     incl_glob = {"*working"}
     incl_ent = {"binary_sensor.specificly_included"}
@@ -197,7 +197,7 @@ def test_with_include_domain_glob_filtering_case4a_include_strong():
 
 
 def test_with_include_glob_filtering_case4a_include_strong():
-    """Test case 4a - include and exclude specified, both have globs, and a specifically included entity."""
+    """Test case 4 - include and exclude specified, both have globs, and a specifically included entity."""
     incl_dom = {}
     incl_glob = {"*working"}
     incl_ent = {"binary_sensor.specificly_included"}
@@ -220,8 +220,8 @@ def test_with_include_glob_filtering_case4a_include_strong():
     assert testfilter("sun.sun") is False
 
 
-def test_exclude_domain_case4b():
-    """Test case 4b - include and exclude specified, with excluded domain."""
+def test_exclude_domain_case5():
+    """Test case 5 - include and exclude specified, with excluded domain."""
     incl_dom = {}
     incl_ent = {"binary_sensor.working"}
     excl_dom = {"binary_sensor"}
@@ -237,8 +237,8 @@ def test_exclude_domain_case4b():
     assert testfilter("sun.sun") is True
 
 
-def test_exclude_glob_case4b():
-    """Test case 4b - include and exclude specified, with excluded glob."""
+def test_exclude_glob_case5():
+    """Test case 5 - include and exclude specified, with excluded glob."""
     incl_dom = {}
     incl_glob = {}
     incl_ent = {"binary_sensor.working"}
@@ -258,8 +258,8 @@ def test_exclude_glob_case4b():
     assert testfilter("sun.sun") is True
 
 
-def test_exclude_glob_case4b_include_strong():
-    """Test case 4b - include and exclude specified, with excluded glob, and a specifically included entity."""
+def test_exclude_glob_case5_include_strong():
+    """Test case 5 - include and exclude specified, with excluded glob, and a specifically included entity."""
     incl_dom = {}
     incl_glob = {}
     incl_ent = {"binary_sensor.working"}
@@ -279,8 +279,8 @@ def test_exclude_glob_case4b_include_strong():
     assert testfilter("sun.sun") is True
 
 
-def test_no_domain_case4c():
-    """Test case 4c - include and exclude specified, with no domains."""
+def test_no_domain_case6():
+    """Test case 6 - include and exclude specified, with no domains."""
     incl_dom = {}
     incl_ent = {"binary_sensor.working"}
     excl_dom = {}


### PR DESCRIPTION
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adjust entity filters to make includes stronger than excludes.

- Filters are now applied as follows when there are domain and/or glob includes (may also have excludes):
    - Entity listed in entities include: include
    - Otherwise, entity listed in entities exclude: exclude
    - Otherwise, entity matches glob include: include
    - Otherwise, entity matches glob exclude: exclude
    - Otherwise, entity matches domain include: include
    - Otherwise: exclude

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59080
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23223

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
