### PR TITLE
Fix ZHA events for logbook

### DIFF
--- a/homeassistant/components/zha/logbook.py
+++ b/homeassistant/components/zha/logbook.py
@@ -62,16 +62,18 @@ def async_describe_events(
                 break
 
         if event_type is None:
-            event_type = (
-                event_data[ATTR_COMMAND] if ATTR_COMMAND in event_data else ZHA_EVENT
-            )
+            event_type = event_data.get(ATTR_COMMAND, ZHA_EVENT)
 
         if event_subtype is not None and event_subtype != event_type:
             event_type = f"{event_type} - {event_subtype}"
 
-        event_type = event_type.replace("_", " ").title()
+        if event_type is not None:
+            event_type = event_type.replace("_", " ").title()
+            if "event" in event_type.lower():
+                message = f"{event_type} was fired"
+            else:
+                message = f"{event_type} event was fired"
 
-        message = f"{event_type} event was fired"
         if event_data["params"]:
             message = f"{message} with parameters: {event_data['params']}"
 

--- a/homeassistant/components/zha/logbook.py
+++ b/homeassistant/components/zha/logbook.py
@@ -62,7 +62,9 @@ def async_describe_events(
                 break
 
         if event_type is None:
-            event_type = event_data[ATTR_COMMAND]
+            event_type = (
+                event_data[ATTR_COMMAND] if ATTR_COMMAND in event_data else ZHA_EVENT
+            )
 
         if event_subtype is not None and event_subtype != event_type:
             event_type = f"{event_type} - {event_subtype}"

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -172,6 +172,19 @@ async def test_zha_logbook_event_device_no_triggers(hass, mock_devices):
                     },
                 },
             ),
+            MockRow(
+                ZHA_EVENT,
+                {
+                    CONF_DEVICE_ID: reg_device.id,
+                    "device_ieee": str(ieee_address),
+                    CONF_UNIQUE_ID: f"{str(ieee_address)}:1:0x0006",
+                    "endpoint_id": 1,
+                    "cluster_id": 6,
+                    "params": {
+                        "test": "test",
+                    },
+                },
+            ),
         ],
     )
 
@@ -180,6 +193,12 @@ async def test_zha_logbook_event_device_no_triggers(hass, mock_devices):
     assert (
         events[0]["message"]
         == "Shake event was fired with parameters: {'test': 'test'}"
+    )
+
+    assert events[1]["name"] == "FakeManufacturer FakeModel"
+    assert events[1]["domain"] == "zha"
+    assert (
+        events[1]["message"] == "Zha Event was fired with parameters: {'test': 'test'}"
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Testing the beta in Prod I realized we need another guard in the ZHA logbook code. Here is the error:

```
Logger: homeassistant.components.websocket_api.http.connection
Source: components/zha/logbook.py:65 
Integration: Home Assistant WebSocket API (documentation, issues) 
First occurred: 9:43:03 AM (3 occurrences) 
Last logged: 9:44:21 AM

[281473395252176] Error handling message: Unknown error (unknown_error)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 387, in ws_event_stream
    last_event_time = await _async_send_historical_events(
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 117, in _async_send_historical_events
    message, last_event_time = await _async_get_ws_stream_events(
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 182, in _async_get_ws_stream_events
    return await get_instance(hass).async_add_executor_job(
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/logbook/websocket_api.py", line 213, in _ws_stream_get_events
    events = event_processor.get_events(start_day, end_day)
  File "/usr/src/homeassistant/homeassistant/components/logbook/processor.py", line 164, in get_events
    return self.humanify(yield_rows(session.execute(stmt)))
  File "/usr/src/homeassistant/homeassistant/components/logbook/processor.py", line 170, in humanify
    return list(
  File "/usr/src/homeassistant/homeassistant/components/logbook/processor.py", line 231, in _humanify
    data = describe_event(event_cache.get(row))
  File "/usr/src/homeassistant/homeassistant/components/zha/logbook.py", line 65, in async_describe_zha_event
    event_type = event_data[ATTR_COMMAND]
KeyError: 'command'
```

This PR corrects this error. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
