### PR TITLE
Provide authentication cookies for Media Extractor streams

### DIFF
--- a/homeassistant/components/media_extractor/__init__.py
+++ b/homeassistant/components/media_extractor/__init__.py
@@ -1,5 +1,6 @@
 """Decorator service for the media_player.play_media service."""
 import logging
+from os.path import exists
 
 import voluptuous as vol
 from youtube_dl import YoutubeDL
@@ -107,6 +108,14 @@ class MediaExtractor:
     def get_stream_selector(self):
         """Return format selector for the media URL."""
         cookies_txt_filepath = self.call_data.get(ATTR_COOKIES_FILEPATH)
+
+        if cookies_txt_filepath and not exists(cookies_txt_filepath):
+            _LOGGER.warning(
+                "Cookies file not found at filepath: %s", cookies_txt_filepath
+            )
+        elif cookies_txt_filepath:
+            _LOGGER.info("Cookies file found: %s", cookies_txt_filepath)
+
         ydl = YoutubeDL(
             {"quiet": True, "logger": _LOGGER, "cookiefile": cookies_txt_filepath}
         )

--- a/homeassistant/components/media_extractor/services.yaml
+++ b/homeassistant/components/media_extractor/services.yaml
@@ -5,6 +5,13 @@ play_media:
     entity:
       domain: media_player
   fields:
+    cookies_txt_filepath:
+      name: cookies.txt filepath
+      description: provided exported cookies.txt to supply youtube-dl for authorized streaming
+      required: false
+      example: "config/twitch.tv_cookies.txt"
+      selector:
+        text:
     media_content_id:
       name: Media content ID
       description: The ID of the content to play. Platform dependent.

--- a/homeassistant/components/media_extractor/services.yaml
+++ b/homeassistant/components/media_extractor/services.yaml
@@ -7,7 +7,7 @@ play_media:
   fields:
     cookies_txt_filepath:
       name: cookies.txt filepath
-      description: provided exported cookies.txt to supply youtube-dl for authorized streaming
+      description: a cookies.txt file to authenticate streaming
       required: false
       example: "config/twitch.tv_cookies.txt"
       selector:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Media Extractor uses `youtube-dl` under the hood to stream video from various sites.

Currently, Media Extractor has no way of providing authentication info to `youtube-dl` so that the streams can benefit from an existing user's subscription with a particular service (e.g. Youtube Premium, Twitch subscriptions)

This change allows users to specify a **filepath** to a **cookies.txt** file, which can be simply passed along to `youtube-dl` which will effectively provide authentication when digesting streams.

## Type of change
Adds an optional field to media_extractor called `cookies_txt_filepath`

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Tested with and without provided cookies.txt path against Twitch streams with success

There are no existing unit tests for media_extractor (that I could find). I haven't added unit tests since changes are additive and minor

- This PR fixes or closes issue: fixes #
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
