### PR TITLE
Improve qnap_qsw firmware coordinator failures

### DIFF
--- a/homeassistant/components/qnap_qsw/coordinator.py
+++ b/homeassistant/components/qnap_qsw/coordinator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from aioqsw.exceptions import APIError, QswError
+from aioqsw.exceptions import QswError
 from aioqsw.localapi import QnapQswApi
 import async_timeout
 
@@ -63,8 +63,6 @@ class QswFirmwareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         async with async_timeout.timeout(QSW_TIMEOUT_SEC):
             try:
                 await self.qsw.check_firmware()
-            except APIError as error:
-                _LOGGER.warning(error)
             except QswError as error:
                 raise UpdateFailed(error) from error
             return self.qsw.data()

--- a/tests/components/qnap_qsw/test_init.py
+++ b/tests/components/qnap_qsw/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+from aioqsw.exceptions import APIError
+
 from homeassistant.components.qnap_qsw.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -9,6 +11,29 @@ from homeassistant.core import HomeAssistant
 from .util import CONFIG
 
 from tests.common import MockConfigEntry
+
+
+async def test_firmware_check_error(hass: HomeAssistant) -> None:
+    """Test firmware update check error."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="qsw_unique_id", data=CONFIG
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.check_firmware",
+        side_effect=APIError,
+    ), patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.validate",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.update",
+        return_value=None,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Address late comments from @MartinHjelmare (MartinHjelmare).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/71019#discussion_r911487678
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
