### PR TITLE
Use FlowResultType in devolo Home Control tests

### DIFF
--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.devolo_home_control.const import DEFAULT_MYDEVOLO, DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult, FlowResultType
 
 from .const import (
     DISCOVERY_INFO,
@@ -15,28 +17,28 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant):
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
 
     await _setup(hass, result)
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials_user(hass):
+async def test_form_invalid_credentials_user(hass: HomeAssistant):
     """Test if we get the error message on invalid credentials."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
@@ -47,7 +49,7 @@ async def test_form_invalid_credentials_user(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_already_configured(hass):
+async def test_form_already_configured(hass: HomeAssistant):
     """Test if we get the error message on already configured."""
     with patch(
         "homeassistant.components.devolo_home_control.Mydevolo.uuid",
@@ -59,17 +61,17 @@ async def test_form_already_configured(hass):
             context={"source": config_entries.SOURCE_USER},
             data={"username": "test-username", "password": "test-password"},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
-async def test_form_advanced_options(hass):
+async def test_form_advanced_options(hass: HomeAssistant):
     """Test if we get the advanced options if user has enabled it."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -100,7 +102,7 @@ async def test_form_advanced_options(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_zeroconf(hass):
+async def test_form_zeroconf(hass: HomeAssistant):
     """Test that the zeroconf confirmation form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -109,13 +111,13 @@ async def test_form_zeroconf(hass):
     )
 
     assert result["step_id"] == "zeroconf_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     await _setup(hass, result)
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials_zeroconf(hass):
+async def test_form_invalid_credentials_zeroconf(hass: HomeAssistant):
     """Test if we get the error message on invalid credentials."""
 
     result = await hass.config_entries.flow.async_init(
@@ -125,7 +127,7 @@ async def test_form_invalid_credentials_zeroconf(hass):
     )
 
     assert result["step_id"] == "zeroconf_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -135,7 +137,7 @@ async def test_form_invalid_credentials_zeroconf(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_zeroconf_wrong_device(hass):
+async def test_zeroconf_wrong_device(hass: HomeAssistant):
     """Test that the zeroconf ignores wrong devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -144,7 +146,7 @@ async def test_zeroconf_wrong_device(hass):
     )
 
     assert result["reason"] == "Not a devolo Home Control gateway."
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -153,10 +155,10 @@ async def test_zeroconf_wrong_device(hass):
     )
 
     assert result["reason"] == "Not a devolo Home Control gateway."
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
 
 
-async def test_form_reauth(hass):
+async def test_form_reauth(hass: HomeAssistant):
     """Test that the reauth confirmation form is served."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})
     mock_config.add_to_hass(hass)
@@ -174,7 +176,7 @@ async def test_form_reauth(hass):
     )
 
     assert result["step_id"] == "reauth_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     with patch(
         "homeassistant.components.devolo_home_control.async_setup_entry",
@@ -189,12 +191,12 @@ async def test_form_reauth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == FlowResultType.ABORT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials_reauth(hass):
+async def test_form_invalid_credentials_reauth(hass: HomeAssistant):
     """Test if we get the error message on invalid credentials."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})
     mock_config.add_to_hass(hass)
@@ -219,7 +221,7 @@ async def test_form_invalid_credentials_reauth(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_uuid_change_reauth(hass):
+async def test_form_uuid_change_reauth(hass: HomeAssistant):
     """Test that the reauth confirmation form is served."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})
     mock_config.add_to_hass(hass)
@@ -237,7 +239,7 @@ async def test_form_uuid_change_reauth(hass):
     )
 
     assert result["step_id"] == "reauth_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     with patch(
         "homeassistant.components.devolo_home_control.async_setup_entry",
@@ -252,11 +254,11 @@ async def test_form_uuid_change_reauth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "reauth_failed"}
 
 
-async def _setup(hass, result):
+async def _setup(hass: HomeAssistant, result: FlowResult):
     """Finish configuration steps."""
     with patch(
         "homeassistant.components.devolo_home_control.async_setup_entry",

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -17,7 +17,7 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -31,7 +31,7 @@ async def test_form(hass: HomeAssistant):
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials_user(hass: HomeAssistant):
+async def test_form_invalid_credentials_user(hass: HomeAssistant) -> None:
     """Test if we get the error message on invalid credentials."""
 
     result = await hass.config_entries.flow.async_init(
@@ -49,7 +49,7 @@ async def test_form_invalid_credentials_user(hass: HomeAssistant):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_already_configured(hass: HomeAssistant):
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test if we get the error message on already configured."""
     with patch(
         "homeassistant.components.devolo_home_control.Mydevolo.uuid",
@@ -65,7 +65,7 @@ async def test_form_already_configured(hass: HomeAssistant):
         assert result["reason"] == "already_configured"
 
 
-async def test_form_advanced_options(hass: HomeAssistant):
+async def test_form_advanced_options(hass: HomeAssistant) -> None:
     """Test if we get the advanced options if user has enabled it."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -102,7 +102,7 @@ async def test_form_advanced_options(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_zeroconf(hass: HomeAssistant):
+async def test_form_zeroconf(hass: HomeAssistant) -> None:
     """Test that the zeroconf confirmation form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -117,7 +117,7 @@ async def test_form_zeroconf(hass: HomeAssistant):
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials_zeroconf(hass: HomeAssistant):
+async def test_form_invalid_credentials_zeroconf(hass: HomeAssistant) -> None:
     """Test if we get the error message on invalid credentials."""
 
     result = await hass.config_entries.flow.async_init(
@@ -137,7 +137,7 @@ async def test_form_invalid_credentials_zeroconf(hass: HomeAssistant):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_zeroconf_wrong_device(hass: HomeAssistant):
+async def test_zeroconf_wrong_device(hass: HomeAssistant) -> None:
     """Test that the zeroconf ignores wrong devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -158,7 +158,7 @@ async def test_zeroconf_wrong_device(hass: HomeAssistant):
     assert result["type"] == FlowResultType.ABORT
 
 
-async def test_form_reauth(hass: HomeAssistant):
+async def test_form_reauth(hass: HomeAssistant) -> None:
     """Test that the reauth confirmation form is served."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})
     mock_config.add_to_hass(hass)
@@ -196,7 +196,7 @@ async def test_form_reauth(hass: HomeAssistant):
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials_reauth(hass: HomeAssistant):
+async def test_form_invalid_credentials_reauth(hass: HomeAssistant) -> None:
     """Test if we get the error message on invalid credentials."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})
     mock_config.add_to_hass(hass)
@@ -221,7 +221,7 @@ async def test_form_invalid_credentials_reauth(hass: HomeAssistant):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_uuid_change_reauth(hass: HomeAssistant):
+async def test_form_uuid_change_reauth(hass: HomeAssistant) -> None:
     """Test that the reauth confirmation form is served."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})
     mock_config.add_to_hass(hass)
@@ -258,7 +258,7 @@ async def test_form_uuid_change_reauth(hass: HomeAssistant):
     assert result2["errors"] == {"base": "reauth_failed"}
 
 
-async def _setup(hass: HomeAssistant, result: FlowResult):
+async def _setup(hass: HomeAssistant, result: FlowResult) -> None:
     """Finish configuration steps."""
     with patch(
         "homeassistant.components.devolo_home_control.async_setup_entry",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The data_entry_flow constants were deprecated in favor of the FlowResultType enum. This MR makes use of it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
