### PR TITLE
Restrict LIFX discovery to enabled interfaces

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -575,7 +575,6 @@ build.json @home-assistant/supervisor
 /homeassistant/components/lg_netcast/ @Drafteed
 /homeassistant/components/life360/ @pnbruckner
 /tests/components/life360/ @pnbruckner
-/homeassistant/components/lifx/ @Djelibeybi
 /homeassistant/components/light/ @home-assistant/core
 /tests/components/light/ @home-assistant/core
 /homeassistant/components/linux_battery/ @fabaff

--- a/homeassistant/components/lifx/config_flow.py
+++ b/homeassistant/components/lifx/config_flow.py
@@ -1,16 +1,93 @@
-"""Config flow flow LIFX."""
-import aiolifx
+"""Config flow for LIFX."""
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from homeassistant import config_entries
+from homeassistant.components import zeroconf
+from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_flow
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
+from .discovery import LifxNetworkScanner
+
+if TYPE_CHECKING:
+    import asyncio
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
-    lifx_ip_addresses = await aiolifx.LifxScan(hass.loop).scan()
-    return len(lifx_ip_addresses) > 0
+    lifx_network_scanner = LifxNetworkScanner(hass=hass)
+    return await lifx_network_scanner.found_lifx_devices()
 
 
-config_entry_flow.register_discovery_flow(DOMAIN, "LIFX", _async_has_devices)
+class LifxConfigFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle LIFX config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialise the LIFX config flow."""
+        self._domain = DOMAIN
+        self._title = "LIFX"
+        self._discovery_function = _async_has_devices
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        await self.async_set_unique_id(self._domain, raise_on_progress=False)
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm setup."""
+        if user_input is None:
+            self._set_confirm_only()
+            return self.async_show_form(step_id="confirm")
+
+        if self.source == config_entries.SOURCE_USER:
+            # Get current discovered entries.
+            in_progress = self._async_in_progress()
+
+            if not (has_devices := bool(in_progress)):
+                has_devices = await cast(
+                    "asyncio.Future[bool]",
+                    self.hass.async_add_job(self._discovery_function, self.hass),
+                )
+
+            if not has_devices:
+                return self.async_abort(reason="no_devices_found")
+
+            # Cancel the discovered one.
+            for flow in in_progress:
+                self.hass.config_entries.flow.async_abort(flow["flow_id"])
+
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        return self.async_create_entry(title=self._title, data={})
+
+    async def async_step_homekit(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Trigger local discovery from HomeKit mDNS."""
+        if self._async_in_progress() or self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if await _async_has_devices(self.hass) is False:
+            _LOGGER.debug("LIFX discovery failed, no devices found")
+            return self.async_abort(reason="no_devices_found")
+
+        _LOGGER.debug("LIFX discovery found devices, creating config entry")
+        await self.async_set_unique_id(self._domain)
+
+        return await self.async_step_confirm()

--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -1,3 +1,12 @@
 """Const for LIFX."""
 
 DOMAIN = "lifx"
+
+DISCOVERY_ERROR = """
+The LIFX integration is configured but no devices were found on any directly
+connected network. Please review your Home Assistant network configuration and
+ensure that a network interface on the same subnet as the LIFX devices is enabled.
+
+See https://www.home-assistant.io/integrations/network for further information
+on how to configure networking for Home Assistant.
+"""

--- a/homeassistant/components/lifx/discovery.py
+++ b/homeassistant/components/lifx/discovery.py
@@ -1,0 +1,75 @@
+"""Home Assistant specific discovery of LIFX devices."""
+from __future__ import annotations
+
+import asyncio
+from ipaddress import IPv4Address, IPv6Address
+import logging
+
+from aiolifx.aiolifx import LifxDiscovery, Light
+
+from homeassistant.components import network
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LifxNetworkScanner:
+    """Scan all network interfaces for any active bulb."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the scanner."""
+        self.hass = hass
+
+    async def found_lifx_devices(self) -> bool:
+        """Return True if a lifx device was found on an enabled interface."""
+
+        enabled_ips: list[
+            IPv4Address | IPv6Address
+        ] = await network.async_get_enabled_source_ips(self.hass)
+        source_ips: list[IPv4Address] = [
+            ip_address
+            for ip_address in enabled_ips
+            if ip_address.version == 4 and ip_address.is_loopback is False
+        ]
+
+        tasks: list[asyncio.Task] = []
+        discoveries: list[LifxDiscovery] = []
+        for source_ip in source_ips:
+            _LOGGER.debug("Looking for LIFX devices using %s", str(source_ip))
+            scan_manager = ScanManager(source_ip)
+            source_ip_discovery = LifxDiscovery(self.hass.loop, scan_manager)
+            discoveries.append(source_ip_discovery)
+            source_ip_discovery.start(listen_ip=str(source_ip))
+            tasks.append(self.hass.loop.create_task(scan_manager.source_ip()))
+
+        (done, pending) = await asyncio.wait(tasks, timeout=1)
+
+        for discovery in discoveries:
+            discovery.cleanup()
+
+        for task in pending:
+            task.cancel()
+
+        lifx_ip_addresses: list[IPv4Address] = [task.result() for task in done]
+        return len(lifx_ip_addresses) > 0
+
+
+class ScanManager:
+    """Temporary manager for LIFX network discovery."""
+
+    def __init__(self, source_ip: IPv4Address) -> None:
+        """Initialize the manager."""
+        self._event = asyncio.Event()
+        self._source_ip = source_ip
+
+    async def source_ip(self) -> IPv4Address:
+        """Return the source IP address if any device is discovered."""
+        await self._event.wait()
+        return self._source_ip
+
+    def register(self, bulb: Light) -> None:
+        """Handle detected bulb."""
+        self._event.set()
+
+    def unregister(self, bulb: Light) -> None:
+        """Handle disappearing bulb."""

--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -29,7 +29,7 @@
       "LIFX Z"
     ]
   },
-  "codeowners": ["@Djelibeybi"],
+  "codeowners": [],
   "iot_class": "local_polling",
   "loggers": ["aiolifx", "aiolifx_effects", "bitstring"]
 }


### PR DESCRIPTION
## Breaking change

LIFX discovery is now restricted to enabled network interfaces only, whereas previousliy it used any interface on which a LIFX device was found. If the integration is already configured but the interface required to discover bulbs is not enabled, all LIFX devices will be offline with an error that links to the network configuration page for Home Assistant.

This meets the Home Assistant architecture requirements. It's also my last submission as code owner.

Signed-off-by: Avi Miller <me@dje.li>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
	  - fixes #74246 
	  - fixes #74267
	  - fixes #74002
	  - fixes #74027
	  - fixes #74021
	  - fixes #72827
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
