### PR TITLE
Cleanup mikrotik device extra_attributes

### DIFF
--- a/homeassistant/components/mikrotik/const.py
+++ b/homeassistant/components/mikrotik/const.py
@@ -44,7 +44,6 @@ PLATFORMS: Final = [Platform.DEVICE_TRACKER]
 
 ATTR_DEVICE_TRACKER: Final = [
     "comment",
-    "mac-address",
     "ssid",
     "interface",
     "signal-strength",

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -86,6 +86,8 @@ class MikrotikDataUpdateCoordinatorTracker(
         """Initialize the tracked device."""
         super().__init__(coordinator)
         self.device = device
+        self._attr_name = str(device.name)
+        self._attr_unique_id = device.mac
 
     @property
     def is_connected(self) -> bool:
@@ -104,12 +106,6 @@ class MikrotikDataUpdateCoordinatorTracker(
         return SOURCE_TYPE_ROUTER
 
     @property
-    def name(self) -> str:
-        """Return the name of the client."""
-        # Stringify to ensure we return a string
-        return str(self.device.name)
-
-    @property
     def hostname(self) -> str:
         """Return the hostname of the client."""
         return self.device.name
@@ -123,11 +119,6 @@ class MikrotikDataUpdateCoordinatorTracker(
     def ip_address(self) -> str:
         """Return the mac address of the client."""
         return self.device.ip_address
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique identifier for this device."""
-        return self.device.mac
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -18,10 +18,6 @@ import homeassistant.util.dt as dt_util
 from .const import DOMAIN
 from .hub import Device, MikrotikDataUpdateCoordinator
 
-# These are normalized to ATTR_IP and ATTR_MAC to conform
-# to device_tracker
-FILTER_ATTRS = ("ip_address", "mac_address")
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -136,6 +132,4 @@ class MikrotikDataUpdateCoordinatorTracker(
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the device state attributes."""
-        if self.is_connected:
-            return {k: v for k, v in self.device.attrs.items() if k not in FILTER_ATTRS}
-        return None
+        return self.device.attrs if self.is_connected else None

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -77,11 +77,10 @@ class Device:
     @property
     def attrs(self) -> dict[str, Any]:
         """Return device attributes."""
-        attr_data = self._wireless_params if self._wireless_params else self._params
+        attr_data = self._wireless_params | self._params
         for attr in ATTR_DEVICE_TRACKER:
             if attr in attr_data:
                 self._attrs[slugify(attr)] = attr_data[attr]
-        self._attrs["ip_address"] = self._params.get("active-address")
         return self._attrs
 
     def update(
@@ -250,7 +249,7 @@ class MikrotikData:
     ) -> list[dict[str, Any]]:
         """Retrieve data from Mikrotik API."""
         try:
-            _LOGGER.info("Running command %s", cmd)
+            _LOGGER.debug("Running command %s", cmd)
             if params:
                 return list(self.api(cmd=cmd, **params))
             return list(self.api(cmd=cmd))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Remove `ip_address` and `mac_address` from extra_attributes and make the code cleaner.
- Get attributes from both DHCP params and WIRLESS params as the `comment` attribute is available through DHCP params only even for wireless clients.
- Change the logging of commands to debug level.
- Use instance attributes in device_tracker

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
