### PR TITLE
Add additional attributes to tank_utility sensors

### DIFF
--- a/homeassistant/components/tank_utility/sensor.py
+++ b/homeassistant/components/tank_utility/sensor.py
@@ -38,6 +38,9 @@ SENSOR_ATTRS = [
     "status",
     "time",
     "time_iso",
+    "battery_warn",
+    "battery_crit",
+    "battery_level",
 ]
 
 

--- a/homeassistant/components/tank_utility/sensor.py
+++ b/homeassistant/components/tank_utility/sensor.py
@@ -41,6 +41,8 @@ SENSOR_ATTRS = [
     "battery_warn",
     "battery_crit",
     "battery_level",
+    "rssi",
+    "temperature"
 ]
 
 

--- a/homeassistant/components/tank_utility/sensor.py
+++ b/homeassistant/components/tank_utility/sensor.py
@@ -42,7 +42,7 @@ SENSOR_ATTRS = [
     "battery_crit",
     "battery_level",
     "rssi",
-    "temperature"
+    "temperature",
 ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds additional attributes pulled from the Tank Utility API response to include the battery state in the HA entity attributes:
-    "battery_warn",
-    "battery_crit",
-    "battery_level",
-    "rssi",
-    "temperature",

Example API JSON output showing the fields exist:

`curl https://data.tankutility.com/api/devices/[REDACTED]\?token\=[REDACTED]`
```json
{
    "device": {
        "device_id": "[REDACTED]",
        "short_device_id": "[REDACTED]",
        "name": "Home Propane",
        "address": "[REDACTED]",
        "account_id": "",
        "fuel_type": "propane",
        "fuel_dealer_id": "",
        "connection_type": "wifi",
        "product_id": "WIFI-G",
        "product_name": "Generac Tank Monitor",
        "supplier_id": "[REDACTED]",
        "status": "deployed",
        "capacity": 120,
        "orientation": "vertical",
        "consumption_types": "cooking",
        "consumption_type": {
            "backup_heating": false,
            "bulk_storage": false,
            "commercial_industrial": false,
            "cooking": true,
            "fireplace": false,
            "generator": false,
            "heating": false,
            "hot_water": false,
            "laundry_dryer": false,
            "pool": false,
            "retail_fill_up": false
        },
        "battery_warn": false,
        "battery_crit": false,
        "battery_level": "good",
        "average_consumption": 0,
        "estimated_fill_date": 0,
        "fixed_transmission_time": -1,
        "reading_interval": 21600,
        "transmission_interval": 86400,
        "threshold_1": -1,
        "threshold_2": -1,
        "change_of_value": -1,
        "lastReading": {
            "tank": 81.696029,
            "temperature": 77.297,
            "time": 1656377351000,
            "time_iso": "2022-06-28T00:49:11.000Z",
            "sw_rev": "12.005",
            "event_code": 1,
            "fixed_transmission_time": -1,
            "reading_interval": 21600,
            "transmission_interval": 86400,
            "threshold_1": -1,
            "threshold_2": -1,
            "change_of_value": -1
        },
        "telemetry": [
            {
                "attempt_no": 0,
                "chn": 1,
                "cipher": 245,
                "ecn": 3,
                "http_status_code": 200,
                "modem_ram": 51032,
                "module_temp": 0,
                "module_voltage": 0,
                "rssi": -64,
                "ssid": "[REDACTED]",
                "time_to_conn": 12.381,
                "tlm_time": 1656377371,
                "type": "wifi"
            }
        ]
    }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.
---> Plugin has no tests currently.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
