### PR TITLE
Remove denonavr from mypy ignore list

### DIFF
--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -138,6 +138,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle multiple receivers found."""
+        errors: dict[str, str] = {}
         if user_input is not None:
             self.host = user_input["select_host"]
             return await self.async_step_connect()
@@ -150,7 +151,9 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-        return self.async_show_form(step_id="select", data_schema=select_scheme)
+        return self.async_show_form(
+            step_id="select", data_schema=select_scheme, errors=errors
+        )
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -90,14 +90,14 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the Denon AVR flow."""
-        self.host = None
-        self.serial_number = None
-        self.model_name = None
+        self.host: str | None = None
+        self.serial_number: str | None = None
+        self.model_name: str | None = None
         self.timeout = DEFAULT_TIMEOUT
         self.show_all_sources = DEFAULT_SHOW_SOURCES
         self.zone2 = DEFAULT_ZONE2
         self.zone3 = DEFAULT_ZONE3
-        self.d_receivers = []
+        self.d_receivers: list[dict[str, Any]] = []
 
     @staticmethod
     @callback
@@ -138,7 +138,6 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle multiple receivers found."""
-        errors = {}
         if user_input is not None:
             self.host = user_input["select_host"]
             return await self.async_step_connect()
@@ -151,9 +150,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-        return self.async_show_form(
-            step_id="select", data_schema=select_scheme, errors=errors
-        )
+        return self.async_show_form(step_id="select", data_schema=select_scheme)
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -169,6 +166,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Connect to the receiver."""
+        assert self.host
         connect_denonavr = ConnectDenonAVR(
             self.host,
             self.timeout,
@@ -185,6 +183,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not success:
             return self.async_abort(reason="cannot_connect")
         receiver = connect_denonavr.receiver
+        assert receiver
 
         if not self.serial_number:
             self.serial_number = receiver.serial_number
@@ -238,6 +237,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             "*", ""
         )
         self.serial_number = discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
+        assert discovery_info.ssdp_location is not None
         self.host = urlparse(discovery_info.ssdp_location).hostname
 
         if self.model_name in IGNORED_MODELS:
@@ -260,6 +260,6 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_confirm()
 
     @staticmethod
-    def construct_unique_id(model_name: str, serial_number: str) -> str:
+    def construct_unique_id(model_name: str | None, serial_number: str | None) -> str:
         """Construct the unique id from the ssdp discovery or user_step."""
         return f"{model_name}-{serial_number}"

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -1,10 +1,11 @@
 """Support for Denon AVR receivers using their HTTP interface."""
 from __future__ import annotations
 
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from datetime import timedelta
 from functools import wraps
 import logging
+from typing import Any, TypeVar
 
 from denonavr import DenonAVR
 from denonavr.const import POWER_ON
@@ -15,6 +16,7 @@ from denonavr.exceptions import (
     AvrTimoutError,
     DenonAvrError,
 )
+from typing_extensions import Concatenate, ParamSpec
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -79,6 +81,10 @@ SERVICE_GET_COMMAND = "get_command"
 SERVICE_SET_DYNAMIC_EQ = "set_dynamic_eq"
 SERVICE_UPDATE_AUDYSSEY = "update_audyssey"
 
