### PR TITLE
Remove visibility from metoffice weather

### DIFF
--- a/homeassistant/components/metoffice/weather.py
+++ b/homeassistant/components/metoffice/weather.py
@@ -27,8 +27,6 @@ from .const import (
     MODE_3HOURLY_LABEL,
     MODE_DAILY,
     MODE_DAILY_LABEL,
-    VISIBILITY_CLASSES,
-    VISIBILITY_DISTANCE_CLASSES,
 )
 
 
@@ -104,19 +102,6 @@ class MetOfficeWeather(CoordinatorEntity, WeatherEntity):
     def temperature_unit(self):
         """Return the unit of measurement."""
         return TEMP_CELSIUS
-
-    @property
-    def visibility(self):
-        """Return the platform visibility."""
-        _visibility = None
-        weather_now = self.coordinator.data.now
-        if hasattr(weather_now, "visibility"):
-            visibility_class = VISIBILITY_CLASSES.get(weather_now.visibility.value)
-            visibility_distance = VISIBILITY_DISTANCE_CLASSES.get(
-                weather_now.visibility.value
-            )
-            _visibility = f"{visibility_class} - {visibility_distance}"
-        return _visibility
 
     @property
     def pressure(self):

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -135,7 +135,6 @@ async def test_one_weather_site_running(hass, requests_mock):
     assert weather.attributes.get("temperature") == 17
     assert weather.attributes.get("wind_speed") == 9
     assert weather.attributes.get("wind_bearing") == "SSE"
-    assert weather.attributes.get("visibility") == "Good - 10-20"
     assert weather.attributes.get("humidity") == 50
 
     # Forecasts added - just pick out 1 entry to check
@@ -159,7 +158,6 @@ async def test_one_weather_site_running(hass, requests_mock):
     assert weather.attributes.get("temperature") == 19
     assert weather.attributes.get("wind_speed") == 9
     assert weather.attributes.get("wind_bearing") == "SSE"
-    assert weather.attributes.get("visibility") == "Good - 10-20"
     assert weather.attributes.get("humidity") == 50
 
     # Also has Forecasts added - again, just pick out 1 entry to check
@@ -231,7 +229,6 @@ async def test_two_weather_sites_running(hass, requests_mock):
     assert weather.attributes.get("temperature") == 17
     assert weather.attributes.get("wind_speed") == 9
     assert weather.attributes.get("wind_bearing") == "SSE"
-    assert weather.attributes.get("visibility") == "Good - 10-20"
     assert weather.attributes.get("humidity") == 50
 
     # Forecasts added - just pick out 1 entry to check
@@ -255,7 +252,6 @@ async def test_two_weather_sites_running(hass, requests_mock):
     assert weather.attributes.get("temperature") == 19
     assert weather.attributes.get("wind_speed") == 9
     assert weather.attributes.get("wind_bearing") == "SSE"
-    assert weather.attributes.get("visibility") == "Good - 10-20"
     assert weather.attributes.get("humidity") == 50
 
     # Also has Forecasts added - again, just pick out 1 entry to check
@@ -279,7 +275,6 @@ async def test_two_weather_sites_running(hass, requests_mock):
     assert weather.attributes.get("temperature") == 14
     assert weather.attributes.get("wind_speed") == 2
     assert weather.attributes.get("wind_bearing") == "E"
-    assert weather.attributes.get("visibility") == "Very Good - 20-40"
     assert weather.attributes.get("humidity") == 60
 
     # Also has Forecast added - just pick out 1 entry to check
@@ -303,7 +298,6 @@ async def test_two_weather_sites_running(hass, requests_mock):
     assert weather.attributes.get("temperature") == 9
     assert weather.attributes.get("wind_speed") == 4
     assert weather.attributes.get("wind_bearing") == "ESE"
-    assert weather.attributes.get("visibility") == "Very Good - 20-40"
     assert weather.attributes.get("humidity") == 75
 
     # All should have Forecast added - again, just picking out 1 entry to check


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Metoffice doesn't provide precise visibility distance, only ranges - i.e., something like "Very good - 20-40 km". This doesn't fit into weather entity model so it's now removed. The old value is still available in a separate sensor provided by this integration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Not particularly happy to remove this but not sure if other options are better...

Alternatively, we could map each range to a single value but not sure it would make more sense. For instance, like this:
"Very poor - Less than 1 km" -> 0.5 km
"Poor - Between 1-4 km" -> 2 km
"Moderate - Between 4-10 km" -> 6 km
"Good - Between 10-20 km" -> 15 km
"Very good - Between 20-40 km" -> 30 km
"Excellent - More than 40 km" -> 40 km
The problem is that these values would be very arbitrary and potentially quite wrong.

Suggestions?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #74309
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
