### PR TITLE
Use FlowResultType in deCONZ test_config_flow

### DIFF
--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -29,11 +29,7 @@ from homeassistant.config_entries import (
     SOURCE_USER,
 )
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
-from homeassistant.data_entry_flow import (
-    RESULT_TYPE_ABORT,
-    RESULT_TYPE_CREATE_ENTRY,
-    RESULT_TYPE_FORM,
-)
+from homeassistant.data_entry_flow import FlowResultType
 
 from .test_gateway import API_KEY, BRIDGEID, setup_deconz_integration
 
@@ -55,14 +51,14 @@ async def test_flow_discovered_bridges(hass, aioclient_mock):
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "1.2.3.4"}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post(
@@ -75,7 +71,7 @@ async def test_flow_discovered_bridges(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == BRIDGEID
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
@@ -100,7 +96,7 @@ async def test_flow_manual_configuration_decision(hass, aioclient_mock):
         result["flow_id"], user_input={CONF_HOST: CONF_MANUAL_INPUT}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
@@ -108,7 +104,7 @@ async def test_flow_manual_configuration_decision(hass, aioclient_mock):
         user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post(
@@ -127,7 +123,7 @@ async def test_flow_manual_configuration_decision(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == BRIDGEID
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
@@ -148,7 +144,7 @@ async def test_flow_manual_configuration(hass, aioclient_mock):
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
@@ -156,7 +152,7 @@ async def test_flow_manual_configuration(hass, aioclient_mock):
         user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post(
@@ -175,7 +171,7 @@ async def test_flow_manual_configuration(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == BRIDGEID
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
@@ -192,7 +188,7 @@ async def test_manual_configuration_after_discovery_timeout(hass, aioclient_mock
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
     assert not hass.config_entries.flow._progress[result["flow_id"]].bridges
 
@@ -205,7 +201,7 @@ async def test_manual_configuration_after_discovery_ResponseError(hass, aioclien
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
     assert not hass.config_entries.flow._progress[result["flow_id"]].bridges
 
@@ -224,7 +220,7 @@ async def test_manual_configuration_update_configuration(hass, aioclient_mock):
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
@@ -232,7 +228,7 @@ async def test_manual_configuration_update_configuration(hass, aioclient_mock):
         user_input={CONF_HOST: "2.3.4.5", CONF_PORT: 80},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post(
@@ -251,7 +247,7 @@ async def test_manual_configuration_update_configuration(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_HOST] == "2.3.4.5"
 
@@ -270,7 +266,7 @@ async def test_manual_configuration_dont_update_configuration(hass, aioclient_mo
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
@@ -278,7 +274,7 @@ async def test_manual_configuration_dont_update_configuration(hass, aioclient_mo
         user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post(
@@ -297,7 +293,7 @@ async def test_manual_configuration_dont_update_configuration(hass, aioclient_mo
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -313,7 +309,7 @@ async def test_manual_configuration_timeout_get_bridge(hass, aioclient_mock):
         DECONZ_DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
@@ -321,7 +317,7 @@ async def test_manual_configuration_timeout_get_bridge(hass, aioclient_mock):
         user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post(
@@ -338,7 +334,7 @@ async def test_manual_configuration_timeout_get_bridge(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "no_bridges"
 
 
@@ -367,7 +363,7 @@ async def test_link_step_fails(hass, aioclient_mock, raised_error, error_string)
         result["flow_id"], user_input={CONF_HOST: "1.2.3.4"}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     aioclient_mock.post("http://1.2.3.4:80/api", exc=raised_error)
@@ -376,7 +372,7 @@ async def test_link_step_fails(hass, aioclient_mock, raised_error, error_string)
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
     assert result["errors"] == {"base": error_string}
 
@@ -391,7 +387,7 @@ async def test_reauth_flow_update_configuration(hass, aioclient_mock):
         context={"source": SOURCE_REAUTH},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     new_api_key = "new_key"
@@ -412,7 +408,7 @@ async def test_reauth_flow_update_configuration(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_API_KEY] == new_api_key
 
@@ -433,7 +429,7 @@ async def test_flow_ssdp_discovery(hass, aioclient_mock):
         context={"source": SOURCE_SSDP},
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "link"
 
     flows = hass.config_entries.flow.async_progress()
@@ -450,7 +446,7 @@ async def test_flow_ssdp_discovery(hass, aioclient_mock):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == BRIDGEID
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
@@ -482,7 +478,7 @@ async def test_ssdp_discovery_update_configuration(hass, aioclient_mock):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_HOST] == "2.3.4.5"
     assert len(mock_setup_entry.mock_calls) == 1
@@ -506,7 +502,7 @@ async def test_ssdp_discovery_dont_update_configuration(hass, aioclient_mock):
         context={"source": SOURCE_SSDP},
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_HOST] == "1.2.3.4"
 
@@ -533,7 +529,7 @@ async def test_ssdp_discovery_dont_update_existing_hassio_configuration(
         context={"source": SOURCE_SSDP},
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_HOST] == "1.2.3.4"
 
@@ -553,7 +549,7 @@ async def test_flow_hassio_discovery(hass):
         ),
         context={"source": SOURCE_HASSIO},
     )
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "hassio_confirm"
     assert result["description_placeholders"] == {"addon": "Mock Addon"}
 
@@ -572,7 +568,7 @@ async def test_flow_hassio_discovery(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["result"].data == {
         CONF_HOST: "mock-deconz",
         CONF_PORT: 80,
@@ -603,7 +599,7 @@ async def test_hassio_discovery_update_configuration(hass, aioclient_mock):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_HOST] == "2.3.4.5"
     assert config_entry.data[CONF_PORT] == 8080
@@ -628,7 +624,7 @@ async def test_hassio_discovery_dont_update_configuration(hass, aioclient_mock):
         context={"source": SOURCE_HASSIO},
     )
 
-    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -638,7 +634,7 @@ async def test_option_flow(hass, aioclient_mock):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "deconz_devices"
 
     result = await hass.config_entries.options.async_configure(
@@ -650,7 +646,7 @@ async def test_option_flow(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_ALLOW_CLIP_SENSOR: False,
         CONF_ALLOW_DECONZ_GROUPS: False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The data entry flow constants have been marked for deprecation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
