### PR TITLE
Add base Entity and ToggleEntity checks to pylint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1500,6 +1500,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             ],
         ),
     ],
+    # "mailbox": [], # ignored as deprecated
     "media_player": [
         ClassTypeHintMatch(
             base_class="Entity",
@@ -2072,6 +2073,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             ],
         ),
     ],
+    # "stt": [],  # ignored as does not provide Entity classes
     "switch": [
         ClassTypeHintMatch(
             base_class="Entity",
@@ -2091,6 +2093,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             ],
         ),
     ],
+    # "tts": [],  # ignored as does not provide Entity classes
     "update": [
         ClassTypeHintMatch(
             base_class="Entity",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add base Entity and ToggleEntity checks to pylint plugin (all platforms)

~It may conflict with #74286 but it will make it easier to add specific methods and properties to the individual platforms as a follow-up whilst minimising further conflicts.~

```console
pylint --disable=all --enable=hass_enforce_type_hints --ignore-missing-annotations=n homeassistant/components/zoneminder 

************* Module homeassistant.components.zoneminder.sensor
homeassistant/components/zoneminder/sensor.py:105:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/zoneminder/sensor.py:115:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/zoneminder/sensor.py:119:4: W7432: Return type should be None (hass-return-type)
homeassistant/components/zoneminder/sensor.py:142:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/zoneminder/sensor.py:146:4: W7432: Return type should be None (hass-return-type)
homeassistant/components/zoneminder/sensor.py:163:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/zoneminder/sensor.py:173:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/zoneminder/sensor.py:177:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.zoneminder.switch
homeassistant/components/zoneminder/switch.py:72:4: W7432: Return type should be ['bool', None] (hass-return-type)
homeassistant/components/zoneminder/switch.py:76:4: W7431: Argument kwargs should be of type Any (hass-argument-type)
homeassistant/components/zoneminder/switch.py:76:4: W7432: Return type should be None (hass-return-type)
homeassistant/components/zoneminder/switch.py:80:4: W7431: Argument kwargs should be of type Any (hass-argument-type)
homeassistant/components/zoneminder/switch.py:80:4: W7432: Return type should be None (hass-return-type)
homeassistant/components/zoneminder/switch.py:63:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/zoneminder/switch.py:67:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.zoneminder.binary_sensor
homeassistant/components/zoneminder/binary_sensor.py:48:4: W7432: Return type should be ['BinarySensorDeviceClass', 'str', None] (hass-return-type)
homeassistant/components/zoneminder/binary_sensor.py:43:4: W7432: Return type should be ['bool', None] (hass-return-type)
homeassistant/components/zoneminder/binary_sensor.py:38:4: W7432: Return type should be ['str', None] (hass-return-type)
homeassistant/components/zoneminder/binary_sensor.py:52:4: W7432: Return type should be None (hass-return-type)
************* Module homeassistant.components.zoneminder.camera
homeassistant/components/zoneminder/camera.py:63:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/zoneminder/camera.py:68:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/zoneminder/camera.py:52:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/zoneminder/camera.py:68:4: W7432: Return type should be bool (hass-return-type)
homeassistant/components/zoneminder/camera.py:56:4: W7432: Return type should be None (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
