### PR TITLE
Fix KeyError from zwave_js diagnostics

### DIFF
--- a/homeassistant/components/zwave_js/diagnostics.py
+++ b/homeassistant/components/zwave_js/diagnostics.py
@@ -94,20 +94,23 @@ def get_device_entities(
         # If the value ID returns as None, we don't need to include this entity
         if (value_id := get_value_id_from_unique_id(entry.unique_id)) is None:
             continue
-        state_key = get_state_key_from_unique_id(entry.unique_id)
 
-        zwave_value = node.values[value_id]
-        primary_value_data = {
-            "command_class": zwave_value.command_class,
-            "command_class_name": zwave_value.command_class_name,
-            "endpoint": zwave_value.endpoint,
-            "property": zwave_value.property_,
-            "property_name": zwave_value.property_name,
-            "property_key": zwave_value.property_key,
-            "property_key_name": zwave_value.property_key_name,
-        }
-        if state_key is not None:
-            primary_value_data["state_key"] = state_key
+        primary_value_data = None
+        if (zwave_value := node.values.get(value_id)) is not None:
+            primary_value_data = {
+                "command_class": zwave_value.command_class,
+                "command_class_name": zwave_value.command_class_name,
+                "endpoint": zwave_value.endpoint,
+                "property": zwave_value.property_,
+                "property_name": zwave_value.property_name,
+                "property_key": zwave_value.property_key,
+                "property_key_name": zwave_value.property_key_name,
+            }
+
+            state_key = get_state_key_from_unique_id(entry.unique_id)
+            if state_key is not None:
+                primary_value_data["state_key"] = state_key
+
         entity = {
             "domain": entry.domain,
             "entity_id": entry.entity_id,

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -10,8 +10,12 @@ from homeassistant.components.zwave_js.diagnostics import (
     async_get_device_diagnostics,
 )
 from homeassistant.components.zwave_js.discovery import async_discover_node_values
-from homeassistant.components.zwave_js.helpers import get_device_id
-from homeassistant.helpers.device_registry import async_get
+from homeassistant.components.zwave_js.helpers import (
+    get_device_id,
+    get_value_id_from_unique_id,
+)
+from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
+from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
 
 from .common import PROPERTY_ULTRAVIOLET
 
@@ -53,7 +57,7 @@ async def test_device_diagnostics(
     version_state,
 ):
     """Test the device level diagnostics data dump."""
-    dev_reg = async_get(hass)
+    dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
     assert device
 
@@ -106,7 +110,7 @@ async def test_device_diagnostics(
 
 async def test_device_diagnostics_error(hass, integration):
     """Test the device diagnostics raises exception when an invalid device is used."""
-    dev_reg = async_get(hass)
+    dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_or_create(
         config_entry_id=integration.entry_id, identifiers={("test", "test")}
     )
@@ -118,3 +122,71 @@ async def test_empty_zwave_value_matcher():
     """Test empty ZwaveValueMatcher is invalid."""
     with pytest.raises(ValueError):
         ZwaveValueMatcher()
+
+
+async def test_device_diagnostics_missing_primary_value(
+    hass,
+    client,
+    multisensor_6,
+    integration,
+    hass_client,
+):
+    """Test that the device diagnostics handles an entity with a missing primary value."""
+    dev_reg = async_get_dev_reg(hass)
+    device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
+    assert device
+
+    entity_id = "sensor.multisensor_6_air_temperature"
+    ent_reg = async_get_ent_reg(hass)
+    entry = ent_reg.async_get(entity_id)
+
+    # check that the primary value for the entity exists in the diagnostics
+    diagnostics_data = await get_diagnostics_for_device(
+        hass, hass_client, integration, device
+    )
+
+    value = multisensor_6.values.get(get_value_id_from_unique_id(entry.unique_id))
+    assert value
+
+    air_entity = next(
+        x for x in diagnostics_data["entities"] if x["entity_id"] == entity_id
+    )
+
+    assert air_entity["primary_value"] == {
+        "command_class": value.command_class,
+        "command_class_name": value.command_class_name,
+        "endpoint": value.endpoint,
+        "property": value.property_,
+        "property_name": value.property_name,
+        "property_key": value.property_key,
+        "property_key_name": value.property_key_name,
+    }
+
+    # make the entity's primary value go missing
+    event = Event(
+        type="value removed",
+        data={
+            "source": "node",
+            "event": "value removed",
+            "nodeId": multisensor_6.node_id,
+            "args": {
+                "commandClassName": value.command_class_name,
+                "commandClass": value.command_class,
+                "endpoint": value.endpoint,
+                "property": value.property_,
+                "prevValue": 0,
+                "propertyName": value.property_name,
+            },
+        },
+    )
+    multisensor_6.receive_event(event)
+
+    diagnostics_data = await get_diagnostics_for_device(
+        hass, hass_client, integration, device
+    )
+
+    air_entity = next(
+        x for x in diagnostics_data["entities"] if x["entity_id"] == entity_id
+    )
+
+    assert air_entity["primary_value"] is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes an issue when attempting to download the Device diagnostics for a Z-Wave JS Device. If one of the Device's entities has a missing primary value, a `KeyError` is raised and the file fails to download. This change prevents the error and allows the file to be downloaded as usual.

If the primary value is unknown, the "primary_value" in the diagnostic data is replaced with `None`, to signify the information is missing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #63255
- Link to documentation pull request: 

I discovered this problem in my own production system while investigating the related issue.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
