### PR TITLE
Remove legacy Sonos grouping services

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -81,8 +81,6 @@ SONOS_TO_REPEAT = {meaning: mode for mode, meaning in REPEAT_TO_SONOS.items()}
 
 UPNP_ERRORS_TO_IGNORE = ["701", "711", "712"]
 
-SERVICE_JOIN = "join"
-SERVICE_UNJOIN = "unjoin"
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"
 SERVICE_SET_TIMER = "set_sleep_timer"
@@ -129,24 +127,7 @@ async def async_setup_entry(
             assert isinstance(entity, SonosMediaPlayerEntity)
             speakers.append(entity.speaker)
 
-        if service_call.service == SERVICE_JOIN:
-            _LOGGER.warning(
-                "Service 'sonos.join' is deprecated and will be removed in 2022.8, please use 'media_player.join'"
-            )
-            master = platform.entities.get(service_call.data[ATTR_MASTER])
-            if master:
-                await SonosSpeaker.join_multi(hass, master.speaker, speakers)  # type: ignore[arg-type]
-            else:
-                _LOGGER.error(
-                    "Invalid master specified for join service: %s",
-                    service_call.data[ATTR_MASTER],
-                )
-        elif service_call.service == SERVICE_UNJOIN:
-            _LOGGER.warning(
-                "Service 'sonos.unjoin' is deprecated and will be removed in 2022.8, please use 'media_player.unjoin'"
-            )
-            await SonosSpeaker.unjoin_multi(hass, speakers)  # type: ignore[arg-type]
-        elif service_call.service == SERVICE_SNAPSHOT:
+        if service_call.service == SERVICE_SNAPSHOT:
             await SonosSpeaker.snapshot_multi(
                 hass, speakers, service_call.data[ATTR_WITH_GROUP]  # type: ignore[arg-type]
             )
@@ -157,20 +138,6 @@ async def async_setup_entry(
 
     config_entry.async_on_unload(
         async_dispatcher_connect(hass, SONOS_CREATE_MEDIA_PLAYER, async_create_entities)
-    )
-
-    hass.services.async_register(
-        SONOS_DOMAIN,
-        SERVICE_JOIN,
-        async_service_handle,
-        cv.make_entity_service_schema({vol.Required(ATTR_MASTER): cv.entity_id}),
-    )
-
-    hass.services.async_register(
-        SONOS_DOMAIN,
-        SERVICE_UNJOIN,
-        async_service_handle,
-        cv.make_entity_service_schema({}),
     )
 
     join_unjoin_schema = cv.make_entity_service_schema(

--- a/homeassistant/components/sonos/services.yaml
+++ b/homeassistant/components/sonos/services.yaml
@@ -1,32 +1,3 @@
-join:
-  name: Join group
-  description: Group player together.
-  fields:
-    master:
-      name: Master
-      description: Entity ID of the player that should become the coordinator of the group.
-      required: true
-      selector:
-        entity:
-          integration: sonos
-          domain: media_player
-    entity_id:
-      name: Entity
-      description: Name of entity that will join the master.
-      required: true
-      selector:
-        entity:
-          integration: sonos
-          domain: media_player
-
-unjoin:
-  name: Unjoin group
-  description: Unjoin the player from a group.
-  target:
-    entity:
-      integration: sonos
-      domain: media_player
-
 snapshot:
   name: Snapshot
   description: Take a snapshot of the media player.

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,23 +1,6 @@
 """Tests for the Sonos Media Player platform."""
-import pytest
-
-from homeassistant.components.sonos import DOMAIN, media_player
 from homeassistant.const import STATE_IDLE
-from homeassistant.core import Context
-from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import device_registry as dr
-
-
-async def test_services(hass, async_autosetup_sonos, hass_read_only_user):
-    """Test join/unjoin requires control access."""
-    with pytest.raises(Unauthorized):
-        await hass.services.async_call(
-            DOMAIN,
-            media_player.SERVICE_JOIN,
-            {"master": "media_player.bla", "entity_id": "media_player.blub"},
-            blocking=True,
-            context=Context(user_id=hass_read_only_user.id),
-        )
 
 
 async def test_device_registry(hass, async_autosetup_sonos, soco):

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -1,0 +1,43 @@
+"""Tests for Sonos services."""
+from unittest.mock import Mock, patch
+
+import pytest
+
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.media_player.const import SERVICE_JOIN
+from homeassistant.components.sonos.const import DATA_SONOS
+from homeassistant.exceptions import HomeAssistantError
+
+
+async def test_media_player_join(hass, async_autosetup_sonos):
+    """Test join service."""
+    valid_entity_id = "media_player.zone_a"
+    mocked_entity_id = "media_player.mocked"
+
+    # Ensure an error is raised if the entity is unknown
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_JOIN,
+            {"entity_id": valid_entity_id, "group_members": mocked_entity_id},
+            blocking=True,
+        )
+
+    # Ensure SonosSpeaker.join_multi is called if entity is found
+    mocked_speaker = Mock()
+    mock_entity_id_mappings = {mocked_entity_id: mocked_speaker}
+
+    with patch.dict(
+        hass.data[DATA_SONOS].entity_id_mappings, mock_entity_id_mappings
+    ), patch(
+        "homeassistant.components.sonos.speaker.SonosSpeaker.join_multi"
+    ) as mock_join_multi:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_JOIN,
+            {"entity_id": valid_entity_id, "group_members": mocked_entity_id},
+            blocking=True,
+        )
+
+        found_speaker = hass.data[DATA_SONOS].entity_id_mappings[valid_entity_id]
+        mock_join_multi.assert_called_with(hass, found_speaker, [mocked_speaker])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `sonos.join` and `sonos.unjoin` services have been removed in favor of the standard `media_player.join` and `media_player.unjoin` services. This deprecation was previously announced in 2022.5.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the legacy integration-specific `join` and `unjoin` services as a followup to #71226.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
