### PR TITLE
Bump aioslimproto to 2.1.1

### DIFF
--- a/homeassistant/components/slimproto/manifest.json
+++ b/homeassistant/components/slimproto/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "iot_class": "local_push",
   "documentation": "https://www.home-assistant.io/integrations/slimproto",
-  "requirements": ["aioslimproto==2.0.1"],
+  "requirements": ["aioslimproto==2.1.0"],
   "codeowners": ["@marcelveldt"],
   "after_dependencies": ["media_source"]
 }

--- a/homeassistant/components/slimproto/manifest.json
+++ b/homeassistant/components/slimproto/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "iot_class": "local_push",
   "documentation": "https://www.home-assistant.io/integrations/slimproto",
-  "requirements": ["aioslimproto==2.1.0"],
+  "requirements": ["aioslimproto==2.1.1"],
   "codeowners": ["@marcelveldt"],
   "after_dependencies": ["media_source"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -250,7 +250,7 @@ aioshelly==2.0.0
 aioskybell==22.6.1
 
 # homeassistant.components.slimproto
-aioslimproto==2.1.0
+aioslimproto==2.1.1
 
 # homeassistant.components.steamist
 aiosteamist==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -250,7 +250,7 @@ aioshelly==2.0.0
 aioskybell==22.6.1
 
 # homeassistant.components.slimproto
-aioslimproto==2.0.1
+aioslimproto==2.1.0
 
 # homeassistant.components.steamist
 aiosteamist==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -219,7 +219,7 @@ aioshelly==2.0.0
 aioskybell==22.6.1
 
 # homeassistant.components.slimproto
-aioslimproto==2.1.0
+aioslimproto==2.1.1
 
 # homeassistant.components.steamist
 aiosteamist==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -219,7 +219,7 @@ aioshelly==2.0.0
 aioskybell==22.6.1
 
 # homeassistant.components.slimproto
-aioslimproto==2.0.1
+aioslimproto==2.1.0
 
 # homeassistant.components.steamist
 aiosteamist==0.3.2


### PR DESCRIPTION
## Proposed change
Bump aioslimproto to 2.1.1 which contains a few important fixes for reported issues.
Changelog:
- https://github.com/home-assistant-libs/aioslimproto/releases/tag/2.1.0
- https://github.com/home-assistant-libs/aioslimproto/releases/tag/2.1.1
- https://github.com/home-assistant-libs/aioslimproto/compare/2.0.1...2.1.1

## Type of change

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #74265 fixes #73611 fixes #72651
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
