### PR TITLE
Use attributes in risco alarm

### DIFF
--- a/homeassistant/components/risco/alarm_control_panel.py
+++ b/homeassistant/components/risco/alarm_control_panel.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -65,44 +66,46 @@ async def async_setup_entry(
 class RiscoAlarm(AlarmControlPanelEntity, RiscoEntity):
     """Representation of a Risco partition."""
 
+    _attr_code_format = CodeFormat.NUMBER
+
     def __init__(self, coordinator, partition_id, code, options):
         """Init the partition."""
         super().__init__(coordinator)
         self._partition_id = partition_id
         self._partition = self.coordinator.data.partitions[self._partition_id]
         self._code = code
-        self._code_arm_required = options[CONF_CODE_ARM_REQUIRED]
+        self._attr_code_arm_required = options[CONF_CODE_ARM_REQUIRED]
         self._code_disarm_required = options[CONF_CODE_DISARM_REQUIRED]
         self._risco_to_ha = options[CONF_RISCO_STATES_TO_HA]
         self._ha_to_risco = options[CONF_HA_STATES_TO_RISCO]
-        self._supported_states = 0
+        self._attr_supported_features = 0
         for state in self._ha_to_risco:
-            self._supported_states |= STATES_TO_SUPPORTED_FEATURES[state]
+            self._attr_supported_features |= STATES_TO_SUPPORTED_FEATURES[state]
 
     def _get_data_from_coordinator(self):
         self._partition = self.coordinator.data.partitions[self._partition_id]
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
-        return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
-            "manufacturer": "Risco",
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.unique_id)},
+            name=self.name,
+            manufacturer="Risco",
+        )
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the partition."""
         return f"Risco {self._risco.site_name} Partition {self._partition_id}"
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return a unique id for that partition."""
         return f"{self._risco.site_uuid}_{self._partition_id}"
 
     @property
-    def state(self):
+    def state(self) -> str | None:
         """Return the state of the device."""
         if self._partition.triggered:
             return STATE_ALARM_TRIGGERED
@@ -120,21 +123,6 @@ class RiscoAlarm(AlarmControlPanelEntity, RiscoEntity):
             return self._risco_to_ha[RISCO_PARTIAL_ARM]
 
         return None
-
-    @property
-    def supported_features(self):
-        """Return the list of supported features."""
-        return self._supported_states
-
-    @property
-    def code_arm_required(self):
-        """Whether the code is required for arm actions."""
-        return self._code_arm_required
-
-    @property
-    def code_format(self):
-        """Return one or more digits/characters."""
-        return CodeFormat.NUMBER
 
     def _validate_code(self, code):
         """Validate given code."""
@@ -164,7 +152,7 @@ class RiscoAlarm(AlarmControlPanelEntity, RiscoEntity):
         await self._arm(STATE_ALARM_ARMED_CUSTOM_BYPASS, code)
 
     async def _arm(self, mode, code):
-        if self._code_arm_required and not self._validate_code(code):
+        if self.code_arm_required and not self._validate_code(code):
             _LOGGER.warning("Wrong code entered for %s", mode)
             return
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use attributes in risco alarm

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
