### PR TITLE
Cache the response from config/device_registry/list

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -1,12 +1,23 @@
 """HTTP views to interact with the device registry."""
+from __future__ import annotations
+
 import voluptuous as vol
 
 from homeassistant import loader
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.decorators import require_admin
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.components.websocket_api.messages import (
+    IDEN_JSON_TEMPLATE,
+    IDEN_TEMPLATE,
+    message_to_json,
+)
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceEntryDisabler, async_get
+from homeassistant.helpers.device_registry import (
+    EVENT_DEVICE_REGISTRY_UPDATED,
+    DeviceEntryDisabler,
+    async_get,
+)
 
 WS_TYPE_LIST = "config/device_registry/list"
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -29,6 +40,36 @@ SCHEMA_WS_UPDATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 async def async_setup(hass):
     """Enable the Device Registry views."""
+
+    cached_list_devices: str | None = None
+
+    @callback
+    def _async_clear_list_device_cache(event: Event) -> None:
+        nonlocal cached_list_devices
+        cached_list_devices = None
+
+    @callback
+    def websocket_list_devices(hass, connection, msg):
+        """Handle list devices command."""
+        nonlocal cached_list_devices
+        if not cached_list_devices:
+            registry = async_get(hass)
+            cached_list_devices = message_to_json(
+                websocket_api.result_message(
+                    IDEN_TEMPLATE,
+                    [_entry_dict(entry) for entry in registry.devices.values()],
+                )
+            )
+        connection.send_message(
+            cached_list_devices.replace(IDEN_JSON_TEMPLATE, str(msg["id"]), 1)
+        )
+
+    hass.bus.async_listen(
+        EVENT_DEVICE_REGISTRY_UPDATED,
+        _async_clear_list_device_cache,
+        run_immediately=True,
+    )
+
     websocket_api.async_register_command(
         hass, WS_TYPE_LIST, websocket_list_devices, SCHEMA_WS_LIST
     )
@@ -39,17 +80,6 @@ async def async_setup(hass):
         hass, websocket_remove_config_entry_from_device
     )
     return True
-
-
-@callback
-def websocket_list_devices(hass, connection, msg):
-    """Handle list devices command."""
-    registry = async_get(hass)
-    connection.send_message(
-        websocket_api.result_message(
-            msg["id"], [_entry_dict(entry) for entry in registry.devices.values()]
-        )
-    )
 
 
 @require_admin

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -29,14 +29,14 @@ def registry(hass):
 
 async def test_list_devices(hass, client, registry):
     """Test list entries."""
-    registry.async_get_or_create(
+    device1 = registry.async_get_or_create(
         config_entry_id="1234",
         connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
-    registry.async_get_or_create(
+    device2 = registry.async_get_or_create(
         config_entry_id="1234",
         identifiers={("bridgeid", "1234")},
         manufacturer="manufacturer",
@@ -83,6 +83,32 @@ async def test_list_devices(hass, client, registry):
             "disabled_by": None,
             "configuration_url": None,
         },
+    ]
+
+    registry.async_remove_device(device2.id)
+    await hass.async_block_till_done()
+
+    await client.send_json({"id": 6, "type": "config/device_registry/list"})
+    msg = await client.receive_json()
+
+    assert msg["result"] == [
+        {
+            "area_id": None,
+            "config_entries": ["1234"],
+            "configuration_url": None,
+            "connections": [["ethernet", "12:34:56:78:90:AB:CD:EF"]],
+            "disabled_by": None,
+            "entry_type": None,
+            "hw_version": None,
+            "id": device1.id,
+            "identifiers": [["bridgeid", "0123"]],
+            "manufacturer": "manufacturer",
+            "model": "model",
+            "name": None,
+            "name_by_user": None,
+            "sw_version": None,
+            "via_device_id": None,
+        }
     ]
 
 


### PR DESCRIPTION
This is part of an optimization cycle to improve the responsiveness of the UI during first pickup and startup

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Same as #74443 for the device registry


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
