### PR TITLE
Use the orjson equivalent default encoder when save_json is passed the default encoder

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -83,7 +83,7 @@ def save_json(
             # For backwards compatibility, if they pass in the
             # default json encoder we use _orjson_default_encoder
             # which is the orjson equivalent to the default encoder.
-            if encoder == DefaultHASSJSONEncoder:
+            if encoder is DefaultHASSJSONEncoder:
                 dump = _orjson_default_encoder
                 json_data = _orjson_default_encoder(data)
             # If they pass a custom encoder that is not the

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -11,6 +11,10 @@ import orjson
 
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.json import (
+    JSONEncoder as DefaultHASSJSONEncoder,
+    json_encoder_default as default_hass_orjson_encoder,
+)
 
 from .file import write_utf8_file, write_utf8_file_atomic
 
@@ -52,6 +56,15 @@ def _orjson_encoder(data: Any) -> str:
     ).decode("utf-8")
 
 
+def _orjson_default_encoder(data: Any) -> str:
+    """JSON encoder that uses orjson with hass defaults."""
+    return orjson.dumps(
+        data,
+        option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS,
+        default=default_hass_orjson_encoder,
+    ).decode("utf-8")
+
+
 def save_json(
     filename: str,
     data: list | dict,
@@ -64,10 +77,20 @@ def save_json(
 
     Returns True on success.
     """
-    dump: Callable[[Any], Any] = json.dumps
+    dump: Callable[[Any], Any]
     try:
         if encoder:
-            json_data = json.dumps(data, indent=2, cls=encoder)
+            # For backwards compatibility, if they pass in the
+            # default json encoder we use _orjson_default_encoder
+            # which is the orjson equivalent to the default encoder.
+            if encoder == DefaultHASSJSONEncoder:
+                dump = _orjson_default_encoder
+                json_data = _orjson_default_encoder(data)
+            # If they pass a custom encoder that is not the
+            # DefaultHASSJSONEncoder, we use the slow path of json.dumps
+            else:
+                dump = json.dumps
+                json_data = json.dumps(data, indent=2, cls=encoder)
         else:
             dump = _orjson_encoder
             json_data = _orjson_encoder(data)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Noticed while investigating #73863 that HACS and maybe others are still falling back to `json`


- We always fell back to using json with passed in encoder, however
  if they pass in the default one we can use the equivalent orjson
  default encoder since its much faster. Currently at least HACS is
  doing this

<img width="1254" alt="Screen Shot 2022-07-03 at 21 46 15" src="https://user-images.githubusercontent.com/663432/177072784-626d5449-1e3c-4dae-aa61-dab348b78555.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
