### PR TITLE
Add trigger/arm_custom_bypass to Template Alarm Control Panel

### DIFF
--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     ATTR_SERVICE_DATA,
     EVENT_CALL_SERVICE,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_ARMED_VACATION,
@@ -62,8 +63,18 @@ OPTIMISTIC_TEMPLATE_ALARM_CONFIG = {
         "entity_id": "alarm_control_panel.test",
         "data": {"code": "{{ this.entity_id }}"},
     },
+    "arm_custom_bypass": {
+        "service": "alarm_control_panel.alarm_arm_custom_bypass",
+        "entity_id": "alarm_control_panel.test",
+        "data": {"code": "{{ this.entity_id }}"},
+    },
     "disarm": {
         "service": "alarm_control_panel.alarm_disarm",
+        "entity_id": "alarm_control_panel.test",
+        "data": {"code": "{{ this.entity_id }}"},
+    },
+    "trigger": {
+        "service": "alarm_control_panel.alarm_trigger",
         "entity_id": "alarm_control_panel.test",
         "data": {"code": "{{ this.entity_id }}"},
     },
@@ -96,6 +107,7 @@ async def test_template_state_text(hass, start_ha):
         STATE_ALARM_ARMED_AWAY,
         STATE_ALARM_ARMED_NIGHT,
         STATE_ALARM_ARMED_VACATION,
+        STATE_ALARM_ARMED_CUSTOM_BYPASS,
         STATE_ALARM_ARMING,
         STATE_ALARM_DISARMED,
         STATE_ALARM_PENDING,
@@ -136,7 +148,9 @@ async def test_optimistic_states(hass, start_ha):
         ("alarm_arm_home", STATE_ALARM_ARMED_HOME),
         ("alarm_arm_night", STATE_ALARM_ARMED_NIGHT),
         ("alarm_arm_vacation", STATE_ALARM_ARMED_VACATION),
+        ("alarm_arm_custom_bypass", STATE_ALARM_ARMED_CUSTOM_BYPASS),
         ("alarm_disarm", STATE_ALARM_DISARMED),
+        ("alarm_trigger", STATE_ALARM_TRIGGERED),
     ]:
         await hass.services.async_call(
             ALARM_DOMAIN, service, {"entity_id": TEMPLATE_NAME}, blocking=True
@@ -259,7 +273,9 @@ async def test_name(hass, start_ha):
         "alarm_arm_away",
         "alarm_arm_night",
         "alarm_arm_vacation",
+        "alarm_arm_custom_bypass",
         "alarm_disarm",
+        "alarm_trigger",
     ],
 )
 async def test_actions(hass, service, start_ha, service_calls):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

[Template Alarm Control Panel](https://www.home-assistant.io/integrations/alarm_control_panel.template/) supports all actions of Alarm Control Panel except `trigger` and `arm_custom_bypass`. Probably this was just an omission, I don't think there is a reason not to support them.

This small and very straightforward PR adds these two missing features (in exactly the same way all other actions are implemented).

Note that `arm_vacation` was also missing but was added very recently (#74261).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: home-assistant/home-assistant.io#23304

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X]  I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

~~If the code communicates with devices, web services, or third-party tools:~~

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
