### PR TITLE
Remove deprecated YAML import for Tautulli

### DIFF
--- a/homeassistant/components/tautulli/config_flow.py
+++ b/homeassistant/components/tautulli/config_flow.py
@@ -4,36 +4,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from pytautulli import (
-    PyTautulli,
-    PyTautulliException,
-    PyTautulliHostConfiguration,
-    exceptions,
-)
+from pytautulli import PyTautulli, PyTautulliException, exceptions
 import voluptuous as vol
 
-from homeassistant.components.sensor import _LOGGER
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_PATH,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_URL,
-    CONF_VERIFY_SSL,
-)
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import (
-    DEFAULT_NAME,
-    DEFAULT_PATH,
-    DEFAULT_PORT,
-    DEFAULT_SSL,
-    DEFAULT_VERIFY_SSL,
-    DOMAIN,
-)
+from .const import DEFAULT_NAME, DOMAIN
 
 
 class TautulliConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -93,33 +72,6 @@ class TautulliConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
             errors=errors,
-        )
-
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Import a config entry from configuration.yaml."""
-        _LOGGER.warning(
-            "Configuration of the Tautulli platform in YAML is deprecated and will be "
-            "removed in Home Assistant 2022.6; Your existing configuration for host %s"
-            "has been imported into the UI automatically and can be safely removed "
-            "from your configuration.yaml file",
-            config[CONF_HOST],
-        )
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-        host_configuration = PyTautulliHostConfiguration(
-            config[CONF_API_KEY],
-            ipaddress=config[CONF_HOST],
-            port=config.get(CONF_PORT, DEFAULT_PORT),
-            ssl=config.get(CONF_SSL, DEFAULT_SSL),
-            verify_ssl=config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-            base_api_path=config.get(CONF_PATH, DEFAULT_PATH),
-        )
-        return await self.async_step_user(
-            {
-                CONF_API_KEY: host_configuration.api_token,
-                CONF_URL: host_configuration.base_url,
-                CONF_VERIFY_SSL: host_configuration.verify_ssl,
-            }
         )
 
     async def validate_input(self, user_input: dict[str, Any]) -> str | None:

--- a/homeassistant/components/tautulli/const.py
+++ b/homeassistant/components/tautulli/const.py
@@ -5,9 +5,5 @@ ATTR_TOP_USER = "top_user"
 
 CONF_MONITORED_USERS = "monitored_users"
 DEFAULT_NAME = "Tautulli"
-DEFAULT_PATH = ""
-DEFAULT_PORT = "8181"
-DEFAULT_SSL = False
-DEFAULT_VERIFY_SSL = True
 DOMAIN = "tautulli"
 LOGGER: Logger = getLogger(__package__)

--- a/homeassistant/components/tautulli/sensor.py
+++ b/homeassistant/components/tautulli/sensor.py
@@ -11,60 +11,22 @@ from pytautulli import (
     PyTautulliApiSession,
     PyTautulliApiUser,
 )
-import voluptuous as vol
 
 from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_MONITORED_CONDITIONS,
-    CONF_NAME,
-    CONF_PATH,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_VERIFY_SSL,
-    DATA_KILOBITS,
-    PERCENTAGE,
-)
+from homeassistant.const import DATA_KILOBITS, PERCENTAGE
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import EntityCategory, EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
 from . import TautulliEntity
-from .const import (
-    ATTR_TOP_USER,
-    CONF_MONITORED_USERS,
-    DEFAULT_NAME,
-    DEFAULT_PATH,
-    DEFAULT_PORT,
-    DEFAULT_SSL,
-    DEFAULT_VERIFY_SSL,
-    DOMAIN,
-)
+from .const import ATTR_TOP_USER, DOMAIN
 from .coordinator import TautulliDataUpdateCoordinator
-
-# Deprecated in Home Assistant 2022.4
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_API_KEY): cv.string,
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_MONITORED_USERS): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
-        vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
-        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    }
-)
 
 
 def get_top_stats(

--- a/tests/components/tautulli/test_config_flow.py
+++ b/tests/components/tautulli/test_config_flow.py
@@ -2,11 +2,10 @@
 from unittest.mock import AsyncMock, patch
 
 from pytautulli import exceptions
-from pytest import LogCaptureFixture
 
 from homeassistant import data_entry_flow
-from homeassistant.components.tautulli.const import DEFAULT_NAME, DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, SOURCE_USER
+from homeassistant.components.tautulli.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 
@@ -125,37 +124,6 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
-
-
-async def test_flow_import(hass: HomeAssistant, caplog: LogCaptureFixture) -> None:
-    """Test import step."""
-    with patch_config_flow_tautulli(AsyncMock()):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=CONF_IMPORT_DATA,
-        )
-    await hass.async_block_till_done()
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"] == CONF_DATA
-    assert "Tautulli platform in YAML" in caplog.text
-
-
-async def test_flow_import_single_instance_allowed(hass: HomeAssistant) -> None:
-    """Test import step single instance allowed."""
-    entry = MockConfigEntry(domain=DOMAIN, data=CONF_DATA)
-    entry.add_to_hass(hass)
-
-    with patch_config_flow_tautulli(AsyncMock()):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=CONF_IMPORT_DATA,
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "single_instance_allowed"
 
 
 async def test_flow_reauth(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration of the Tautulli
integration has been removed.

Tautulli is now configured via the UI, any existing YAML
configuration has been imported in previous releases and can now be safely
removed from your YAML configuration files

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
