### PR TITLE
Bump NextDNS backend library

### DIFF
--- a/homeassistant/components/nextdns/manifest.json
+++ b/homeassistant/components/nextdns/manifest.json
@@ -3,7 +3,7 @@
   "name": "NextDNS",
   "documentation": "https://www.home-assistant.io/integrations/nextdns",
   "codeowners": ["@bieniu"],
-  "requirements": ["nextdns==1.0.0"],
+  "requirements": ["nextdns==1.0.1"],
   "config_flow": true,
   "iot_class": "cloud_polling",
   "loggers": ["nextdns"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1092,7 +1092,7 @@ nextcloudmonitor==1.1.0
 nextcord==2.0.0a8
 
 # homeassistant.components.nextdns
-nextdns==1.0.0
+nextdns==1.0.1
 
 # homeassistant.components.niko_home_control
 niko-home-control==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -760,7 +760,7 @@ nexia==2.0.1
 nextcord==2.0.0a8
 
 # homeassistant.components.nextdns
-nextdns==1.0.0
+nextdns==1.0.1
 
 # homeassistant.components.nfandroidtv
 notifications-android-tv==0.1.5

--- a/tests/components/nextdns/test_diagnostics.py
+++ b/tests/components/nextdns/test_diagnostics.py
@@ -44,10 +44,10 @@ async def test_entry_diagnostics(hass, hass_client):
         "doq_queries": 10,
         "dot_queries": 30,
         "udp_queries": 40,
-        "doh_queries_ratio": 22.2,
-        "doq_queries_ratio": 11.1,
-        "dot_queries_ratio": 33.3,
-        "udp_queries_ratio": 44.4,
+        "doh_queries_ratio": 20.0,
+        "doq_queries_ratio": 10.0,
+        "dot_queries_ratio": 30.0,
+        "udp_queries_ratio": 40.0,
     }
     assert result["status_coordinator_data"] == {
         "all_queries": 100,

--- a/tests/components/nextdns/test_diagnostics.py
+++ b/tests/components/nextdns/test_diagnostics.py
@@ -43,10 +43,12 @@ async def test_entry_diagnostics(hass, hass_client):
         "doh_queries": 20,
         "doq_queries": 10,
         "dot_queries": 30,
+        "tcp_queries": 0,
         "udp_queries": 40,
         "doh_queries_ratio": 20.0,
         "doq_queries_ratio": 10.0,
         "dot_queries_ratio": 30.0,
+        "tcp_queries_ratio": 0.0,
         "udp_queries_ratio": 40.0,
     }
     assert result["status_coordinator_data"] == {

--- a/tests/components/nextdns/test_sensor.py
+++ b/tests/components/nextdns/test_sensor.py
@@ -197,7 +197,7 @@ async def test_sensor(hass):
 
     state = hass.states.get("sensor.fake_profile_dns_over_https_queries_ratio")
     assert state
-    assert state.state == "22.2"
+    assert state.state == "20.0"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
@@ -217,7 +217,7 @@ async def test_sensor(hass):
 
     state = hass.states.get("sensor.fake_profile_dns_over_quic_queries_ratio")
     assert state
-    assert state.state == "11.1"
+    assert state.state == "10.0"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
@@ -237,7 +237,7 @@ async def test_sensor(hass):
 
     state = hass.states.get("sensor.fake_profile_dns_over_tls_queries_ratio")
     assert state
-    assert state.state == "33.3"
+    assert state.state == "30.0"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
@@ -347,7 +347,7 @@ async def test_sensor(hass):
 
     state = hass.states.get("sensor.fake_profile_udp_queries_ratio")
     assert state
-    assert state.state == "44.4"
+    assert state.state == "40.0"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `nextdns` library to fix an uncaught exception.

Changelog: https://github.com/bieniu/nextdns/compare/1.0.0...1.0.1

EDIT: By the way, a bug with counting the percentages of protocols used has been fixed. This is the reason for the changes in tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
