### PR TITLE
Fix false-positive in pylint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1432,11 +1432,14 @@ def _is_valid_type(
         # Other cases of xxx[yyy, zzz, aaa, ...]`
         for i in reversed(_INNER_MATCH_POSSIBILITIES):
             if match := _TYPE_HINT_MATCHERS[f"x_of_y_{i}"].match(expected_type):
+                # Case (i == 1) is separate because node.slice is is not a Tuple
                 if i == 1:
                     return _is_valid_type(
                         match.group(1), node.value
                     ) and _is_valid_type(match.group(2), node.slice)
 
+                # This special case is separate because we want Mapping[str, Any]
+                # to also match dict[str, int] and similar
                 if (
                     i == 2
                     and in_return
@@ -1453,6 +1456,7 @@ def _is_valid_type(
                         # and _is_valid_type(match.group(3), node.slice.elts[1])
                     )
 
+                # This is the default case
                 return (
                     _is_valid_type(match.group(1), node.value)
                     and isinstance(node.slice, nodes.Tuple)

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -51,7 +51,7 @@ class ClassTypeHintMatch:
 
 
 _INNER_MATCH = r"(.*?]*)"
-_INNER_MATCH_POSSIBILITIES = [1, 2, 3, 4, 5]
+_INNER_MATCH_POSSIBILITIES = [i + 1 for i in range(5)]
 _TYPE_HINT_MATCHERS: dict[str, re.Pattern[str]] = {
     # a_or_b matches items such as "DiscoveryInfoType | None"
     "a_or_b": re.compile(r"^(\w+) \| (\w+)$"),

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1460,9 +1460,10 @@ def _is_valid_type(
                 return (
                     _is_valid_type(match.group(1), node.value)
                     and isinstance(node.slice, nodes.Tuple)
+                    and len(node.slice.elts) == i
                     and all(
                         _is_valid_type(match.group(n + 2), node.slice.elts[n])
-                        for n in range(i - 1)
+                        for n in range(i)
                     )
                 )
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1419,16 +1419,6 @@ def _is_valid_type(
     # Special case for `xxx[aaa, bbb, ccc, ...]
     if (
         isinstance(node, nodes.Subscript)
-        and not isinstance(node.slice, nodes.Tuple)
-        and (match := _TYPE_HINT_MATCHERS["x_of_y_1"].match(expected_type))
-    ):
-        return _is_valid_type(match.group(1), node.value) and _is_valid_type(
-            match.group(2), node.slice
-        )
-
-    # Special case for `xxx[aaa, bbb, ccc, ...]
-    if (
-        isinstance(node, nodes.Subscript)
         and isinstance(node.slice, nodes.Tuple)
         and (
             match := _TYPE_HINT_MATCHERS[f"x_of_y_{len(node.slice.elts)}"].match(
@@ -1462,6 +1452,14 @@ def _is_valid_type(
                 _is_valid_type(match.group(n + 2), node.slice.elts[n])
                 for n in range(len(node.slice.elts))
             )
+        )
+
+    # Special case for xxx[yyy]
+    if match := _TYPE_HINT_MATCHERS["x_of_y_1"].match(expected_type):
+        return (
+            isinstance(node, nodes.Subscript)
+            and _is_valid_type(match.group(1), node.value)
+            and _is_valid_type(match.group(2), node.slice)
         )
 
     # Name occurs when a namespace is not used, eg. "HomeAssistant"

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -51,21 +51,23 @@ def test_regex_get_module_platform(
             ("tuple", "int", "int", "int", "int", "int"),
         ),
         ("Awaitable[None]", 1, ("Awaitable", "None")),
+        ("list[dict[str, str]]", 1, ("list", "dict[str, str]")),
+        ("list[dict[str, Any]]", 1, ("list", "dict[str, Any]")),
     ],
 )
-def test_regex_x_of_y_comma_z(
+def test_regex_x_of_y_i(
     hass_enforce_type_hints: ModuleType,
     string: str,
     expected_count: int,
     expected_items: tuple[str, ...],
 ) -> None:
-    """Test x_of_y_comma_z regexes."""
+    """Test x_of_y_i regexes."""
     matchers: dict[str, re.Pattern] = hass_enforce_type_hints._TYPE_HINT_MATCHERS
 
     assert (match := matchers[f"x_of_y_{expected_count}"].match(string))
     assert match.group(0) == string
-    for n in range(expected_count):
-        assert match.group(n + 1) == expected_items[n]
+    for index in range(expected_count):
+        assert match.group(index + 1) == expected_items[index]
 
 
 @pytest.mark.parametrize(
@@ -731,7 +733,7 @@ def test_valid_long_tuple(
     # Set ignore option
     type_hint_checker.config.ignore_missing_annotations = False
 
-    class_node, rgbw_node, rgbww_node = astroid.extract_node(
+    class_node, _, _ = astroid.extract_node(
         """
     class Entity():
         pass

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -40,53 +40,32 @@ def test_regex_get_module_platform(
 
 
 @pytest.mark.parametrize(
-    ("string", "expected_x", "expected_y", "expected_z", "expected_a"),
+    ("string", "expected_count", "expected_items"),
     [
-        ("list[dict[str, str]]", "list", "dict", "str", "str"),
-        ("list[dict[str, Any]]", "list", "dict", "str", "Any"),
-    ],
-)
-def test_regex_x_of_y_of_z_comma_a(
-    hass_enforce_type_hints: ModuleType,
-    string: str,
-    expected_x: str,
-    expected_y: str,
-    expected_z: str,
-    expected_a: str,
-) -> None:
-    """Test x_of_y_of_z_comma_a regexes."""
-    matchers: dict[str, re.Pattern] = hass_enforce_type_hints._TYPE_HINT_MATCHERS
-
-    assert (match := matchers["x_of_y_of_z_comma_a"].match(string))
-    assert match.group(0) == string
-    assert match.group(1) == expected_x
-    assert match.group(2) == expected_y
-    assert match.group(3) == expected_z
-    assert match.group(4) == expected_a
-
-
-@pytest.mark.parametrize(
-    ("string", "expected_x", "expected_y", "expected_z"),
-    [
-        ("Callable[..., None]", "Callable", "...", "None"),
-        ("Callable[..., Awaitable[None]]", "Callable", "...", "Awaitable[None]"),
+        ("Callable[..., None]", 2, ("Callable", "...", "None")),
+        ("Callable[..., Awaitable[None]]", 2, ("Callable", "...", "Awaitable[None]")),
+        ("tuple[int, int, int, int]", 4, ("tuple", "int", "int", "int", "int")),
+        (
+            "tuple[int, int, int, int, int]",
+            5,
+            ("tuple", "int", "int", "int", "int", "int"),
+        ),
+        ("Awaitable[None]", 1, ("Awaitable", "None")),
     ],
 )
 def test_regex_x_of_y_comma_z(
     hass_enforce_type_hints: ModuleType,
     string: str,
-    expected_x: str,
-    expected_y: str,
-    expected_z: str,
+    expected_count: int,
+    expected_items: tuple[str, ...],
 ) -> None:
     """Test x_of_y_comma_z regexes."""
     matchers: dict[str, re.Pattern] = hass_enforce_type_hints._TYPE_HINT_MATCHERS
 
-    assert (match := matchers["x_of_y_comma_z"].match(string))
+    assert (match := matchers[f"x_of_y_{expected_count}"].match(string))
     assert match.group(0) == string
-    assert match.group(1) == expected_x
-    assert match.group(2) == expected_y
-    assert match.group(3) == expected_z
+    for n in range(expected_count):
+        assert match.group(n + 1) == expected_items[n]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix false-positive in pylint plugin

Subscripts with more than two items were not handled.
```console
pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/demo/light.py

************* Module homeassistant.components.demo.light
homeassistant/components/demo/light.py:199:4: W7432: Return type should be ['tuple[int, int, int, int]', None] (hass-return-type)
homeassistant/components/demo/light.py:204:4: W7432: Return type should be ['tuple[int, int, int, int, int]', None] (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
