### PR TITLE
Guard invalid data sensor significant change

### DIFF
--- a/homeassistant/components/sensor/significant_change.py
+++ b/homeassistant/components/sensor/significant_change.py
@@ -63,13 +63,23 @@ def async_check_significant_change(
         absolute_change = 1.0
         percentage_change = 2.0
 
+    try:
+        # New state is invalid, don't report it
+        new_state_f = float(new_state)
+    except ValueError:
+        return False
+
+    try:
+        # Old state was invalid, we should report again
+        old_state_f = float(old_state)
+    except ValueError:
+        return True
+
     if absolute_change is not None and percentage_change is not None:
         return _absolute_and_relative_change(
-            float(old_state), float(new_state), absolute_change, percentage_change
+            old_state_f, new_state_f, absolute_change, percentage_change
         )
     if absolute_change is not None:
-        return check_absolute_change(
-            float(old_state), float(new_state), absolute_change
-        )
+        return check_absolute_change(old_state_f, new_state_f, absolute_change)
 
     return None

--- a/tests/components/sensor/test_significant_change.py
+++ b/tests/components/sensor/test_significant_change.py
@@ -52,6 +52,8 @@ TEMP_FREEDOM_ATTRS = {
         ("12.1", "12.2", TEMP_CELSIUS_ATTRS, False),
         ("70", "71", TEMP_FREEDOM_ATTRS, True),
         ("70", "70.5", TEMP_FREEDOM_ATTRS, False),
+        ("fail", "70", TEMP_FREEDOM_ATTRS, True),
+        ("70", "fail", TEMP_FREEDOM_ATTRS, False),
     ],
 )
 async def test_significant_change_temperature(old_state, new_state, attrs, result):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Significant change checker for sensor would fail if state set to non-numeric data

Fixes part of #74342

```
Logger: homeassistant
Source: components/sensor/significant_change.py:68
First occurred: 4:54:01 AM (2 occurrences)
Last logged: 4:54:01 AM

Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/google_assistant/report_state.py", line 79, in async_entity_state_listener
    if not checker.async_is_significant_change(new_state, extra_arg=entity_data):
  File "/usr/src/homeassistant/homeassistant/helpers/significant_change.py", line 206, in async_is_significant_change
    result = check_significantly_changed(
  File "/usr/src/homeassistant/homeassistant/components/sensor/significant_change.py", line 68, in async_check_significant_change
    float(old_state), float(new_state), absolute_change, percentage_change
ValueError: could not convert string to float: 'fail'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
