### PR TITLE
Use attributes in nx584 alarm

### DIFF
--- a/homeassistant/components/nx584/alarm_control_panel.py
+++ b/homeassistant/components/nx584/alarm_control_panel.py
@@ -55,9 +55,9 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the NX584 platform."""
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
+    name: str = config[CONF_NAME]
+    host: str = config[CONF_HOST]
+    port: int = config[CONF_PORT]
 
     url = f"http://{host}:{port}"
 
@@ -92,32 +92,18 @@ async def async_setup_platform(
 class NX584Alarm(alarm.AlarmControlPanelEntity):
     """Representation of a NX584-based alarm panel."""
 
+    _attr_code_format = alarm.CodeFormat.NUMBER
+    _attr_state: str | None
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
     )
 
-    def __init__(self, name, alarm_client, url):
+    def __init__(self, name: str, alarm_client: client.Client, url: str) -> None:
         """Init the nx584 alarm panel."""
-        self._name = name
-        self._state = None
+        self._attr_name = name
         self._alarm = alarm_client
         self._url = url
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def code_format(self):
-        """Return one or more digits/characters."""
-        return alarm.CodeFormat.NUMBER
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
 
     def update(self) -> None:
         """Process new events from panel."""
@@ -129,11 +115,11 @@ class NX584Alarm(alarm.AlarmControlPanelEntity):
                 "Unable to connect to %(host)s: %(reason)s",
                 {"host": self._url, "reason": ex},
             )
-            self._state = None
+            self._attr_state = None
             zones = []
         except IndexError:
             _LOGGER.error("NX584 reports no partitions")
-            self._state = None
+            self._attr_state = None
             zones = []
 
         bypassed = False
@@ -147,15 +133,15 @@ class NX584Alarm(alarm.AlarmControlPanelEntity):
                 break
 
         if not part["armed"]:
-            self._state = STATE_ALARM_DISARMED
+            self._attr_state = STATE_ALARM_DISARMED
         elif bypassed:
-            self._state = STATE_ALARM_ARMED_HOME
+            self._attr_state = STATE_ALARM_ARMED_HOME
         else:
-            self._state = STATE_ALARM_ARMED_AWAY
+            self._attr_state = STATE_ALARM_ARMED_AWAY
 
         for flag in part["condition_flags"]:
             if flag == "Siren on":
-                self._state = STATE_ALARM_TRIGGERED
+                self._attr_state = STATE_ALARM_TRIGGERED
 
     def alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
@@ -169,10 +155,10 @@ class NX584Alarm(alarm.AlarmControlPanelEntity):
         """Send arm away command."""
         self._alarm.arm("exit")
 
-    def alarm_bypass(self, zone):
+    def alarm_bypass(self, zone: int) -> None:
         """Send bypass command."""
         self._alarm.set_bypass(zone, True)
 
-    def alarm_unbypass(self, zone):
+    def alarm_unbypass(self, zone: int) -> None:
         """Send bypass command."""
         self._alarm.set_bypass(zone, False)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use attributes in nx584 alarm

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
