### PR TITLE
Add CalendarEntity checks to pylint plugin

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -222,8 +222,9 @@ class CalendarEventDevice(Entity):
             "description": event["description"],
         }
 
+    @final
     @property
-    def state(self) -> str | None:
+    def state(self) -> str:
         """Return the state of the calendar event."""
         if (event := self.event) is None:
             return STATE_OFF
@@ -276,8 +277,9 @@ class CalendarEntity(Entity):
             "description": event.description if event.description else "",
         }
 
+    @final
     @property
-    def state(self) -> str | None:
+    def state(self) -> str:
         """Return the state of the calendar event."""
         if (event := self.event) is None:
             return STATE_OFF

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -591,6 +591,7 @@ _TOGGLE_ENTITY_MATCH: list[TypeHintMatch] = [
     ),
 ]
 _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
+    "air_quality": [],  # ignored as deprecated
     "alarm_control_panel": [
         ClassTypeHintMatch(
             base_class="Entity",
@@ -713,6 +714,34 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                     function_name="press",
                     return_type=None,
                     has_async_counterpart=True,
+                ),
+            ],
+        ),
+    ],
+    "calendar": [
+        ClassTypeHintMatch(
+            base_class="Entity",
+            matches=_ENTITY_MATCH,
+        ),
+        ClassTypeHintMatch(
+            base_class="CalendarEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="event",
+                    return_type=["CalendarEvent", None],
+                ),
+                TypeHintMatch(
+                    function_name="state",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="async_get_events",
+                    arg_types={
+                        1: "HomeAssistant",
+                        2: "datetime",
+                        3: "datetime",
+                    },
+                    return_type="list[CalendarEvent]",
                 ),
             ],
         ),

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -591,7 +591,7 @@ _TOGGLE_ENTITY_MATCH: list[TypeHintMatch] = [
     ),
 ]
 _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
-    "air_quality": [],  # ignored as deprecated
+    # "air_quality": [],  # ignored as deprecated
     "alarm_control_panel": [
         ClassTypeHintMatch(
             base_class="Entity",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -731,10 +731,6 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                     return_type=["CalendarEvent", None],
                 ),
                 TypeHintMatch(
-                    function_name="state",
-                    return_type=["str", None],
-                ),
-                TypeHintMatch(
                     function_name="async_get_events",
                     arg_types={
                         1: "HomeAssistant",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add CalendarEntity checks to pylint plugin

```console
pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/**/calendar.py

************* Module homeassistant.components.demo.calendar
homeassistant/components/demo/calendar.py:75:37: W7431: Argument 2 should be of type HomeAssistant (hass-argument-type)
homeassistant/components/demo/calendar.py:75:43: W7431: Argument 3 should be of type datetime (hass-argument-type)
homeassistant/components/demo/calendar.py:75:55: W7431: Argument 4 should be of type datetime (hass-argument-type)
homeassistant/components/demo/calendar.py:105:4: W7432: Return type should be ['str', None] (hass-return-type)
************* Module homeassistant.components.caldav.calendar
homeassistant/components/caldav/calendar.py:138:37: W7431: Argument 2 should be of type HomeAssistant (hass-argument-type)
homeassistant/components/caldav/calendar.py:138:43: W7431: Argument 3 should be of type datetime (hass-argument-type)
homeassistant/components/caldav/calendar.py:138:55: W7431: Argument 4 should be of type datetime (hass-argument-type)
homeassistant/components/caldav/calendar.py:138:4: W7432: Return type should be list[CalendarEvent] (hass-return-type)
homeassistant/components/caldav/calendar.py:142:4: W7432: Return type should be None (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
