### PR TITLE
Don't allow using deprecated features of WeatherEntity

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -171,16 +171,16 @@ class Forecast(TypedDict, total=False):
     datetime: str
     precipitation_probability: int | None
     native_precipitation: float | None
-    precipitation: float | None
+    precipitation: None
     native_pressure: float | None
-    pressure: float | None
+    pressure: None
     native_temperature: float | None
-    temperature: float | None
+    temperature: None
     native_templow: float | None
-    templow: float | None
+    templow: None
     wind_bearing: float | str | None
     native_wind_speed: float | None
-    wind_speed: float | None
+    wind_speed: None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -218,33 +218,33 @@ class WeatherEntity(Entity):
     _attr_humidity: float | None = None
     _attr_ozone: float | None = None
     _attr_precision: float
-    _attr_pressure: float | None = (
+    _attr_pressure: None = (
         None  # Provide backwards compatibility. Use _attr_native_pressure
     )
-    _attr_pressure_unit: str | None = (
+    _attr_pressure_unit: None = (
         None  # Provide backwards compatibility. Use _attr_native_pressure_unit
     )
     _attr_state: None = None
-    _attr_temperature: float | None = (
+    _attr_temperature: None = (
         None  # Provide backwards compatibility. Use _attr_native_temperature
     )
-    _attr_temperature_unit: str | None = (
+    _attr_temperature_unit: None = (
         None  # Provide backwards compatibility. Use _attr_native_temperature_unit
     )
-    _attr_visibility: float | None = (
+    _attr_visibility: None = (
         None  # Provide backwards compatibility. Use _attr_native_visibility
     )
-    _attr_visibility_unit: str | None = (
+    _attr_visibility_unit: None = (
         None  # Provide backwards compatibility. Use _attr_native_visibility_unit
     )
-    _attr_precipitation_unit: str | None = (
+    _attr_precipitation_unit: None = (
         None  # Provide backwards compatibility. Use _attr_native_precipitation_unit
     )
     _attr_wind_bearing: float | str | None = None
-    _attr_wind_speed: float | None = (
+    _attr_wind_speed: None = (
         None  # Provide backwards compatibility. Use _attr_native_wind_speed
     )
-    _attr_wind_speed_unit: str | None = (
+    _attr_wind_speed_unit: None = (
         None  # Provide backwards compatibility. Use _attr_native_wind_speed_unit
     )
 
@@ -321,6 +321,7 @@ class WeatherEntity(Entity):
             return
         self.async_registry_entry_updated()
 
+    @final
     @property
     def temperature(self) -> float | None:
         """Return the temperature for backward compatibility.
@@ -345,6 +346,7 @@ class WeatherEntity(Entity):
 
         return self._attr_native_temperature_unit
 
+    @final
     @property
     def temperature_unit(self) -> str | None:
         """Return the temperature unit for backward compatibility.
@@ -376,6 +378,7 @@ class WeatherEntity(Entity):
 
         return self._default_temperature_unit
 
+    @final
     @property
     def pressure(self) -> float | None:
         """Return the pressure for backward compatibility.
@@ -400,6 +403,7 @@ class WeatherEntity(Entity):
 
         return self._attr_native_pressure_unit
 
+    @final
     @property
     def pressure_unit(self) -> str | None:
         """Return the pressure unit for backward compatibility.
@@ -436,6 +440,7 @@ class WeatherEntity(Entity):
         """Return the humidity in native units."""
         return self._attr_humidity
 
+    @final
     @property
     def wind_speed(self) -> float | None:
         """Return the wind_speed for backward compatibility.
@@ -460,6 +465,7 @@ class WeatherEntity(Entity):
 
         return self._attr_native_wind_speed_unit
 
+    @final
     @property
     def wind_speed_unit(self) -> str | None:
         """Return the wind_speed unit for backward compatibility.
@@ -505,6 +511,7 @@ class WeatherEntity(Entity):
         """Return the ozone level."""
         return self._attr_ozone
 
+    @final
     @property
     def visibility(self) -> float | None:
         """Return the visibility for backward compatibility.
@@ -529,6 +536,7 @@ class WeatherEntity(Entity):
 
         return self._attr_native_visibility_unit
 
+    @final
     @property
     def visibility_unit(self) -> str | None:
         """Return the visibility unit for backward compatibility.
@@ -573,6 +581,7 @@ class WeatherEntity(Entity):
 
         return self._attr_native_precipitation_unit
 
+    @final
     @property
     def precipitation_unit(self) -> str | None:
         """Return the precipitation unit for backward compatibility.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't allow using deprecated features of WeatherEntity

This does not break custom components as the changes are not enforced in run time, but only by linters

All core integrations providing weather must be migrated before this PR can be merged:
- #74407
- #74037
- #74059 
- #74039
- #74409
- #74047
- #74043
- #74048
- #74385
- #74387
- #74386
- #74259
- #74391
- #74297
- #74392
- #74312
- #73981
- #73910
- #73913
- #72999
- #74060
- #74050
- #74225

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
