### PR TITLE
Address Blebox uniapi review sidenotes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,8 +131,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/binary_sensor/ @home-assistant/core
 /tests/components/binary_sensor/ @home-assistant/core
 /homeassistant/components/bizkaibus/ @UgaitzEtxebarria
-/homeassistant/components/blebox/ @bbx-a @bbx-jp @riokuu
-/tests/components/blebox/ @bbx-a @bbx-jp @riokuu
+/homeassistant/components/blebox/ @bbx-a @riokuu
+/tests/components/blebox/ @bbx-a @riokuu
 /homeassistant/components/blink/ @fronzbot
 /tests/components/blink/ @fronzbot
 /homeassistant/components/blueprint/ @home-assistant/core

--- a/homeassistant/components/blebox/const.py
+++ b/homeassistant/components/blebox/const.py
@@ -3,13 +3,7 @@
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
-from homeassistant.const import (
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import TEMP_CELSIUS
 
 DOMAIN = "blebox"
 PRODUCT = "product"
@@ -30,19 +24,6 @@ BLEBOX_TO_HASS_DEVICE_CLASSES = {
     "temperature": SensorDeviceClass.TEMPERATURE,
 }
 
-BLEBOX_TO_HASS_COVER_STATES = {
-    None: None,
-    0: STATE_CLOSING,  # moving down
-    1: STATE_OPENING,  # moving up
-    2: STATE_OPEN,  # manually stopped
-    3: STATE_CLOSED,  # lower limit
-    4: STATE_OPEN,  # upper limit / open
-    # gateController
-    5: STATE_OPEN,  # overload
-    6: STATE_OPEN,  # motor failure
-    # 7 is not used
-    8: STATE_OPEN,  # safety stop
-}
 
 BLEBOX_TO_UNIT_MAP = {"celsius": TEMP_CELSIUS}
 

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -9,12 +9,26 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPENING
+from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BleBoxEntity, create_blebox_entities
-from .const import BLEBOX_TO_HASS_COVER_STATES, BLEBOX_TO_HASS_DEVICE_CLASSES
+from .const import BLEBOX_TO_HASS_DEVICE_CLASSES
+
+BLEBOX_TO_HASS_COVER_STATES = {
+    None: None,
+    0: STATE_CLOSING,  # moving down
+    1: STATE_OPENING,  # moving up
+    2: STATE_OPEN,  # manually stopped
+    3: STATE_CLOSED,  # lower limit
+    4: STATE_OPEN,  # upper limit / open
+    # gateController
+    5: STATE_OPEN,  # overload
+    6: STATE_OPEN,  # motor failure
+    # 7 is not used
+    8: STATE_OPEN,  # safety stop
+}
 
 
 async def async_setup_entry(

--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -165,10 +165,10 @@ class BleBoxLightEntity(BleBoxEntity, LightEntity):
         else:
             try:
                 await self._feature.async_on(value)
-            except ValueError as ex:
-                _LOGGER.error(
-                    "Turning on '%s' failed: Bad value %s (%s)", self.name, value, ex
-                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"Turning on '{self.name}' failed: Bad value {value}"
+                ) from exc
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""

--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from blebox_uniapi.error import BadOnValueError
 import blebox_uniapi.light
 from blebox_uniapi.light import BleboxColorMode
 
@@ -166,7 +165,7 @@ class BleBoxLightEntity(BleBoxEntity, LightEntity):
         else:
             try:
                 await self._feature.async_on(value)
-            except BadOnValueError as ex:
+            except ValueError as ex:
                 _LOGGER.error(
                     "Turning on '%s' failed: Bad value %s (%s)", self.name, value, ex
                 )

--- a/homeassistant/components/blebox/manifest.json
+++ b/homeassistant/components/blebox/manifest.json
@@ -3,8 +3,8 @@
   "name": "BleBox devices",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/blebox",
-  "requirements": ["blebox_uniapi==2.0.0"],
-  "codeowners": ["@bbx-a", "@bbx-jp", "@riokuu"],
+  "requirements": ["blebox_uniapi==2.0.1"],
+  "codeowners": ["@bbx-a", "@riokuu"],
   "iot_class": "local_polling",
   "loggers": ["blebox_uniapi"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -402,7 +402,7 @@ bimmer_connected==0.9.6
 bizkaibus==0.1.1
 
 # homeassistant.components.blebox
-blebox_uniapi==2.0.0
+blebox_uniapi==2.0.1
 
 # homeassistant.components.blink
 blinkpy==0.19.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -317,7 +317,7 @@ bellows==0.31.0
 bimmer_connected==0.9.6
 
 # homeassistant.components.blebox
-blebox_uniapi==2.0.0
+blebox_uniapi==2.0.1
 
 # homeassistant.components.blink
 blinkpy==0.19.0

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -513,13 +513,14 @@ async def test_turn_on_failure(feature, hass, config, caplog):
     await async_setup_entity(hass, config, entity_id)
 
     feature_mock.sensible_on_value = 123
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_ON,
-        {"entity_id": entity_id},
-        blocking=True,
-    )
+    with pytest.raises(ValueError) as info:
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {"entity_id": entity_id},
+            blocking=True,
+        )
 
-    assert (
-        f"Turning on '{feature_mock.full_name}' failed: Bad value 123 ()" in caplog.text
+    assert f"Turning on '{feature_mock.full_name}' failed: Bad value 123" in str(
+        info.value
     )

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -509,7 +509,7 @@ async def test_turn_on_failure(feature, hass, config, caplog):
     caplog.set_level(logging.ERROR)
 
     feature_mock, entity_id = feature
-    feature_mock.async_on = AsyncMock(side_effect=blebox_uniapi.error.BadOnValueError)
+    feature_mock.async_on = AsyncMock(side_effect=ValueError)
     await async_setup_entity(hass, config, entity_id)
 
     feature_mock.sensible_on_value = 123


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Changelog of dependency upgrade: https://pypi.org/project/blebox-uniapi/2.0.1/
- https://github.com/blebox/blebox_uniapi/compare/v2.0.0...v2.0.1
- Codeowner update, removed @bbx-jp. 
- Adjusted test to match raised error. 
- Dict `BLEBOX_TO_HASS_COVER_STATES` moved to `cover.py` module.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
Related to @MartinHjelmare sidenotes https://github.com/home-assistant/core/pull/73834

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
