### PR TITLE
Revert "Migrate aemet to native_*"

### DIFF
--- a/homeassistant/components/aemet/__init__.py
+++ b/homeassistant/components/aemet/__init__.py
@@ -1,30 +1,18 @@
 """The AEMET OpenData component."""
-from __future__ import annotations
-
 import logging
-from typing import Any
 
 from aemet_opendata.interface import AEMET
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_NAME,
-    Platform,
-)
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_STATION_UPDATES,
     DOMAIN,
     ENTRY_NAME,
     ENTRY_WEATHER_COORDINATOR,
-    FORECAST_MODES,
     PLATFORMS,
-    RENAMED_FORECAST_SENSOR_KEYS,
 )
 from .weather_update_coordinator import WeatherUpdateCoordinator
 
@@ -33,8 +21,6 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up AEMET OpenData as config entry."""
-    await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
-
     name = entry.data[CONF_NAME]
     api_key = entry.data[CONF_API_KEY]
     latitude = entry.data[CONF_LATITUDE]
@@ -74,24 +60,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-@callback
-def async_migrate_entity_entry(entry: er.RegistryEntry) -> dict[str, Any] | None:
-    """Migrate AEMET entity entries.
-
-    - Migrates unique ID from old forecast sensors to the new unique ID
-    """
-    if entry.domain != Platform.SENSOR:
-        return None
-    for old_key, new_key in RENAMED_FORECAST_SENSOR_KEYS.items():
-        for forecast_mode in FORECAST_MODES:
-            old_suffix = f"-forecast-{forecast_mode}-{old_key}"
-            if entry.unique_id.endswith(old_suffix):
-                new_suffix = f"-forecast-{forecast_mode}-{new_key}"
-                return {
-                    "new_unique_id": entry.unique_id.replace(old_suffix, new_suffix)
-                }
-
-    # No migration needed
-    return None

--- a/homeassistant/components/aemet/const.py
+++ b/homeassistant/components/aemet/const.py
@@ -18,10 +18,6 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SNOWY,
     ATTR_CONDITION_SUNNY,
     ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_NATIVE_PRECIPITATION,
-    ATTR_FORECAST_NATIVE_TEMP,
-    ATTR_FORECAST_NATIVE_TEMP_LOW,
-    ATTR_FORECAST_NATIVE_WIND_SPEED,
     ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_PRECIPITATION_PROBABILITY,
     ATTR_FORECAST_TEMP,
@@ -163,13 +159,13 @@ CONDITIONS_MAP = {
 
 FORECAST_MONITORED_CONDITIONS = [
     ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_NATIVE_PRECIPITATION,
+    ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_PRECIPITATION_PROBABILITY,
-    ATTR_FORECAST_NATIVE_TEMP,
-    ATTR_FORECAST_NATIVE_TEMP_LOW,
+    ATTR_FORECAST_TEMP,
+    ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
-    ATTR_FORECAST_NATIVE_WIND_SPEED,
+    ATTR_FORECAST_WIND_SPEED,
 ]
 MONITORED_CONDITIONS = [
     ATTR_API_CONDITION,
@@ -210,7 +206,7 @@ FORECAST_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         name="Condition",
     ),
     SensorEntityDescription(
-        key=ATTR_FORECAST_NATIVE_PRECIPITATION,
+        key=ATTR_FORECAST_PRECIPITATION,
         name="Precipitation",
         native_unit_of_measurement=PRECIPITATION_MILLIMETERS_PER_HOUR,
     ),
@@ -220,13 +216,13 @@ FORECAST_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(
-        key=ATTR_FORECAST_NATIVE_TEMP,
+        key=ATTR_FORECAST_TEMP,
         name="Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
     SensorEntityDescription(
-        key=ATTR_FORECAST_NATIVE_TEMP_LOW,
+        key=ATTR_FORECAST_TEMP_LOW,
         name="Temperature Low",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -242,17 +238,11 @@ FORECAST_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=DEGREE,
     ),
     SensorEntityDescription(
-        key=ATTR_FORECAST_NATIVE_WIND_SPEED,
+        key=ATTR_FORECAST_WIND_SPEED,
         name="Wind speed",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
     ),
 )
-RENAMED_FORECAST_SENSOR_KEYS = {
-    ATTR_FORECAST_PRECIPITATION: ATTR_FORECAST_NATIVE_PRECIPITATION,
-    ATTR_FORECAST_TEMP: ATTR_FORECAST_NATIVE_TEMP,
-    ATTR_FORECAST_TEMP_LOW: ATTR_FORECAST_NATIVE_TEMP_LOW,
-    ATTR_FORECAST_WIND_SPEED: ATTR_FORECAST_NATIVE_WIND_SPEED,
-}
 WEATHER_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key=ATTR_API_CONDITION,

--- a/homeassistant/components/aemet/sensor.py
+++ b/homeassistant/components/aemet/sensor.py
@@ -45,13 +45,17 @@ async def async_setup_entry(
     entities.extend(
         [
             AemetForecastSensor(
-                f"{domain_data[ENTRY_NAME]} {mode} Forecast",
-                f"{unique_id}-forecast-{mode}",
+                name_prefix,
+                unique_id_prefix,
                 weather_coordinator,
                 mode,
                 description,
             )
             for mode in FORECAST_MODES
+            if (
+                (name_prefix := f"{domain_data[ENTRY_NAME]} {mode} Forecast")
+                and (unique_id_prefix := f"{unique_id}-forecast-{mode}")
+            )
             for description in FORECAST_SENSOR_TYPES
             if description.key in FORECAST_MONITORED_CONDITIONS
         ]
@@ -85,14 +89,14 @@ class AemetSensor(AbstractAemetSensor):
     def __init__(
         self,
         name,
-        unique_id_prefix,
+        unique_id,
         weather_coordinator: WeatherUpdateCoordinator,
         description: SensorEntityDescription,
     ):
         """Initialize the sensor."""
         super().__init__(
             name=name,
-            unique_id=f"{unique_id_prefix}-{description.key}",
+            unique_id=f"{unique_id}-{description.key}",
             coordinator=weather_coordinator,
             description=description,
         )
@@ -109,7 +113,7 @@ class AemetForecastSensor(AbstractAemetSensor):
     def __init__(
         self,
         name,
-        unique_id_prefix,
+        unique_id,
         weather_coordinator: WeatherUpdateCoordinator,
         forecast_mode,
         description: SensorEntityDescription,
@@ -117,7 +121,7 @@ class AemetForecastSensor(AbstractAemetSensor):
         """Initialize the sensor."""
         super().__init__(
             name=name,
-            unique_id=f"{unique_id_prefix}-{description.key}",
+            unique_id=f"{unique_id}-{description.key}",
             coordinator=weather_coordinator,
             description=description,
         )

--- a/homeassistant/components/aemet/weather.py
+++ b/homeassistant/components/aemet/weather.py
@@ -1,12 +1,7 @@
 """Support for the AEMET OpenData service."""
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    LENGTH_MILLIMETERS,
-    PRESSURE_HPA,
-    SPEED_KILOMETERS_PER_HOUR,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import PRESSURE_HPA, SPEED_KILOMETERS_PER_HOUR, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -52,10 +47,9 @@ class AemetWeather(CoordinatorEntity[WeatherUpdateCoordinator], WeatherEntity):
     """Implementation of an AEMET OpenData sensor."""
 
     _attr_attribution = ATTRIBUTION
-    _attr_native_precipitation_unit = LENGTH_MILLIMETERS
-    _attr_native_pressure_unit = PRESSURE_HPA
-    _attr_native_temperature_unit = TEMP_CELSIUS
-    _attr_native_wind_speed_unit = SPEED_KILOMETERS_PER_HOUR
+    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_pressure_unit = PRESSURE_HPA
+    _attr_wind_speed_unit = SPEED_KILOMETERS_PER_HOUR
 
     def __init__(
         self,
@@ -89,12 +83,12 @@ class AemetWeather(CoordinatorEntity[WeatherUpdateCoordinator], WeatherEntity):
         return self.coordinator.data[ATTR_API_HUMIDITY]
 
     @property
-    def native_pressure(self):
+    def pressure(self):
         """Return the pressure."""
         return self.coordinator.data[ATTR_API_PRESSURE]
 
     @property
-    def native_temperature(self):
+    def temperature(self):
         """Return the temperature."""
         return self.coordinator.data[ATTR_API_TEMPERATURE]
 
@@ -104,6 +98,6 @@ class AemetWeather(CoordinatorEntity[WeatherUpdateCoordinator], WeatherEntity):
         return self.coordinator.data[ATTR_API_WIND_BEARING]
 
     @property
-    def native_wind_speed(self):
+    def wind_speed(self):
         """Return the wind speed."""
         return self.coordinator.data[ATTR_API_WIND_SPEED]

--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -44,13 +44,13 @@ import async_timeout
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_NATIVE_PRECIPITATION,
-    ATTR_FORECAST_NATIVE_TEMP,
-    ATTR_FORECAST_NATIVE_TEMP_LOW,
-    ATTR_FORECAST_NATIVE_WIND_SPEED,
+    ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_PRECIPITATION_PROBABILITY,
+    ATTR_FORECAST_TEMP,
+    ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_SPEED,
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -406,10 +406,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: self._get_precipitation_prob_day(
                 day
             ),
-            ATTR_FORECAST_NATIVE_TEMP: self._get_temperature_day(day),
-            ATTR_FORECAST_NATIVE_TEMP_LOW: self._get_temperature_low_day(day),
+            ATTR_FORECAST_TEMP: self._get_temperature_day(day),
+            ATTR_FORECAST_TEMP_LOW: self._get_temperature_low_day(day),
             ATTR_FORECAST_TIME: dt_util.as_utc(date).isoformat(),
-            ATTR_FORECAST_NATIVE_WIND_SPEED: self._get_wind_speed_day(day),
+            ATTR_FORECAST_WIND_SPEED: self._get_wind_speed_day(day),
             ATTR_FORECAST_WIND_BEARING: self._get_wind_bearing_day(day),
         }
 
@@ -421,13 +421,13 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
         return {
             ATTR_FORECAST_CONDITION: condition,
-            ATTR_FORECAST_NATIVE_PRECIPITATION: self._calc_precipitation(day, hour),
+            ATTR_FORECAST_PRECIPITATION: self._calc_precipitation(day, hour),
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: self._calc_precipitation_prob(
                 day, hour
             ),
-            ATTR_FORECAST_NATIVE_TEMP: self._get_temperature(day, hour),
+            ATTR_FORECAST_TEMP: self._get_temperature(day, hour),
             ATTR_FORECAST_TIME: dt_util.as_utc(forecast_dt).isoformat(),
-            ATTR_FORECAST_NATIVE_WIND_SPEED: self._get_wind_speed(day, hour),
+            ATTR_FORECAST_WIND_SPEED: self._get_wind_speed(day, hour),
             ATTR_FORECAST_WIND_BEARING: self._get_wind_bearing(day, hour),
         }
 

--- a/tests/components/aemet/test_init.py
+++ b/tests/components/aemet/test_init.py
@@ -2,15 +2,11 @@
 
 from unittest.mock import patch
 
-import pytest
 import requests_mock
 
 from homeassistant.components.aemet.const import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from .util import aemet_requests_mock
@@ -46,83 +42,3 @@ async def test_unload_entry(hass):
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.state is ConfigEntryState.NOT_LOADED
-
-
-@pytest.mark.parametrize(
-    "old_unique_id,new_unique_id",
-    [
-        # Sensors which should be migrated
-        (
-            "aemet_unique_id-forecast-daily-precipitation",
-            "aemet_unique_id-forecast-daily-native_precipitation",
-        ),
-        (
-            "aemet_unique_id-forecast-daily-temperature",
-            "aemet_unique_id-forecast-daily-native_temperature",
-        ),
-        (
-            "aemet_unique_id-forecast-daily-templow",
-            "aemet_unique_id-forecast-daily-native_templow",
-        ),
-        (
-            "aemet_unique_id-forecast-daily-wind_speed",
-            "aemet_unique_id-forecast-daily-native_wind_speed",
-        ),
-        (
-            "aemet_unique_id-forecast-hourly-precipitation",
-            "aemet_unique_id-forecast-hourly-native_precipitation",
-        ),
-        (
-            "aemet_unique_id-forecast-hourly-temperature",
-            "aemet_unique_id-forecast-hourly-native_temperature",
-        ),
-        (
-            "aemet_unique_id-forecast-hourly-templow",
-            "aemet_unique_id-forecast-hourly-native_templow",
-        ),
-        (
-            "aemet_unique_id-forecast-hourly-wind_speed",
-            "aemet_unique_id-forecast-hourly-native_wind_speed",
-        ),
-        # Already migrated
-        (
-            "aemet_unique_id-forecast-daily-native_templow",
-            "aemet_unique_id-forecast-daily-native_templow",
-        ),
-        # No migration needed
-        (
-            "aemet_unique_id-forecast-daily-condition",
-            "aemet_unique_id-forecast-daily-condition",
-        ),
-    ],
-)
-async def test_migrate_unique_id_sensor(
-    hass: HomeAssistant,
-    old_unique_id: str,
-    new_unique_id: str,
-) -> None:
-    """Test migration of unique_id."""
-    now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")
-    with patch("homeassistant.util.dt.now", return_value=now), patch(
-        "homeassistant.util.dt.utcnow", return_value=now
-    ), requests_mock.mock() as _m:
-        aemet_requests_mock(_m)
-        config_entry = MockConfigEntry(
-            domain=DOMAIN, unique_id="aemet_unique_id", data=CONFIG
-        )
-        config_entry.add_to_hass(hass)
-
-        entity_registry = er.async_get(hass)
-        entity: er.RegistryEntry = entity_registry.async_get_or_create(
-            domain=SENSOR_DOMAIN,
-            platform=DOMAIN,
-            unique_id=old_unique_id,
-            config_entry=config_entry,
-        )
-        assert entity.unique_id == old_unique_id
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        entity_migrated = entity_registry.async_get(entity.entity_id)
-        assert entity_migrated
-        assert entity_migrated.unique_id == new_unique_id


### PR DESCRIPTION
Reverts home-assistant/core#74037, the PR unnecessarily changes `entity_id` of some aemet sensors.

Background in review comment by @MartinHjelmare 