### PR TITLE
Wait for discovery to complete before starting apple_tv

### DIFF
--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -54,8 +54,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if manager.is_on:
         await manager.connect_once(raise_missing_credentials=True)
         if not manager.atv:
-            name = entry.data[CONF_NAME]
-            raise ConfigEntryNotReady(f"Failed to find device {name}")
+            address = entry.data[CONF_ADDRESS]
+            raise ConfigEntryNotReady(f"Not found at {address}, waiting for discovery")
 
     hass.data.setdefault(DOMAIN, {})[entry.unique_id] = manager
 

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -53,6 +53,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if manager.is_on:
         await manager.connect_once(raise_missing_credentials=True)
+        if not manager.atv:
+            name = entry.data[CONF_NAME]
+            raise ConfigEntryNotReady(f"Failed to find device {name}")
 
     hass.data.setdefault(DOMAIN, {})[entry.unique_id] = manager
 

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -298,24 +298,30 @@ class AppleTVManager:
     async def _connect(self, conf, raise_missing_credentials):
         """Connect to device."""
         credentials = self.config_entry.data[CONF_CREDENTIALS]
-        session = async_get_clientsession(self.hass)
-
+        name = self.config_entry.data[CONF_NAME]
+        missing_protocols = []
         for protocol_int, creds in credentials.items():
             protocol = Protocol(int(protocol_int))
             if conf.get_service(protocol) is not None:
                 conf.set_credentials(protocol, creds)
-            elif raise_missing_credentials:
-                raise ConfigEntryNotReady(
-                    "Protocol {protocol.name} not found for {self.config_entry.data[CONF_NAME]}, waiting for discovery."
-                )
             else:
-                _LOGGER.warning(
-                    "Protocol %s not found for %s, functionality will be reduced",
-                    protocol.name,
-                    self.config_entry.data[CONF_NAME],
+                missing_protocols.append(protocol.name)
+
+        if missing_protocols:
+            missing_protocols_str = ", ".join(missing_protocols)
+            if raise_missing_credentials:
+                raise ConfigEntryNotReady(
+                    f"Protocol(s) {missing_protocols_str} not yet found for {name}, waiting for discovery."
                 )
+            _LOGGER.info(
+                "Protocol(s) %s not yet found for %s, trying later",
+                missing_protocols_str,
+                name,
+            )
+            return
 
         _LOGGER.debug("Connecting to device %s", self.config_entry.data[CONF_NAME])
+        session = async_get_clientsession(self.hass)
         self.atv = await connect(conf, self.hass.loop, session=session)
         self.atv.listener = self
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wait for discovery to complete before starting apple_tv.

We now also raise ConfigEntryNotReady when the device is offline so they get feedback in the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66704
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
