### PR TITLE
Make dispatcher setup lazy

### DIFF
--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -41,26 +41,13 @@ def async_dispatcher_connect(
     """
     if DATA_DISPATCHER not in hass.data:
         hass.data[DATA_DISPATCHER] = {}
-
-    job = HassJob(
-        catch_log_exception(
-            target,
-            lambda *args: "Exception in {} when dispatching '{}': {}".format(
-                # Functions wrapped in partial do not have a __name__
-                getattr(target, "__name__", None) or str(target),
-                signal,
-                args,
-            ),
-        )
-    )
-
-    hass.data[DATA_DISPATCHER].setdefault(signal, []).append(job)
+    hass.data[DATA_DISPATCHER].setdefault(signal, {})[target] = None
 
     @callback
     def async_remove_dispatcher() -> None:
         """Remove signal listener."""
         try:
-            hass.data[DATA_DISPATCHER][signal].remove(job)
+            del hass.data[DATA_DISPATCHER][signal][target]
         except (KeyError, ValueError):
             # KeyError is key target listener did not exist
             # ValueError if listener did not exist within signal
@@ -75,6 +62,21 @@ def dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
     hass.loop.call_soon_threadsafe(async_dispatcher_send, hass, signal, *args)
 
 
+def _generate_job(signal: str, target: Callable[..., Any]) -> HassJob:
+    """Generate a HassJob for a signal and target."""
+    return HassJob(
+        catch_log_exception(
+            target,
+            lambda *args: "Exception in {} when dispatching '{}': {}".format(
+                # Functions wrapped in partial do not have a __name__
+                getattr(target, "__name__", None) or str(target),
+                signal,
+                args,
+            ),
+        )
+    )
+
+
 @callback
 @bind_hass
 def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
@@ -82,7 +84,9 @@ def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None:
 
     This method must be run in the event loop.
     """
-    target_list = hass.data.get(DATA_DISPATCHER, {}).get(signal, [])
-
-    for job in target_list:
+    target_list = hass.data.get(DATA_DISPATCHER, {}).get(signal, {})
+    for target, job in target_list.items():
+        if job is None:
+            job = _generate_job(signal, target)
+            target_list[target] = job
         hass.async_add_hass_job(job, *args)

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -311,7 +311,7 @@ async def test_internal_discovery_callback_fill_out_group_fail(
         await hass.async_block_till_done()
 
         # when called with incomplete info, it should use HTTP to get missing
-        discover = signal.mock_calls[0][1][0]
+        discover = signal.mock_calls[-1][1][0]
         assert discover == full_info
         get_multizone_status_mock.assert_called_once()
 
@@ -352,7 +352,7 @@ async def test_internal_discovery_callback_fill_out_group(
         await hass.async_block_till_done()
 
         # when called with incomplete info, it should use HTTP to get missing
-        discover = signal.mock_calls[0][1][0]
+        discover = signal.mock_calls[-1][1][0]
         assert discover == full_info
         get_multizone_status_mock.assert_called_once()
 
@@ -423,23 +423,25 @@ async def test_internal_discovery_callback_fill_out_cast_type_manufacturer(
         # when called with incomplete info, it should use HTTP to get missing
         get_cast_type_mock.assert_called_once()
         assert get_cast_type_mock.call_count == 1
-        discover = signal.mock_calls[0][1][0]
+        discover = signal.mock_calls[2][1][0]
         assert discover == full_info
         assert "Fetched cast details for unknown model 'Chromecast'" in caplog.text
 
+        signal.reset_mock()
         # Call again, the model name should be fetched from cache
         discover_cast(FAKE_MDNS_SERVICE, info)
         await hass.async_block_till_done()
         assert get_cast_type_mock.call_count == 1  # No additional calls
-        discover = signal.mock_calls[1][1][0]
+        discover = signal.mock_calls[0][1][0]
         assert discover == full_info
 
+        signal.reset_mock()
         # Call for another model, need to call HTTP again
         get_cast_type_mock.return_value = full_info2.cast_info
         discover_cast(FAKE_MDNS_SERVICE, info2)
         await hass.async_block_till_done()
         assert get_cast_type_mock.call_count == 2
-        discover = signal.mock_calls[2][1][0]
+        discover = signal.mock_calls[0][1][0]
         assert discover == full_info2
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Noticed while investigating #73863

- Many of the dispatchers that get setup never actually run since they
  do not get an update, or if they do only get an update in the far future. When
  the dispatcher is setup it builds a `HassJob` and a `catch_log_exception` wrapper
  which takes a bit of startup time. We can defer building the wrapper and
  job until the first time the dispatcher is used to save some memory
  and startup time

<img width="1260" alt="Screen Shot 2022-07-03 at 17 05 31" src="https://user-images.githubusercontent.com/663432/177059462-92f0d808-d517-4d32-879d-bf52899364d9.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