+_DenonDeviceT = TypeVar("_DenonDeviceT", bound="DenonDevice")
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -131,6 +137,75 @@ async def async_setup_entry(
     async_add_entities(entities, update_before_add=True)
 
 
+def async_log_errors(
+    func: Callable[Concatenate[_DenonDeviceT, _P], Awaitable[_R]],
+) -> Callable[Concatenate[_DenonDeviceT, _P], Coroutine[Any, Any, _R | None]]:
+    """
+    Log errors occurred when calling a Denon AVR receiver.
+
+    Decorates methods of DenonDevice class.
+    Declaration of staticmethod for this method is at the end of this class.
+    """
+
+    @wraps(func)
+    async def wrapper(
+        self: _DenonDeviceT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R | None:
+        # pylint: disable=protected-access
+        available = True
+        try:
+            return await func(self, *args, **kwargs)
+        except AvrTimoutError:
+            available = False
+            if self._available is True:
+                _LOGGER.warning(
+                    "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
+                    self._receiver.host,
+                )
+                self._available = False
+        except AvrNetworkError:
+            available = False
+            if self._available is True:
+                _LOGGER.warning(
+                    "Network error connecting to Denon AVR receiver at host %s. Device is unavailable",
+                    self._receiver.host,
+                )
+                self._available = False
+        except AvrForbiddenError:
+            available = False
+            if self._available is True:
+                _LOGGER.warning(
+                    "Denon AVR receiver at host %s responded with HTTP 403 error. Device is unavailable. Please consider power cycling your receiver",
+                    self._receiver.host,
+                )
+                self._available = False
+        except AvrCommandError as err:
+            available = False
+            _LOGGER.error(
+                "Command %s failed with error: %s",
+                func.__name__,
+                err,
+            )
+        except DenonAvrError as err:
+            available = False
+            _LOGGER.error(
+                "Error %s occurred in method %s for Denon AVR receiver",
+                err,
+                func.__name__,
+                exc_info=True,
+            )
+        finally:
+            if available is True and self._available is False:
+                _LOGGER.info(
+                    "Denon AVR receiver at host %s is available again",
+                    self._receiver.host,
+                )
+                self._available = True
+        return None
+
+    return wrapper
+
+
 class DenonDevice(MediaPlayerEntity):
     """Representation of a Denon Media Player Device."""
 
@@ -144,6 +219,7 @@ class DenonDevice(MediaPlayerEntity):
         """Initialize the device."""
         self._attr_name = receiver.name
         self._attr_unique_id = unique_id
+        assert config_entry.unique_id
         self._attr_device_info = DeviceInfo(
             configuration_url=f"http://{config_entry.data[CONF_HOST]}/",
             identifiers={(DOMAIN, config_entry.unique_id)},
@@ -162,71 +238,6 @@ class DenonDevice(MediaPlayerEntity):
             and MediaPlayerEntityFeature.SELECT_SOUND_MODE
         )
         self._available = True
-
-    def async_log_errors(
-        func: Coroutine,
-    ) -> Coroutine:
-        """
-        Log errors occurred when calling a Denon AVR receiver.
-
-        Decorates methods of DenonDevice class.
-        Declaration of staticmethod for this method is at the end of this class.
-        """
-
-        @wraps(func)
-        async def wrapper(self, *args, **kwargs):
-            # pylint: disable=protected-access
-            available = True
-            try:
-                return await func(self, *args, **kwargs)
-            except AvrTimoutError:
-                available = False
-                if self._available is True:
-                    _LOGGER.warning(
-                        "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
-                        self._receiver.host,
-                    )
-                    self._available = False
-            except AvrNetworkError:
-                available = False
-                if self._available is True:
-                    _LOGGER.warning(
-                        "Network error connecting to Denon AVR receiver at host %s. Device is unavailable",
-                        self._receiver.host,
-                    )
-                    self._available = False
-            except AvrForbiddenError:
-                available = False
-                if self._available is True:
-                    _LOGGER.warning(
-                        "Denon AVR receiver at host %s responded with HTTP 403 error. Device is unavailable. Please consider power cycling your receiver",
-                        self._receiver.host,
-                    )
-                    self._available = False
-            except AvrCommandError as err:
-                available = False
-                _LOGGER.error(
-                    "Command %s failed with error: %s",
-                    func.__name__,
-                    err,
-                )
-            except DenonAvrError as err:
-                available = False
-                _LOGGER.error(
-                    "Error %s occurred in method %s for Denon AVR receiver",
-                    err,
-                    func.__name__,
-                    exc_info=True,
-                )
-            finally:
-                if available is True and self._available is False:
-                    _LOGGER.info(
-                        "Denon AVR receiver at host %s is available again",
-                        self._receiver.host,
-                    )
-                    self._available = True
-
-        return wrapper
 
     @async_log_errors
     async def async_update(self) -> None:
@@ -466,8 +477,3 @@ class DenonDevice(MediaPlayerEntity):
 
         if self._update_audyssey:
             await self._receiver.async_update_audyssey()
-
-    # Decorator defined before is a staticmethod
-    async_log_errors = staticmethod(  # pylint: disable=no-staticmethod-decorator
-        async_log_errors
-    )

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -159,7 +159,8 @@ def async_log_errors(
             available = False
             if self._available is True:
                 _LOGGER.warning(
-                    "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
+                    "Timeout connecting to Denon AVR receiver at host %s. "
+                    "Device is unavailable",
                     self._receiver.host,
                 )
                 self._available = False
@@ -167,7 +168,8 @@ def async_log_errors(
             available = False
             if self._available is True:
                 _LOGGER.warning(
-                    "Network error connecting to Denon AVR receiver at host %s. Device is unavailable",
+                    "Network error connecting to Denon AVR receiver at host %s. "
+                    "Device is unavailable",
                     self._receiver.host,
                 )
                 self._available = False
@@ -175,7 +177,9 @@ def async_log_errors(
             available = False
             if self._available is True:
                 _LOGGER.warning(
-                    "Denon AVR receiver at host %s responded with HTTP 403 error. Device is unavailable. Please consider power cycling your receiver",
+                    "Denon AVR receiver at host %s responded with HTTP 403 error. "
+                    "Device is unavailable. Please consider power cycling your "
+                    "receiver",
                     self._receiver.host,
                 )
                 self._available = False

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -23,12 +23,12 @@ class ConnectDenonAVR:
     ) -> None:
         """Initialize the class."""
         self._async_client_getter = async_client_getter
-        self._receiver = None
+        self._receiver: DenonAVR | None = None
         self._host = host
         self._show_all_inputs = show_all_inputs
         self._timeout = timeout
 
-        self._zones = {}
+        self._zones: dict[str, str | None] = {}
         if zone2:
             self._zones["Zone2"] = None
         if zone3:
@@ -42,6 +42,7 @@ class ConnectDenonAVR:
     async def async_connect_receiver(self) -> bool:
         """Connect to the DenonAVR receiver."""
         await self.async_init_receiver_class()
+        assert self._receiver
 
         if (
             self._receiver.manufacturer is None
@@ -70,7 +71,7 @@ class ConnectDenonAVR:
 
         return True
 
-    async def async_init_receiver_class(self) -> bool:
+    async def async_init_receiver_class(self) -> None:
         """Initialize the DenonAVR class asynchronously."""
         receiver = DenonAVR(
             host=self._host,

--- a/mypy.ini
+++ b/mypy.ini
@@ -2647,9 +2647,6 @@ ignore_errors = true
 [mypy-homeassistant.components.denonavr.config_flow]
 ignore_errors = true
 
-[mypy-homeassistant.components.denonavr.media_player]
-ignore_errors = true
-
 [mypy-homeassistant.components.denonavr.receiver]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2647,9 +2647,6 @@ ignore_errors = true
 [mypy-homeassistant.components.denonavr.config_flow]
 ignore_errors = true
 
-[mypy-homeassistant.components.denonavr.receiver]
-ignore_errors = true
-
 [mypy-homeassistant.components.evohome]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2644,9 +2644,6 @@ ignore_errors = true
 [mypy-homeassistant.components.conversation.default_agent]
 ignore_errors = true
 
-[mypy-homeassistant.components.denonavr.config_flow]
-ignore_errors = true
-
 [mypy-homeassistant.components.evohome]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -24,7 +24,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.conversation",
     "homeassistant.components.conversation.default_agent",
     "homeassistant.components.denonavr.config_flow",
-    "homeassistant.components.denonavr.receiver",
     "homeassistant.components.evohome",
     "homeassistant.components.evohome.climate",
     "homeassistant.components.evohome.water_heater",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -23,7 +23,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.cloud.http_api",
     "homeassistant.components.conversation",
     "homeassistant.components.conversation.default_agent",
-    "homeassistant.components.denonavr.config_flow",
     "homeassistant.components.evohome",
     "homeassistant.components.evohome.climate",
     "homeassistant.components.evohome.water_heater",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -24,7 +24,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.conversation",
     "homeassistant.components.conversation.default_agent",
     "homeassistant.components.denonavr.config_flow",
-    "homeassistant.components.denonavr.media_player",
     "homeassistant.components.denonavr.receiver",
     "homeassistant.components.evohome",
     "homeassistant.components.evohome.climate",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove denonavr from mypy ignore list

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
