### PR TITLE
Fix key collision between platforms in esphome state updates

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -151,11 +151,6 @@ async def async_setup_entry(  # noqa: C901
     )
 
     @callback
-    def async_on_state(state: EntityState) -> None:
-        """Send dispatcher updates when a new state is received."""
-        entry_data.async_update_state(hass, state)
-
-    @callback
     def async_on_service_call(service: HomeassistantServiceCall) -> None:
         """Call service when user automation in ESPHome config is triggered."""
         domain, service_name = service.service.split(".", 1)
@@ -288,7 +283,7 @@ async def async_setup_entry(  # noqa: C901
             entity_infos, services = await cli.list_entities_services()
             await entry_data.async_update_static_infos(hass, entry, entity_infos)
             await _setup_services(hass, entry_data, services)
-            await cli.subscribe_states(async_on_state)
+            await cli.subscribe_states(entry_data.async_update_state)
             await cli.subscribe_service_calls(async_on_service_call)
             await cli.subscribe_home_assistant_states(async_on_state_subscription)
 
@@ -564,11 +559,11 @@ async def platform_async_setup_entry(
     entry_data.info[component_key] = {}
     entry_data.old_info[component_key] = {}
     entry_data.state[component_key] = {}
+    entry_data.register_state_type(state_type, component_key)
 
     @callback
     def async_list_entities(infos: list[EntityInfo]) -> None:
         """Update entities of this platform when entities are listed."""
-        key_to_component = entry_data.key_to_component
         old_infos = entry_data.info[component_key]
         new_infos: dict[int, EntityInfo] = {}
         add_entities = []
@@ -587,12 +582,10 @@ async def platform_async_setup_entry(
                 entity = entity_type(entry_data, component_key, info.key)
                 add_entities.append(entity)
             new_infos[info.key] = info
-            key_to_component[info.key] = component_key
 
         # Remove old entities
         for info in old_infos.values():
             entry_data.async_remove_entity(hass, component_key, info.key)
-            key_to_component.pop(info.key, None)
 
         # First copy the now-old info into the backup object
         entry_data.old_info[component_key] = entry_data.info[component_key]
@@ -714,13 +707,8 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         )
 
         self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                (
-                    f"esphome_{self._entry_id}"
-                    f"_update_{self._component_key}_{self._key}"
-                ),
-                self._on_state_update,
+            self._entry_data.async_subscribe_state_update(
+                self._component_key, self._key, self._on_state_update
             )
         )
 

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -559,7 +559,6 @@ async def platform_async_setup_entry(
     entry_data.info[component_key] = {}
     entry_data.old_info[component_key] = {}
     entry_data.state[component_key] = {}
-    entry_data.register_state_type(state_type, component_key)
 
     @callback
     def async_list_entities(infos: list[EntityInfo]) -> None:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -45,6 +45,7 @@ from aioesphomeapi import (
 from aioesphomeapi.model import ButtonInfo
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import Store
@@ -54,37 +55,37 @@ _LOGGER = logging.getLogger(__name__)
 
 # Mapping from ESPHome info type to HA platform
 INFO_TYPE_TO_PLATFORM: dict[type[EntityInfo], str] = {
-    BinarySensorInfo: "binary_sensor",
-    ButtonInfo: "button",
-    CameraInfo: "camera",
-    ClimateInfo: "climate",
-    CoverInfo: "cover",
-    FanInfo: "fan",
-    LightInfo: "light",
-    LockInfo: "lock",
-    MediaPlayerInfo: "media_player",
-    NumberInfo: "number",
-    SelectInfo: "select",
-    SensorInfo: "sensor",
-    SwitchInfo: "switch",
-    TextSensorInfo: "sensor",
+    BinarySensorInfo: Platform.BINARY_SENSOR,
+    ButtonInfo: Platform.BINARY_SENSOR,
+    CameraInfo: Platform.BINARY_SENSOR,
+    ClimateInfo: Platform.CLIMATE,
+    CoverInfo: Platform.COVER,
+    FanInfo: Platform.FAN,
+    LightInfo: Platform.LIGHT,
+    LockInfo: Platform.LOCK,
+    MediaPlayerInfo: Platform.MEDIA_PLAYER,
+    NumberInfo: Platform.NUMBER,
+    SelectInfo: Platform.SELECT,
+    SensorInfo: Platform.SENSOR,
+    SwitchInfo: Platform.SWITCH,
+    TextSensorInfo: Platform.SENSOR,
 }
 
 STATE_TYPE_TO_COMPONENT_KEY = {
-    BinarySensorState: "binary_sensor",
-    EntityState: "button",
-    CameraState: "camera",
-    ClimateState: "climate",
-    CoverState: "cover",
-    FanState: "fan",
-    LightState: "light",
-    LockState: "lock",
-    MediaPlayerState: "media_player",
-    NumberState: "number",
-    SelectState: "select",
-    SensorState: "sensor",
-    SwitchState: "switch",
-    TextSensorState: "sensor",
+    BinarySensorState: Platform.BINARY_SENSOR,
+    EntityState: Platform.BINARY_SENSOR,
+    CameraState: Platform.BINARY_SENSOR,
+    ClimateState: Platform.CLIMATE,
+    CoverState: Platform.COVER,
+    FanState: Platform.FAN,
+    LightState: Platform.LIGHT,
+    LockState: Platform.LOCK,
+    MediaPlayerState: Platform.MEDIA_PLAYER,
+    NumberState: Platform.NUMBER,
+    SelectState: Platform.SELECT,
+    SensorState: Platform.SENSOR,
+    SwitchState: Platform.SWITCH,
+    TextSensorState: Platform.SENSOR,
 }
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #74231

Regressed in #73409

### Outside the scope of this PR:

When testing this I discovered nothing prevents the user from creating an `esphome` device that uses the same `name` for two entities with the same platform. 

The second entity will never work because the name is the unique id in the entity registry `"unique_id": "issue74231switchissue_74321_same_name"` and they will get a `Platform esphome does not generate unique IDs. ID issue74231switchissue_74321_same_name already exists - ignoring switch.issue_74321_same_name`.  

Maybe we should prevent users from creating the same name on that same platform when they compile their yaml?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
