### PR TITLE
Remove input_datetime from mypy ignore list

### DIFF
--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime as py_datetime
 import logging
-from typing import cast
+from typing import Any
 
 import voluptuous as vol
 
@@ -85,23 +85,32 @@ def has_date_or_time(conf):
     raise vol.Invalid("Entity needs at least a date or a time")
 
 
-def valid_initial(conf):
+def valid_initial(conf: dict[str, Any]) -> dict[str, Any]:
     """Check the initial value is valid."""
-    if not (initial := conf.get(CONF_INITIAL)):
+    if not (conf.get(CONF_INITIAL)):
         return conf
 
+    # Ensure we can parse the initial value, raise vol.Invalid on failure
+    parse_initial_datetime(conf)
+    return conf
+
+
+def parse_initial_datetime(conf: dict[str, Any]) -> py_datetime.datetime:
+    """Check the initial value is valid."""
+    initial: str = conf[CONF_INITIAL]
+
     if conf[CONF_HAS_DATE] and conf[CONF_HAS_TIME]:
-        if dt_util.parse_datetime(initial) is not None:
-            return conf
+        if (datetime := dt_util.parse_datetime(initial)) is not None:
+            return datetime
         raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a datetime")
 
     if conf[CONF_HAS_DATE]:
-        if dt_util.parse_date(initial) is not None:
-            return conf
+        if (date := dt_util.parse_date(initial)) is not None:
+            return py_datetime.datetime.combine(date, DEFAULT_TIME)
         raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a date")
 
-    if dt_util.parse_time(initial) is not None:
-        return conf
+    if (time := dt_util.parse_time(initial)) is not None:
+        return py_datetime.datetime.combine(py_datetime.date.today(), time)
     raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a time")
 
 
@@ -231,22 +240,10 @@ class InputDatetime(RestoreEntity):
         self.editable = True
         self._current_datetime = None
 
-        if not (initial := config.get(CONF_INITIAL)):
+        if not config.get(CONF_INITIAL):
             return
 
-        if self.has_date and self.has_time:
-            current_datetime = cast(
-                py_datetime.datetime, dt_util.parse_datetime(initial)
-            )
-        elif self.has_date:
-            date = cast(py_datetime.date, dt_util.parse_date(initial))
-            current_datetime = py_datetime.datetime.combine(date, DEFAULT_TIME)
-
-        else:
-            time = cast(py_datetime.time, dt_util.parse_time(initial))
-            current_datetime = py_datetime.datetime.combine(
-                py_datetime.date.today(), time
-            )
+        current_datetime = parse_initial_datetime(config)
 
         # If the user passed in an initial value with a timezone, convert it to right tz
         if current_datetime.tzinfo is not None:

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime as py_datetime
 import logging
+from typing import cast
 
 import voluptuous as vol
 
@@ -234,16 +235,15 @@ class InputDatetime(RestoreEntity):
             return
 
         if self.has_date and self.has_time:
-            current_datetime = dt_util.parse_datetime(initial)
-            assert current_datetime is not None  # has been validated by valid_initial
+            current_datetime = cast(
+                py_datetime.datetime, dt_util.parse_datetime(initial)
+            )
         elif self.has_date:
-            date = dt_util.parse_date(initial)
-            assert date is not None  # has been validated by valid_initial
+            date = cast(py_datetime.date, dt_util.parse_date(initial))
             current_datetime = py_datetime.datetime.combine(date, DEFAULT_TIME)
 
         else:
-            time = dt_util.parse_time(initial)
-            assert time is not None  # has been validated by valid_initial
+            time = cast(py_datetime.time, dt_util.parse_time(initial))
             current_datetime = py_datetime.datetime.combine(
                 py_datetime.date.today(), time
             )

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -235,13 +235,19 @@ class InputDatetime(RestoreEntity):
 
         if self.has_date and self.has_time:
             current_datetime = dt_util.parse_datetime(initial)
+            if current_datetime is None:
+                raise ValueError(f"Unable to parse datetime from {initial}")
 
         elif self.has_date:
             date = dt_util.parse_date(initial)
+            if date is None:
+                raise ValueError(f"Unable to parse date from {initial}")
             current_datetime = py_datetime.datetime.combine(date, DEFAULT_TIME)
 
         else:
             time = dt_util.parse_time(initial)
+            if time is None:
+                raise ValueError(f"Unable to parse date from {initial}")
             current_datetime = py_datetime.datetime.combine(
                 py_datetime.date.today(), time
             )

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -235,19 +235,15 @@ class InputDatetime(RestoreEntity):
 
         if self.has_date and self.has_time:
             current_datetime = dt_util.parse_datetime(initial)
-            if current_datetime is None:
-                raise ValueError(f"Unable to parse datetime from {initial}")
-
+            assert current_datetime is not None  # has been validated by valid_initial
         elif self.has_date:
             date = dt_util.parse_date(initial)
-            if date is None:
-                raise ValueError(f"Unable to parse date from {initial}")
+            assert date is not None  # has been validated by valid_initial
             current_datetime = py_datetime.datetime.combine(date, DEFAULT_TIME)
 
         else:
             time = dt_util.parse_time(initial)
-            if time is None:
-                raise ValueError(f"Unable to parse date from {initial}")
+            assert time is not None  # has been validated by valid_initial
             current_datetime = py_datetime.datetime.combine(
                 py_datetime.date.today(), time
             )

--- a/mypy.ini
+++ b/mypy.ini
@@ -2716,9 +2716,6 @@ ignore_errors = true
 [mypy-homeassistant.components.influxdb]
 ignore_errors = true
 
-[mypy-homeassistant.components.input_datetime]
-ignore_errors = true
-
 [mypy-homeassistant.components.izone.climate]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -47,7 +47,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.icloud.device_tracker",
     "homeassistant.components.icloud.sensor",
     "homeassistant.components.influxdb",
-    "homeassistant.components.input_datetime",
     "homeassistant.components.izone.climate",
     "homeassistant.components.konnected",
     "homeassistant.components.konnected.config_flow",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove input_datetime from mypy ignore list

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
