### PR TITLE
Fix Life360 unload

### DIFF
--- a/homeassistant/components/life360/__init__.py
+++ b/homeassistant/components/life360/__init__.py
@@ -171,7 +171,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload config entry."""
-    del hass.data[DOMAIN].coordinators[entry.entry_id]
 
     # Unload components for our platforms.
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        del hass.data[DOMAIN].coordinators[entry.entry_id]
+
+    return unload_ok

--- a/homeassistant/components/life360/__init__.py
+++ b/homeassistant/components/life360/__init__.py
@@ -124,11 +124,11 @@ class IntegData:
     """Integration data."""
 
     cfg_options: dict[str, Any] | None = None
-    # ConfigEntry.unique_id: Life360DataUpdateCoordinator
+    # ConfigEntry.entry_id: Life360DataUpdateCoordinator
     coordinators: dict[str, Life360DataUpdateCoordinator] = field(
         init=False, default_factory=dict
     )
-    # member_id: ConfigEntry.unique_id
+    # member_id: ConfigEntry.entry_id
     tracked_members: dict[str, str] = field(init=False, default_factory=dict)
     logged_circles: list[str] = field(init=False, default_factory=list)
     logged_places: list[str] = field(init=False, default_factory=list)
@@ -175,5 +175,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Unload components for our platforms.
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         del hass.data[DOMAIN].coordinators[entry.entry_id]
+        # Remove any members that were tracked by this entry.
+        for member_id, entry_id in hass.data[DOMAIN].tracked_members.copy().items():
+            if entry_id == entry.entry_id:
+                del hass.data[DOMAIN].tracked_members[member_id]
 
     return unload_ok

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -78,13 +78,13 @@ async def async_setup_entry(
 
         new_entities = []
         for member_id, member in coordinator.data.members.items():
-            tracked_by_account = tracked_members.get(member_id)
-            if new_member := not tracked_by_account:
-                tracked_members[member_id] = entry.unique_id
-                LOGGER.debug("Member: %s", member.name)
+            tracked_by_entry = tracked_members.get(member_id)
+            if new_member := not tracked_by_entry:
+                tracked_members[member_id] = entry.entry_id
+                LOGGER.debug("Member: %s (%s)", member.name, entry.unique_id)
             if (
                 new_member
-                or tracked_by_account == entry.unique_id
+                or tracked_by_entry == entry.entry_id
                 and not new_members_only
             ):
                 new_entities.append(Life360DeviceTracker(coordinator, member_id))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to: https://github.com/home-assistant/core/pull/72461#pullrequestreview-1024314262

Fix `async_unload_entry` by only deleting coordinator after platforms are
unloaded successfully.

Also, when unloading a config entry, forget any members that were tracked
by that config entry (since their device tracker entities will have been removed
from the system.) Note that if any of those members happen to be in any circles
accessible via other config entries (i.e., other Life360 accounts), entities will be
re-created for them via these other config entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
