### PR TITLE
Add enforce_type_hints to vscode tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -648,14 +648,14 @@ jobs:
         run: |
           . venv/bin/activate
           python --version
-          pylint homeassistant
+          pylint --ignore-missing-annotations=y homeassistant
       - name: Run pylint (partially)
         if: needs.changes.outputs.test_full_suite == 'false'
         shell: bash
         run: |
           . venv/bin/activate
           python --version
-          pylint homeassistant/components/${{ needs.changes.outputs.integrations_glob }}
+          pylint --ignore-missing-annotations=y homeassistant/components/${{ needs.changes.outputs.integrations_glob }}
 
   mypy:
     name: Check mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         files: ^(homeassistant|pylint)/.+\.py$
       - id: pylint
         name: pylint
-        entry: script/run-in-env.sh pylint -j 0
+        entry: script/run-in-env.sh pylint -j 0 --ignore-missing-annotations=y
         language: script
         types: [python]
         files: ^homeassistant/.+\.py$

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,20 +57,6 @@
       "problemMatcher": []
     },
     {
-      "label": "Pylint (enforce_type_hint)",
-      "type": "shell",
-      "command": "pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/${input:integrationName}",
-      "group": {
-        "kind": "test",
-        "isDefault": true
-      },
-      "presentation": {
-        "reveal": "always",
-        "panel": "new"
-      },
-      "problemMatcher": []
-    },
-    {
       "label": "Code Coverage",
       "detail": "Generate code coverage report for a given integration.",
       "type": "shell",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,6 +57,20 @@
       "problemMatcher": []
     },
     {
+      "label": "Pylint (enforce_type_hint)",
+      "type": "shell",
+      "command": "pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/${input:integrationName}",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Code Coverage",
       "detail": "Generate code coverage report for a given integration.",
       "type": "shell",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1243,7 +1243,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         (
             "ignore-missing-annotations",
             {
-                "default": True,
+                "default": False,
                 "type": "yn",
                 "metavar": "<y or n>",
                 "help": "Set to ``no`` if you wish to check functions that do not "

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -120,6 +120,9 @@ def test_ignore_no_annotations(
     hass_enforce_type_hints: ModuleType, type_hint_checker: BaseChecker, code: str
 ) -> None:
     """Ensure that _is_valid_type is not run if there are no annotations."""
+    # Set ignore option
+    type_hint_checker.config.ignore_missing_annotations = True
+
     func_node = astroid.extract_node(
         code,
         "homeassistant.components.pylint_test",
@@ -539,6 +542,9 @@ def test_ignore_invalid_entity_properties(
     linter: UnittestLinter, type_hint_checker: BaseChecker
 ) -> None:
     """Check invalid entity properties are ignored by default."""
+    # Set ignore option
+    type_hint_checker.config.ignore_missing_annotations = True
+
     class_node = astroid.extract_node(
         """
     class LockEntity():


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add enforce_type_hints to vscode tasks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
