### PR TITLE
Migrate Elgato to new entity naming style

### DIFF
--- a/homeassistant/components/elgato/entity.py
+++ b/homeassistant/components/elgato/entity.py
@@ -12,6 +12,8 @@ from .const import DOMAIN
 class ElgatoEntity(Entity):
     """Defines an Elgato entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, client: Elgato, info: Info, mac: str | None) -> None:
         """Initialize an Elgato entity."""
         self.client = client

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -66,6 +66,8 @@ class ElgatoLight(
 ):
     """Defines an Elgato Light."""
 
+    _attr_name = "Light"
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[State],
@@ -80,7 +82,6 @@ class ElgatoLight(
 
         self._attr_min_mireds = 143
         self._attr_max_mireds = 344
-        self._attr_name = info.display_name or info.product_name
         self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
         self._attr_unique_id = info.serial_number
 

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -66,8 +66,6 @@ class ElgatoLight(
 ):
     """Defines an Elgato Light."""
 
-    _attr_name = "Light"
-
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[State],

--- a/tests/components/elgato/test_button.py
+++ b/tests/components/elgato/test_button.py
@@ -25,12 +25,12 @@ async def test_button_identify(
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
-    state = hass.states.get("button.identify")
+    state = hass.states.get("button.frenck_identify")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:help"
     assert state.state == STATE_UNKNOWN
 
-    entry = entity_registry.async_get("button.identify")
+    entry = entity_registry.async_get("button.frenck_identify")
     assert entry
     assert entry.unique_id == "CN11A1A00001_identify"
     assert entry.entity_category == EntityCategory.CONFIG
@@ -53,14 +53,14 @@ async def test_button_identify(
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.identify"},
+        {ATTR_ENTITY_ID: "button.frenck_identify"},
         blocking=True,
     )
 
     assert len(mock_elgato.identify.mock_calls) == 1
     mock_elgato.identify.assert_called_with()
 
-    state = hass.states.get("button.identify")
+    state = hass.states.get("button.frenck_identify")
     assert state
     assert state.state == "2021-11-13T11:48:00+00:00"
 
@@ -79,7 +79,7 @@ async def test_button_identify_error(
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
-            {ATTR_ENTITY_ID: "button.identify"},
+            {ATTR_ENTITY_ID: "button.frenck_identify"},
             blocking=True,
         )
         await hass.async_block_till_done()

--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -40,7 +40,7 @@ async def test_light_state_temperature(
     entity_registry = er.async_get(hass)
 
     # First segment of the strip
-    state = hass.states.get("light.frenck")
+    state = hass.states.get("light.frenck_light")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 54
     assert state.attributes.get(ATTR_COLOR_TEMP) == 297
@@ -51,7 +51,7 @@ async def test_light_state_temperature(
     assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [ColorMode.COLOR_TEMP]
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.frenck")
+    entry = entity_registry.async_get("light.frenck_light")
     assert entry
     assert entry.unique_id == "CN11A1A00001"
 
@@ -83,7 +83,7 @@ async def test_light_state_color(
     entity_registry = er.async_get(hass)
 
     # First segment of the strip
-    state = hass.states.get("light.frenck")
+    state = hass.states.get("light.frenck_light")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 128
     assert state.attributes.get(ATTR_COLOR_TEMP) is None
@@ -97,7 +97,7 @@ async def test_light_state_color(
     ]
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.frenck")
+    entry = entity_registry.async_get("light.frenck_light")
     assert entry
     assert entry.unique_id == "CN11A1A00001"
 
@@ -111,7 +111,7 @@ async def test_light_change_state_temperature(
     mock_elgato: MagicMock,
 ) -> None:
     """Test the change of state of a Elgato Key Light device."""
-    state = hass.states.get("light.frenck")
+    state = hass.states.get("light.frenck_light")
     assert state
     assert state.state == STATE_ON
 
@@ -119,7 +119,7 @@ async def test_light_change_state_temperature(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.frenck",
+            ATTR_ENTITY_ID: "light.frenck_light",
             ATTR_BRIGHTNESS: 255,
             ATTR_COLOR_TEMP: 100,
         },
@@ -135,7 +135,7 @@ async def test_light_change_state_temperature(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.frenck",
+            ATTR_ENTITY_ID: "light.frenck_light",
             ATTR_BRIGHTNESS: 255,
         },
         blocking=True,
@@ -149,7 +149,7 @@ async def test_light_change_state_temperature(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.frenck"},
+        {ATTR_ENTITY_ID: "light.frenck_light"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -160,7 +160,7 @@ async def test_light_change_state_temperature(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.frenck",
+            ATTR_ENTITY_ID: "light.frenck_light",
             ATTR_BRIGHTNESS: 255,
             ATTR_HS_COLOR: (10.1, 20.2),
         },
@@ -188,12 +188,12 @@ async def test_light_unavailable(
         await hass.services.async_call(
             LIGHT_DOMAIN,
             service,
-            {ATTR_ENTITY_ID: "light.frenck"},
+            {ATTR_ENTITY_ID: "light.frenck_light"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
-    state = hass.states.get("light.frenck")
+    state = hass.states.get("light.frenck_light")
     assert state
     assert state.state == STATE_UNAVAILABLE
 
@@ -208,7 +208,7 @@ async def test_light_identify(
         DOMAIN,
         SERVICE_IDENTIFY,
         {
-            ATTR_ENTITY_ID: "light.frenck",
+            ATTR_ENTITY_ID: "light.frenck_light",
         },
         blocking=True,
     )
@@ -231,7 +231,7 @@ async def test_light_identify_error(
             DOMAIN,
             SERVICE_IDENTIFY,
             {
-                ATTR_ENTITY_ID: "light.frenck",
+                ATTR_ENTITY_ID: "light.frenck_light",
             },
             blocking=True,
         )

--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -40,7 +40,7 @@ async def test_light_state_temperature(
     entity_registry = er.async_get(hass)
 
     # First segment of the strip
-    state = hass.states.get("light.frenck_light")
+    state = hass.states.get("light.frenck")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 54
     assert state.attributes.get(ATTR_COLOR_TEMP) == 297
@@ -51,7 +51,7 @@ async def test_light_state_temperature(
     assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [ColorMode.COLOR_TEMP]
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.frenck_light")
+    entry = entity_registry.async_get("light.frenck")
     assert entry
     assert entry.unique_id == "CN11A1A00001"
 
@@ -83,7 +83,7 @@ async def test_light_state_color(
     entity_registry = er.async_get(hass)
 
     # First segment of the strip
-    state = hass.states.get("light.frenck_light")
+    state = hass.states.get("light.frenck")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 128
     assert state.attributes.get(ATTR_COLOR_TEMP) is None
@@ -97,7 +97,7 @@ async def test_light_state_color(
     ]
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.frenck_light")
+    entry = entity_registry.async_get("light.frenck")
     assert entry
     assert entry.unique_id == "CN11A1A00001"
 
@@ -111,7 +111,7 @@ async def test_light_change_state_temperature(
     mock_elgato: MagicMock,
 ) -> None:
     """Test the change of state of a Elgato Key Light device."""
-    state = hass.states.get("light.frenck_light")
+    state = hass.states.get("light.frenck")
     assert state
     assert state.state == STATE_ON
 
@@ -119,7 +119,7 @@ async def test_light_change_state_temperature(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.frenck_light",
+            ATTR_ENTITY_ID: "light.frenck",
             ATTR_BRIGHTNESS: 255,
             ATTR_COLOR_TEMP: 100,
         },
@@ -135,7 +135,7 @@ async def test_light_change_state_temperature(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.frenck_light",
+            ATTR_ENTITY_ID: "light.frenck",
             ATTR_BRIGHTNESS: 255,
         },
         blocking=True,
@@ -149,7 +149,7 @@ async def test_light_change_state_temperature(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.frenck_light"},
+        {ATTR_ENTITY_ID: "light.frenck"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -160,7 +160,7 @@ async def test_light_change_state_temperature(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.frenck_light",
+            ATTR_ENTITY_ID: "light.frenck",
             ATTR_BRIGHTNESS: 255,
             ATTR_HS_COLOR: (10.1, 20.2),
         },
@@ -188,12 +188,12 @@ async def test_light_unavailable(
         await hass.services.async_call(
             LIGHT_DOMAIN,
             service,
-            {ATTR_ENTITY_ID: "light.frenck_light"},
+            {ATTR_ENTITY_ID: "light.frenck"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
-    state = hass.states.get("light.frenck_light")
+    state = hass.states.get("light.frenck")
     assert state
     assert state.state == STATE_UNAVAILABLE
 
@@ -208,7 +208,7 @@ async def test_light_identify(
         DOMAIN,
         SERVICE_IDENTIFY,
         {
-            ATTR_ENTITY_ID: "light.frenck_light",
+            ATTR_ENTITY_ID: "light.frenck",
         },
         blocking=True,
     )
@@ -231,7 +231,7 @@ async def test_light_identify_error(
             DOMAIN,
             SERVICE_IDENTIFY,
             {
-                ATTR_ENTITY_ID: "light.frenck_light",
+                ATTR_ENTITY_ID: "light.frenck",
             },
             blocking=True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Elgato integration to use the new entity naming style and sets the flag.

ref #73217

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
