### PR TITLE
Use pydeconz interface controls for cover platform

### DIFF
--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from pydeconz.interfaces.lights import CoverAction
 from pydeconz.models.event import EventType
 from pydeconz.models.light.cover import Cover
 
@@ -21,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
-DEVICE_CLASS = {
+DECONZ_TYPE_TO_DEVICE_CLASS = {
     "Level controllable output": CoverDeviceClass.DAMPER,
     "Window covering controller": CoverDeviceClass.SHADE,
     "Window covering device": CoverDeviceClass.SHADE,
@@ -40,8 +41,7 @@ async def async_setup_entry(
     @callback
     def async_add_cover(_: EventType, cover_id: str) -> None:
         """Add cover from deCONZ."""
-        cover = gateway.api.lights.covers[cover_id]
-        async_add_entities([DeconzCover(cover, gateway)])
+        async_add_entities([DeconzCover(cover_id, gateway)])
 
     gateway.register_platform_add_device_callback(
         async_add_cover,
@@ -55,9 +55,9 @@ class DeconzCover(DeconzDevice, CoverEntity):
     TYPE = DOMAIN
     _device: Cover
 
-    def __init__(self, device: Cover, gateway: DeconzGateway) -> None:
+    def __init__(self, cover_id: str, gateway: DeconzGateway) -> None:
         """Set up cover device."""
-        super().__init__(device, gateway)
+        super().__init__(cover := gateway.api.lights.covers[cover_id], gateway)
 
         self._attr_supported_features = CoverEntityFeature.OPEN
         self._attr_supported_features |= CoverEntityFeature.CLOSE
@@ -70,7 +70,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
             self._attr_supported_features |= CoverEntityFeature.STOP_TILT
             self._attr_supported_features |= CoverEntityFeature.SET_TILT_POSITION
 
-        self._attr_device_class = DEVICE_CLASS.get(self._device.type)
+        self._attr_device_class = DECONZ_TYPE_TO_DEVICE_CLASS.get(cover.type)
 
     @property
     def current_cover_position(self) -> int:
@@ -85,19 +85,31 @@ class DeconzCover(DeconzDevice, CoverEntity):
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = 100 - cast(int, kwargs[ATTR_POSITION])
-        await self._device.set_position(lift=position)
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            lift=position,
+        )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
-        await self._device.open()
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            action=CoverAction.OPEN,
+        )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self._device.close()
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            action=CoverAction.CLOSE,
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
-        await self._device.stop()
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            action=CoverAction.STOP,
+        )
 
     @property
     def current_cover_tilt_position(self) -> int | None:
@@ -109,16 +121,28 @@ class DeconzCover(DeconzDevice, CoverEntity):
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Tilt the cover to a specific position."""
         position = 100 - cast(int, kwargs[ATTR_TILT_POSITION])
-        await self._device.set_position(tilt=position)
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            tilt=position,
+        )
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open cover tilt."""
-        await self._device.set_position(tilt=0)
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            tilt=0,
+        )
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close cover tilt."""
-        await self._device.set_position(tilt=100)
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            tilt=100,
+        )
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop cover tilt."""
-        await self._device.stop()
+        await self.gateway.api.lights.covers.set_state(
+            id=self._device.resource_id,
+            action=CoverAction.STOP,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move controls over to the interface class in pydeconz
Similar to 
- https://github.com/home-assistant/core/pull/72317
- https://github.com/home-assistant/core/pull/73670
- https://github.com/home-assistant/core/pull/73748

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
