### PR TITLE
Use attributes in manual alarm

### DIFF
--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -5,6 +5,7 @@ import copy
 import datetime
 import logging
 import re
+from typing import Any
 
 import voluptuous as vol
 
@@ -185,6 +186,16 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
     A trigger_time of zero disables the alarm_trigger service.
     """
 
+    _attr_should_poll = False
+    _attr_supported_features = (
+        AlarmControlPanelEntityFeature.ARM_HOME
+        | AlarmControlPanelEntityFeature.ARM_AWAY
+        | AlarmControlPanelEntityFeature.ARM_NIGHT
+        | AlarmControlPanelEntityFeature.ARM_VACATION
+        | AlarmControlPanelEntityFeature.TRIGGER
+        | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+    )
+
     def __init__(
         self,
         hass,
@@ -198,13 +209,13 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         """Init the manual alarm panel."""
         self._state = STATE_ALARM_DISARMED
         self._hass = hass
-        self._name = name
+        self._attr_name = name
         if code_template:
             self._code = code_template
             self._code.hass = hass
         else:
             self._code = code or None
-        self._code_arm_required = code_arm_required
+        self._attr_code_arm_required = code_arm_required
         self._disarm_after_trigger = disarm_after_trigger
         self._previous_state = self._state
         self._state_ts = None
@@ -222,17 +233,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         }
 
     @property
-    def should_poll(self):
-        """Return the polling state."""
-        return False
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the device."""
         if self._state == STATE_ALARM_TRIGGERED:
             if self._within_pending_time(self._state):
@@ -252,18 +253,6 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
             return STATE_ALARM_ARMING
 
         return self._state
-
-    @property
-    def supported_features(self) -> int:
-        """Return the list of supported features."""
-        return (
-            AlarmControlPanelEntityFeature.ARM_HOME
-            | AlarmControlPanelEntityFeature.ARM_AWAY
-            | AlarmControlPanelEntityFeature.ARM_NIGHT
-            | AlarmControlPanelEntityFeature.ARM_VACATION
-            | AlarmControlPanelEntityFeature.TRIGGER
-            | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
-        )
 
     @property
     def _active_state(self):
@@ -289,18 +278,13 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         return self._state_ts + self._pending_time(state) > dt_util.utcnow()
 
     @property
-    def code_format(self):
+    def code_format(self) -> alarm.CodeFormat | None:
         """Return one or more digits/characters."""
         if self._code is None:
             return None
         if isinstance(self._code, str) and re.search("^\\d+$", self._code):
             return alarm.CodeFormat.NUMBER
         return alarm.CodeFormat.TEXT
-
-    @property
-    def code_arm_required(self):
-        """Whether the code is required for arm actions."""
-        return self._code_arm_required
 
     def alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
@@ -313,7 +297,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        if self._code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_HOME
         ):
             return
@@ -322,7 +306,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        if self._code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_AWAY
         ):
             return
@@ -331,7 +315,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
-        if self._code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_NIGHT
         ):
             return
@@ -340,7 +324,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_vacation(self, code: str | None = None) -> None:
         """Send arm vacation command."""
-        if self._code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_VACATION
         ):
             return
@@ -349,7 +333,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_custom_bypass(self, code: str | None = None) -> None:
         """Send arm custom bypass command."""
-        if self._code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_CUSTOM_BYPASS
         ):
             return
@@ -367,7 +351,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
             return
         self._update_state(STATE_ALARM_TRIGGERED)
 
-    def _update_state(self, state):
+    def _update_state(self, state: str) -> None:
         """Update the state."""
         if self._state == state:
             return
@@ -414,7 +398,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         return check
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         if self.state in (STATE_ALARM_PENDING, STATE_ALARM_ARMING):
             return {

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -297,7 +297,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        if self._attr_code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_HOME
         ):
             return
@@ -306,7 +306,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        if self._attr_code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_AWAY
         ):
             return
@@ -315,7 +315,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
-        if self._attr_code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_NIGHT
         ):
             return
@@ -324,7 +324,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_vacation(self, code: str | None = None) -> None:
         """Send arm vacation command."""
-        if self._attr_code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_VACATION
         ):
             return
@@ -333,7 +333,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_custom_bypass(self, code: str | None = None) -> None:
         """Send arm custom bypass command."""
-        if self._attr_code_arm_required and not self._validate_code(
+        if self.code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_CUSTOM_BYPASS
         ):
             return

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -297,7 +297,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        if self.code_arm_required and not self._validate_code(
+        if self._attr_code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_HOME
         ):
             return
@@ -306,7 +306,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        if self.code_arm_required and not self._validate_code(
+        if self._attr_code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_AWAY
         ):
             return
@@ -315,7 +315,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
-        if self.code_arm_required and not self._validate_code(
+        if self._attr_code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_NIGHT
         ):
             return
@@ -324,7 +324,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_vacation(self, code: str | None = None) -> None:
         """Send arm vacation command."""
-        if self.code_arm_required and not self._validate_code(
+        if self._attr_code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_VACATION
         ):
             return
@@ -333,7 +333,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
 
     def alarm_arm_custom_bypass(self, code: str | None = None) -> None:
         """Send arm custom bypass command."""
-        if self.code_arm_required and not self._validate_code(
+        if self._attr_code_arm_required and not self._validate_code(
             code, STATE_ALARM_ARMED_CUSTOM_BYPASS
         ):
             return


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use attributes in manual alarm

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
