### PR TITLE
Set route as attribute for here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -145,11 +145,6 @@ def sensor_descriptions(travel_mode: str) -> tuple[SensorEntityDescription, ...]
             key=ATTR_DISTANCE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
-        SensorEntityDescription(
-            name="Route",
-            icon="mdi:directions",
-            key=ATTR_ROUTE,
-        ),
     )
 
 
@@ -217,7 +212,7 @@ async def async_setup_entry(
     sensors: list[HERETravelTimeSensor] = []
     for sensor_description in sensor_descriptions(config_entry.data[CONF_MODE]):
         sensors.append(
-            HERETravelTimeSensor(
+            WithRouteSensor(
                 config_entry.entry_id,
                 config_entry.data[CONF_NAME],
                 sensor_description,
@@ -272,6 +267,19 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
         """Return the attribution."""
         if self.coordinator.data is not None:
             return self.coordinator.data.get(ATTR_ATTRIBUTION)
+        return None
+
+
+class WithRouteSensor(HERETravelTimeSensor):
+    """HERETravelTimeSensor with route as an attribute."""
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the route street names separated by semicolon."""
+        if self.coordinator.data is not None:
+            return {
+                ATTR_ROUTE: self.coordinator.data[ATTR_ROUTE],
+            }
         return None
 
 

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.here_travel_time.config_flow import default_options
 from homeassistant.components.here_travel_time.const import (
+    ATTR_ROUTE,
     CONF_ARRIVAL_TIME,
     CONF_DEPARTURE_TIME,
     CONF_DESTINATION_ENTITY_ID,
@@ -158,49 +159,34 @@ async def test_sensor(
     )
     assert duration.attributes.get(ATTR_ICON) == icon
     assert duration.state == expected_duration
-
-    assert (
-        hass.states.get("sensor.test_duration_in_traffic").state
-        == expected_duration_in_traffic
-    )
-    assert hass.states.get("sensor.test_distance").state == expected_distance
-    assert hass.states.get("sensor.test_route").state == (
+    assert duration.attributes.get(ATTR_ROUTE) == (
         "US-29 - K St NW; US-29 - Whitehurst Fwy; "
         "I-495 N - Capital Beltway; MD-187 S - Old Georgetown Rd"
     )
-    assert (
-        hass.states.get("sensor.test_duration_in_traffic").state
-        == expected_duration_in_traffic
-    )
-    assert hass.states.get("sensor.test_origin").state == "22nd St NW"
-    assert (
-        hass.states.get("sensor.test_origin").attributes.get(ATTR_LATITUDE)
-        == CAR_ORIGIN_LATITUDE
-    )
-    assert (
-        hass.states.get("sensor.test_origin").attributes.get(ATTR_LONGITUDE)
-        == CAR_ORIGIN_LONGITUDE
+
+    duration_in_traffic = hass.states.get("sensor.test_duration_in_traffic")
+    assert duration_in_traffic.state == expected_duration_in_traffic
+    assert duration_in_traffic.attributes.get(ATTR_ROUTE) == (
+        "US-29 - K St NW; US-29 - Whitehurst Fwy; "
+        "I-495 N - Capital Beltway; MD-187 S - Old Georgetown Rd"
     )
 
-    assert hass.states.get("sensor.test_origin").state == "22nd St NW"
-    assert (
-        hass.states.get("sensor.test_origin").attributes.get(ATTR_LATITUDE)
-        == CAR_ORIGIN_LATITUDE
-    )
-    assert (
-        hass.states.get("sensor.test_origin").attributes.get(ATTR_LONGITUDE)
-        == CAR_ORIGIN_LONGITUDE
+    distance = hass.states.get("sensor.test_distance")
+    assert distance.state == expected_distance
+    assert distance.attributes.get(ATTR_ROUTE) == (
+        "US-29 - K St NW; US-29 - Whitehurst Fwy; "
+        "I-495 N - Capital Beltway; MD-187 S - Old Georgetown Rd"
     )
 
-    assert hass.states.get("sensor.test_destination").state == "Service Rd S"
-    assert (
-        hass.states.get("sensor.test_destination").attributes.get(ATTR_LATITUDE)
-        == CAR_DESTINATION_LATITUDE
-    )
-    assert (
-        hass.states.get("sensor.test_destination").attributes.get(ATTR_LONGITUDE)
-        == CAR_DESTINATION_LONGITUDE
-    )
+    origin = hass.states.get("sensor.test_origin")
+    assert origin.state == "22nd St NW"
+    assert origin.attributes.get(ATTR_LATITUDE) == CAR_ORIGIN_LATITUDE
+    assert origin.attributes.get(ATTR_LONGITUDE) == CAR_ORIGIN_LONGITUDE
+
+    destination = hass.states.get("sensor.test_destination")
+    assert destination.state == "Service Rd S"
+    assert destination.attributes.get(ATTR_LATITUDE) == CAR_DESTINATION_LATITUDE
+    assert destination.attributes.get(ATTR_LONGITUDE) == CAR_DESTINATION_LONGITUDE
 
 
 @pytest.mark.usefixtures("valid_response")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The single `here_travel_time` sensor with attributes is split up into separate sensors for `Duration`, `Duration in Traffic`, `Distance` with the `Route` as an attribute and separate sensors `Origin` and `Destination` with the name as the sensor state and the coordinates as attributes. This allows better integration into Blueprints, Automations and the UI in general.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the added `Route` sensor and supply it as an attribute instead to avoid the 255 character limit as described in https://github.com/home-assistant/core/issues/74301


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74301
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
