### PR TITLE
Search/replace RESULT_TYPE_* by FlowResultType enum

### DIFF
--- a/tests/auth/mfa_modules/test_insecure_example.py
+++ b/tests/auth/mfa_modules/test_insecure_example.py
@@ -100,37 +100,37 @@ async def test_login(hass):
 
     provider = hass.auth.auth_providers[0]
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mfa"
     assert result["data_schema"].schema.get("pin") == str
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"pin": "invalid-code"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_code"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"pin": "123456"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"].id == "mock-id"
 
 
@@ -147,9 +147,9 @@ async def test_setup_flow(hass):
     flow = await auth_module.async_setup_flow("new-user")
 
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init({"pin": "abcdefg"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert auth_module._data[1]["user_id"] == "new-user"
     assert auth_module._data[1]["pin"] == "abcdefg"

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -133,25 +133,25 @@ async def test_login_flow_validates_mfa(hass):
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["data_schema"].schema.get("code") == str
 
@@ -170,7 +170,7 @@ async def test_login_flow_validates_mfa(hass):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -187,7 +187,7 @@ async def test_login_flow_validates_mfa(hass):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -195,7 +195,7 @@ async def test_login_flow_validates_mfa(hass):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "too_many_retry"
 
     # wait service call finished
@@ -203,13 +203,13 @@ async def test_login_flow_validates_mfa(hass):
 
     # restart login
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["data_schema"].schema.get("code") == str
 
@@ -228,7 +228,7 @@ async def test_login_flow_validates_mfa(hass):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": MOCK_CODE}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
 
 
@@ -243,14 +243,14 @@ async def test_setup_user_notify_service(hass):
 
     flow = await notify_auth_module.async_setup_flow("test-user")
     step = await flow.async_step_init()
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "init"
     schema = step["data_schema"]
     schema({"notify_service": "test2"})
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         step = await flow.async_step_init({"notify_service": "test1"})
-        assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert step["type"] == data_entry_flow.FlowResultType.FORM
         assert step["step_id"] == "setup"
 
     # wait service call finished
@@ -266,7 +266,7 @@ async def test_setup_user_notify_service(hass):
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE_2):
         step = await flow.async_step_setup({"code": "invalid"})
-        assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert step["type"] == data_entry_flow.FlowResultType.FORM
         assert step["step_id"] == "setup"
         assert step["errors"]["base"] == "invalid_code"
 
@@ -283,7 +283,7 @@ async def test_setup_user_notify_service(hass):
 
     with patch("pyotp.HOTP.verify", return_value=True):
         step = await flow.async_step_setup({"code": MOCK_CODE_2})
-        assert step["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_include_exclude_config(hass):
@@ -332,7 +332,7 @@ async def test_setup_user_no_notify_service(hass):
 
     flow = await notify_auth_module.async_setup_flow("test-user")
     step = await flow.async_step_init()
-    assert step["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert step["type"] == data_entry_flow.FlowResultType.ABORT
     assert step["reason"] == "no_available_service"
 
 
@@ -369,13 +369,13 @@ async def test_not_raise_exception_when_service_not_exist(hass):
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unknown_error"
 
     # wait service call finished

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -93,24 +93,24 @@ async def test_login_flow_validates_mfa(hass):
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mfa"
     assert result["data_schema"].schema.get("code") == str
 
@@ -118,7 +118,7 @@ async def test_login_flow_validates_mfa(hass):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -126,7 +126,7 @@ async def test_login_flow_validates_mfa(hass):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": MOCK_CODE}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
 
 

--- a/tests/auth/providers/test_command_line.py
+++ b/tests/auth/providers/test_command_line.py
@@ -114,18 +114,18 @@ async def test_login_flow_validates(provider):
     """Test login flow."""
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "bad-user", "password": "bad-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "good-user", "password": "good-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "good-user"
 
 
@@ -135,5 +135,5 @@ async def test_strip_username(provider):
     result = await flow.async_step_init(
         {"username": "\t\ngood-user ", "password": "good-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "good-user"

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -115,24 +115,24 @@ async def test_login_flow_validates(data, hass):
     )
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "TEST-user ", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-USER", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "test-USER"
 
 
@@ -216,24 +216,24 @@ async def test_legacy_login_flow_validates(legacy_data, hass):
     )
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "test-user"
 
 

--- a/tests/auth/providers/test_legacy_api_password.py
+++ b/tests/auth/providers/test_legacy_api_password.py
@@ -55,15 +55,15 @@ async def test_verify_login(hass, provider):
 async def test_login_flow_works(hass, manager):
     """Test wrong config."""
     result = await manager.login_flow.async_init(handler=("legacy_api_password", None))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await manager.login_flow.async_configure(
         flow_id=result["flow_id"], user_input={"password": "not-hello"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await manager.login_flow.async_configure(
         flow_id=result["flow_id"], user_input={"password": "test-password"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -168,12 +168,12 @@ async def test_create_new_user(hass):
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert step["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     credential = step["result"]
     assert credential is not None
 
@@ -237,12 +237,12 @@ async def test_login_as_existing_user(mock_hass):
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert step["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     credential = step["result"]
     user = await manager.async_get_user_by_credentials(credential)
@@ -728,14 +728,14 @@ async def test_login_with_auth_module(mock_hass):
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
     # After auth_provider validated, request auth module input form
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     step = await manager.login_flow.async_configure(
@@ -743,7 +743,7 @@ async def test_login_with_auth_module(mock_hass):
     )
 
     # Invalid code error
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
     assert step["errors"] == {"base": "invalid_code"}
 
@@ -752,7 +752,7 @@ async def test_login_with_auth_module(mock_hass):
     )
 
     # Finally passed, get credential
-    assert step["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert step["result"]
     assert step["result"].id == "mock-id"
 
@@ -803,21 +803,21 @@ async def test_login_with_multi_auth_module(mock_hass):
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
     # After auth_provider validated, request select auth module
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "select_mfa_module"
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"multi_factor_auth_module": "module2"}
     )
 
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     step = await manager.login_flow.async_configure(
@@ -825,7 +825,7 @@ async def test_login_with_multi_auth_module(mock_hass):
     )
 
     # Finally passed, get credential
-    assert step["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert step["result"]
     assert step["result"].id == "mock-id"
 
@@ -871,13 +871,13 @@ async def test_auth_module_expired_session(mock_hass):
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
-    assert step["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert step["type"] == data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     with patch(
@@ -888,7 +888,7 @@ async def test_auth_module_expired_session(mock_hass):
             step["flow_id"], {"pin": "test-pin"}
         )
         # login flow abort due session timeout
-        assert step["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert step["type"] == data_entry_flow.FlowResultType.ABORT
         assert step["reason"] == "login_expired"
 
 

--- a/tests/components/abode/test_config_flow.py
+++ b/tests/components/abode/test_config_flow.py
@@ -23,7 +23,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
 
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -39,7 +39,7 @@ async def test_one_config_allowed(hass: HomeAssistant) -> None:
 
     step_user_result = await flow.async_step_user()
 
-    assert step_user_result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert step_user_result["type"] == data_entry_flow.FlowResultType.ABORT
     assert step_user_result["reason"] == "single_instance_allowed"
 
 
@@ -104,7 +104,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=conf
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "user@email.com"
         assert result["data"] == {
             CONF_USERNAME: "user@email.com",
@@ -125,7 +125,7 @@ async def test_step_mfa(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=conf
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
 
     with patch(
@@ -147,7 +147,7 @@ async def test_step_mfa(hass: HomeAssistant) -> None:
             result["flow_id"], user_input={"mfa_code": "123456"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "user@email.com"
         assert result["data"] == {
             CONF_USERNAME: "user@email.com",
@@ -175,7 +175,7 @@ async def test_step_reauth(hass: HomeAssistant) -> None:
             data=conf,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
 
         with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
@@ -184,7 +184,7 @@ async def test_step_reauth(hass: HomeAssistant) -> None:
                 user_input=conf,
             )
 
-            assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+            assert result["type"] == data_entry_flow.FlowResultType.ABORT
             assert result["reason"] == "reauth_successful"
 
         assert len(hass.config_entries.async_entries()) == 1

--- a/tests/components/abode/test_init.py
+++ b/tests/components/abode/test_init.py
@@ -75,7 +75,7 @@ async def test_invalid_credentials(hass: HomeAssistant) -> None:
         ),
     ), patch(
         "homeassistant.components.abode.config_flow.AbodeFlowHandler.async_step_reauth",
-        return_value={"type": data_entry_flow.RESULT_TYPE_FORM},
+        return_value={"type": data_entry_flow.FlowResultType.FORM},
     ) as mock_async_step_reauth:
         await setup_platform(hass, ALARM_DOMAIN)
 

--- a/tests/components/accuweather/test_config_flow.py
+++ b/tests/components/accuweather/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -134,7 +134,7 @@ async def test_create_entry(hass):
             data=VALID_CONFIG,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "abcd"
         assert result["data"][CONF_NAME] == "abcd"
         assert result["data"][CONF_LATITUDE] == 55.55
@@ -171,14 +171,14 @@ async def test_options_flow(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_FORECAST: True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_FORECAST: True}
 
         await hass.async_block_till_done()

--- a/tests/components/acmeda/test_config_flow.py
+++ b/tests/components/acmeda/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_show_form_no_hubs(hass, mock_hub_discover):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
 
     # Check we performed the discovery
@@ -66,7 +66,7 @@ async def test_show_form_one_hub(hass, mock_hub_discover, mock_hub_run):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == dummy_hub_1.id
     assert result["result"].data == {
         CONF_HOST: DUMMY_HOST1,
@@ -91,7 +91,7 @@ async def test_show_form_two_hubs(hass, mock_hub_discover):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Check we performed the discovery
@@ -117,7 +117,7 @@ async def test_create_second_entry(hass, mock_hub_run, mock_hub_discover):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == dummy_hub_2.id
     assert result["result"].data == {
         CONF_HOST: DUMMY_HOST2,

--- a/tests/components/adguard/test_config_flow.py
+++ b/tests/components/adguard/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_show_authenticate_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -55,7 +55,7 @@ async def test_connection_error(
     )
 
     assert result
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "user"
     assert result.get("errors") == {"base": "cannot_connect"}
 
@@ -78,14 +78,14 @@ async def test_full_flow_implementation(
 
     assert result
     assert result.get("flow_id")
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=FIXTURE_USER_INPUT
     )
     assert result2
-    assert result2.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2.get("title") == FIXTURE_USER_INPUT[CONF_HOST]
 
     data = result2.get("data")
@@ -132,7 +132,7 @@ async def test_hassio_already_configured(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_HASSIO},
     )
     assert result
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
 
 
@@ -154,7 +154,7 @@ async def test_hassio_ignored(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_HASSIO},
     )
     assert result
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
 
 
@@ -176,14 +176,14 @@ async def test_hassio_confirm(
         context={"source": config_entries.SOURCE_HASSIO},
     )
     assert result
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "hassio_confirm"
     assert result.get("description_placeholders") == {"addon": "AdGuard Home Addon"}
 
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result2
-    assert result2.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2.get("title") == "AdGuard Home Addon"
 
     data = result2.get("data")
@@ -215,6 +215,6 @@ async def test_hassio_connection_error(
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "hassio_confirm"
     assert result.get("errors") == {"base": "cannot_connect"}

--- a/tests/components/advantage_air/test_config_flow.py
+++ b/tests/components/advantage_air/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_form(hass, aioclient_mock):
     result1 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result1["type"] == data_entry_flow.FlowResultType.FORM
     assert result1["step_id"] == "user"
     assert result1["errors"] == {}
 
@@ -33,7 +33,7 @@ async def test_form(hass, aioclient_mock):
         )
 
     assert len(aioclient_mock.mock_calls) == 1
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testname"
     assert result2["data"] == USER_INPUT
     await hass.async_block_till_done()
@@ -47,7 +47,7 @@ async def test_form(hass, aioclient_mock):
         result3["flow_id"],
         USER_INPUT,
     )
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result4["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_form_cannot_connect(hass, aioclient_mock):
@@ -66,7 +66,7 @@ async def test_form_cannot_connect(hass, aioclient_mock):
         USER_INPUT,
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
     assert len(aioclient_mock.mock_calls) == 1

--- a/tests/components/aemet/test_config_flow.py
+++ b/tests/components/aemet/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_form(hass):
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == SOURCE_USER
         assert result["errors"] == {}
 
@@ -49,7 +49,7 @@ async def test_form(hass):
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == CONFIG[CONF_NAME]
         assert result["data"][CONF_LATITUDE] == CONFIG[CONF_LATITUDE]
         assert result["data"][CONF_LONGITUDE] == CONFIG[CONF_LONGITUDE]
@@ -79,14 +79,14 @@ async def test_form_options(hass):
 
         result = await hass.config_entries.options.async_init(entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_STATION_UPDATES: False}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert entry.options == {
             CONF_STATION_UPDATES: False,
         }
@@ -97,14 +97,14 @@ async def test_form_options(hass):
 
         result = await hass.config_entries.options.async_init(entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_STATION_UPDATES: True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert entry.options == {
             CONF_STATION_UPDATES: True,
         }

--- a/tests/components/agent_dvr/test_config_flow.py
+++ b/tests/components/agent_dvr/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_user_device_exists_abort(
@@ -35,7 +35,7 @@ async def test_user_device_exists_abort(
         data={CONF_HOST: "example.local", CONF_PORT: 8090},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_connection_error(
@@ -53,7 +53,7 @@ async def test_connection_error(
 
     assert result["errors"]["base"] == "cannot_connect"
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_full_user_flow_implementation(
@@ -78,7 +78,7 @@ async def test_full_user_flow_implementation(
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "example.local", CONF_PORT: 8090}
@@ -88,7 +88,7 @@ async def test_full_user_flow_implementation(
     assert result["data"][CONF_PORT] == 8090
     assert result["data"][SERVER_URL] == "http://example.local:8090/"
     assert result["title"] == "DESKTOP"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries(config_flow.DOMAIN)
     assert entries[0].unique_id == "c0715bba-c2d0-48ef-9e3e-bc81c9ea4447"

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -84,7 +84,7 @@ async def test_create_entry(hass, aioclient_mock):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == CONFIG[CONF_NAME]
     assert result["data"][CONF_LATITUDE] == CONFIG[CONF_LATITUDE]
     assert result["data"][CONF_LONGITUDE] == CONFIG[CONF_LONGITUDE]
@@ -106,7 +106,7 @@ async def test_create_entry_with_nearest_method(hass, aioclient_mock):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == CONFIG[CONF_NAME]
     assert result["data"][CONF_LATITUDE] == CONFIG[CONF_LATITUDE]
     assert result["data"][CONF_LONGITUDE] == CONFIG[CONF_LONGITUDE]

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -72,7 +72,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch("pyairnow.WebServiceAPI._get", return_value=MOCK_RESPONSE), patch(
@@ -86,7 +86,7 @@ async def test_form(hass):
 
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["data"] == CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -66,7 +66,7 @@ async def test_duplicate_error(hass, config, config_entry, data):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -126,7 +126,7 @@ async def test_errors(hass, data, exc, errors, integration_type):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=data
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == errors
 
 
@@ -183,14 +183,14 @@ async def test_options_flow(hass, config_entry):
         await hass.config_entries.async_setup(config_entry.entry_id)
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_SHOW_ON_MAP: False}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_SHOW_ON_MAP: False}
 
 
@@ -205,7 +205,7 @@ async def test_step_geography_by_coords(hass, config, setup_airvisual):
         result["flow_id"], user_input=config
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Cloud API (51.528308, -0.3817765)"
     assert result["data"] == {
         CONF_API_KEY: "abcde12345",
@@ -237,7 +237,7 @@ async def test_step_geography_by_name(hass, config, setup_airvisual):
         result["flow_id"], user_input=config
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Cloud API (Beijing, Beijing, China)"
     assert result["data"] == {
         CONF_API_KEY: "abcde12345",
@@ -265,7 +265,7 @@ async def test_step_node_pro(hass, config, setup_airvisual):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Node/Pro (192.168.1.100)"
     assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
@@ -282,7 +282,7 @@ async def test_step_reauth(hass, config_entry, setup_airvisual):
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     new_api_key = "defgh67890"
@@ -293,7 +293,7 @@ async def test_step_reauth(hass, config_entry, setup_airvisual):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_API_KEY: new_api_key}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
 
     assert len(hass.config_entries.async_entries()) == 1
@@ -306,7 +306,7 @@ async def test_step_user(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
@@ -315,7 +315,7 @@ async def test_step_user(hass):
         data={"type": INTEGRATION_TYPE_GEOGRAPHY_COORDS},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "geography_by_coords"
 
     result = await hass.config_entries.flow.async_init(
@@ -324,7 +324,7 @@ async def test_step_user(hass):
         data={"type": INTEGRATION_TYPE_GEOGRAPHY_NAME},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "geography_by_name"
 
     result = await hass.config_entries.flow.async_init(
@@ -333,5 +333,5 @@ async def test_step_user(hass):
         data={"type": INTEGRATION_TYPE_NODE_PRO},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "node_pro"

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_form(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == SOURCE_USER
         assert result["errors"] == {}
 
@@ -55,7 +55,7 @@ async def test_form(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == f"Airzone {CONFIG[CONF_HOST]}:{CONFIG[CONF_PORT]}"
         assert result["data"][CONF_HOST] == CONFIG[CONF_HOST]
         assert result["data"][CONF_PORT] == CONFIG[CONF_PORT]
@@ -84,7 +84,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == SOURCE_USER
         assert result["errors"] == {CONF_ID: "invalid_system_id"}
 
@@ -95,7 +95,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
             result["flow_id"], CONFIG_ID1
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 
@@ -103,7 +103,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert (
             result["title"]
             == f"Airzone {CONFIG_ID1[CONF_HOST]}:{CONFIG_ID1[CONF_PORT]}"

--- a/tests/components/alarmdecoder/test_config_flow.py
+++ b/tests/components/alarmdecoder/test_config_flow.py
@@ -62,7 +62,7 @@ async def test_setups(hass: HomeAssistant, protocol, connection, title):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
@@ -70,7 +70,7 @@ async def test_setups(hass: HomeAssistant, protocol, connection, title):
         {CONF_PROTOCOL: protocol},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "protocol"
 
     with patch("homeassistant.components.alarmdecoder.config_flow.AdExt.open"), patch(
@@ -82,7 +82,7 @@ async def test_setups(hass: HomeAssistant, protocol, connection, title):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], connection
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == title
         assert result["data"] == {
             **connection,
@@ -105,7 +105,7 @@ async def test_setup_connection_error(hass: HomeAssistant):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
@@ -113,7 +113,7 @@ async def test_setup_connection_error(hass: HomeAssistant):
         {CONF_PROTOCOL: protocol},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "protocol"
 
     with patch(
@@ -123,7 +123,7 @@ async def test_setup_connection_error(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], connection_settings
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -133,7 +133,7 @@ async def test_setup_connection_error(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], connection_settings
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "unknown"}
 
 
@@ -152,7 +152,7 @@ async def test_options_arm_flow(hass: HomeAssistant):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -160,7 +160,7 @@ async def test_options_arm_flow(hass: HomeAssistant):
         user_input={"edit_selection": "Arming Settings"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "arm_settings"
 
     with patch(
@@ -171,7 +171,7 @@ async def test_options_arm_flow(hass: HomeAssistant):
             user_input=user_input,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options == {
         OPTIONS_ARM: user_input,
         OPTIONS_ZONES: DEFAULT_ZONE_OPTIONS,
@@ -190,7 +190,7 @@ async def test_options_zone_flow(hass: HomeAssistant):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -198,7 +198,7 @@ async def test_options_zone_flow(hass: HomeAssistant):
         user_input={"edit_selection": "Zones"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_select"
 
     result = await hass.config_entries.options.async_configure(
@@ -214,7 +214,7 @@ async def test_options_zone_flow(hass: HomeAssistant):
             user_input=zone_settings,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options == {
         OPTIONS_ARM: DEFAULT_ARM_OPTIONS,
         OPTIONS_ZONES: {zone_number: zone_settings},
@@ -223,7 +223,7 @@ async def test_options_zone_flow(hass: HomeAssistant):
     # Make sure zone can be removed...
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -231,7 +231,7 @@ async def test_options_zone_flow(hass: HomeAssistant):
         user_input={"edit_selection": "Zones"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_select"
 
     result = await hass.config_entries.options.async_configure(
@@ -247,7 +247,7 @@ async def test_options_zone_flow(hass: HomeAssistant):
             user_input={},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options == {
         OPTIONS_ARM: DEFAULT_ARM_OPTIONS,
         OPTIONS_ZONES: {},
@@ -266,7 +266,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -274,7 +274,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={"edit_selection": "Zones"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_select"
 
     # Zone Number must be int
@@ -283,7 +283,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={CONF_ZONE_NUMBER: "asd"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_select"
     assert result["errors"] == {CONF_ZONE_NUMBER: "int"}
 
@@ -292,7 +292,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={CONF_ZONE_NUMBER: zone_number},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
 
     # CONF_RELAY_ADDR & CONF_RELAY_CHAN are inclusive
@@ -301,7 +301,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={**zone_settings, CONF_RELAY_ADDR: "1"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
     assert result["errors"] == {"base": "relay_inclusive"}
 
@@ -310,7 +310,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={**zone_settings, CONF_RELAY_CHAN: "1"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
     assert result["errors"] == {"base": "relay_inclusive"}
 
@@ -320,7 +320,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={**zone_settings, CONF_RELAY_ADDR: "abc", CONF_RELAY_CHAN: "abc"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
     assert result["errors"] == {
         CONF_RELAY_ADDR: "int",
@@ -333,7 +333,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={**zone_settings, CONF_ZONE_LOOP: "1"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
     assert result["errors"] == {CONF_ZONE_LOOP: "loop_rfid"}
 
@@ -343,7 +343,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={**zone_settings, CONF_ZONE_RFID: "rfid123", CONF_ZONE_LOOP: "ab"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
     assert result["errors"] == {CONF_ZONE_LOOP: "int"}
 
@@ -353,7 +353,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
         user_input={**zone_settings, CONF_ZONE_RFID: "rfid123", CONF_ZONE_LOOP: "5"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "zone_details"
     assert result["errors"] == {CONF_ZONE_LOOP: "loop_range"}
 
@@ -372,7 +372,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant):
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options == {
         OPTIONS_ARM: DEFAULT_ARM_OPTIONS,
         OPTIONS_ZONES: {
@@ -420,7 +420,7 @@ async def test_one_device_allowed(hass, protocol, connection):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
@@ -428,11 +428,11 @@ async def test_one_device_allowed(hass, protocol, connection):
         {CONF_PROTOCOL: protocol},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "protocol"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], connection
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/almond/test_config_flow.py
+++ b/tests/components/almond/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_hassio(hass):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "hassio_confirm"
 
     with patch(
@@ -67,7 +67,7 @@ async def test_hassio(hass):
 
     assert len(mock_setup.mock_calls) == 1
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     entry = hass.config_entries.async_entries(DOMAIN)[0]
@@ -83,15 +83,15 @@ async def test_abort_if_existing_entry(hass):
     flow.hass = hass
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
     result = await flow.async_step_import({})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
     result = await flow.async_step_hassio(HassioServiceInfo(config={}))
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -123,7 +123,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         "https://almond.stanford.edu/me/api/oauth2/authorize"
         f"?response_type=code&client_id={CLIENT_ID_VALUE}"

--- a/tests/components/amberelectric/test_config_flow.py
+++ b/tests/components/amberelectric/test_config_flow.py
@@ -67,7 +67,7 @@ async def test_single_site(hass: HomeAssistant, single_site_api: Mock) -> None:
     initial_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert initial_result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert initial_result.get("type") == data_entry_flow.FlowResultType.FORM
     assert initial_result.get("step_id") == "user"
 
     # Test filling in API key
@@ -76,7 +76,7 @@ async def test_single_site(hass: HomeAssistant, single_site_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_API_TOKEN: API_KEY},
     )
-    assert enter_api_key_result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert enter_api_key_result.get("type") == data_entry_flow.FlowResultType.FORM
     assert enter_api_key_result.get("step_id") == "site"
 
     select_site_result = await hass.config_entries.flow.async_configure(
@@ -85,7 +85,7 @@ async def test_single_site(hass: HomeAssistant, single_site_api: Mock) -> None:
     )
 
     # Show available sites
-    assert select_site_result.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert select_site_result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert select_site_result.get("title") == "Home"
     data = select_site_result.get("data")
     assert data
@@ -102,7 +102,7 @@ async def test_no_site(hass: HomeAssistant, no_site_api: Mock) -> None:
         data={CONF_API_TOKEN: "psk_123456789"},
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     # Goes back to the user step
     assert result.get("step_id") == "user"
     assert result.get("errors") == {"api_token": "no_site"}
@@ -113,7 +113,7 @@ async def test_invalid_key(hass: HomeAssistant, invalid_key_api: Mock) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "user"
 
     # Test filling in API key
@@ -122,7 +122,7 @@ async def test_invalid_key(hass: HomeAssistant, invalid_key_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_API_TOKEN: "psk_123456789"},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     # Goes back to the user step
     assert result.get("step_id") == "user"
     assert result.get("errors") == {"api_token": "invalid_api_token"}
@@ -133,7 +133,7 @@ async def test_unknown_error(hass: HomeAssistant, api_error: Mock) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "user"
 
     # Test filling in API key
@@ -142,7 +142,7 @@ async def test_unknown_error(hass: HomeAssistant, api_error: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_API_TOKEN: "psk_123456789"},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     # Goes back to the user step
     assert result.get("step_id") == "user"
     assert result.get("errors") == {"api_token": "unknown_error"}

--- a/tests/components/ambiclimate/test_config_flow.py
+++ b/tests/components/ambiclimate/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_abort_if_no_implementation_registered(hass):
     flow.hass = hass
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_configuration"
 
 
@@ -48,12 +48,12 @@ async def test_abort_if_already_setup(hass):
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_USER},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     with pytest.raises(data_entry_flow.AbortFlow):
         result = await flow.async_step_code()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -63,7 +63,7 @@ async def test_full_flow_implementation(hass):
     flow = await init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert (
         result["description_placeholders"]["cb_url"]
@@ -78,7 +78,7 @@ async def test_full_flow_implementation(hass):
 
     with patch("ambiclimate.AmbiclimateOAuth.get_access_token", return_value="test"):
         result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Ambiclimate"
     assert result["data"]["callback_url"] == "https://example.com/api/ambiclimate"
     assert result["data"][CONF_CLIENT_SECRET] == "secret"
@@ -86,14 +86,14 @@ async def test_full_flow_implementation(hass):
 
     with patch("ambiclimate.AmbiclimateOAuth.get_access_token", return_value=None):
         result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
     with patch(
         "ambiclimate.AmbiclimateOAuth.get_access_token",
         side_effect=ambiclimate.AmbiclimateOauthError(),
     ):
         result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_abort_invalid_code(hass):
@@ -103,7 +103,7 @@ async def test_abort_invalid_code(hass):
 
     with patch("ambiclimate.AmbiclimateOAuth.get_access_token", return_value=None):
         result = await flow.async_step_code("invalid")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "access_token"
 
 
@@ -115,7 +115,7 @@ async def test_already_setup(hass):
         context={"source": config_entries.SOURCE_USER},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 

--- a/tests/components/ambient_station/test_config_flow.py
+++ b/tests/components/ambient_station/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_duplicate_error(hass, config, config_entry, setup_ambient_station
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -31,7 +31,7 @@ async def test_errors(hass, config, devices, error, setup_ambient_station):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
 
@@ -40,7 +40,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -49,7 +49,7 @@ async def test_step_user(hass, config, setup_ambient_station):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "67890fghij67"
     assert result["data"] == {
         CONF_API_KEY: "12345abcde12345abcde",

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_user(hass, config, eth_mac, wifi_mac):
     flow_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER, "show_advanced_options": True}
     )
-    assert flow_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert flow_result["type"] == data_entry_flow.FlowResultType.FORM
     assert flow_result["step_id"] == "user"
 
     # test with all provided
@@ -110,7 +110,7 @@ async def test_user(hass, config, eth_mac, wifi_mac):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == HOST
         assert result["data"] == config
 
@@ -134,7 +134,7 @@ async def test_user_adbkey(hass):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == HOST
         assert result["data"] == config_data
 
@@ -152,7 +152,7 @@ async def test_error_both_key_server(hass):
         data=config_data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "key_and_server"}
 
     with patch(
@@ -164,7 +164,7 @@ async def test_error_both_key_server(hass):
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == HOST
         assert result2["data"] == CONFIG_ADB_SERVER
 
@@ -179,7 +179,7 @@ async def test_error_invalid_key(hass):
         data=config_data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "adbkey_not_file"}
 
     with patch(
@@ -191,7 +191,7 @@ async def test_error_invalid_key(hass):
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == HOST
         assert result2["data"] == CONFIG_ADB_SERVER
 
@@ -219,7 +219,7 @@ async def test_invalid_mac(hass, config, eth_mac, wifi_mac):
             data=config,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "invalid_unique_id"
 
 
@@ -237,7 +237,7 @@ async def test_abort_if_host_exist(hass):
         data=config_data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -260,7 +260,7 @@ async def test_abort_if_unique_exist(hass):
             data=CONFIG_ADB_SERVER,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -275,7 +275,7 @@ async def test_on_connect_failed(hass):
         result = await hass.config_entries.flow.async_configure(
             flow_result["flow_id"], user_input=CONFIG_ADB_SERVER
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -285,7 +285,7 @@ async def test_on_connect_failed(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=CONFIG_ADB_SERVER
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["errors"] == {"base": "unknown"}
 
     with patch(
@@ -297,7 +297,7 @@ async def test_on_connect_failed(hass):
         )
         await hass.async_block_till_done()
 
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result3["title"] == HOST
         assert result3["data"] == CONFIG_ADB_SERVER
 
@@ -320,7 +320,7 @@ async def test_options_flow(hass):
         await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         # test app form with existing app
@@ -330,7 +330,7 @@ async def test_options_flow(hass):
                 CONF_APPS: "app1",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "apps"
 
         # test change value in apps form
@@ -340,7 +340,7 @@ async def test_options_flow(hass):
                 CONF_APP_NAME: "Appl1",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         # test app form with new app
@@ -350,7 +350,7 @@ async def test_options_flow(hass):
                 CONF_APPS: APPS_NEW_ID,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "apps"
 
         # test save value for new app
@@ -361,7 +361,7 @@ async def test_options_flow(hass):
                 CONF_APP_NAME: "Appl2",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         # test app form for delete
@@ -371,7 +371,7 @@ async def test_options_flow(hass):
                 CONF_APPS: "app1",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "apps"
 
         # test delete app1
@@ -382,7 +382,7 @@ async def test_options_flow(hass):
                 CONF_APP_DELETE: True,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         # test rules form with existing rule
@@ -392,7 +392,7 @@ async def test_options_flow(hass):
                 CONF_STATE_DETECTION_RULES: "com.plexapp.android",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "rules"
 
         # test change value in rule form with invalid json rule
@@ -402,7 +402,7 @@ async def test_options_flow(hass):
                 CONF_RULE_VALUES: "a",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "rules"
         assert result["errors"] == {"base": "invalid_det_rules"}
 
@@ -413,7 +413,7 @@ async def test_options_flow(hass):
                 CONF_RULE_VALUES: json.dumps({"a": "b"}),
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "rules"
         assert result["errors"] == {"base": "invalid_det_rules"}
 
@@ -424,7 +424,7 @@ async def test_options_flow(hass):
                 CONF_RULE_VALUES: json.dumps(["standby"]),
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         # test rule form with new rule
@@ -434,7 +434,7 @@ async def test_options_flow(hass):
                 CONF_STATE_DETECTION_RULES: RULES_NEW_ID,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "rules"
 
         # test save value for new rule
@@ -445,7 +445,7 @@ async def test_options_flow(hass):
                 CONF_RULE_VALUES: json.dumps(VALID_DETECT_RULE),
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         # test rules form with delete existing rule
@@ -455,7 +455,7 @@ async def test_options_flow(hass):
                 CONF_STATE_DETECTION_RULES: "com.plexapp.android",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "rules"
 
         # test delete rule
@@ -465,7 +465,7 @@ async def test_options_flow(hass):
                 CONF_RULE_DELETE: True,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -479,7 +479,7 @@ async def test_options_flow(hass):
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         apps_options = config_entry.options[CONF_APPS]
         assert apps_options.get("app1") is None

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -71,7 +71,7 @@ async def test_user_input_device_not_found(hass, mrp_device):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -79,7 +79,7 @@ async def test_user_input_device_not_found(hass, mrp_device):
         {"device_input": "none"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "no_devices_found"}
 
 
@@ -95,7 +95,7 @@ async def test_user_input_unexpected_error(hass, mock_scan):
         {"device_input": "dummy"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -104,31 +104,31 @@ async def test_user_adds_full_device(hass, full_device, pairing):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"device_input": "MRP Device"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {
         "name": "MRP Device",
         "type": "Unknown",
     }
 
     result3 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["description_placeholders"] == {"protocol": "MRP"}
 
     result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"pin": 1111}
     )
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
     assert result4["description_placeholders"] == {"protocol": "DMAP", "pin": 1111}
 
     result5 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result5["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result5["type"] == data_entry_flow.FlowResultType.FORM
     assert result5["description_placeholders"] == {"protocol": "AirPlay"}
 
     result6 = await hass.config_entries.flow.async_configure(
@@ -157,14 +157,14 @@ async def test_user_adds_dmap_device(hass, dmap_device, dmap_pin, pairing):
         result["flow_id"],
         {"device_input": "DMAP Device"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {
         "name": "DMAP Device",
         "type": "Unknown",
     }
 
     result3 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["description_placeholders"] == {"pin": 1111, "protocol": "DMAP"}
 
     result6 = await hass.config_entries.flow.async_configure(
@@ -195,7 +195,7 @@ async def test_user_adds_dmap_device_failed(hass, dmap_device, dmap_pin, pairing
     await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "device_did_not_pair"
 
 
@@ -211,7 +211,7 @@ async def test_user_adds_device_with_ip_filter(
         result["flow_id"],
         {"device_input": "127.0.0.1"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {
         "name": "DMAP Device",
         "type": "Unknown",
@@ -268,7 +268,7 @@ async def test_user_adds_existing_device(hass, mrp_device):
         result["flow_id"],
         {"device_input": "127.0.0.1"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "already_configured"}
 
 
@@ -294,7 +294,7 @@ async def test_user_connection_failed(hass, mrp_device, pairing_mock):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "setup_failed"
 
 
@@ -315,7 +315,7 @@ async def test_user_start_pair_error_failed(hass, mrp_device, pairing_mock):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "invalid_auth"
 
 
@@ -336,14 +336,14 @@ async def test_user_pair_service_with_password(
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "password"
 
     result3 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {},
     )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "setup_failed"
 
 
@@ -363,14 +363,14 @@ async def test_user_pair_disabled_service(hass, dmap_with_requirement, pairing_m
         result["flow_id"],
         {},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "protocol_disabled"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "setup_failed"
 
 
@@ -390,7 +390,7 @@ async def test_user_pair_ignore_unsupported(hass, dmap_with_requirement, pairing
         result["flow_id"],
         {},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "setup_failed"
 
 
@@ -416,7 +416,7 @@ async def test_user_pair_invalid_pin(hass, mrp_device, pairing_mock):
         result["flow_id"],
         {"pin": 1111},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -442,7 +442,7 @@ async def test_user_pair_unexpected_error(hass, mrp_device, pairing_mock):
         result["flow_id"],
         {"pin": 1111},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -463,7 +463,7 @@ async def test_user_pair_backoff_error(hass, mrp_device, pairing_mock):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "backoff"
 
 
@@ -484,7 +484,7 @@ async def test_user_pair_begin_unexpected_error(hass, mrp_device, pairing_mock):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "unknown"
 
 
@@ -499,14 +499,14 @@ async def test_ignores_disabled_service(hass, airplay_with_disabled_mrp, pairing
         result["flow_id"],
         {"device_input": "mrpid"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["description_placeholders"] == {
         "name": "AirPlay Device",
         "type": "Unknown",
     }
 
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {"protocol": "AirPlay"}
 
     result3 = await hass.config_entries.flow.async_configure(
@@ -541,7 +541,7 @@ async def test_zeroconf_unsupported_service_aborts(hass):
             properties={},
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown"
 
 
@@ -560,7 +560,7 @@ async def test_zeroconf_add_mrp_device(hass, mrp_device, pairing):
             type="_mediaremotetv._tcp.local.",
         ),
     )
-    assert unrelated_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert unrelated_result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -575,7 +575,7 @@ async def test_zeroconf_add_mrp_device(hass, mrp_device, pairing):
             type="_mediaremotetv._tcp.local.",
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["description_placeholders"] == {
         "name": "MRP Device",
         "type": "Unknown",
@@ -585,7 +585,7 @@ async def test_zeroconf_add_mrp_device(hass, mrp_device, pairing):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {"protocol": "MRP"}
 
     result3 = await hass.config_entries.flow.async_configure(
@@ -605,7 +605,7 @@ async def test_zeroconf_add_dmap_device(hass, dmap_device, dmap_pin, pairing):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=DMAP_SERVICE
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["description_placeholders"] == {
         "name": "DMAP Device",
         "type": "Unknown",
@@ -615,7 +615,7 @@ async def test_zeroconf_add_dmap_device(hass, dmap_device, dmap_pin, pairing):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {"protocol": "DMAP", "pin": 1111}
 
     result3 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
@@ -654,7 +654,7 @@ async def test_zeroconf_ip_change(hass, mock_scan):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(mock_async_setup.mock_calls) == 2
     assert entry.data[CONF_ADDRESS] == "127.0.0.1"
@@ -693,7 +693,7 @@ async def test_zeroconf_ip_change_via_secondary_identifier(hass, mock_scan):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(mock_async_setup.mock_calls) == 2
     assert entry.data[CONF_ADDRESS] == "127.0.0.1"
@@ -709,7 +709,7 @@ async def test_zeroconf_add_existing_aborts(hass, dmap_device):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=DMAP_SERVICE
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -718,7 +718,7 @@ async def test_zeroconf_add_but_device_not_found(hass, mock_scan):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=DMAP_SERVICE
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
 
 
@@ -729,7 +729,7 @@ async def test_zeroconf_add_existing_device(hass, dmap_device):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=DMAP_SERVICE
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -740,7 +740,7 @@ async def test_zeroconf_unexpected_error(hass, mock_scan):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=DMAP_SERVICE
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown"
 
 
@@ -764,7 +764,7 @@ async def test_zeroconf_abort_if_other_in_progress(hass, mock_scan):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     mock_scan.result = [
@@ -786,7 +786,7 @@ async def test_zeroconf_abort_if_other_in_progress(hass, mock_scan):
             properties={"UniqueIdentifier": "mrpid", "Name": "Kitchen"},
         ),
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_in_progress"
 
 
@@ -844,7 +844,7 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "device_not_found"
 
 
@@ -904,7 +904,7 @@ async def test_zeroconf_additional_protocol_resolve_failure(
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "inconsistent_device"
 
 
@@ -930,7 +930,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
             properties={"deviceid": "airplayid"},
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     await hass.async_block_till_done()
 
     mock_scan.result = [
@@ -981,7 +981,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
         {},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "pair_no_pin"
     assert result2["description_placeholders"] == {"pin": ANY, "protocol": "RAOP"}
 
@@ -991,7 +991,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
         {},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == "pair_with_pin"
     assert result3["description_placeholders"] == {"protocol": "MRP"}
 
@@ -999,7 +999,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
         result["flow_id"],
         {"pin": 1234},
     )
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
     assert result4["step_id"] == "pair_with_pin"
     assert result4["description_placeholders"] == {"protocol": "AirPlay"}
 
@@ -1007,7 +1007,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
         result["flow_id"],
         {"pin": 1234},
     )
-    assert result5["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result5["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 # Re-configuration
@@ -1030,13 +1030,13 @@ async def test_reconfigure_update_credentials(hass, mrp_device, pairing):
         result["flow_id"],
         {},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {"protocol": "MRP"}
 
     result3 = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"pin": 1111}
     )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
 
     assert config_entry.data == {
@@ -1058,7 +1058,7 @@ async def test_option_start_off(hass):
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_START_OFF: True}
@@ -1083,5 +1083,5 @@ async def test_zeroconf_rejects_ipv6(hass):
             properties={"CtlN": "Apple TV"},
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "ipv6_not_supported"

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -160,7 +160,7 @@ class OAuthFixture:
         )
 
         result = await self.hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result.get("title") == self.title
         assert "data" in result
         assert "token" in result["data"]
@@ -417,7 +417,7 @@ async def test_config_flow_no_credentials(hass):
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -444,7 +444,7 @@ async def test_config_flow_other_domain(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -467,7 +467,7 @@ async def test_config_flow(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
     result = await oauth_fixture.complete_external_step(result)
     assert (
         result["data"].get("auth_implementation") == "fake_integration_some_client_id"
@@ -511,14 +511,14 @@ async def test_config_flow_multiple_entries(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "pick_implementation"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"implementation": "fake_integration_some_client_id2"},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
     oauth_fixture.client_id = CLIENT_ID + "2"
     oauth_fixture.title = CLIENT_ID + "2"
     result = await oauth_fixture.complete_external_step(result)
@@ -548,7 +548,7 @@ async def test_config_flow_create_delete_credential(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -565,7 +565,7 @@ async def test_config_flow_with_config_credential(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
     oauth_fixture.title = DEFAULT_IMPORT_NAME
     result = await oauth_fixture.complete_external_step(result)
     # Uses the imported auth domain for compatibility
@@ -583,7 +583,7 @@ async def test_import_without_setup(hass, config_credential):
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -612,7 +612,7 @@ async def test_websocket_without_platform(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -687,7 +687,7 @@ async def test_platform_with_auth_implementation(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
     oauth_fixture.title = DEFAULT_IMPORT_NAME
     result = await oauth_fixture.complete_external_step(result)
     # Uses the imported auth domain for compatibility
@@ -745,7 +745,7 @@ async def test_name(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
     oauth_fixture.title = NAME
     result = await oauth_fixture.complete_external_step(result)
     assert (

--- a/tests/components/arcam_fmj/test_config_flow.py
+++ b/tests/components/arcam_fmj/test_config_flow.py
@@ -65,11 +65,11 @@ async def test_ssdp(hass, dummy_client):
         context={CONF_SOURCE: SOURCE_SSDP},
         data=MOCK_DISCOVER,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Arcam FMJ ({MOCK_HOST})"
     assert result["data"] == MOCK_CONFIG_ENTRY
 
@@ -86,7 +86,7 @@ async def test_ssdp_abort(hass):
         context={CONF_SOURCE: SOURCE_SSDP},
         data=MOCK_DISCOVER,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -99,11 +99,11 @@ async def test_ssdp_unable_to_connect(hass, dummy_client):
         context={CONF_SOURCE: SOURCE_SSDP},
         data=MOCK_DISCOVER,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -122,7 +122,7 @@ async def test_ssdp_update(hass):
         context={CONF_SOURCE: SOURCE_SSDP},
         data=MOCK_DISCOVER,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     assert entry.data[CONF_HOST] == MOCK_HOST
@@ -137,7 +137,7 @@ async def test_user(hass, aioclient_mock):
         data=None,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     user_input = {
@@ -149,7 +149,7 @@ async def test_user(hass, aioclient_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Arcam FMJ ({MOCK_HOST})"
     assert result["data"] == MOCK_CONFIG_ENTRY
     assert result["result"].unique_id == MOCK_UUID
@@ -168,7 +168,7 @@ async def test_invalid_ssdp(hass, aioclient_mock):
         context={CONF_SOURCE: SOURCE_USER},
         data=user_input,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Arcam FMJ ({MOCK_HOST})"
     assert result["data"] == MOCK_CONFIG_ENTRY
     assert result["result"].unique_id is None
@@ -187,7 +187,7 @@ async def test_user_wrong(hass, aioclient_mock):
         context={CONF_SOURCE: SOURCE_USER},
         data=user_input,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Arcam FMJ ({MOCK_HOST})"
     assert result["result"].unique_id is None
 

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -81,7 +81,7 @@ async def test_user(hass, mock_unique_id, unique_id):
     flow_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER, "show_advanced_options": True}
     )
-    assert flow_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert flow_result["type"] == data_entry_flow.FlowResultType.FORM
     assert flow_result["step_id"] == "user"
 
     # test with all provided
@@ -92,7 +92,7 @@ async def test_user(hass, mock_unique_id, unique_id):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == HOST
         assert result["data"] == CONFIG_DATA
 
@@ -116,7 +116,7 @@ async def test_error_wrong_password_ssh(hass, config, error):
         data=config_data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
 
@@ -136,7 +136,7 @@ async def test_error_invalid_ssh(hass):
             data=config_data,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "ssh_not_file"}
 
 
@@ -152,7 +152,7 @@ async def test_error_invalid_host(hass):
             data=CONFIG_DATA,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_host"}
 
 
@@ -168,7 +168,7 @@ async def test_abort_if_not_unique_id_setup(hass):
         context={"source": SOURCE_USER},
         data=CONFIG_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_unique_id"
 
 
@@ -192,7 +192,7 @@ async def test_update_uniqueid_exist(hass, mock_unique_id):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == HOST
         assert result["data"] == CONFIG_DATA
         prev_entry = hass.config_entries.async_get_entry(existing_entry.entry_id)
@@ -214,7 +214,7 @@ async def test_abort_invalid_unique_id(hass):
             context={"source": SOURCE_USER},
             data=CONFIG_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "invalid_unique_id"
 
 
@@ -244,7 +244,7 @@ async def test_on_connect_failed(hass, side_effect, error):
         result = await hass.config_entries.flow.async_configure(
             flow_result["flow_id"], user_input=CONFIG_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": error}
 
 
@@ -262,7 +262,7 @@ async def test_options_flow(hass):
         await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -276,7 +276,7 @@ async def test_options_flow(hass):
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options[CONF_CONSIDER_HOME] == 20
         assert config_entry.options[CONF_TRACK_UNKNOWN] is True
         assert config_entry.options[CONF_INTERFACE] == "aaa"

--- a/tests/components/atag/test_config_flow.py
+++ b/tests/components/atag/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_show_form(hass: HomeAssistant, aioclient_mock: AiohttpClientMocke
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -30,7 +30,7 @@ async def test_adding_second_device(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     with patch(
         "pyatag.AtagOne.id",
@@ -39,7 +39,7 @@ async def test_adding_second_device(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=USER_INPUT
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_connection_error(
@@ -53,7 +53,7 @@ async def test_connection_error(
         data=USER_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -66,7 +66,7 @@ async def test_unauthorized(hass: HomeAssistant, aioclient_mock: AiohttpClientMo
         context={"source": config_entries.SOURCE_USER},
         data=USER_INPUT,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "unauthorized"}
 
@@ -81,6 +81,6 @@ async def test_full_flow_implementation(
         context={"source": config_entries.SOURCE_USER},
         data=USER_INPUT,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == UID
     assert result["result"].unique_id == UID

--- a/tests/components/aurora/test_config_flow.py
+++ b/tests/components/aurora/test_config_flow.py
@@ -101,7 +101,7 @@ async def test_option_flow(hass):
             data=None,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -109,6 +109,6 @@ async def test_option_flow(hass):
         user_input={"forecast_threshold": 65},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"]["forecast_threshold"] == 65

--- a/tests/components/aurora_abb_powerone/test_config_flow.py
+++ b/tests/components/aurora_abb_powerone/test_config_flow.py
@@ -58,7 +58,7 @@ async def test_form(hass):
             {CONF_PORT: "/dev/ttyUSB7", CONF_ADDRESS: 7},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert result2["data"] == {
         CONF_PORT: "/dev/ttyUSB7",

--- a/tests/components/aussie_broadband/test_init.py
+++ b/tests/components/aussie_broadband/test_init.py
@@ -23,7 +23,7 @@ async def test_auth_failure(hass: HomeAssistant) -> None:
     """Test init with an authentication failure."""
     with patch(
         "homeassistant.components.aussie_broadband.config_flow.ConfigFlow.async_step_reauth",
-        return_value={"type": data_entry_flow.RESULT_TYPE_FORM},
+        return_value={"type": data_entry_flow.FlowResultType.FORM},
     ) as mock_async_step_reauth:
         await setup_platform(hass, side_effect=AuthenticationException())
         mock_async_step_reauth.assert_called_once()

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -64,7 +64,7 @@ async def test_ws_setup_depose_mfa(hass, hass_ws_client):
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert flow["type"] == data_entry_flow.FlowResultType.FORM
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
     assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}
@@ -83,7 +83,7 @@ async def test_ws_setup_depose_mfa(hass, hass_ws_client):
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert flow["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None
 

--- a/tests/components/awair/test_config_flow.py
+++ b/tests/components/awair/test_config_flow.py
@@ -21,7 +21,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -95,7 +95,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
         context={"source": SOURCE_REAUTH, "unique_id": UNIQUE_ID},
         data={**CONFIG, CONF_ACCESS_TOKEN: "blah"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
 
@@ -105,7 +105,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
             user_input=CONFIG,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {CONF_ACCESS_TOKEN: "invalid_access_token"}
 
@@ -117,7 +117,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
             user_input=CONFIG,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
 
 
@@ -133,7 +133,7 @@ async def test_reauth_error(hass: HomeAssistant) -> None:
         context={"source": SOURCE_REAUTH, "unique_id": UNIQUE_ID},
         data={**CONFIG, CONF_ACCESS_TOKEN: "blah"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
 
@@ -143,7 +143,7 @@ async def test_reauth_error(hass: HomeAssistant) -> None:
             user_input=CONFIG,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unknown"
 
 
@@ -160,7 +160,7 @@ async def test_create_entry(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "foo@bar.com (32406)"
         assert result["data"][CONF_ACCESS_TOKEN] == CONFIG[CONF_ACCESS_TOKEN]
         assert result["result"].unique_id == UNIQUE_ID

--- a/tests/components/azure_devops/test_config_flow.py
+++ b/tests/components/azure_devops/test_config_flow.py
@@ -27,7 +27,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -41,7 +41,7 @@ async def test_authorization_error(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -50,7 +50,7 @@ async def test_authorization_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -67,7 +67,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -76,7 +76,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth"
         assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -91,7 +91,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -100,7 +100,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -117,7 +117,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -126,7 +126,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth"
         assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -146,7 +146,7 @@ async def test_project_error(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -155,7 +155,7 @@ async def test_project_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "project_error"}
 
@@ -177,7 +177,7 @@ async def test_reauth_project_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -186,7 +186,7 @@ async def test_reauth_project_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth"
         assert result2["errors"] == {"base": "project_error"}
 
@@ -208,7 +208,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
         assert result["errors"] == {"base": "invalid_auth"}
 
@@ -229,7 +229,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "reauth_successful"
 
 
@@ -253,7 +253,7 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -263,7 +263,7 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert len(mock_setup_entry.mock_calls) == 1
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert (
             result2["title"]
             == f"{FIXTURE_USER_INPUT[CONF_ORG]}/{FIXTURE_USER_INPUT[CONF_PROJECT]}"

--- a/tests/components/azure_event_hub/test_config_flow.py
+++ b/tests/components/azure_event_hub/test_config_flow.py
@@ -63,7 +63,7 @@ async def test_form(
         result2["flow_id"],
         step2_config.copy(),
     )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "test-instance"
     assert result3["data"] == data_config
     mock_setup_entry.assert_called_once()
@@ -79,7 +79,7 @@ async def test_import(hass, mock_setup_entry):
         data=IMPORT_CONFIG.copy(),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "test-instance"
     options = {
         CONF_SEND_INTERVAL: import_config.pop(CONF_SEND_INTERVAL),
@@ -109,7 +109,7 @@ async def test_single_instance(hass, source):
         context={"source": source},
         data=BASE_CONFIG_CS.copy(),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -138,7 +138,7 @@ async def test_connection_error_sas(
         result["flow_id"],
         SAS_CONFIG.copy(),
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": error_message}
 
 
@@ -168,7 +168,7 @@ async def test_connection_error_cs(
         result["flow_id"],
         CS_CONFIG.copy(),
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": error_message}
 
 
@@ -176,13 +176,13 @@ async def test_options_flow(hass, entry):
     """Test options flow."""
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["last_step"]
 
     updated = await hass.config_entries.options.async_configure(
         result["flow_id"], UPDATE_OPTIONS
     )
-    assert updated["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert updated["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert updated["data"] == UPDATE_OPTIONS
     await hass.async_block_till_done()

--- a/tests/components/balboa/test_config_flow.py
+++ b/tests/components/balboa/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_options_flow(hass: HomeAssistant, client: MagicMock) -> None:
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     with patch(
@@ -137,5 +137,5 @@ async def test_options_flow(hass: HomeAssistant, client: MagicMock) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert dict(config_entry.options) == {CONF_SYNC_TIME: True}

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -159,7 +159,7 @@ async def test_already_configured(hass, valid_feature_mock):
         context={"source": config_entries.SOURCE_USER},
         data={config_flow.CONF_HOST: "172.2.3.4", config_flow.CONF_PORT: 80},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "address_already_configured"
 
 

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -250,7 +250,7 @@ async def test_reauth_shows_user_step(hass):
         context={"source": config_entries.SOURCE_REAUTH},
         data={"username": "blink@example.com", "password": "invalid_password"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -280,7 +280,7 @@ async def test_options_flow(hass):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "simple_options"
 
     result = await hass.config_entries.options.async_configure(
@@ -288,6 +288,6 @@ async def test_options_flow(hass):
         user_input={"scan_interval": 5},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {"scan_interval": 5}
     assert mock_blink.refresh_rate == 5

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -55,7 +55,7 @@ async def test_connection_error(hass):
             data=FIXTURE_USER_INPUT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -75,7 +75,7 @@ async def test_full_user_flow_implementation(hass):
             context={"source": config_entries.SOURCE_USER},
             data=FIXTURE_USER_INPUT,
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
         assert result2["data"] == FIXTURE_COMPLETE_ENTRY
 
@@ -98,7 +98,7 @@ async def test_options_flow_implementation(hass):
         await hass.async_block_till_done()
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "account_options"
 
         result = await hass.config_entries.options.async_configure(
@@ -107,7 +107,7 @@ async def test_options_flow_implementation(hass):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == {
             CONF_READ_ONLY: True,
         }

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -38,7 +38,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -88,7 +88,7 @@ async def test_authorize_no_ip_control(hass):
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "no_ip_control"
 
 
@@ -117,7 +117,7 @@ async def test_duplicate_error(hass):
             result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -135,14 +135,14 @@ async def test_create_entry(hass):
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["result"].unique_id == "very_unique_string"
         assert result["title"] == "TV-Model"
         assert result["data"] == {
@@ -168,14 +168,14 @@ async def test_create_entry_with_ipv6_address(hass):
             data={CONF_HOST: "2001:db8::1428:57ab"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["result"].unique_id == "very_unique_string"
         assert result["title"] == "TV-Model"
         assert result["data"] == {
@@ -214,7 +214,7 @@ async def test_options_flow(hass):
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result = await hass.config_entries.options.async_configure(
@@ -222,5 +222,5 @@ async def test_options_flow(hass):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_IGNORED_SOURCES: ["HDMI 1", "HDMI 2"]}

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -21,7 +21,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -37,7 +37,7 @@ async def test_create_entry_with_hostname(hass):
             data={CONF_HOST: "example.local", CONF_TYPE: "laser"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "HL-L2340DW 0123456789"
         assert result["data"][CONF_HOST] == "example.local"
         assert result["data"][CONF_TYPE] == "laser"
@@ -53,7 +53,7 @@ async def test_create_entry_with_ipv4_address(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "HL-L2340DW 0123456789"
         assert result["data"][CONF_HOST] == "127.0.0.1"
         assert result["data"][CONF_TYPE] == "laser"
@@ -71,7 +71,7 @@ async def test_create_entry_with_ipv6_address(hass):
             data={CONF_HOST: "2001:db8::1428:57ab", CONF_TYPE: "laser"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "HL-L2340DW 0123456789"
         assert result["data"][CONF_HOST] == "2001:db8::1428:57ab"
         assert result["data"][CONF_TYPE] == "laser"
@@ -116,7 +116,7 @@ async def test_unsupported_model_error(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unsupported_model"
 
 
@@ -133,7 +133,7 @@ async def test_device_exists_abort(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -155,7 +155,7 @@ async def test_zeroconf_snmp_error(hass):
             ),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -176,7 +176,7 @@ async def test_zeroconf_unsupported_model(hass):
             ),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unsupported_model"
         assert len(mock_get_data.mock_calls) == 0
 
@@ -208,7 +208,7 @@ async def test_zeroconf_device_exists_abort(hass):
             ),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
     # Test config entry got updated with latest IP
@@ -235,7 +235,7 @@ async def test_zeroconf_no_probe_existing_device(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(mock_get_data.mock_calls) == 0
 
@@ -264,13 +264,13 @@ async def test_zeroconf_confirm_create_entry(hass):
         assert result["step_id"] == "zeroconf_confirm"
         assert result["description_placeholders"]["model"] == "HL-L2340DW"
         assert result["description_placeholders"]["serial_number"] == "0123456789"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_TYPE: "laser"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "HL-L2340DW 0123456789"
         assert result["data"][CONF_HOST] == "127.0.0.1"
         assert result["data"][CONF_TYPE] == "laser"

--- a/tests/components/brunt/test_config_flow.py
+++ b/tests/components/brunt/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "test-username"
     assert result2["data"] == CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
@@ -57,7 +57,7 @@ async def test_form_duplicate_login(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -80,17 +80,17 @@ async def test_form_error(hass, side_effect, error_message):
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": error_message}
 
 
 @pytest.mark.parametrize(
     "side_effect, result_type, password, step_id, reason",
     [
-        (None, data_entry_flow.RESULT_TYPE_ABORT, "test", None, "reauth_successful"),
+        (None, data_entry_flow.FlowResultType.ABORT, "test", None, "reauth_successful"),
         (
             Exception,
-            data_entry_flow.RESULT_TYPE_FORM,
+            data_entry_flow.FlowResultType.FORM,
             CONFIG[CONF_PASSWORD],
             "reauth_confirm",
             None,
@@ -115,7 +115,7 @@ async def test_reauth(hass, side_effect, result_type, password, step_id, reason)
         },
         data=None,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     with patch(
         "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_connection_error(
@@ -54,7 +54,7 @@ async def test_connection_error(
 
     assert result["errors"] == {"base": "cannot_connect"}
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_user_device_exists_abort(
@@ -75,7 +75,7 @@ async def test_user_device_exists_abort(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_full_user_flow_implementation(
@@ -94,7 +94,7 @@ async def test_full_user_flow_implementation(
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -114,7 +114,7 @@ async def test_full_user_flow_implementation(
     assert result["data"][CONF_PORT] == 80
     assert result["data"][CONF_DEVICE_IDENT] == "RVS21.831F/127"
     assert result["title"] == "RVS21.831F/127"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries(config_flow.DOMAIN)
     assert entries[0].unique_id == "RVS21.831F/127"
@@ -136,7 +136,7 @@ async def test_full_user_flow_implementation_without_auth(
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -153,7 +153,7 @@ async def test_full_user_flow_implementation_without_auth(
     assert result["data"][CONF_PORT] == 80
     assert result["data"][CONF_DEVICE_IDENT] == "RVS21.831F/127"
     assert result["title"] == "RVS21.831F/127"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries(config_flow.DOMAIN)
     assert entries[0].unique_id == "RVS21.831F/127"

--- a/tests/components/buienradar/test_config_flow.py
+++ b/tests/components/buienradar/test_config_flow.py
@@ -96,7 +96,7 @@ async def test_options_flow(hass):
     ), patch(
         "homeassistant.components.buienradar.async_unload_entry", return_value=True
     ):
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/cast/test_config_flow.py
+++ b/tests/components/cast/test_config_flow.py
@@ -24,10 +24,10 @@ async def test_creating_entry_sets_up_media_player(hass):
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 
@@ -190,7 +190,7 @@ async def test_option_flow(hass, parameter_data):
 
     # Test ignore_cec and uuid options are hidden if advanced options are disabled
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "basic_options"
     data_schema = result["data_schema"].schema
     assert set(data_schema) == {"known_hosts"}
@@ -201,7 +201,7 @@ async def test_option_flow(hass, parameter_data):
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context=context
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "basic_options"
     data_schema = result["data_schema"].schema
     for other_param in basic_parameters:
@@ -218,7 +218,7 @@ async def test_option_flow(hass, parameter_data):
         result["flow_id"],
         user_input=user_input_dict,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "advanced_options"
     for other_param in basic_parameters:
         if other_param == parameter:
@@ -243,7 +243,7 @@ async def test_option_flow(hass, parameter_data):
         result["flow_id"],
         user_input=user_input_dict,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] is None
     for other_param in advanced_parameters:
         if other_param == parameter:
@@ -257,7 +257,7 @@ async def test_option_flow(hass, parameter_data):
         result["flow_id"],
         user_input={"known_hosts": ""},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] is None
     expected_data = {**orig_data, "known_hosts": []}
     if parameter in advanced_parameters:

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_user(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -27,7 +27,7 @@ async def test_user(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_HOST: HOST, CONF_PORT: PORT}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
@@ -42,7 +42,7 @@ async def test_user_with_bad_cert(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -53,7 +53,7 @@ async def test_user_with_bad_cert(hass):
             result["flow_id"], user_input={CONF_HOST: HOST, CONF_PORT: PORT}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
@@ -78,7 +78,7 @@ async def test_import_host_only(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
@@ -100,7 +100,7 @@ async def test_import_host_and_port(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
@@ -122,7 +122,7 @@ async def test_import_non_default_port(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{HOST}:888"
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == 888
@@ -144,7 +144,7 @@ async def test_import_with_name(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
@@ -163,7 +163,7 @@ async def test_bad_import(hass):
             data={CONF_HOST: HOST},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "import_failed"
 
 
@@ -180,7 +180,7 @@ async def test_abort_if_already_setup(hass):
         context={"source": config_entries.SOURCE_IMPORT},
         data={CONF_HOST: HOST, CONF_PORT: PORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     result = await hass.config_entries.flow.async_init(
@@ -188,7 +188,7 @@ async def test_abort_if_already_setup(hass):
         context={"source": config_entries.SOURCE_USER},
         data={CONF_HOST: HOST, CONF_PORT: PORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -205,7 +205,7 @@ async def test_abort_on_socket_failed(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_HOST: HOST}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "resolve_failed"}
 
     with patch(
@@ -215,7 +215,7 @@ async def test_abort_on_socket_failed(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_HOST: HOST}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "connection_timeout"}
 
     with patch(
@@ -225,5 +225,5 @@ async def test_abort_on_socket_failed(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_HOST: HOST}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "connection_refused"}

--- a/tests/components/climacell/test_config_flow.py
+++ b/tests/components/climacell/test_config_flow.py
@@ -33,14 +33,14 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_TIMESTEP: 1}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_TIMESTEP] == 1
     assert entry.options[CONF_TIMESTEP] == 1

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -132,7 +132,7 @@ async def test_implementation(hass, flow_handler, current_request_with_host):
             TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == "http://example.com/auth"
 
     flow_finished.set_result(

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1075,7 +1075,7 @@ async def test_ignore_flow(hass, hass_ws_client):
         result = await hass.config_entries.flow.async_init(
             "test", context={"source": core_ce.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         await ws_client.send_json(
             {

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -183,7 +183,7 @@ async def test_no_user_input(crownstone_setup: MockFixture, hass: HomeAssistant)
         DOMAIN, context={"source": "user"}
     )
     # show the login form
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert crownstone_setup.call_count == 0
 
@@ -211,7 +211,7 @@ async def test_abort_if_configured(crownstone_setup: MockFixture, hass: HomeAssi
     result = await start_config_flow(hass, get_mocked_crownstone_cloud())
 
     # test if we abort if we try to configure the same entry
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert crownstone_setup.call_count == 0
 
@@ -228,7 +228,7 @@ async def test_authentication_errors(
 
     result = await start_config_flow(hass, cloud)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
     # side effect: auth error account not verified
@@ -238,7 +238,7 @@ async def test_authentication_errors(
 
     result = await start_config_flow(hass, cloud)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "account_not_verified"}
     assert crownstone_setup.call_count == 0
 
@@ -251,7 +251,7 @@ async def test_unknown_error(crownstone_setup: MockFixture, hass: HomeAssistant)
 
     result = await start_config_flow(hass, cloud)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "unknown_error"}
     assert crownstone_setup.call_count == 0
 
@@ -271,14 +271,14 @@ async def test_successful_login_no_usb(
 
     result = await start_config_flow(hass, get_mocked_crownstone_cloud())
     # should show usb form
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_config"
 
     # don't setup USB dongle, create entry
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_USB_PATH: DONT_USE_USB}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == entry_data_without_usb
     assert result["options"] == entry_options_without_usb
     assert crownstone_setup.call_count == 1
@@ -304,7 +304,7 @@ async def test_successful_login_with_usb(
         hass, get_mocked_crownstone_cloud(create_mocked_spheres(2))
     )
     # should show usb form
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_config"
     assert pyserial_comports_none_types.call_count == 1
 
@@ -324,7 +324,7 @@ async def test_successful_login_with_usb(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_USB_PATH: port_select}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_sphere_config"
     assert pyserial_comports_none_types.call_count == 2
     assert usb_path.call_count == 1
@@ -333,7 +333,7 @@ async def test_successful_login_with_usb(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_USB_SPHERE: "sphere_name_1"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == entry_data_with_usb
     assert result["options"] == entry_options_with_usb
     assert crownstone_setup.call_count == 1
@@ -356,7 +356,7 @@ async def test_successful_login_with_manual_usb_path(
         hass, get_mocked_crownstone_cloud(create_mocked_spheres(1))
     )
     # should show usb form
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_config"
     assert pyserial_comports.call_count == 1
 
@@ -365,7 +365,7 @@ async def test_successful_login_with_manual_usb_path(
         result["flow_id"], user_input={CONF_USB_PATH: MANUAL_PATH}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_manual_config"
     assert pyserial_comports.call_count == 2
 
@@ -377,7 +377,7 @@ async def test_successful_login_with_manual_usb_path(
 
     # since we only have 1 sphere here, test that it's automatically selected and
     # creating entry without asking for user input
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == entry_data_with_manual_usb
     assert result["options"] == entry_options_with_manual_usb
     assert crownstone_setup.call_count == 1
@@ -413,7 +413,7 @@ async def test_options_flow_setup_usb(
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     schema = result["data_schema"].schema
@@ -427,7 +427,7 @@ async def test_options_flow_setup_usb(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_USE_USB_OPTION: True}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_config"
     assert pyserial_comports.call_count == 1
 
@@ -447,7 +447,7 @@ async def test_options_flow_setup_usb(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_USB_PATH: port_select}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_sphere_config"
     assert pyserial_comports.call_count == 2
     assert usb_path.call_count == 1
@@ -456,7 +456,7 @@ async def test_options_flow_setup_usb(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_USB_SPHERE: "sphere_name_1"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == create_mocked_entry_options_conf(
         usb_path="/dev/serial/by-id/crownstone-usb", usb_sphere="sphere_id_1"
     )
@@ -490,7 +490,7 @@ async def test_options_flow_remove_usb(hass: HomeAssistant):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     schema = result["data_schema"].schema
@@ -507,7 +507,7 @@ async def test_options_flow_remove_usb(hass: HomeAssistant):
             CONF_USB_SPHERE_OPTION: "sphere_name_0",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == create_mocked_entry_options_conf(
         usb_path=None, usb_sphere=None
     )
@@ -543,13 +543,13 @@ async def test_options_flow_manual_usb_path(
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_USE_USB_OPTION: True}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_config"
     assert pyserial_comports.call_count == 1
 
@@ -558,7 +558,7 @@ async def test_options_flow_manual_usb_path(
         result["flow_id"], user_input={CONF_USB_PATH: MANUAL_PATH}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "usb_manual_config"
     assert pyserial_comports.call_count == 2
 
@@ -568,7 +568,7 @@ async def test_options_flow_manual_usb_path(
         result["flow_id"], user_input={CONF_USB_MANUAL_PATH: path}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == create_mocked_entry_options_conf(
         usb_path=path, usb_sphere="sphere_id_0"
     )
@@ -602,14 +602,14 @@ async def test_options_flow_change_usb_sphere(hass: HomeAssistant):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_USE_USB_OPTION: True, CONF_USB_SPHERE_OPTION: "sphere_name_2"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == create_mocked_entry_options_conf(
         usb_path="/dev/serial/by-id/crownstone-usb", usb_sphere="sphere_id_2"
     )

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -425,7 +425,7 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -433,7 +433,7 @@ async def test_options_flow(hass):
         user_input={CONF_SHOW_ALL_SOURCES: True, CONF_ZONE2: True, CONF_ZONE3: True},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         CONF_SHOW_ALL_SOURCES: True,
         CONF_ZONE2: True,

--- a/tests/components/dexcom/test_config_flow.py
+++ b/tests/components/dexcom/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -33,7 +33,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == CONFIG[CONF_USERNAME]
     assert result2["data"] == CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
@@ -54,7 +54,7 @@ async def test_form_account_error(hass):
             CONFIG,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -73,7 +73,7 @@ async def test_form_session_error(hass):
             CONFIG,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -92,7 +92,7 @@ async def test_form_unknown_error(hass):
             CONFIG,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -107,14 +107,14 @@ async def test_option_flow_default(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
         CONF_UNIT_OF_MEASUREMENT: MG_DL,
     }
@@ -131,14 +131,14 @@ async def test_option_flow(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_UNIT_OF_MEASUREMENT: MMOL_L},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_UNIT_OF_MEASUREMENT: MMOL_L,
     }

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -87,10 +87,10 @@ async def fixture(hass, hass_client_no_auth):
     result = await hass.config_entries.flow.async_init(
         "dialogflow", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     webhook_id = result["result"].data["webhook_id"]
 
     return await hass_client_no_auth(), webhook_id

--- a/tests/components/discord/test_config_flow.py
+++ b/tests/components/discord/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_flow_user(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=CONF_INPUT,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"] == CONF_DATA
 
@@ -45,7 +45,7 @@ async def test_flow_user_already_configured(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=CONF_INPUT,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -58,7 +58,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_USER},
             data=CONF_DATA,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -67,7 +67,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=CONF_INPUT,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"] == CONF_DATA
 
@@ -81,7 +81,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_USER},
             data=CONF_DATA,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -90,7 +90,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=CONF_INPUT,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"] == CONF_DATA
 
@@ -104,7 +104,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_USER},
             data=CONF_DATA,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "unknown"}
 
@@ -113,7 +113,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=CONF_INPUT,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"] == CONF_DATA
 
@@ -131,7 +131,7 @@ async def test_flow_reauth(hass: HomeAssistant) -> None:
         data=entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     new_conf = {CONF_API_TOKEN: "1234567890123"}
@@ -141,7 +141,7 @@ async def test_flow_reauth(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=new_conf,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -150,6 +150,6 @@ async def test_flow_reauth(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=new_conf,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert entry.data == CONF_DATA | new_conf

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -84,7 +84,7 @@ async def test_user_flow_undiscovered_manual(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -92,7 +92,7 @@ async def test_user_flow_undiscovered_manual(hass: HomeAssistant) -> None:
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -118,7 +118,7 @@ async def test_user_flow_discovered_manual(
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -126,7 +126,7 @@ async def test_user_flow_discovered_manual(
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -134,7 +134,7 @@ async def test_user_flow_discovered_manual(
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -158,7 +158,7 @@ async def test_user_flow_selected(hass: HomeAssistant, ssdp_scanner_mock: Mock) 
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -166,7 +166,7 @@ async def test_user_flow_selected(hass: HomeAssistant, ssdp_scanner_mock: Mock) 
         result["flow_id"], user_input={CONF_HOST: MOCK_DEVICE_NAME}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -188,7 +188,7 @@ async def test_user_flow_uncontactable(
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -196,7 +196,7 @@ async def test_user_flow_uncontactable(
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
     assert result["step_id"] == "manual"
 
@@ -221,7 +221,7 @@ async def test_user_flow_embedded_st(
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -229,7 +229,7 @@ async def test_user_flow_embedded_st(
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -251,7 +251,7 @@ async def test_user_flow_wrong_st(hass: HomeAssistant, domain_data_mock: Mock) -
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -259,7 +259,7 @@ async def test_user_flow_wrong_st(hass: HomeAssistant, domain_data_mock: Mock) -
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "not_dmr"}
     assert result["step_id"] == "manual"
 
@@ -271,7 +271,7 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -279,7 +279,7 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -302,7 +302,7 @@ async def test_ssdp_flow_unavailable(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpError
@@ -312,7 +312,7 @@ async def test_ssdp_flow_unavailable(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -342,7 +342,7 @@ async def test_ssdp_flow_existing(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == NEW_DEVICE_LOCATION
 
@@ -357,7 +357,7 @@ async def test_ssdp_flow_duplicate_location(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == MOCK_DEVICE_LOCATION
 
@@ -382,7 +382,7 @@ async def test_ssdp_flow_upnp_udn(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == NEW_DEVICE_LOCATION
 
@@ -398,7 +398,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
     # Service list does not contain services
@@ -410,7 +410,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
     # AVTransport service is missing
@@ -426,7 +426,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=discovery
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
 
@@ -448,7 +448,7 @@ async def test_ssdp_single_service(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
 
@@ -462,7 +462,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "alternative_integration"
 
     discovery = dataclasses.replace(MOCK_DISCOVERY)
@@ -475,7 +475,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "alternative_integration"
 
     for manufacturer, model in [
@@ -493,7 +493,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_SSDP},
             data=discovery,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "alternative_integration"
 
 
@@ -507,7 +507,7 @@ async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> No
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {}
 
@@ -526,7 +526,7 @@ async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> No
         context={"source": config_entries.SOURCE_UNIGNORE},
         data={"unique_id": MOCK_DEVICE_UDN},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -534,7 +534,7 @@ async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> No
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -559,7 +559,7 @@ async def test_unignore_flow_offline(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {}
 
@@ -572,7 +572,7 @@ async def test_unignore_flow_offline(
         context={"source": config_entries.SOURCE_UNIGNORE},
         data={"unique_id": MOCK_DEVICE_UDN},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "discovery_error"
 
 
@@ -583,7 +583,7 @@ async def test_options_flow(
     config_entry_mock.add_to_hass(hass)
     result = await hass.config_entries.options.async_init(config_entry_mock.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {}
 
@@ -597,7 +597,7 @@ async def test_options_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {"base": "invalid_url"}
 
@@ -612,7 +612,7 @@ async def test_options_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_LISTEN_PORT: 2222,
         CONF_CALLBACK_URL_OVERRIDE: "http://override/callback",

--- a/tests/components/dlna_dms/test_config_flow.py
+++ b/tests/components/dlna_dms/test_config_flow.py
@@ -86,7 +86,7 @@ async def test_user_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -95,7 +95,7 @@ async def test_user_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -119,7 +119,7 @@ async def test_user_flow_no_devices(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
 
 
@@ -130,7 +130,7 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -138,7 +138,7 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -161,7 +161,7 @@ async def test_ssdp_flow_unavailable(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     upnp_factory_mock.async_create_device.side_effect = UpnpError
@@ -171,7 +171,7 @@ async def test_ssdp_flow_unavailable(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -201,7 +201,7 @@ async def test_ssdp_flow_existing(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == NEW_DEVICE_LOCATION
 
@@ -216,7 +216,7 @@ async def test_ssdp_flow_duplicate_location(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == MOCK_DEVICE_LOCATION
 
@@ -230,7 +230,7 @@ async def test_ssdp_flow_bad_data(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "bad_ssdp"
 
     # Missing USN
@@ -240,7 +240,7 @@ async def test_ssdp_flow_bad_data(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "bad_ssdp"
 
 
@@ -280,7 +280,7 @@ async def test_duplicate_name(
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -288,7 +288,7 @@ async def test_duplicate_name(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: new_device_location,
@@ -318,7 +318,7 @@ async def test_ssdp_flow_upnp_udn(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == NEW_DEVICE_LOCATION
 
@@ -334,7 +334,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dms"
 
     # Service list does not contain services
@@ -346,7 +346,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dms"
 
     # ContentDirectory service is missing
@@ -362,7 +362,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=discovery
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dms"
 
 
@@ -384,5 +384,5 @@ async def test_ssdp_single_service(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_dms"

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_user_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     doorbirdapi = _get_mock_doorbirdapi_return_values(
@@ -188,7 +188,7 @@ async def test_form_zeroconf_correct_oui(hass):
             ),
         )
         await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -251,7 +251,7 @@ async def test_form_zeroconf_correct_oui_wrong_device(hass, doorbell_state_side_
             ),
         )
         await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_doorbird_device"
 
 
@@ -271,7 +271,7 @@ async def test_form_user_cannot_connect(hass):
             VALID_CONFIG,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -312,12 +312,12 @@ async def test_options_flow(hass):
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_EVENTS: "eventa,   eventc,    eventq"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_EVENTS: ["eventa", "eventc", "eventq"]}

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -562,7 +562,7 @@ async def test_options_flow(hass):
     with patch(
         "homeassistant.components.dsmr.async_setup_entry", return_value=True
     ), patch("homeassistant.components.dsmr.async_unload_entry", return_value=True):
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/dunehd/test_config_flow.py
+++ b/tests/components/dunehd/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_create_entry(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG_HOSTNAME
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "dunehd-host"
         assert result["data"] == {CONF_HOST: "dunehd-host"}
 
@@ -90,6 +90,6 @@ async def test_create_entry_with_ipv6_address(hass):
             data={CONF_HOST: "2001:db8::1428:57ab"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "2001:db8::1428:57ab"
         assert result["data"] == {CONF_HOST: "2001:db8::1428:57ab"}

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_abort_if_already_setup(hass):
 
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -36,7 +36,7 @@ async def test_user_step_without_user_input(hass):
     flow.hass.data[DATA_ECOBEE_CONFIG] = {}
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -53,7 +53,7 @@ async def test_pin_request_succeeds(hass):
 
         result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert result["description_placeholders"] == {"pin": "test-pin"}
 
@@ -70,7 +70,7 @@ async def test_pin_request_fails(hass):
 
         result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "pin_request_failed"
 
@@ -92,7 +92,7 @@ async def test_token_request_succeeds(hass):
 
         result = await flow.async_step_authorize(user_input={})
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == DOMAIN
         assert result["data"] == {
             CONF_API_KEY: "test-api-key",
@@ -116,7 +116,7 @@ async def test_token_request_fails(hass):
 
         result = await flow.async_step_authorize(user_input={})
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert result["errors"]["base"] == "token_request_failed"
         assert result["description_placeholders"] == {"pin": "test-pin"}
@@ -131,7 +131,7 @@ async def test_import_flow_triggered_but_no_ecobee_conf(hass):
 
     result = await flow.async_step_import(import_data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -155,7 +155,7 @@ async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_valid_t
 
         result = await flow.async_step_import(import_data=None)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == DOMAIN
         assert result["data"] == {
             CONF_API_KEY: "test-api-key",

--- a/tests/components/elmax/test_config_flow.py
+++ b/tests/components/elmax/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -60,7 +60,7 @@ async def test_standard_setup(hass):
             },
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_one_config_allowed(hass):
@@ -94,7 +94,7 @@ async def test_one_config_allowed(hass):
             CONF_ELMAX_PANEL_PIN: MOCK_PANEL_PIN,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -115,7 +115,7 @@ async def test_invalid_credentials(hass):
             },
         )
         assert login_result["step_id"] == "user"
-        assert login_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert login_result["type"] == data_entry_flow.FlowResultType.FORM
         assert login_result["errors"] == {"base": "invalid_auth"}
 
 
@@ -136,7 +136,7 @@ async def test_connection_error(hass):
             },
         )
         assert login_result["step_id"] == "user"
-        assert login_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert login_result["type"] == data_entry_flow.FlowResultType.FORM
         assert login_result["errors"] == {"base": "network_error"}
 
 
@@ -164,7 +164,7 @@ async def test_unhandled_error(hass):
             },
         )
         assert result["step_id"] == "panels"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "unknown"}
 
 
@@ -193,7 +193,7 @@ async def test_invalid_pin(hass):
             },
         )
         assert result["step_id"] == "panels"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_pin"}
 
 
@@ -215,7 +215,7 @@ async def test_no_online_panel(hass):
             },
         )
         assert login_result["step_id"] == "user"
-        assert login_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert login_result["type"] == data_entry_flow.FlowResultType.FORM
         assert login_result["errors"] == {"base": "no_panel_online"}
 
 
@@ -231,7 +231,7 @@ async def test_show_reauth(hass):
             CONF_ELMAX_PASSWORD: MOCK_PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
 
@@ -272,7 +272,7 @@ async def test_reauth_flow(hass):
                 CONF_ELMAX_PASSWORD: MOCK_PASSWORD,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         await hass.async_block_till_done()
         assert result["reason"] == "reauth_successful"
 
@@ -316,7 +316,7 @@ async def test_reauth_panel_disappeared(hass):
             },
         )
         assert result["step_id"] == "reauth_confirm"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "reauth_panel_disappeared"}
 
 
@@ -358,7 +358,7 @@ async def test_reauth_invalid_pin(hass):
             },
         )
         assert result["step_id"] == "reauth_confirm"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_pin"}
 
 
@@ -400,5 +400,5 @@ async def test_reauth_bad_login(hass):
             },
         )
         assert result["step_id"] == "reauth_confirm"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_auth"}

--- a/tests/components/enocean/test_config_flow.py
+++ b/tests/components/enocean/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_user_flow_cannot_create_multiple_instances(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -37,7 +37,7 @@ async def test_user_flow_with_detected_dongle(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "detect"
     devices = result["data_schema"].schema.get("device").container
     assert FAKE_DONGLE_PATH in devices
@@ -51,7 +51,7 @@ async def test_user_flow_with_no_detected_dongle(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "manual"
 
 
@@ -64,7 +64,7 @@ async def test_detection_flow_with_valid_path(hass):
             DOMAIN, context={"source": "detect"}, data={CONF_DEVICE: USER_PROVIDED_PATH}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_DEVICE] == USER_PROVIDED_PATH
 
 
@@ -82,7 +82,7 @@ async def test_detection_flow_with_custom_path(hass):
             data={CONF_DEVICE: USER_PROVIDED_PATH},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "manual"
 
 
@@ -100,7 +100,7 @@ async def test_detection_flow_with_invalid_path(hass):
             data={CONF_DEVICE: USER_PROVIDED_PATH},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "detect"
     assert CONF_DEVICE in result["errors"]
 
@@ -114,7 +114,7 @@ async def test_manual_flow_with_valid_path(hass):
             DOMAIN, context={"source": "manual"}, data={CONF_DEVICE: USER_PROVIDED_PATH}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_DEVICE] == USER_PROVIDED_PATH
 
 
@@ -130,7 +130,7 @@ async def test_manual_flow_with_invalid_path(hass):
             DOMAIN, context={"source": "manual"}, data={CONF_DEVICE: USER_PROVIDED_PATH}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "manual"
     assert CONF_DEVICE in result["errors"]
 
@@ -146,7 +146,7 @@ async def test_import_flow_with_valid_path(hass):
             data=DATA_TO_IMPORT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_DEVICE] == DATA_TO_IMPORT[CONF_DEVICE]
 
 
@@ -164,5 +164,5 @@ async def test_import_flow_with_invalid_path(hass):
             data=DATA_TO_IMPORT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "invalid_dongle_path"

--- a/tests/components/environment_canada/test_config_flow.py
+++ b/tests/components/environment_canada/test_config_flow.py
@@ -64,7 +64,7 @@ async def test_create_entry(hass):
             flow["flow_id"], FAKE_CONFIG
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == FAKE_CONFIG
         assert result["title"] == FAKE_TITLE
 
@@ -89,7 +89,7 @@ async def test_create_same_entry_twice(hass):
             flow["flow_id"], FAKE_CONFIG
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -135,6 +135,6 @@ async def test_lat_lon_not_specified(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=fake_config
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == FAKE_CONFIG
         assert result["title"] == FAKE_TITLE

--- a/tests/components/faa_delays/test_config_flow.py
+++ b/tests/components/faa_delays/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_duplicate_error(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=conf
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 

--- a/tests/components/fireservicerota/test_config_flow.py
+++ b/tests/components/fireservicerota/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -55,7 +55,7 @@ async def test_abort_if_already_setup(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_CONF
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -91,7 +91,7 @@ async def test_step_user(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == MOCK_CONF[CONF_USERNAME]
         assert result["data"] == {
             "auth_implementation": "fireservicerota",
@@ -131,7 +131,7 @@ async def test_reauth(hass):
         )
 
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "homeassistant.components.fireservicerota.config_flow.FireServiceRota"
@@ -147,5 +147,5 @@ async def test_reauth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Flick Electric: test-username"
     assert result2["data"] == CONF
     assert len(mock_setup_entry.mock_calls) == 1
@@ -65,7 +65,7 @@ async def test_form_duplicate_login(hass):
     ):
         result = await _flow_submit(hass)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -77,7 +77,7 @@ async def test_form_invalid_auth(hass):
     ):
         result = await _flow_submit(hass)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
 
@@ -89,7 +89,7 @@ async def test_form_cannot_connect(hass):
     ):
         result = await _flow_submit(hass)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -101,5 +101,5 @@ async def test_form_generic_exception(hass):
     ):
         result = await _flow_submit(hass)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}

--- a/tests/components/flipr/test_config_flow.py
+++ b/tests/components/flipr/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
 
@@ -67,7 +67,7 @@ async def test_nominal_case(hass, mock_setup):
 
     assert len(mock_flipr_client.mock_calls) == 1
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "flipid"
     assert result["data"] == {
         CONF_EMAIL: "dummylogin",
@@ -91,7 +91,7 @@ async def test_multiple_flip_id(hass, mock_setup):
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "flipr_id"
 
         result = await hass.config_entries.flow.async_configure(
@@ -101,7 +101,7 @@ async def test_multiple_flip_id(hass, mock_setup):
 
     assert len(mock_flipr_client.mock_calls) == 1
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "FLIP2"
     assert result["data"] == {
         CONF_EMAIL: "dummylogin",

--- a/tests/components/flunearyou/test_config_flow.py
+++ b/tests/components/flunearyou/test_config_flow.py
@@ -14,7 +14,7 @@ async def test_duplicate_error(hass, config, config_entry, setup_flunearyou):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -35,7 +35,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -44,7 +44,7 @@ async def test_step_user(hass, config, setup_flunearyou):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "51.528308, -0.3817765"
     assert result["data"] == {
         CONF_LATITUDE: 51.528308,

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -58,7 +58,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -78,7 +78,7 @@ async def test_config_flow(hass, config_entry):
             DOMAIN, context={"source": SOURCE_USER}, data=config_data
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "My Music on myhost"
         assert result["data"][CONF_HOST] == config_data[CONF_HOST]
         assert result["data"][CONF_PORT] == config_data[CONF_PORT]
@@ -91,7 +91,7 @@ async def test_config_flow(hass, config_entry):
             data=config_entry.data,
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_zeroconf_updates_title(hass, config_entry):
@@ -112,7 +112,7 @@ async def test_zeroconf_updates_title(hass, config_entry):
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert config_entry.title == "zeroconf_test"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
@@ -128,7 +128,7 @@ async def test_config_flow_no_websocket(hass, config_entry):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=config_entry.data
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_config_flow_zeroconf_invalid(hass):
@@ -146,7 +146,7 @@ async def test_config_flow_zeroconf_invalid(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )  # doesn't create the entry, tries to show form but gets abort
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
     # test with forked-daapd version < 27
     discovery_info = zeroconf.ZeroconfServiceInfo(
@@ -161,7 +161,7 @@ async def test_config_flow_zeroconf_invalid(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )  # doesn't create the entry, tries to show form but gets abort
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
     # test with verbose mtd-version from Firefly
     discovery_info = zeroconf.ZeroconfServiceInfo(
@@ -176,7 +176,7 @@ async def test_config_flow_zeroconf_invalid(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )  # doesn't create the entry, tries to show form but gets abort
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
     # test with svn mtd-version from Firefly
     discovery_info = zeroconf.ZeroconfServiceInfo(
@@ -191,7 +191,7 @@ async def test_config_flow_zeroconf_invalid(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )  # doesn't create the entry, tries to show form but gets abort
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
 
 
@@ -213,7 +213,7 @@ async def test_config_flow_zeroconf_valid(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_options_flow(hass, config_entry):
@@ -229,7 +229,7 @@ async def test_options_flow(hass, config_entry):
         await hass.async_block_till_done()
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
@@ -240,4 +240,4 @@ async def test_options_flow(hass, config_entry):
                 CONF_MAX_PLAYLISTS: 8,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -80,7 +80,7 @@ async def test_user_valid(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -98,7 +98,7 @@ async def test_user_valid(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == CAMERA_NAME
         assert result["data"] == VALID_CONFIG
 
@@ -111,7 +111,7 @@ async def test_user_invalid_auth(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -129,7 +129,7 @@ async def test_user_invalid_auth(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_auth"}
 
 
@@ -139,7 +139,7 @@ async def test_user_cannot_connect(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -157,7 +157,7 @@ async def test_user_cannot_connect(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -167,7 +167,7 @@ async def test_user_invalid_response(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -187,7 +187,7 @@ async def test_user_invalid_response(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_response"}
 
 
@@ -203,7 +203,7 @@ async def test_user_already_configured(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -218,7 +218,7 @@ async def test_user_already_configured(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -228,7 +228,7 @@ async def test_user_unknown_exception(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -243,5 +243,5 @@ async def test_user_unknown_exception(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "unknown"}

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_user(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # test with all provided
@@ -53,7 +53,7 @@ async def test_user(hass: HomeAssistant):
         context={"source": SOURCE_USER},
         data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
 
@@ -64,7 +64,7 @@ async def test_import(hass: HomeAssistant):
         context={"source": SOURCE_IMPORT},
         data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
 
@@ -75,7 +75,7 @@ async def test_zeroconf(hass: HomeAssistant):
         context={"source": SOURCE_ZEROCONF},
         data=MOCK_ZEROCONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
 
@@ -94,7 +94,7 @@ async def test_link(hass: HomeAssistant, router: Mock):
         )
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["result"].unique_id == MOCK_HOST
         assert result["title"] == MOCK_HOST
         assert result["data"][CONF_HOST] == MOCK_HOST
@@ -118,7 +118,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
         context={"source": SOURCE_IMPORT},
         data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     # Should fail, same MOCK_HOST (flow)
@@ -127,7 +127,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
         context={"source": SOURCE_USER},
         data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -144,7 +144,7 @@ async def test_on_link_failed(hass: HomeAssistant):
         side_effect=AuthorizationError(),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "register_failed"}
 
     with patch(
@@ -152,7 +152,7 @@ async def test_on_link_failed(hass: HomeAssistant):
         side_effect=HttpRequestError(),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -160,5 +160,5 @@ async def test_on_link_failed(hass: HomeAssistant):
         side_effect=InvalidTokenError(),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "unknown"}

--- a/tests/components/freedompro/test_config_flow.py
+++ b/tests/components/freedompro/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -77,6 +77,6 @@ async def test_create_entry(hass):
             data=VALID_CONFIG,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "Freedompro"
         assert result["data"][CONF_API_KEY] == "ksdjfgslkjdfksjdfksjgfksjd"

--- a/tests/components/gdacs/test_config_flow.py
+++ b/tests/components/gdacs/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_duplicate_error(hass, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=conf
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -38,7 +38,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -55,7 +55,7 @@ async def test_step_import(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=conf
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
         CONF_LATITUDE: -41.2,
@@ -75,7 +75,7 @@ async def test_step_user(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=conf
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
         CONF_LATITUDE: -41.2,

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -68,7 +68,7 @@ async def test_form(hass, fakeimg_png, user_flow, mock_create_stream):
             user_flow["flow_id"],
             TESTDATA,
         )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -104,7 +104,7 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
             data,
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -131,7 +131,7 @@ async def test_form_only_stillimage_gif(hass, fakeimg_gif, user_flow):
             data,
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["options"][CONF_CONTENT_TYPE] == "image/gif"
 
 
@@ -148,7 +148,7 @@ async def test_form_only_svg_whitespace(hass, fakeimgbytes_svg, user_flow):
             data,
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @respx.mock
@@ -175,7 +175,7 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
             data,
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @respx.mock
@@ -186,31 +186,31 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
         (
             "http://localhost:812{{3}}/static/icons/favicon-apple-180x180.png",
             "http://localhost:8123/static/icons/favicon-apple-180x180.png",
-            data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
             None,
         ),
         (
             "{% if 1 %}https://bla{% else %}https://yo{% endif %}",
             "https://bla/",
-            data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
             None,
         ),
         (
             "http://{{example.org",
             "http://example.org",
-            data_entry_flow.RESULT_TYPE_FORM,
+            data_entry_flow.FlowResultType.FORM,
             {"still_image_url": "template_error"},
         ),
         (
             "invalid1://invalid:4\\1",
             "invalid1://invalid:4%5c1",
-            data_entry_flow.RESULT_TYPE_FORM,
+            data_entry_flow.FlowResultType.FORM,
             {"still_image_url": "malformed_url"},
         ),
         (
             "relative/urls/are/not/allowed.jpg",
             "relative/urls/are/not/allowed.jpg",
-            data_entry_flow.RESULT_TYPE_FORM,
+            data_entry_flow.FlowResultType.FORM,
             {"still_image_url": "relative_url"},
         ),
     ],
@@ -246,7 +246,7 @@ async def test_form_rtsp_mode(hass, fakeimg_png, user_flow, mock_create_stream):
             user_flow["flow_id"], data
         )
     assert "errors" not in result2, f"errors={result2['errors']}"
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -280,7 +280,7 @@ async def test_form_only_stream(hass, fakeimgbytes_jpg, mock_create_stream):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "127_0_0_1"
     assert result3["options"] == {
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
@@ -314,7 +314,7 @@ async def test_form_still_and_stream_not_provided(hass, user_flow):
             CONF_VERIFY_SSL: False,
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "no_still_image_or_stream_url"}
 
 
@@ -492,7 +492,7 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # try updating the still image url
@@ -503,10 +503,10 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
             result["flow_id"],
             user_input=data,
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         result3 = await hass.config_entries.options.async_init(mock_entry.entry_id)
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result3["type"] == data_entry_flow.FlowResultType.FORM
         assert result3["step_id"] == "init"
 
         # verify that an invalid template reports the correct UI error.
@@ -515,7 +515,7 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
             result3["flow_id"],
             user_input=data,
         )
-        assert result4.get("type") == data_entry_flow.RESULT_TYPE_FORM
+        assert result4.get("type") == data_entry_flow.FlowResultType.FORM
         assert result4["errors"] == {"still_image_url": "template_error"}
 
         # verify that an invalid template reports the correct UI error.
@@ -526,7 +526,7 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
             user_input=data,
         )
 
-        assert result5.get("type") == data_entry_flow.RESULT_TYPE_FORM
+        assert result5.get("type") == data_entry_flow.FlowResultType.FORM
         assert result5["errors"] == {"stream_source": "template_error"}
 
         # verify that an relative stream url is rejected.
@@ -536,7 +536,7 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
             result5["flow_id"],
             user_input=data,
         )
-        assert result6.get("type") == data_entry_flow.RESULT_TYPE_FORM
+        assert result6.get("type") == data_entry_flow.FlowResultType.FORM
         assert result6["errors"] == {"stream_source": "relative_url"}
 
         # verify that an malformed stream url is rejected.
@@ -546,7 +546,7 @@ async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream
             result6["flow_id"],
             user_input=data,
         )
-    assert result7.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result7.get("type") == data_entry_flow.FlowResultType.FORM
     assert result7["errors"] == {"stream_source": "malformed_url"}
 
 
@@ -583,7 +583,7 @@ async def test_options_only_stream(hass, fakeimgbytes_png, mock_create_stream):
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # try updating the config options
@@ -592,7 +592,7 @@ async def test_options_only_stream(hass, fakeimgbytes_png, mock_create_stream):
             result["flow_id"],
             user_input=data,
         )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["data"][CONF_CONTENT_TYPE] == "image/jpeg"
 
 
@@ -607,12 +607,12 @@ async def test_import(hass, fakeimg_png):
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TESTDATA_YAML
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Yaml Defined Name"
     await hass.async_block_till_done()
     # Any name defined in yaml should end up as the entity id.
     assert hass.states.get("camera.yaml_defined_name")
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 # These above can be deleted after deprecation period is finished.
@@ -707,7 +707,7 @@ async def test_use_wallclock_as_timestamps_option(
     result = await hass.config_entries.options.async_init(
         mock_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     with patch(
         "homeassistant.components.generic.async_setup_entry", return_value=True
@@ -716,4 +716,4 @@ async def test_use_wallclock_as_timestamps_option(
             result["flow_id"],
             user_input={CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True, **TESTDATA},
         )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -157,10 +157,10 @@ async def webhook_id(hass, geofency_client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     return result["result"].data["webhook_id"]

--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_duplicate_error(hass, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=conf
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -34,7 +34,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -56,7 +56,7 @@ async def test_step_import(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=conf
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
         CONF_LATITUDE: -41.2,
@@ -81,7 +81,7 @@ async def test_step_user(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=conf
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
         CONF_LATITUDE: -41.2,

--- a/tests/components/geonetnz_volcano/test_config_flow.py
+++ b/tests/components/geonetnz_volcano/test_config_flow.py
@@ -32,7 +32,7 @@ async def test_show_form(hass):
 
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -55,7 +55,7 @@ async def test_step_import(hass):
         "homeassistant.components.geonetnz_volcano.async_setup", return_value=True
     ):
         result = await flow.async_step_import(import_config=conf)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
         CONF_LATITUDE: -41.2,
@@ -81,7 +81,7 @@ async def test_step_user(hass):
         "homeassistant.components.geonetnz_volcano.async_setup", return_value=True
     ):
         result = await flow.async_step_user(user_input=conf)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
         CONF_LATITUDE: -41.2,

--- a/tests/components/gios/test_config_flow.py
+++ b/tests/components/gios/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_show_form(hass):
 
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -98,7 +98,7 @@ async def test_create_entry(hass):
 
         result = await flow.async_step_user(user_input=CONFIG)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "Test Name 1"
         assert result["data"][CONF_STATION_ID] == CONFIG[CONF_STATION_ID]
 

--- a/tests/components/glances/test_config_flow.py
+++ b/tests/components/glances/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         glances.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("homeassistant.components.glances.Glances.get_data", autospec=True):
@@ -109,14 +109,14 @@ async def test_options(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={glances.CONF_SCAN_INTERVAL: 10}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         glances.CONF_SCAN_INTERVAL: 10,
     }

--- a/tests/components/goalzero/test_config_flow.py
+++ b/tests/components/goalzero/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_flow_user(hass: HomeAssistant):
             result["flow_id"],
             user_input=CONF_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == DEFAULT_NAME
         assert result["data"] == CONF_DATA
         assert result["result"].unique_id == MAC
@@ -47,7 +47,7 @@ async def test_flow_user_already_configured(hass: HomeAssistant):
         DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -58,7 +58,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "cannot_connect"
 
@@ -70,7 +70,7 @@ async def test_flow_user_invalid_host(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "invalid_host"
 
@@ -82,7 +82,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "unknown"
 
@@ -97,14 +97,14 @@ async def test_dhcp_discovery(hass: HomeAssistant):
             context={"source": SOURCE_DHCP},
             data=CONF_DHCP_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == MANUFACTURER
         assert result["data"] == CONF_DATA
         assert result["result"].unique_id == MAC
@@ -114,7 +114,7 @@ async def test_dhcp_discovery(hass: HomeAssistant):
             context={"source": SOURCE_DHCP},
             data=CONF_DHCP_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -128,7 +128,7 @@ async def test_dhcp_discovery_failed(hass: HomeAssistant):
             context={"source": SOURCE_DHCP},
             data=CONF_DHCP_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
     with patch_config_flow_yeti(mocked_yeti) as yetimock:
@@ -138,7 +138,7 @@ async def test_dhcp_discovery_failed(hass: HomeAssistant):
             context={"source": SOURCE_DHCP},
             data=CONF_DHCP_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "invalid_host"
 
     with patch_config_flow_yeti(mocked_yeti) as yetimock:
@@ -148,5 +148,5 @@ async def test_dhcp_discovery_failed(hass: HomeAssistant):
             context={"source": SOURCE_DHCP},
             data=CONF_DHCP_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unknown"

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_minimum_fields(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -44,7 +44,7 @@ async def test_minimum_fields(hass):
         MOCK_CONFIG,
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == DEFAULT_NAME
     assert result2["data"] == {
         CONF_NAME: DEFAULT_NAME,
@@ -60,14 +60,14 @@ async def test_invalid_config_entry(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         MOCK_CONFIG,
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -91,7 +91,7 @@ async def test_options_flow(hass, mock_config):
         mock_config.entry_id, data=None
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -108,7 +108,7 @@ async def test_options_flow(hass, mock_config):
             CONF_TRANSIT_ROUTING_PREFERENCE: "less_walking",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"] == {
         CONF_MODE: "driving",
@@ -144,7 +144,7 @@ async def test_options_flow_departure_time(hass, mock_config):
         mock_config.entry_id, data=None
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -161,7 +161,7 @@ async def test_options_flow_departure_time(hass, mock_config):
             CONF_TRANSIT_ROUTING_PREFERENCE: "less_walking",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"] == {
         CONF_MODE: "driving",
@@ -192,7 +192,7 @@ async def test_dupe(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -204,13 +204,13 @@ async def test_dupe(hass):
         },
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -223,4 +223,4 @@ async def test_dupe(hass):
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -65,10 +65,10 @@ async def webhook_id(hass, gpslogger_client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     return result["result"].data["webhook_id"]

--- a/tests/components/gree/test_config_flow.py
+++ b/tests/components/gree/test_config_flow.py
@@ -23,10 +23,10 @@ async def test_creating_entry_sets_up_climate(hass):
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 
@@ -52,10 +52,10 @@ async def test_creating_entry_has_no_devices(hass):
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
         await hass.async_block_till_done()
 

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -50,7 +50,7 @@ async def test_show_authenticate_form(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -68,7 +68,7 @@ async def test_incorrect_login(hass):
             result["flow_id"], FIXTURE_USER_INPUT
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -110,7 +110,7 @@ async def test_multiple_plant_ids(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "plant"
 
         user_input = {CONF_PLANT_ID: "123456"}
@@ -119,7 +119,7 @@ async def test_multiple_plant_ids(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
     assert result["data"][CONF_PLANT_ID] == "123456"
@@ -144,7 +144,7 @@ async def test_one_plant_on_account(hass):
             result["flow_id"], user_input
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
     assert result["data"][CONF_PLANT_ID] == "123456"

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -21,7 +21,7 @@ async def test_duplicate_error(hass, config, config_entry, setup_guardian):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -34,7 +34,7 @@ async def test_connect_error(hass, config):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {CONF_IP_ADDRESS: "cannot_connect"}
 
 
@@ -55,13 +55,13 @@ async def test_step_user(hass, config, setup_guardian):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "ABCDEF123456"
     assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
@@ -85,13 +85,13 @@ async def test_step_zeroconf(hass, setup_guardian):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=zeroconf_data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "ABCDEF123456"
     assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
@@ -115,7 +115,7 @@ async def test_step_zeroconf_already_in_progress(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=zeroconf_data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_init(
@@ -136,13 +136,13 @@ async def test_step_dhcp(hass, setup_guardian):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_DHCP}, data=dhcp_data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "ABCDEF123456"
     assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
@@ -162,7 +162,7 @@ async def test_step_dhcp_already_in_progress(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_DHCP}, data=dhcp_data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_init(
@@ -188,7 +188,7 @@ async def test_step_dhcp_already_setup_match_mac(hass):
             macaddress="aa:bb:cc:dd:ab:cd",
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -210,5 +210,5 @@ async def test_step_dhcp_already_setup_match_ip(hass):
             macaddress="aa:bb:cc:dd:ab:cd",
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/hangouts/test_config_flow.py
+++ b/tests/components/hangouts/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_flow_works(hass, aioclient_mock):
         result = await flow.async_step_user(
             {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == EMAIL
 
 
@@ -38,7 +38,7 @@ async def test_flow_works_with_authcode(hass, aioclient_mock):
                 "authorization_code": "c29tZXJhbmRvbXN0cmluZw==",
             }
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == EMAIL
 
 
@@ -57,12 +57,12 @@ async def test_flow_works_with_2fa(hass, aioclient_mock):
         result = await flow.async_step_user(
             {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "2fa"
 
     with patch("homeassistant.components.hangouts.config_flow.get_auth"):
         result = await flow.async_step_2fa({"2fa": 123456})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == EMAIL
 
 
@@ -81,7 +81,7 @@ async def test_flow_with_unknown_2fa(hass, aioclient_mock):
         result = await flow.async_step_user(
             {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"]["base"] == "invalid_2fa_method"
 
 
@@ -100,7 +100,7 @@ async def test_flow_invalid_login(hass, aioclient_mock):
         result = await flow.async_step_user(
             {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"]["base"] == "invalid_login"
 
 
@@ -119,7 +119,7 @@ async def test_flow_invalid_2fa(hass, aioclient_mock):
         result = await flow.async_step_user(
             {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "2fa"
 
     with patch(
@@ -128,5 +128,5 @@ async def test_flow_invalid_2fa(hass, aioclient_mock):
     ):
         result = await flow.async_step_2fa({"2fa": 123456})
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"]["base"] == "invalid_2fa"

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -201,7 +201,7 @@ async def test_options_flow(hass, mock_hc, mock_write_config):
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -209,7 +209,7 @@ async def test_options_flow(hass, mock_hc, mock_write_config):
         user_input={"activity": PREVIOUS_ACTIVE_ACTIVITY, "delay_secs": 0.4},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "activity": PREVIOUS_ACTIVE_ACTIVITY,
         "delay_secs": 0.4,

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_flow_aborts_already_setup(hass, config_entry):
     flow = HeosFlowHandler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -27,7 +27,7 @@ async def test_no_host_shows_form(hass):
     flow = HeosFlowHandler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -38,7 +38,7 @@ async def test_cannot_connect_shows_error_form(hass, controller):
     result = await hass.config_entries.flow.async_init(
         heos.DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "127.0.0.1"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"][CONF_HOST] == "cannot_connect"
     assert controller.connect.call_count == 1
@@ -54,7 +54,7 @@ async def test_create_entry_when_host_valid(hass, controller):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": SOURCE_USER}, data=data
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["result"].unique_id == DOMAIN
         assert result["title"] == "Controller (127.0.0.1)"
         assert result["data"] == data
@@ -70,7 +70,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": SOURCE_USER}, data=data
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["result"].unique_id == DOMAIN
         assert result["title"] == "Controller (127.0.0.1)"
         assert result["data"] == {CONF_HOST: "127.0.0.1"}
@@ -118,7 +118,7 @@ async def test_discovery_flow_aborts_already_setup(
     flow = HeosFlowHandler()
     flow.hass = hass
     result = await flow.async_step_ssdp(discovery_data)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -151,5 +151,5 @@ async def test_import_sets_the_unique_id(hass, controller):
             data={CONF_HOST: "127.0.0.2"},
         )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == DOMAIN

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -141,7 +141,7 @@ async def test_step_user(hass: HomeAssistant, menu_options) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -166,7 +166,7 @@ async def test_step_origin_coordinates(
     menu_result = await hass.config_entries.flow.async_configure(
         user_step_result["flow_id"], {"next_step_id": "origin_coordinates"}
     )
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert menu_result["type"] == data_entry_flow.FlowResultType.FORM
 
     location_selector_result = await hass.config_entries.flow.async_configure(
         menu_result["flow_id"],
@@ -189,7 +189,7 @@ async def test_step_origin_entity(
     menu_result = await hass.config_entries.flow.async_configure(
         user_step_result["flow_id"], {"next_step_id": "origin_entity"}
     )
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert menu_result["type"] == data_entry_flow.FlowResultType.FORM
 
     entity_selector_result = await hass.config_entries.flow.async_configure(
         menu_result["flow_id"],
@@ -206,7 +206,7 @@ async def test_step_destination_coordinates(
     menu_result = await hass.config_entries.flow.async_configure(
         origin_step_result["flow_id"], {"next_step_id": "destination_coordinates"}
     )
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert menu_result["type"] == data_entry_flow.FlowResultType.FORM
 
     location_selector_result = await hass.config_entries.flow.async_configure(
         menu_result["flow_id"],
@@ -218,7 +218,9 @@ async def test_step_destination_coordinates(
             }
         },
     )
-    assert location_selector_result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert (
+        location_selector_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    )
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.data == {
         CONF_NAME: "test",
@@ -239,13 +241,13 @@ async def test_step_destination_entity(
     menu_result = await hass.config_entries.flow.async_configure(
         origin_step_result["flow_id"], {"next_step_id": "destination_entity"}
     )
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert menu_result["type"] == data_entry_flow.FlowResultType.FORM
 
     entity_selector_result = await hass.config_entries.flow.async_configure(
         menu_result["flow_id"],
         {"destination_entity_id": "zone.home"},
     )
-    assert entity_selector_result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert entity_selector_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.data == {
         CONF_NAME: "test",
@@ -327,7 +329,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -350,7 +352,7 @@ async def test_options_flow_arrival_time_step(
     menu_result = await hass.config_entries.options.async_configure(
         option_init_result["flow_id"], {"next_step_id": "arrival_time"}
     )
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert menu_result["type"] == data_entry_flow.FlowResultType.FORM
     time_selector_result = await hass.config_entries.options.async_configure(
         option_init_result["flow_id"],
         user_input={
@@ -358,7 +360,7 @@ async def test_options_flow_arrival_time_step(
         },
     )
 
-    assert time_selector_result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert time_selector_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
         CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
@@ -376,7 +378,7 @@ async def test_options_flow_departure_time_step(
     menu_result = await hass.config_entries.options.async_configure(
         option_init_result["flow_id"], {"next_step_id": "departure_time"}
     )
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert menu_result["type"] == data_entry_flow.FlowResultType.FORM
     time_selector_result = await hass.config_entries.options.async_configure(
         option_init_result["flow_id"],
         user_input={
@@ -384,7 +386,7 @@ async def test_options_flow_departure_time_step(
         },
     )
 
-    assert time_selector_result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert time_selector_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
         CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
@@ -403,7 +405,7 @@ async def test_options_flow_no_time_step(
         option_init_result["flow_id"], {"next_step_id": "no_time"}
     )
 
-    assert menu_result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert menu_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
         CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
@@ -434,7 +436,7 @@ async def test_import_flow_entity_id(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "namespace test_name"
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
@@ -476,7 +478,7 @@ async def test_import_flow_coordinates(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "test_name"
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
@@ -519,7 +521,7 @@ async def test_dupe_import(hass: HomeAssistant) -> None:
             CONF_TRAFFIC_MODE: TRAFFIC_MODE_ENABLED,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
@@ -539,7 +541,7 @@ async def test_dupe_import(hass: HomeAssistant) -> None:
             CONF_TRAFFIC_MODE: TRAFFIC_MODE_ENABLED,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
@@ -559,7 +561,7 @@ async def test_dupe_import(hass: HomeAssistant) -> None:
             CONF_TRAFFIC_MODE: TRAFFIC_MODE_ENABLED,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
@@ -579,7 +581,7 @@ async def test_dupe_import(hass: HomeAssistant) -> None:
             CONF_TRAFFIC_MODE: TRAFFIC_MODE_ENABLED,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
@@ -599,5 +601,5 @@ async def test_dupe_import(hass: HomeAssistant) -> None:
             CONF_TRAFFIC_MODE: TRAFFIC_MODE_ENABLED,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/hisense_aehw4a1/test_init.py
+++ b/tests/components/hisense_aehw4a1/test_init.py
@@ -22,10 +22,10 @@ async def test_creating_entry_sets_up_climate_discovery(hass):
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -46,7 +46,7 @@ async def test_import_flow(hass):
             data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == USERNAME
     assert result["data"] == {
         CONF_USERNAME: USERNAME,
@@ -70,7 +70,7 @@ async def test_user_flow(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -94,7 +94,7 @@ async def test_user_flow(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == USERNAME
     assert result2["data"] == {
         CONF_USERNAME: USERNAME,
@@ -119,7 +119,7 @@ async def test_user_flow_2fa(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -136,7 +136,7 @@ async def test_user_flow_2fa(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == CONF_CODE
     assert result2["errors"] == {}
 
@@ -157,7 +157,7 @@ async def test_user_flow_2fa(hass):
             },
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == "configuration"
     assert result3["errors"] == {}
 
@@ -185,7 +185,7 @@ async def test_user_flow_2fa(hass):
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result4["title"] == USERNAME
     assert result4["data"] == {
         CONF_USERNAME: USERNAME,
@@ -239,7 +239,7 @@ async def test_reauth_flow(hass):
             data=mock_config.data,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_password"}
 
     with patch(
@@ -263,7 +263,7 @@ async def test_reauth_flow(hass):
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == UPDATED_PASSWORD
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -298,7 +298,7 @@ async def test_reauth_2fa_flow(hass):
             data=mock_config.data,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_password"}
 
     with patch(
@@ -338,7 +338,7 @@ async def test_reauth_2fa_flow(hass):
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == UPDATED_PASSWORD
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
@@ -370,14 +370,14 @@ async def test_option_flow(hass):
         data=None,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_SCAN_INTERVAL: UPDATED_SCAN_INTERVAL}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_SCAN_INTERVAL] == UPDATED_SCAN_INTERVAL
 
 
@@ -387,7 +387,7 @@ async def test_user_flow_2fa_send_new_code(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -404,7 +404,7 @@ async def test_user_flow_2fa_send_new_code(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == CONF_CODE
     assert result2["errors"] == {}
 
@@ -419,7 +419,7 @@ async def test_user_flow_2fa_send_new_code(hass):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == CONF_CODE
     assert result3["errors"] == {}
 
@@ -440,7 +440,7 @@ async def test_user_flow_2fa_send_new_code(hass):
             },
         )
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
     assert result4["step_id"] == "configuration"
     assert result4["errors"] == {}
 
@@ -465,7 +465,7 @@ async def test_user_flow_2fa_send_new_code(hass):
         )
         await hass.async_block_till_done()
 
-    assert result5["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result5["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result5["title"] == USERNAME
     assert result5["data"] == {
         CONF_USERNAME: USERNAME,
@@ -507,7 +507,7 @@ async def test_abort_if_existing_entry(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -517,7 +517,7 @@ async def test_user_flow_invalid_username(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -529,7 +529,7 @@ async def test_user_flow_invalid_username(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "invalid_username"}
 
@@ -540,7 +540,7 @@ async def test_user_flow_invalid_password(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -552,7 +552,7 @@ async def test_user_flow_invalid_password(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "invalid_password"}
 
@@ -564,7 +564,7 @@ async def test_user_flow_no_internet_connection(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -576,7 +576,7 @@ async def test_user_flow_no_internet_connection(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "no_internet_available"}
 
@@ -588,7 +588,7 @@ async def test_user_flow_2fa_no_internet_connection(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -602,7 +602,7 @@ async def test_user_flow_2fa_no_internet_connection(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == CONF_CODE
     assert result2["errors"] == {}
 
@@ -615,7 +615,7 @@ async def test_user_flow_2fa_no_internet_connection(hass):
             {CONF_CODE: MFA_CODE},
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == CONF_CODE
     assert result3["errors"] == {"base": "no_internet_available"}
 
@@ -626,7 +626,7 @@ async def test_user_flow_2fa_invalid_code(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -640,7 +640,7 @@ async def test_user_flow_2fa_invalid_code(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == CONF_CODE
     assert result2["errors"] == {}
 
@@ -652,7 +652,7 @@ async def test_user_flow_2fa_invalid_code(hass):
             result["flow_id"],
             {CONF_CODE: MFA_INVALID_CODE},
         )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == CONF_CODE
     assert result3["errors"] == {"base": "invalid_code"}
 
@@ -663,7 +663,7 @@ async def test_user_flow_unknown_error(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -676,7 +676,7 @@ async def test_user_flow_unknown_error(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -686,7 +686,7 @@ async def test_user_flow_2fa_unknown_error(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -700,7 +700,7 @@ async def test_user_flow_2fa_unknown_error(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == CONF_CODE
 
     with patch(
@@ -712,7 +712,7 @@ async def test_user_flow_2fa_unknown_error(hass):
             {CONF_CODE: MFA_CODE},
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == "configuration"
     assert result3["errors"] == {}
 
@@ -733,6 +733,6 @@ async def test_user_flow_2fa_unknown_error(hass):
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
     assert result4["step_id"] == "configuration"
     assert result4["errors"] == {"base": "unknown"}

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"

--- a/tests/components/home_plus_control/test_config_flow.py
+++ b/tests/components/home_plus_control/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["step_id"] == "auth"
     assert result["url"] == (
         f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
@@ -77,7 +77,7 @@ async def test_full_flow(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Home+ Control"
     config_data = result["data"]
     assert config_data["token"]["refresh_token"] == "mock-refresh-token"
@@ -109,7 +109,7 @@ async def test_abort_if_entry_in_progress(hass, current_request_with_host):
     result = await hass.config_entries.flow.async_init(
         "home_plus_control", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -134,7 +134,7 @@ async def test_abort_if_entry_exists(hass, current_request_with_host):
     result = await hass.config_entries.flow.async_init(
         "home_plus_control", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -165,7 +165,7 @@ async def test_abort_if_invalid_token(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["step_id"] == "auth"
     assert result["url"] == (
         f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
@@ -189,5 +189,5 @@ async def test_abort_if_invalid_token(
     )
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_error"

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
         result["flow_id"],
         {"include_domains": ["light"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "pairing"
 
     with patch(
@@ -74,7 +74,7 @@ async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     bridge_name = (result3["title"].split(":"))[0]
     assert bridge_name == SHORT_BRIDGE_NAME
     assert result3["data"] == {
@@ -112,7 +112,7 @@ async def test_setup_in_bridge_mode_name_taken(hass, mock_get_source_ip):
         result["flow_id"],
         {"include_domains": ["light"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "pairing"
 
     with patch(
@@ -130,7 +130,7 @@ async def test_setup_in_bridge_mode_name_taken(hass, mock_get_source_ip):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] != SHORT_BRIDGE_NAME
     assert result3["title"].startswith(SHORT_BRIDGE_NAME)
     bridge_name = (result3["title"].split(":"))[0]
@@ -194,7 +194,7 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
         result["flow_id"],
         {"include_domains": ["camera", "media_player", "light", "lock", "remote"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "pairing"
 
     with patch(
@@ -212,7 +212,7 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"][:11] == "HASS Bridge"
     bridge_name = (result3["title"].split(":"))[0]
     assert result3["data"] == {
@@ -257,7 +257,7 @@ async def test_import(hass, mock_get_source_ip):
         context={"source": config_entries.SOURCE_IMPORT},
         data={CONF_NAME: "mock_name", CONF_PORT: 12345},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "port_name_in_use"
 
     with patch(
@@ -273,7 +273,7 @@ async def test_import(hass, mock_get_source_ip):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "othername:56789"
     assert result2["data"] == {
         "name": "othername",
@@ -296,7 +296,7 @@ async def test_options_flow_exclude_mode_advanced(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -307,14 +307,14 @@ async def test_options_flow_exclude_mode_advanced(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={"entities": ["climate.old"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "advanced"
 
     with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
@@ -323,7 +323,7 @@ async def test_options_flow_exclude_mode_advanced(hass, mock_get_source_ip):
             user_input={},
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "devices": [],
         "mode": "bridge",
@@ -351,7 +351,7 @@ async def test_options_flow_exclude_mode_basic(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -362,7 +362,7 @@ async def test_options_flow_exclude_mode_basic(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
     entities = result["data_schema"]({})["entities"]
     assert entities == ["climate.front_gate"]
@@ -375,7 +375,7 @@ async def test_options_flow_exclude_mode_basic(hass, mock_get_source_ip):
         result["flow_id"],
         user_input={"entities": ["climate.old"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -430,7 +430,7 @@ async def test_options_flow_devices(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -441,7 +441,7 @@ async def test_options_flow_devices(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
     entry = entity_reg.async_get("light.ceiling_lights")
@@ -461,7 +461,7 @@ async def test_options_flow_devices(
             user_input={"devices": [device_id]},
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "devices": [device_id],
         "mode": "bridge",
@@ -510,7 +510,7 @@ async def test_options_flow_devices_preserved_when_advanced_off(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -521,7 +521,7 @@ async def test_options_flow_devices_preserved_when_advanced_off(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -531,7 +531,7 @@ async def test_options_flow_devices_preserved_when_advanced_off(
         },
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "devices": ["1fabcabcabcabcabcabcabcabcabc"],
         "mode": "bridge",
@@ -567,7 +567,7 @@ async def test_options_flow_include_mode_with_non_existant_entity(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -578,7 +578,7 @@ async def test_options_flow_include_mode_with_non_existant_entity(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "include"
 
     entities = result["data_schema"]({})["entities"]
@@ -590,7 +590,7 @@ async def test_options_flow_include_mode_with_non_existant_entity(
             "entities": ["climate.new", "climate.front_gate"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -626,7 +626,7 @@ async def test_options_flow_exclude_mode_with_non_existant_entity(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -637,7 +637,7 @@ async def test_options_flow_exclude_mode_with_non_existant_entity(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
     entities = result["data_schema"]({})["entities"]
@@ -649,7 +649,7 @@ async def test_options_flow_exclude_mode_with_non_existant_entity(
             "entities": ["climate.new", "climate.front_gate"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -676,7 +676,7 @@ async def test_options_flow_include_mode_basic(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -687,14 +687,14 @@ async def test_options_flow_include_mode_basic(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "include"
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={"entities": ["climate.new"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -723,7 +723,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -734,7 +734,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -743,7 +743,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
             "entities": ["climate.old", "camera.excluded"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
 
     result3 = await hass.config_entries.options.async_configure(
@@ -751,7 +751,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
         user_input={"camera_copy": ["camera.native_h264"]},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -769,7 +769,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -780,7 +780,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -789,7 +789,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
             "entities": ["climate.old", "camera.excluded"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
 
     result3 = await hass.config_entries.options.async_configure(
@@ -797,7 +797,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
         user_input={"camera_copy": ["camera.native_h264"]},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert config_entry.options == {
         "mode": "bridge",
@@ -828,7 +828,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -839,7 +839,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "include"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -848,7 +848,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
             "entities": ["camera.native_h264", "camera.transcode_h264"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
 
     result3 = await hass.config_entries.options.async_configure(
@@ -856,7 +856,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
         user_input={"camera_copy": ["camera.native_h264"]},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -874,7 +874,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": ["fan", "vacuum", "climate", "camera"],
@@ -899,7 +899,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
     assert result["data_schema"]({}) == {
         "entities": ["camera.native_h264", "camera.transcode_h264"],
@@ -916,7 +916,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
             "entities": ["climate.old", "camera.excluded"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
     assert result2["data_schema"]({}) == {
         "camera_copy": ["camera.native_h264"],
@@ -930,7 +930,7 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
         user_input={"camera_copy": []},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "entity_config": {"camera.native_h264": {}},
         "filter": {
@@ -960,7 +960,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -971,7 +971,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "include"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -980,7 +980,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
             "entities": ["camera.audio", "camera.no_audio"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
 
     result3 = await hass.config_entries.options.async_configure(
@@ -988,7 +988,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
         user_input={"camera_audio": ["camera.audio"]},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -1006,7 +1006,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": ["fan", "vacuum", "climate", "camera"],
@@ -1031,7 +1031,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
     assert result["data_schema"]({}) == {
         "entities": ["camera.audio", "camera.no_audio"],
@@ -1048,7 +1048,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
             "entities": ["climate.old", "camera.excluded"],
         },
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
     assert result2["data_schema"]({}) == {
         "camera_copy": [],
@@ -1062,7 +1062,7 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
         user_input={"camera_audio": []},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "entity_config": {"camera.audio": {}},
         "filter": {
@@ -1103,7 +1103,7 @@ async def test_options_flow_blocked_when_from_yaml(hass, mock_get_source_ip):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "yaml"
 
     with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
@@ -1111,7 +1111,7 @@ async def test_options_flow_blocked_when_from_yaml(hass, mock_get_source_ip):
             result["flow_id"],
             user_input={},
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
@@ -1131,7 +1131,7 @@ async def test_options_flow_include_mode_basic_accessory(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": [
@@ -1151,7 +1151,7 @@ async def test_options_flow_include_mode_basic_accessory(
         user_input={"domains": ["media_player"], "mode": "accessory"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "accessory"
     assert _get_schema_default(result2["data_schema"].schema, "entities") is None
 
@@ -1159,7 +1159,7 @@ async def test_options_flow_include_mode_basic_accessory(
         result2["flow_id"],
         user_input={"entities": "media_player.tv"},
     )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "accessory",
         "filter": {
@@ -1177,7 +1177,7 @@ async def test_options_flow_include_mode_basic_accessory(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": ["media_player"],
@@ -1190,7 +1190,7 @@ async def test_options_flow_include_mode_basic_accessory(
         user_input={"domains": ["media_player"], "mode": "accessory"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "accessory"
     assert (
         _get_schema_default(result2["data_schema"].schema, "entities")
@@ -1201,7 +1201,7 @@ async def test_options_flow_include_mode_basic_accessory(
         result2["flow_id"],
         user_input={"entities": "media_player.tv"},
     )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "accessory",
         "filter": {
@@ -1226,7 +1226,7 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
         result["flow_id"],
         {"include_domains": ["light"]},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "pairing"
 
     # We need to actually setup the config entry or the data
@@ -1244,7 +1244,7 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"][:11] == "HASS Bridge"
     bridge_name = (result3["title"].split(":"))[0]
     assert result3["data"] == {
@@ -1272,7 +1272,7 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     schema = result["data_schema"].schema
     assert _get_schema_default(schema, "mode") == "bridge"
@@ -1283,14 +1283,14 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
         user_input={"domains": ["camera"], "mode": "accessory"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "accessory"
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={"entities": "camera.tv"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "cameras"
 
     with patch(
@@ -1305,7 +1305,7 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "entity_config": {"camera.tv": {"video_codec": "copy"}},
         "mode": "accessory",
@@ -1363,7 +1363,7 @@ async def test_options_flow_exclude_mode_skips_category_entities(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": [
@@ -1387,7 +1387,7 @@ async def test_options_flow_exclude_mode_skips_category_entities(
         },
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "exclude"
     assert _get_schema_default(result2["data_schema"].schema, "entities") == []
 
@@ -1409,7 +1409,7 @@ async def test_options_flow_exclude_mode_skips_category_entities(
             ]
         },
     )
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -1451,7 +1451,7 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": [
@@ -1475,7 +1475,7 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
         },
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "exclude"
     assert _get_schema_default(result2["data_schema"].schema, "entities") == []
 
@@ -1491,7 +1491,7 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
         result2["flow_id"],
         user_input={"entities": ["media_player.tv", "switch.other"]},
     )
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {
@@ -1529,7 +1529,7 @@ async def test_options_flow_include_mode_allows_hidden_entities(
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["data_schema"]({}) == {
         "domains": [
@@ -1553,7 +1553,7 @@ async def test_options_flow_include_mode_allows_hidden_entities(
         },
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "include"
     assert _get_schema_default(result2["data_schema"].schema, "entities") == []
 
@@ -1569,7 +1569,7 @@ async def test_options_flow_include_mode_allows_hidden_entities(
             ]
         },
     )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         "mode": "bridge",
         "filter": {

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_show_authenticate_form(hass: HomeAssistant) -> None:
         context={"source": SOURCE_USER},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -53,7 +53,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == FAKE_CONFIG
 
 
@@ -70,7 +70,7 @@ async def test_show_option_form(
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
 
@@ -91,7 +91,7 @@ async def test_create_option_entry(
         user_input={CONF_COOL_AWAY_TEMPERATURE: 1, CONF_HEAT_AWAY_TEMPERATURE: 2},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         CONF_COOL_AWAY_TEMPERATURE: 1,
         CONF_HEAT_AWAY_TEMPERATURE: 2,

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_show_set_form(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -54,7 +54,7 @@ async def test_urlize_plain_host(hass, requests_mock):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=user_input
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert user_input[CONF_URL] == f"http://{host}/"
 
@@ -85,7 +85,7 @@ async def test_already_configured(hass, requests_mock, login_requests_mock):
         data=FIXTURE_USER_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -96,7 +96,7 @@ async def test_connection_error(hass, requests_mock):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_URL: "unknown"}
 
@@ -142,7 +142,7 @@ async def test_login_error(hass, login_requests_mock, code, errors):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == errors
 
@@ -164,7 +164,7 @@ async def test_success(hass, login_requests_mock):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_URL] == FIXTURE_USER_INPUT[CONF_URL]
     assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
@@ -195,7 +195,7 @@ async def test_ssdp(hass):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["data_schema"]({})[CONF_URL] == url
 
@@ -209,7 +209,7 @@ async def test_options(hass):
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     recipient = "+15555550000"

--- a/tests/components/huisbaasje/test_config_flow.py
+++ b/tests/components/huisbaasje/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -68,7 +68,7 @@ async def test_form_invalid_auth(hass):
             },
         )
 
-    assert form_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert form_result["type"] == data_entry_flow.FlowResultType.FORM
     assert form_result["errors"] == {"base": "invalid_auth"}
 
 
@@ -90,7 +90,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert form_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert form_result["type"] == data_entry_flow.FlowResultType.FORM
     assert form_result["errors"] == {"base": "cannot_connect"}
 
 
@@ -112,7 +112,7 @@ async def test_form_unknown_error(hass):
             },
         )
 
-    assert form_result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert form_result["type"] == data_entry_flow.FlowResultType.FORM
     assert form_result["errors"] == {"base": "unknown"}
 
 
@@ -148,5 +148,5 @@ async def test_form_entry_exists(hass):
             },
         )
 
-    assert form_result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert form_result["type"] == data_entry_flow.FlowResultType.ABORT
     assert form_result["reason"] == "already_configured"

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -273,7 +273,7 @@ async def test_options_flow(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -281,7 +281,7 @@ async def test_options_flow(hass):
             user_input={CONF_FILTER: ["0"], CONF_OFFSET: 15, CONF_REAL_TIME: False},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {
             CONF_FILTER: [
                 {
@@ -329,7 +329,7 @@ async def test_options_flow_invalid_auth(hass):
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         assert result["errors"] == {"base": "invalid_auth"}
@@ -364,7 +364,7 @@ async def test_options_flow_cannot_connect(hass):
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -166,7 +166,7 @@ async def test_user_if_no_configuration(hass: HomeAssistant) -> None:
     """Check flow behavior when no configuration is present."""
     result = await _init_flow(hass)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["handler"] == DOMAIN
 
@@ -181,7 +181,7 @@ async def test_user_existing_id_abort(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -197,7 +197,7 @@ async def test_user_client_errors(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"]["base"] == "cannot_connect"
 
     # Fail the auth check call.
@@ -207,7 +207,7 @@ async def test_user_client_errors(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "auth_required_error"
 
 
@@ -226,7 +226,7 @@ async def test_user_confirm_cannot_connect(hass: HomeAssistant) -> None:
         side_effect=[good_client, bad_client],
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -242,7 +242,7 @@ async def test_user_confirm_id_error(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "no_id"
 
 
@@ -256,7 +256,7 @@ async def test_user_noauth_flow_success(hass: HomeAssistant) -> None:
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["handler"] == DOMAIN
     assert result["title"] == TEST_TITLE
     assert result["data"] == {
@@ -275,7 +275,7 @@ async def test_user_auth_required(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -289,7 +289,7 @@ async def test_auth_static_token_auth_required_fail(hass: HomeAssistant) -> None
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "auth_required_error"
 
 
@@ -309,7 +309,7 @@ async def test_auth_static_token_success(hass: HomeAssistant) -> None:
             hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["handler"] == DOMAIN
     assert result["title"] == TEST_TITLE
     assert result["data"] == {
@@ -335,7 +335,7 @@ async def test_auth_static_token_login_connect_fail(hass: HomeAssistant) -> None
             hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -358,7 +358,7 @@ async def test_auth_static_token_login_fail(hass: HomeAssistant) -> None:
             hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_access_token"
 
 
@@ -373,7 +373,7 @@ async def test_auth_create_token_approval_declined(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
     client.async_request_token = AsyncMock(return_value=TEST_REQUEST_TOKEN_FAIL)
@@ -387,7 +387,7 @@ async def test_auth_create_token_approval_declined(hass: HomeAssistant) -> None:
             hass, result, user_input={CONF_CREATE_TOKEN: True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "create_token"
         assert result["description_placeholders"] == {
             CONF_AUTH_ID: TEST_AUTH_ID,
@@ -395,13 +395,13 @@ async def test_auth_create_token_approval_declined(hass: HomeAssistant) -> None:
 
         result = await _configure_flow(hass, result)
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+        assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
         assert result["step_id"] == "create_token_external"
 
         # The flow will be automatically advanced by the auth token response.
 
         result = await _configure_flow(hass, result)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "auth_new_token_not_granted_error"
 
 
@@ -479,7 +479,7 @@ async def test_auth_create_token_when_issued_token_fails(
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
     client.async_request_token = AsyncMock(return_value=TEST_REQUEST_TOKEN_SUCCESS)
@@ -492,14 +492,14 @@ async def test_auth_create_token_when_issued_token_fails(
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: True}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "create_token"
         assert result["description_placeholders"] == {
             CONF_AUTH_ID: TEST_AUTH_ID,
         }
 
         result = await _configure_flow(hass, result)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+        assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
         assert result["step_id"] == "create_token_external"
 
         # The flow will be automatically advanced by the auth token response.
@@ -508,7 +508,7 @@ async def test_auth_create_token_when_issued_token_fails(
         client.async_client_connect = AsyncMock(return_value=False)
 
         result = await _configure_flow(hass, result)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -523,7 +523,7 @@ async def test_auth_create_token_success(hass: HomeAssistant) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
     client.async_request_token = AsyncMock(return_value=TEST_REQUEST_TOKEN_SUCCESS)
@@ -536,19 +536,19 @@ async def test_auth_create_token_success(hass: HomeAssistant) -> None:
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: True}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "create_token"
         assert result["description_placeholders"] == {
             CONF_AUTH_ID: TEST_AUTH_ID,
         }
 
         result = await _configure_flow(hass, result)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+        assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
         assert result["step_id"] == "create_token_external"
 
         # The flow will be automatically advanced by the auth token response.
         result = await _configure_flow(hass, result)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["handler"] == DOMAIN
         assert result["title"] == TEST_TITLE
         assert result["data"] == {
@@ -594,7 +594,7 @@ async def test_auth_create_token_success_but_login_fail(
         # The flow will be automatically advanced by the auth token response.
         result = await _configure_flow(hass, result)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "auth_new_token_not_work_error"
 
 
@@ -614,7 +614,7 @@ async def test_ssdp_success(hass: HomeAssistant) -> None:
     ):
         result = await _configure_flow(hass, result)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["handler"] == DOMAIN
     assert result["title"] == TEST_TITLE
     assert result["data"] == {
@@ -635,7 +635,7 @@ async def test_ssdp_cannot_connect(hass: HomeAssistant) -> None:
         result = await _init_flow(hass, source=SOURCE_SSDP, data=TEST_SSDP_SERVICE_INFO)
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -653,7 +653,7 @@ async def test_ssdp_missing_serial(hass: HomeAssistant) -> None:
         result = await _init_flow(hass, source=SOURCE_SSDP, data=bad_data)
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "no_id"
 
 
@@ -672,7 +672,7 @@ async def test_ssdp_failure_bad_port_json(hass: HomeAssistant) -> None:
         result = await _configure_flow(hass, result)
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_PORT] == const.DEFAULT_PORT_JSON
 
 
@@ -693,7 +693,7 @@ async def test_ssdp_failure_bad_port_ui(hass: HomeAssistant) -> None:
     ):
         result = await _init_flow(hass, source=SOURCE_SSDP, data=bad_data)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
 
         client.async_request_token = AsyncMock(return_value=TEST_REQUEST_TOKEN_FAIL)
@@ -702,7 +702,7 @@ async def test_ssdp_failure_bad_port_ui(hass: HomeAssistant) -> None:
             hass, result, user_input={CONF_CREATE_TOKEN: True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "create_token"
 
         # Verify a working URL is used despite the bad port number
@@ -726,8 +726,8 @@ async def test_ssdp_abort_duplicates(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result_1["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result_2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result_1["type"] == data_entry_flow.FlowResultType.FORM
+    assert result_2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result_2["reason"] == "already_in_progress"
 
 
@@ -745,7 +745,7 @@ async def test_options_priority(hass: HomeAssistant) -> None:
         assert hass.states.get(TEST_ENTITY_ID_1) is not None
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         new_priority = 1
@@ -754,7 +754,7 @@ async def test_options_priority(hass: HomeAssistant) -> None:
             user_input={CONF_PRIORITY: new_priority},
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_PRIORITY] == new_priority
 
         # Turn the light on and ensure the new priority is used.
@@ -788,14 +788,14 @@ async def test_options_effect_show_list(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={CONF_EFFECT_SHOW_LIST: ["effect1", "effect3"]},
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         # effect1 and effect3 only, so effect2 & external sources are hidden.
         assert result["data"][CONF_EFFECT_HIDE_LIST] == sorted(
@@ -818,7 +818,7 @@ async def test_options_effect_hide_list_cannot_connect(hass: HomeAssistant) -> N
         client.async_client_connect = AsyncMock(return_value=False)
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -845,13 +845,13 @@ async def test_reauth_success(hass: HomeAssistant) -> None:
             data=config_data,
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
         assert CONF_TOKEN in config_entry.data
 
@@ -877,5 +877,5 @@ async def test_reauth_cannot_connect(hass: HomeAssistant) -> None:
             data=config_data,
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"

--- a/tests/components/ialarm/test_config_flow.py
+++ b/tests/components/ialarm/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch(
@@ -36,7 +36,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == TEST_DATA["host"]
     assert result2["data"] == TEST_DATA
     assert len(mock_setup_entry.mock_calls) == 1
@@ -56,7 +56,7 @@ async def test_form_cannot_connect(hass):
             result["flow_id"], TEST_DATA
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -74,7 +74,7 @@ async def test_form_exception(hass):
             result["flow_id"], TEST_DATA
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -100,5 +100,5 @@ async def test_form_already_exists(hass):
             result["flow_id"], TEST_DATA
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -162,7 +162,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=None
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # test with required
@@ -171,7 +171,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
         context={"source": SOURCE_USER},
         data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_TRUSTED_DEVICE
 
 
@@ -187,7 +187,7 @@ async def test_user_with_cookie(hass: HomeAssistant, service_authenticated: Magi
             CONF_WITH_FAMILY: WITH_FAMILY,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == USERNAME
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
@@ -208,7 +208,7 @@ async def test_login_failed(hass: HomeAssistant):
             context={"source": SOURCE_USER},
             data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {CONF_PASSWORD: "invalid_auth"}
 
 
@@ -221,7 +221,7 @@ async def test_no_device(
         context={"source": SOURCE_USER},
         data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_device"
 
 
@@ -234,7 +234,7 @@ async def test_trusted_device(hass: HomeAssistant, service: MagicMock):
     )
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_TRUSTED_DEVICE
 
 
@@ -249,7 +249,7 @@ async def test_trusted_device_success(hass: HomeAssistant, service: MagicMock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_TRUSTED_DEVICE: 0}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_VERIFICATION_CODE
 
 
@@ -266,7 +266,7 @@ async def test_send_verification_code_failed(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_TRUSTED_DEVICE: 0}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_TRUSTED_DEVICE
     assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
 
@@ -283,7 +283,7 @@ async def test_verification_code(hass: HomeAssistant, service: MagicMock):
     )
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_VERIFICATION_CODE
 
 
@@ -302,7 +302,7 @@ async def test_verification_code_success(hass: HomeAssistant, service: MagicMock
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_VERIFICATION_CODE: "0"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == USERNAME
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
@@ -328,7 +328,7 @@ async def test_validate_verification_code_failed(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_VERIFICATION_CODE: "0"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_TRUSTED_DEVICE
     assert result["errors"] == {"base": "validate_verification_code"}
 
@@ -347,7 +347,7 @@ async def test_2fa_code_success(hass: HomeAssistant, service_2fa: MagicMock):
         result["flow_id"], {CONF_VERIFICATION_CODE: "0"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == USERNAME
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
@@ -371,7 +371,7 @@ async def test_validate_2fa_code_failed(
         result["flow_id"], {CONF_VERIFICATION_CODE: "0"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == CONF_VERIFICATION_CODE
     assert result["errors"] == {"base": "validate_verification_code"}
 
@@ -389,13 +389,13 @@ async def test_password_update(hass: HomeAssistant, service_authenticated: Magic
         data={**MOCK_CONFIG, "unique_id": USERNAME},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_PASSWORD: PASSWORD_2}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert config_entry.data[CONF_PASSWORD] == PASSWORD_2
 
@@ -413,7 +413,7 @@ async def test_password_update_wrong_password(hass: HomeAssistant):
         data={**MOCK_CONFIG, "unique_id": USERNAME},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService.authenticate",
@@ -423,5 +423,5 @@ async def test_password_update_wrong_password(hass: HomeAssistant):
             result["flow_id"], {CONF_PASSWORD: PASSWORD_2}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {CONF_PASSWORD: "invalid_auth"}

--- a/tests/components/ifttt/test_init.py
+++ b/tests/components/ifttt/test_init.py
@@ -15,10 +15,10 @@ async def test_config_flow_registers_webhook(hass, hass_client_no_auth):
     result = await hass.config_entries.flow.async_init(
         "ifttt", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     webhook_id = result["result"].data["webhook_id"]
 
     ifttt_events = []

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -71,7 +71,7 @@ async def _init_form(hass, modem_type):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -118,7 +118,7 @@ async def test_fail_on_existing(hass: HomeAssistant):
         data={**MOCK_USER_INPUT_HUB_V2, CONF_HUB_VERSION: 2},
         context={"source": config_entries.SOURCE_USER},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -223,7 +223,7 @@ async def _options_init_form(hass, entry_id, step):
     with patch(PATCH_ASYNC_SETUP_ENTRY, return_value=True):
         result = await hass.config_entries.options.async_init(entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -279,7 +279,7 @@ async def test_import_existing(hass: HomeAssistant):
     result = await _import_config(
         hass, {**MOCK_IMPORT_MINIMUM_HUB_V2, CONF_PORT: 25105, CONF_HUB_VERSION: 2}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -295,7 +295,7 @@ async def test_import_failed_connection(hass: HomeAssistant):
             data={**MOCK_IMPORT_MINIMUM_HUB_V2, CONF_PORT: 25105, CONF_HUB_VERSION: 2},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -329,7 +329,7 @@ async def test_options_change_hub_config(hass: HomeAssistant):
     }
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {}
     assert config_entry.data == {**user_input, CONF_HUB_VERSION: 2}
 
@@ -353,7 +353,7 @@ async def test_options_add_device_override(hass: HomeAssistant):
     }
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_OVERRIDE]) == 1
     assert config_entry.options[CONF_OVERRIDE][0][CONF_ADDRESS] == "1A.2B.3C"
     assert config_entry.options[CONF_OVERRIDE][0][CONF_CAT] == 4
@@ -397,7 +397,7 @@ async def test_options_remove_device_override(hass: HomeAssistant):
     user_input = {CONF_ADDRESS: "1A.2B.3C"}
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_OVERRIDE]) == 1
 
 
@@ -429,7 +429,7 @@ async def test_options_remove_device_override_with_x10(hass: HomeAssistant):
     user_input = {CONF_ADDRESS: "1A.2B.3C"}
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_OVERRIDE]) == 1
     assert len(config_entry.options[CONF_X10]) == 1
 
@@ -454,7 +454,7 @@ async def test_options_add_x10_device(hass: HomeAssistant):
     }
     result2, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_X10]) == 1
     assert config_entry.options[CONF_X10][0][CONF_HOUSECODE] == "c"
     assert config_entry.options[CONF_X10][0][CONF_UNITCODE] == 12
@@ -470,7 +470,7 @@ async def test_options_add_x10_device(hass: HomeAssistant):
     }
     result3, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_X10]) == 2
     assert config_entry.options[CONF_X10][1][CONF_HOUSECODE] == "d"
     assert config_entry.options[CONF_X10][1][CONF_UNITCODE] == 10
@@ -511,7 +511,7 @@ async def test_options_remove_x10_device(hass: HomeAssistant):
     user_input = {CONF_DEVICE: "Housecode: C, Unitcode: 4"}
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_X10]) == 1
 
 
@@ -546,7 +546,7 @@ async def test_options_remove_x10_device_with_override(hass: HomeAssistant):
     user_input = {CONF_DEVICE: "Housecode: C, Unitcode: 4"}
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(config_entry.options[CONF_X10]) == 1
     assert len(config_entry.options[CONF_OVERRIDE]) == 1
 
@@ -562,14 +562,14 @@ async def test_options_dup_selection(hass: HomeAssistant):
     config_entry.add_to_hass(hass)
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {STEP_ADD_OVERRIDE: True, STEP_ADD_X10: True},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "select_single"}
 
 
@@ -593,7 +593,7 @@ async def test_options_override_bad_data(hass: HomeAssistant):
     }
     result, _ = await _options_form(hass, result["flow_id"], user_input)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "input_error"}
 
 
@@ -611,7 +611,7 @@ async def test_discovery_via_usb(hass):
         "insteon", context={"source": config_entries.SOURCE_USB}, data=discovery_info
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm_usb"
 
     with patch("homeassistant.components.insteon.config_flow.async_connect"), patch(
@@ -622,7 +622,7 @@ async def test_discovery_via_usb(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["data"] == {"device": "/dev/ttyINSTEON"}
 
 
@@ -646,5 +646,5 @@ async def test_discovery_via_usb_already_setup(hass):
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -9,7 +9,7 @@ async def test_duplicate_error(hass, config, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -18,7 +18,7 @@ async def test_invalid_zip_code(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data={CONF_ZIP_CODE: "bad"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_ZIP_CODE: "invalid_zip_code"}
 
 
@@ -27,7 +27,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -36,6 +36,6 @@ async def test_step_user(hass, config, setup_iqvia):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "12345"
     assert result["data"] == {CONF_ZIP_CODE: "12345"}

--- a/tests/components/islamic_prayer_times/test_config_flow.py
+++ b/tests/components/islamic_prayer_times/test_config_flow.py
@@ -26,13 +26,13 @@ async def test_flow_works(hass):
     result = await hass.config_entries.flow.async_init(
         islamic_prayer_times.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Islamic Prayer Times"
 
 
@@ -48,14 +48,14 @@ async def test_options(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_CALC_METHOD: "makkah"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_CALC_METHOD] == "makkah"
 
 
@@ -71,5 +71,5 @@ async def test_integration_already_configured(hass):
         islamic_prayer_times.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/iss/test_config_flow.py
+++ b/tests/components/iss/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_create_entry(hass: HomeAssistant):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
 
     with patch("homeassistant.components.iss.async_setup_entry", return_value=True):
@@ -28,7 +28,7 @@ async def test_create_entry(hass: HomeAssistant):
             {},
         )
 
-        assert result.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result.get("result").data == {}
 
 
@@ -44,7 +44,7 @@ async def test_integration_already_exists(hass: HomeAssistant):
         DOMAIN, context={"source": SOURCE_USER}, data={}
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "single_instance_allowed"
 
 
@@ -60,7 +60,7 @@ async def test_abort_no_home(hass: HomeAssistant):
         DOMAIN, context={"source": SOURCE_USER}, data={}
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "latitude_longitude_not_defined"
 
 

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -116,7 +116,7 @@ async def test_form(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
@@ -130,7 +130,7 @@ async def test_form(hass: HomeAssistant):
             MOCK_USER_INPUT,
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
@@ -154,7 +154,7 @@ async def test_form_invalid_host(hass: HomeAssistant):
         },
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_host"}
 
 
@@ -172,7 +172,7 @@ async def test_form_invalid_auth(hass: HomeAssistant):
             MOCK_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {CONF_PASSWORD: "invalid_auth"}
 
 
@@ -190,7 +190,7 @@ async def test_form_unknown_exeption(hass: HomeAssistant):
             MOCK_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -208,7 +208,7 @@ async def test_form_isy_connection_error(hass: HomeAssistant):
             MOCK_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -226,7 +226,7 @@ async def test_form_isy_parse_response_error(hass: HomeAssistant, caplog):
             MOCK_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert "ISY Could not parse response, poorly formatted XML." in caplog.text
 
 
@@ -246,7 +246,7 @@ async def test_form_no_name_in_response(hass: HomeAssistant):
             MOCK_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -257,7 +257,7 @@ async def test_form_existing_config_entry(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE):
@@ -265,7 +265,7 @@ async def test_form_existing_config_entry(hass: HomeAssistant):
             result["flow_id"],
             MOCK_USER_INPUT,
         )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_import_flow_some_fields(hass: HomeAssistant) -> None:
@@ -282,7 +282,7 @@ async def test_import_flow_some_fields(hass: HomeAssistant) -> None:
             data=MOCK_IMPORT_BASIC_CONFIG,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == f"http://{MOCK_HOSTNAME}"
     assert result["data"][CONF_USERNAME] == MOCK_USERNAME
     assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
@@ -303,7 +303,7 @@ async def test_import_flow_with_https(hass: HomeAssistant) -> None:
             data=MOCK_IMPORT_WITH_SSL,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == f"https://{MOCK_HOSTNAME}"
     assert result["data"][CONF_USERNAME] == MOCK_USERNAME
     assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
@@ -323,7 +323,7 @@ async def test_import_flow_all_fields(hass: HomeAssistant) -> None:
             data=MOCK_IMPORT_FULL_CONFIG,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == f"http://{MOCK_HOSTNAME}"
     assert result["data"][CONF_USERNAME] == MOCK_USERNAME
     assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
@@ -356,7 +356,7 @@ async def test_form_ssdp_already_configured(hass: HomeAssistant) -> None:
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_form_ssdp(hass: HomeAssistant):
@@ -375,7 +375,7 @@ async def test_form_ssdp(hass: HomeAssistant):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -391,7 +391,7 @@ async def test_form_ssdp(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
@@ -425,7 +425,7 @@ async def test_form_ssdp_existing_entry(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == f"http://3.3.3.3:80{ISY_URL_POSTFIX}"
 
@@ -456,7 +456,7 @@ async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == f"http://3.3.3.3:80/{ISY_URL_POSTFIX}"
 
@@ -487,7 +487,7 @@ async def test_form_ssdp_existing_entry_with_alternate_port(hass: HomeAssistant)
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == f"http://3.3.3.3:1443/{ISY_URL_POSTFIX}"
 
@@ -518,7 +518,7 @@ async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == f"https://3.3.3.3:443/{ISY_URL_POSTFIX}"
 
@@ -535,7 +535,7 @@ async def test_form_dhcp(hass: HomeAssistant):
             macaddress=MOCK_MAC,
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -551,7 +551,7 @@ async def test_form_dhcp(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
@@ -571,7 +571,7 @@ async def test_form_dhcp_with_polisy(hass: HomeAssistant):
             macaddress=MOCK_POLISY_MAC,
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
     assert (
@@ -591,7 +591,7 @@ async def test_form_dhcp_with_polisy(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_POLISY_USER_INPUT
@@ -621,7 +621,7 @@ async def test_form_dhcp_existing_entry(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == f"http://1.2.3.4{ISY_URL_POSTFIX}"
 
@@ -651,7 +651,7 @@ async def test_form_dhcp_existing_entry_preserves_port(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == f"http://1.2.3.4:1443{ISY_URL_POSTFIX}"
     assert entry.data[CONF_USERNAME] == "bob"
@@ -677,7 +677,7 @@ async def test_form_dhcp_existing_ignored_entry(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -42,10 +42,10 @@ async def test_not_found(hass, mock_disco):
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
         await hass.async_block_till_done()
 
@@ -71,10 +71,10 @@ async def test_found(hass, mock_disco):
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/jellyfin/test_config_flow.py
+++ b/tests/components/jellyfin/test_config_flow.py
@@ -27,7 +27,7 @@ async def test_abort_if_existing_entry(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 

--- a/tests/components/keenetic_ndms2/test_config_flow.py
+++ b/tests/components/keenetic_ndms2/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_flow_works(hass: HomeAssistant, connect) -> None:
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -63,7 +63,7 @@ async def test_flow_works(hass: HomeAssistant, connect) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == MOCK_NAME
     assert result2["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1
@@ -98,7 +98,7 @@ async def test_options(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -106,7 +106,7 @@ async def test_options(hass: HomeAssistant) -> None:
         user_input=MOCK_OPTIONS,
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["data"] == MOCK_OPTIONS
 
 
@@ -126,7 +126,7 @@ async def test_host_already_configured(hass: HomeAssistant, connect) -> None:
         result["flow_id"], user_input=MOCK_DATA
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
 
 
@@ -139,7 +139,7 @@ async def test_connection_error(hass: HomeAssistant, connect_error) -> None:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_DATA
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -153,7 +153,7 @@ async def test_ssdp_works(hass: HomeAssistant, connect) -> None:
         data=discovery_info,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -168,7 +168,7 @@ async def test_ssdp_works(hass: HomeAssistant, connect) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == MOCK_NAME
     assert result2["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1
@@ -189,7 +189,7 @@ async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
         data=discovery_info,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -210,7 +210,7 @@ async def test_ssdp_ignored(hass: HomeAssistant) -> None:
         data=discovery_info,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -236,7 +236,7 @@ async def test_ssdp_update_host(hass: HomeAssistant) -> None:
         data=discovery_info,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == new_ip
 
@@ -254,7 +254,7 @@ async def test_ssdp_reject_no_udn(hass: HomeAssistant) -> None:
         data=discovery_info,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_udn"
 
 
@@ -270,5 +270,5 @@ async def test_ssdp_reject_non_keenetic(hass: HomeAssistant) -> None:
         data=discovery_info,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_keenetic_ndms2"

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -69,14 +69,14 @@ async def test_form_options(hass, aioclient_mock):
     assert config_entry.state is ConfigEntryState.LOADED
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_REVERSE: True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {CONF_REVERSE: True}
 
     await hass.async_block_till_done()

--- a/tests/components/launch_library/test_config_flow.py
+++ b/tests/components/launch_library/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_create_entry(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
 
     with patch(
@@ -27,7 +27,7 @@ async def test_create_entry(hass):
             {},
         )
 
-        assert result.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result.get("result").data == {}
 
 
@@ -43,5 +43,5 @@ async def test_integration_already_exists(hass):
         DOMAIN, context={"source": SOURCE_USER}, data={}
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "single_instance_allowed"

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_step_import(hass):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "pchk"
         assert result["data"] == IMPORT_DATA
 
@@ -65,7 +65,7 @@ async def test_step_import_existing_host(hass):
         await hass.async_block_till_done()
 
         # Check if config entry was updated
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "existing_configuration_updated"
         assert mock_entry.source == config_entries.SOURCE_IMPORT
         assert mock_entry.data == IMPORT_DATA
@@ -91,5 +91,5 @@ async def test_step_import_error(hass, error, reason):
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == reason

--- a/tests/components/life360/test_config_flow.py
+++ b/tests/components/life360/test_config_flow.py
@@ -106,7 +106,7 @@ async def test_user_show_form(hass, life360_api):
 
     life360_api.get_authorization.assert_not_called()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert not result["errors"]
 
@@ -134,7 +134,7 @@ async def test_user_config_flow_success(hass, life360_api):
 
     life360_api.get_authorization.assert_called_once()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEST_USER.lower()
     assert result["data"] == TEST_CONFIG_DATA
     assert result["options"] == DEFAULT_OPTIONS
@@ -159,7 +159,7 @@ async def test_user_config_flow_error(hass, life360_api, caplog, exception, erro
 
     life360_api.get_authorization.assert_called_once()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]
     assert result["errors"]["base"] == error
@@ -190,7 +190,7 @@ async def test_user_config_flow_already_configured(hass, life360_api):
 
     life360_api.get_authorization.assert_not_called()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -220,7 +220,7 @@ async def test_reauth_config_flow_success(hass, life360_api, caplog, state):
 
     life360_api.get_authorization.assert_called_once()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     assert "Reauthorization successful" in caplog.text
@@ -250,7 +250,7 @@ async def test_reauth_config_flow_login_error(hass, life360_api, caplog):
 
     life360_api.get_authorization.assert_called_once()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"]
     assert result["errors"]["base"] == "invalid_auth"
@@ -274,7 +274,7 @@ async def test_reauth_config_flow_login_error(hass, life360_api, caplog):
 
     life360_api.get_authorization.assert_called_once()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     assert "Reauthorization successful" in caplog.text
@@ -292,7 +292,7 @@ async def test_options_flow(hass):
     await hass.config_entries.async_setup(config_entry.entry_id)
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert not result["errors"]
 
@@ -303,7 +303,7 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_configure(flow_id, USER_OPTIONS)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == TEST_OPTIONS
 
     assert config_entry.options == TEST_OPTIONS

--- a/tests/components/litejet/test_config_flow.py
+++ b/tests/components/litejet/test_config_flow.py
@@ -85,7 +85,7 @@ async def test_options(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -93,5 +93,5 @@ async def test_options(hass):
         user_input={CONF_DEFAULT_TRANSITION: 12},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_DEFAULT_TRANSITION: 12}

--- a/tests/components/local_ip/test_config_flow.py
+++ b/tests/components/local_ip/test_config_flow.py
@@ -11,10 +11,10 @@ async def test_config_flow(hass, mock_get_source_ip):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     state = hass.states.get(f"sensor.{DOMAIN}")
@@ -32,5 +32,5 @@ async def test_already_setup(hass, mock_get_source_ip):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -41,10 +41,10 @@ async def webhook_id(hass, locative_client):
     result = await hass.config_entries.flow.async_init(
         "locative", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     return result["result"].data["webhook_id"]

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -66,7 +66,7 @@ async def test_step_import(
     flow = init_config_flow(hass)
 
     result = await flow.async_step_import()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -86,18 +86,18 @@ async def test_full_flow_implementation(
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await flow.async_step_user({"flow_impl": "test-other"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["description_placeholders"] == {
         "authorization_url": "http://example.com"
     }
 
     result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Logi Circle ({})".format("testId")
 
 
@@ -115,7 +115,7 @@ async def test_abort_if_no_implementation_registered(hass):
     flow.hass = hass
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_configuration"
 
 
@@ -128,21 +128,21 @@ async def test_abort_if_already_setup(hass):
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_USER},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     with pytest.raises(data_entry_flow.AbortFlow):
         result = await flow.async_step_code()
 
     result = await flow.async_step_auth()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "external_setup"
 
 
@@ -161,7 +161,7 @@ async def test_abort_if_authorize_fails(
     mock_logi_circle.authorize.side_effect = side_effect
 
     result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "external_error"
 
     result = await flow.async_step_auth()
@@ -173,7 +173,7 @@ async def test_not_pick_implementation_if_only_one(hass):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -101,7 +101,7 @@ async def test_bridge_cannot_connect(hass):
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
@@ -124,7 +124,7 @@ async def test_bridge_cannot_connect_unknown_error(hass):
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
@@ -144,7 +144,7 @@ async def test_bridge_invalid_ssl_error(hass):
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
@@ -171,7 +171,7 @@ async def test_duplicate_bridge_import(hass):
             data=entry_mock_data,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(mock_setup_entry.mock_calls) == 0
 

--- a/tests/components/lyric/test_config_flow.py
+++ b/tests/components/lyric/test_config_flow.py
@@ -40,7 +40,7 @@ async def test_abort_if_no_configuration(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
@@ -71,7 +71,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -132,7 +132,7 @@ async def test_abort_if_authorization_timeout(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -196,7 +196,7 @@ async def test_reauthentication_flow(
         ) as mock_setup:
             result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/mailgun/test_init.py
+++ b/tests/components/mailgun/test_init.py
@@ -37,10 +37,10 @@ async def webhook_id_with_api_key(hass):
     result = await hass.config_entries.flow.async_init(
         "mailgun", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     return result["result"].data["webhook_id"]
 
@@ -57,10 +57,10 @@ async def webhook_id_without_api_key(hass):
     result = await hass.config_entries.flow.async_init(
         "mailgun", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     return result["result"].data["webhook_id"]
 

--- a/tests/components/mazda/test_config_flow.py
+++ b/tests/components/mazda/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -71,7 +71,7 @@ async def test_account_already_exists(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -95,7 +95,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -109,7 +109,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -120,7 +120,7 @@ async def test_form_account_locked(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -134,7 +134,7 @@ async def test_form_account_locked(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "account_locked"}
 
@@ -206,7 +206,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {}
 
@@ -220,7 +220,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "reauth_successful"
 
 
@@ -249,7 +249,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -258,7 +258,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -288,7 +288,7 @@ async def test_reauth_account_locked(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -297,7 +297,7 @@ async def test_reauth_account_locked(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "account_locked"}
 
@@ -327,7 +327,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -336,7 +336,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -366,7 +366,7 @@ async def test_reauth_unknown_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -375,7 +375,7 @@ async def test_reauth_unknown_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "user"
         assert result2["errors"] == {"base": "unknown"}
 
@@ -405,7 +405,7 @@ async def test_reauth_user_has_new_email_address(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         # Change the email and ensure the entry and its unique id gets
@@ -419,5 +419,5 @@ async def test_reauth_user_has_new_email_address(hass: HomeAssistant) -> None:
         assert (
             mock_config.unique_id == FIXTURE_USER_INPUT_REAUTH_CHANGED_EMAIL[CONF_EMAIL]
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "reauth_successful"

--- a/tests/components/meater/test_config_flow.py
+++ b/tests/components/meater/test_config_flow.py
@@ -37,7 +37,7 @@ async def test_duplicate_error(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=conf
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -83,7 +83,7 @@ async def test_user_flow(hass, mock_meater):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -93,7 +93,7 @@ async def test_user_flow(hass, mock_meater):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], conf)
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_USERNAME: "user@host.com",
         CONF_PASSWORD: "password123",
@@ -126,7 +126,7 @@ async def test_reauth_flow(hass, mock_meater):
         data=data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] is None
 
@@ -136,7 +136,7 @@ async def test_reauth_flow(hass, mock_meater):
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]

--- a/tests/components/met_eireann/test_config_flow.py
+++ b/tests/components/met_eireann/test_config_flow.py
@@ -64,7 +64,7 @@ async def test_create_entry(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=test_data
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == test_data.get("name")
     assert result["data"] == test_data
 
@@ -85,11 +85,11 @@ async def test_flow_entry_already_exists(hass):
     result1 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=test_data
     )
-    assert result1["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result1["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Create the second entry and assert that it is aborted
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=test_data
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -121,7 +121,7 @@ async def test_user(hass, client_single):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # test with all provided with search returning only 1 place
@@ -130,7 +130,7 @@ async def test_user(hass, client_single):
         context={"source": SOURCE_USER},
         data={CONF_CITY: CITY_1_POSTAL},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == f"{CITY_1_LAT}, {CITY_1_LON}"
     assert result["title"] == f"{CITY_1}"
     assert result["data"][CONF_LATITUDE] == str(CITY_1_LAT)
@@ -146,14 +146,14 @@ async def test_user_list(hass, client_multiple):
         context={"source": SOURCE_USER},
         data={CONF_CITY: CITY_2_NAME},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "cities"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_CITY: f"{CITY_3};{CITY_3_LAT};{CITY_3_LON}"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == f"{CITY_3_LAT}, {CITY_3_LON}"
     assert result["title"] == f"{CITY_3}"
     assert result["data"][CONF_LATITUDE] == str(CITY_3_LAT)
@@ -168,7 +168,7 @@ async def test_import(hass, client_multiple):
         context={"source": SOURCE_IMPORT},
         data={CONF_CITY: CITY_2_NAME},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == f"{CITY_2_LAT}, {CITY_2_LON}"
     assert result["title"] == f"{CITY_2}"
     assert result["data"][CONF_LATITUDE] == str(CITY_2_LAT)
@@ -183,7 +183,7 @@ async def test_search_failed(hass, client_empty):
         data={CONF_CITY: CITY_1_POSTAL},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_CITY: "empty"}
 
 
@@ -201,7 +201,7 @@ async def test_abort_if_already_setup(hass, client_single):
         context={"source": SOURCE_IMPORT},
         data={CONF_CITY: CITY_1_POSTAL},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     # Should fail, same CITY same postal code (flow)
@@ -210,7 +210,7 @@ async def test_abort_if_already_setup(hass, client_single):
         context={"source": SOURCE_USER},
         data={CONF_CITY: CITY_1_POSTAL},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -226,7 +226,7 @@ async def test_options_flow(hass: HomeAssistant):
     assert config_entry.options == {}
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # Default
@@ -234,7 +234,7 @@ async def test_options_flow(hass: HomeAssistant):
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options[CONF_MODE] == FORECAST_MODE_DAILY
 
     # Manual
@@ -243,5 +243,5 @@ async def test_options_flow(hass: HomeAssistant):
         result["flow_id"],
         user_input={CONF_MODE: FORECAST_MODE_HOURLY},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options[CONF_MODE] == FORECAST_MODE_HOURLY

--- a/tests/components/meteoclimatic/test_config_flow.py
+++ b/tests/components/meteoclimatic/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_user(hass, client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # test with all provided
@@ -51,7 +51,7 @@ async def test_user(hass, client):
         context={"source": SOURCE_USER},
         data={CONF_STATION_CODE: TEST_STATION_CODE},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == TEST_STATION_CODE
     assert result["title"] == TEST_STATION_NAME
     assert result["data"][CONF_STATION_CODE] == TEST_STATION_CODE
@@ -68,7 +68,7 @@ async def test_not_found(hass):
             context={"source": SOURCE_USER},
             data={CONF_STATION_CODE: TEST_STATION_CODE},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "not_found"
 
@@ -84,5 +84,5 @@ async def test_unknown_error(hass):
             context={"source": SOURCE_USER},
             data={CONF_STATION_CODE: TEST_STATION_CODE},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unknown"

--- a/tests/components/mikrotik/test_config_flow.py
+++ b/tests/components/mikrotik/test_config_flow.py
@@ -89,14 +89,14 @@ async def test_flow_works(hass, api):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=DEMO_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Home router"
     assert result["data"][CONF_NAME] == "Home router"
     assert result["data"][CONF_HOST] == "0.0.0.0"
@@ -115,7 +115,7 @@ async def test_options(hass, api):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "device_tracker"
 
     result = await hass.config_entries.options.async_configure(
@@ -127,7 +127,7 @@ async def test_options(hass, api):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_DETECTION_TIME: 30,
         CONF_ARP_PING: True,
@@ -179,7 +179,7 @@ async def test_connection_error(hass, conn_error):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=DEMO_USER_INPUT
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -193,7 +193,7 @@ async def test_wrong_credentials(hass, auth_error):
         result["flow_id"], user_input=DEMO_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {
         CONF_USERNAME: "invalid_auth",
         CONF_PASSWORD: "invalid_auth",

--- a/tests/components/modem_callerid/test_config_flow.py
+++ b/tests/components/modem_callerid/test_config_flow.py
@@ -37,14 +37,14 @@ async def test_flow_usb(hass: HomeAssistant):
             context={CONF_SOURCE: SOURCE_USB},
             data=DISCOVERY_INFO,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "usb_confirm"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={CONF_DEVICE: phone_modem.DEFAULT_PORT},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == {CONF_DEVICE: com_port().device}
 
 
@@ -56,7 +56,7 @@ async def test_flow_usb_cannot_connect(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -78,7 +78,7 @@ async def test_flow_user(hass: HomeAssistant):
             context={CONF_SOURCE: SOURCE_USER},
             data={CONF_DEVICE: port_select},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == {CONF_DEVICE: port.device}
 
         result = await hass.config_entries.flow.async_init(
@@ -86,7 +86,7 @@ async def test_flow_user(hass: HomeAssistant):
             context={CONF_SOURCE: SOURCE_USER},
             data={CONF_DEVICE: port_select},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "no_devices_found"
 
 
@@ -107,7 +107,7 @@ async def test_flow_user_error(hass: HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={CONF_DEVICE: port_select}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "cannot_connect"}
 
@@ -116,7 +116,7 @@ async def test_flow_user_error(hass: HomeAssistant):
             result["flow_id"],
             user_input={CONF_DEVICE: port_select},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] == {CONF_DEVICE: port.device}
 
 
@@ -129,7 +129,7 @@ async def test_flow_user_no_port_list(hass: HomeAssistant):
             context={CONF_SOURCE: SOURCE_USER},
             data={CONF_DEVICE: phone_modem.DEFAULT_PORT},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "no_devices_found"
 
 
@@ -141,7 +141,7 @@ async def test_abort_user_with_existing_flow(hass: HomeAssistant):
             context={CONF_SOURCE: SOURCE_USB},
             data=DISCOVERY_INFO,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "usb_confirm"
 
         result2 = await hass.config_entries.flow.async_init(
@@ -150,5 +150,5 @@ async def test_abort_user_with_existing_flow(hass: HomeAssistant):
             data={},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "already_in_progress"

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -107,7 +107,7 @@ async def test_options_flow(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -115,5 +115,5 @@ async def test_options_flow(hass):
             user_input={CONF_SOURCE_1: "one", CONF_SOURCE_4: "", CONF_SOURCE_5: "five"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options[CONF_SOURCES] == {"1": "one", "5": "five"}

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -372,7 +372,7 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -380,7 +380,7 @@ async def test_options_flow(hass):
         user_input={const.CONF_WAIT_FOR_PUSH: False},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         const.CONF_WAIT_FOR_PUSH: False,
     }

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -79,13 +79,13 @@ async def test_hassio_success(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_HASSIO},
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "hassio_confirm"
     assert result.get("description_placeholders") == {"addon": "motionEye"}
     assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result2.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result2.get("type") == data_entry_flow.FlowResultType.FORM
     assert result2.get("step_id") == "user"
     assert "flow_id" in result2
 
@@ -109,7 +109,7 @@ async def test_hassio_success(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3.get("title") == "Add-on"
     assert result3.get("data") == {
         CONF_URL: TEST_URL,
@@ -287,7 +287,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert dict(config_entry.data) == {**new_data, CONF_WEBHOOK_ID: "test-webhook-id"}
 
@@ -337,7 +337,7 @@ async def test_duplicate(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert mock_client.async_client_close.called
 
@@ -354,7 +354,7 @@ async def test_hassio_already_configured(hass: HomeAssistant) -> None:
         data=HassioServiceInfo(config={"addon": "motionEye", "url": TEST_URL}),
         context={"source": config_entries.SOURCE_HASSIO},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
 
 
@@ -369,7 +369,7 @@ async def test_hassio_ignored(hass: HomeAssistant) -> None:
         data=HassioServiceInfo(config={"addon": "motionEye", "url": TEST_URL}),
         context={"source": config_entries.SOURCE_HASSIO},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
 
 
@@ -378,14 +378,14 @@ async def test_hassio_abort_if_already_in_progress(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
 
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         data=HassioServiceInfo(config={"addon": "motionEye", "url": TEST_URL}),
         context={"source": config_entries.SOURCE_HASSIO},
     )
-    assert result2.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result2.get("reason") == "already_in_progress"
 
 
@@ -397,12 +397,12 @@ async def test_hassio_clean_up_on_user_flow(hass: HomeAssistant) -> None:
         data=HassioServiceInfo(config={"addon": "motionEye", "url": TEST_URL}),
         context={"source": config_entries.SOURCE_HASSIO},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
 
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result2.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result2.get("type") == data_entry_flow.FlowResultType.FORM
     assert "flow_id" in result2
 
     mock_client = create_mock_motioneye_client()
@@ -426,7 +426,7 @@ async def test_hassio_clean_up_on_user_flow(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(mock_setup_entry.mock_calls) == 1
 
     flows = hass.config_entries.flow.async_progress()
@@ -449,7 +449,7 @@ async def test_options(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -460,7 +460,7 @@ async def test_options(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_WEBHOOK_SET]
         assert result["data"][CONF_WEBHOOK_SET_OVERWRITE]
         assert CONF_STREAM_URL_TEMPLATE not in result["data"]
@@ -492,7 +492,7 @@ async def test_advanced_options(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_WEBHOOK_SET]
         assert result["data"][CONF_WEBHOOK_SET_OVERWRITE]
         assert CONF_STREAM_URL_TEMPLATE not in result["data"]
@@ -511,7 +511,7 @@ async def test_advanced_options(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_WEBHOOK_SET]
         assert result["data"][CONF_WEBHOOK_SET_OVERWRITE]
         assert result["data"][CONF_STREAM_URL_TEMPLATE] == "http://moo"

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -218,7 +218,7 @@ async def test_hassio_ignored(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_HASSIO},
     )
     assert result
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
 
 
@@ -277,7 +277,7 @@ async def test_option_flow(hass, mqtt_mock_entry_no_yaml_config, mock_try_connec
     mqtt_mock.async_connect.reset_mock()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "broker"
 
     result = await hass.config_entries.options.async_configure(
@@ -289,7 +289,7 @@ async def test_option_flow(hass, mqtt_mock_entry_no_yaml_config, mock_try_connec
             mqtt.CONF_PASSWORD: "pass",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "options"
 
     await hass.async_block_till_done()
@@ -311,7 +311,7 @@ async def test_option_flow(hass, mqtt_mock_entry_no_yaml_config, mock_try_connec
             "will_retain": True,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert config_entry.data == {
         mqtt.CONF_BROKER: "another-broker",
@@ -352,7 +352,7 @@ async def test_disable_birth_will(
     mqtt_mock.async_connect.reset_mock()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "broker"
 
     result = await hass.config_entries.options.async_configure(
@@ -364,7 +364,7 @@ async def test_disable_birth_will(
             mqtt.CONF_PASSWORD: "pass",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "options"
 
     await hass.async_block_till_done()
@@ -386,7 +386,7 @@ async def test_disable_birth_will(
             "will_retain": True,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert config_entry.data == {
         mqtt.CONF_BROKER: "another-broker",
@@ -448,7 +448,7 @@ async def test_option_flow_default_suggested_values(
 
     # Test default/suggested values from config
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "broker"
     defaults = {
         mqtt.CONF_BROKER: "test-broker",
@@ -472,7 +472,7 @@ async def test_option_flow_default_suggested_values(
             mqtt.CONF_PASSWORD: "p4ss",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "options"
     defaults = {
         mqtt.CONF_DISCOVERY: True,
@@ -506,11 +506,11 @@ async def test_option_flow_default_suggested_values(
             "will_retain": True,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Test updated default/suggested values from config
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "broker"
     defaults = {
         mqtt.CONF_BROKER: "another-broker",
@@ -529,7 +529,7 @@ async def test_option_flow_default_suggested_values(
         result["flow_id"],
         user_input={mqtt.CONF_BROKER: "another-broker", mqtt.CONF_PORT: 2345},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "options"
     defaults = {
         mqtt.CONF_DISCOVERY: False,
@@ -563,7 +563,7 @@ async def test_option_flow_default_suggested_values(
             "will_retain": True,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Make sure all MQTT related jobs are done before ending the test
     await hass.async_block_till_done()
@@ -717,7 +717,7 @@ async def test_try_connection_with_advanced_parameters(
 
         # Test default/suggested values from config
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "broker"
         defaults = {
             mqtt.CONF_BROKER: "test-broker",
@@ -741,7 +741,7 @@ async def test_try_connection_with_advanced_parameters(
                 mqtt.CONF_PASSWORD: "p4ss",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "options"
 
         # check if the username and password was set from config flow and not from configuration.yaml

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -32,7 +32,7 @@ async def test_form_create_entry_without_auth(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {}
 
@@ -51,7 +51,7 @@ async def test_form_create_entry_without_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.2.3"
     assert result["data"]["host"] == "10.10.2.3"
     assert len(mock_setup_entry.mock_calls) == 1
@@ -62,7 +62,7 @@ async def test_form_create_entry_with_auth(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {}
 
@@ -80,7 +80,7 @@ async def test_form_create_entry_with_auth(hass):
             VALID_CONFIG,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "credentials"
 
         result = await hass.config_entries.flow.async_configure(
@@ -89,7 +89,7 @@ async def test_form_create_entry_with_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.2.3"
     assert result["data"]["host"] == "10.10.2.3"
     assert result["data"]["username"] == "fake_username"
@@ -120,7 +120,7 @@ async def test_reauth_successful(hass):
             data=entry.data,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
 
         result = await hass.config_entries.flow.async_configure(
@@ -128,7 +128,7 @@ async def test_reauth_successful(hass):
             user_input=VALID_AUTH,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
 
 
@@ -152,7 +152,7 @@ async def test_reauth_unsuccessful(hass):
             data=entry.data,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
 
         result = await hass.config_entries.flow.async_configure(
@@ -160,7 +160,7 @@ async def test_reauth_unsuccessful(hass):
             user_input=VALID_AUTH,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_unsuccessful"
 
 
@@ -189,7 +189,7 @@ async def test_form_with_auth_errors(hass, error):
             data=VALID_CONFIG,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "credentials"
 
     with patch(
@@ -244,7 +244,7 @@ async def test_form_abort(hass):
             data=VALID_CONFIG,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "device_unsupported"
 
 
@@ -271,7 +271,7 @@ async def test_form_already_configured(hass):
             {"host": "1.1.1.1"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     # Test config entry got updated with latest IP
@@ -298,7 +298,7 @@ async def test_zeroconf(hass):
             if flow["flow_id"] == result["flow_id"]
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert context["title_placeholders"]["host"] == "10.10.2.3"
     assert context["confirm_only"] is True
@@ -313,7 +313,7 @@ async def test_zeroconf(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.2.3"
     assert result["data"] == {"host": "10.10.2.3"}
     assert len(mock_setup_entry.mock_calls) == 1
@@ -339,7 +339,7 @@ async def test_zeroconf_with_auth(hass):
             if flow["flow_id"] == result["flow_id"]
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "credentials"
     assert result["errors"] == {}
     assert context["title_placeholders"]["host"] == "10.10.2.3"
@@ -359,7 +359,7 @@ async def test_zeroconf_with_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.2.3"
     assert result["data"]["host"] == "10.10.2.3"
     assert result["data"]["username"] == "fake_username"
@@ -380,7 +380,7 @@ async def test_zeroconf_host_already_configured(hass):
         context={"source": SOURCE_ZEROCONF},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -404,5 +404,5 @@ async def test_zeroconf_errors(hass, error):
             context={"source": SOURCE_ZEROCONF},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == reason

--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -85,7 +85,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         "neato", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -111,7 +111,7 @@ async def test_reauth(
     result = await hass.config_entries.flow.async_init(
         "neato", context={"source": config_entries.SOURCE_REAUTH}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     # Confirm reauth flow
@@ -148,7 +148,7 @@ async def test_reauth(
 
     new_entry = hass.config_entries.async_get_entry("my_entry")
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
     assert new_entry.state == config_entries.ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(NEATO_DOMAIN)) == 1

--- a/tests/components/nest/test_config_flow_legacy.py
+++ b/tests/components/nest/test_config_flow_legacy.py
@@ -24,7 +24,7 @@ async def test_abort_if_single_instance_allowed(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -40,14 +40,14 @@ async def test_full_flow_implementation(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"flow_impl": "nest"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
     assert (
         result["description_placeholders"]
@@ -69,7 +69,7 @@ async def test_full_flow_implementation(hass):
         )
         await hass.async_block_till_done()
         assert len(mock_setup.mock_calls) == 1
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"]["tokens"] == {"access_token": "yoo"}
         assert result["data"]["impl_domain"] == "nest"
         assert result["title"] == "Nest (via configuration.yaml)"
@@ -83,7 +83,7 @@ async def test_not_pick_implementation_if_only_one(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
 
@@ -99,7 +99,7 @@ async def test_abort_if_timeout_generating_auth_url(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "authorize_url_timeout"
 
 
@@ -115,7 +115,7 @@ async def test_abort_if_exception_generating_auth_url(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown_authorize_url_generation"
 
 
@@ -127,7 +127,7 @@ async def test_verify_code_timeout(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     with patch(
@@ -137,7 +137,7 @@ async def test_verify_code_timeout(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"code": "123ABC"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "link"
         assert result["errors"] == {"code": "timeout"}
 
@@ -150,7 +150,7 @@ async def test_verify_code_invalid(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     with patch(
@@ -160,7 +160,7 @@ async def test_verify_code_invalid(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"code": "123ABC"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "link"
         assert result["errors"] == {"code": "invalid_pin"}
 
@@ -173,7 +173,7 @@ async def test_verify_code_unknown_error(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     with patch(
@@ -183,7 +183,7 @@ async def test_verify_code_unknown_error(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"code": "123ABC"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "link"
         assert result["errors"] == {"code": "unknown"}
 
@@ -196,7 +196,7 @@ async def test_verify_code_exception(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     with patch(
@@ -206,7 +206,7 @@ async def test_verify_code_exception(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"code": "123ABC"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "link"
         assert result["errors"] == {"code": "internal_error"}
 
@@ -220,7 +220,7 @@ async def test_step_import(hass):
     flow = hass.config_entries.flow.async_progress()[0]
     result = await hass.config_entries.flow.async_configure(flow["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
 

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_abort_if_existing_entry(hass):
     result = await hass.config_entries.flow.async_init(
         "netatmo", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
     result = await hass.config_entries.flow.async_init(
@@ -50,7 +50,7 @@ async def test_abort_if_existing_entry(hass):
             type="mock_type",
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -142,28 +142,28 @@ async def test_option_flow(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "public_weather_areas"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_NEW_AREA: "Home"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "public_weather"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input=valid_option
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "public_weather_areas"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     for k, v in expected_result.items():
         assert config_entry.options[CONF_WEATHER_AREAS]["Home"][k] == v
 
@@ -200,28 +200,28 @@ async def test_option_flow_wrong_coordinates(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "public_weather_areas"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_NEW_AREA: "Home"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "public_weather"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input=valid_option
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "public_weather_areas"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     for k, v in expected_result.items():
         assert config_entry.options[CONF_WEATHER_AREAS]["Home"][k] == v
 
@@ -289,7 +289,7 @@ async def test_reauth(
     result = await hass.config_entries.flow.async_init(
         "netatmo", context={"source": config_entries.SOURCE_REAUTH}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     # Confirm reauth flow
@@ -326,7 +326,7 @@ async def test_reauth(
 
     new_entry2 = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
     assert new_entry2.state == config_entries.ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -115,7 +115,7 @@ async def test_user(hass, service):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Have to provide all config
@@ -127,7 +127,7 @@ async def test_user(hass, service):
             CONF_PASSWORD: PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
@@ -142,7 +142,7 @@ async def test_user_connect_error(hass, service_failed):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Have to provide all config
@@ -154,7 +154,7 @@ async def test_user_connect_error(hass, service_failed):
             CONF_PASSWORD: PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
 
@@ -164,7 +164,7 @@ async def test_user_incomplete_info(hass, service_incomplete):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Have to provide all config
@@ -176,7 +176,7 @@ async def test_user_incomplete_info(hass, service_incomplete):
             CONF_PASSWORD: PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE_INCOMPLETE
     assert result["data"].get(CONF_HOST) == HOST
@@ -198,14 +198,14 @@ async def test_abort_if_already_setup(hass, service):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_PASSWORD: PASSWORD},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -231,7 +231,7 @@ async def test_ssdp_already_configured(hass):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -257,7 +257,7 @@ async def test_ssdp_ipv6(hass):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "not_ipv4_address"
 
 
@@ -277,13 +277,13 @@ async def test_ssdp(hass, service):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_PASSWORD: PASSWORD}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
@@ -309,13 +309,13 @@ async def test_ssdp_port_5555(hass, service_5555):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_PASSWORD: PASSWORD}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
@@ -340,7 +340,7 @@ async def test_options_flow(hass, service):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -350,7 +350,7 @@ async def test_options_flow(hass, service):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         CONF_CONSIDER_HOME: 1800,
     }

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -22,7 +22,7 @@ async def test_form_create_entry(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {}
 
@@ -36,7 +36,7 @@ async def test_form_create_entry(hass):
             {CONF_API_KEY: "fake_api_key"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "profiles"
 
         result = await hass.config_entries.flow.async_configure(
@@ -44,7 +44,7 @@ async def test_form_create_entry(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Fake Profile"
     assert result["data"][CONF_API_KEY] == "fake_api_key"
     assert result["data"][CONF_PROFILE_ID] == "xyz12"
@@ -96,5 +96,5 @@ async def test_form_already_configured(hass):
         result["flow_id"], {CONF_PROFILE_NAME: "Fake Profile"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/nfandroidtv/test_config_flow.py
+++ b/tests/components/nfandroidtv/test_config_flow.py
@@ -37,7 +37,7 @@ async def test_flow_user(hass):
             result["flow_id"],
             user_input=CONF_CONFIG_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == NAME
         assert result["data"] == CONF_DATA
 
@@ -62,7 +62,7 @@ async def test_flow_user_already_configured(hass):
             result["flow_id"],
             user_input=CONF_CONFIG_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -76,7 +76,7 @@ async def test_flow_user_cannot_connect(hass):
             context={"source": config_entries.SOURCE_USER},
             data=CONF_CONFIG_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "cannot_connect"}
 
@@ -91,6 +91,6 @@ async def test_flow_user_unknown_error(hass):
             context={"source": config_entries.SOURCE_USER},
             data=CONF_CONFIG_FLOW,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "unknown"}

--- a/tests/components/nightscout/test_config_flow.py
+++ b/tests/components/nightscout/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with _patch_glucose_readings(), _patch_server_status(), _patch_async_setup_entry() as mock_setup_entry:
@@ -34,7 +34,7 @@ async def test_form(hass):
             CONFIG,
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == SERVER_STATUS.name  # pylint: disable=maybe-no-member
         assert result2["data"] == CONFIG
         await hass.async_block_till_done()
@@ -56,7 +56,7 @@ async def test_user_form_cannot_connect(hass):
             {CONF_URL: "https://some.url:1234"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -78,7 +78,7 @@ async def test_user_form_api_key_required(hass):
             {CONF_URL: "https://some.url:1234"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -97,7 +97,7 @@ async def test_user_form_unexpected_exception(hass):
             {CONF_URL: "https://some.url:1234"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -112,7 +112,7 @@ async def test_user_form_duplicate(hass):
             context={"source": config_entries.SOURCE_USER},
             data=CONFIG,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -58,7 +58,7 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
 
@@ -73,7 +73,7 @@ async def test_step_user_connection_error(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -88,7 +88,7 @@ async def test_step_user_unexpected_exception(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_step_user(hass: HomeAssistant) -> None:
@@ -105,7 +105,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "NINA"
 
 
@@ -120,7 +120,7 @@ async def test_step_user_no_selection(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "no_selection"}
 
@@ -139,7 +139,7 @@ async def test_step_user_already_configured(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "single_instance_allowed"
 
 
@@ -168,7 +168,7 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -183,7 +183,7 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"] is None
 
         assert dict(config_entry.data) == {
@@ -221,7 +221,7 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -236,7 +236,7 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
         assert result["errors"] == {"base": "no_selection"}
 
@@ -262,7 +262,7 @@ async def test_options_flow_connection_error(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -287,7 +287,7 @@ async def test_options_flow_unexpected_exception(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_options_flow_entity_removal(hass: HomeAssistant) -> None:
@@ -321,7 +321,7 @@ async def test_options_flow_entity_removal(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         entity_registry: er = er.async_get(hass)
         entries = er.async_entries_for_config_entry(

--- a/tests/components/nmap_tracker/test_config_flow.py
+++ b/tests/components/nmap_tracker/test_config_flow.py
@@ -202,7 +202,7 @@ async def test_options_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     assert result["data_schema"]({}) == {
@@ -231,7 +231,7 @@ async def test_options_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         CONF_HOSTS: "192.168.1.0/24,192.168.2.0/24",
         CONF_HOME_INTERVAL: 5,

--- a/tests/components/notion/test_config_flow.py
+++ b/tests/components/notion/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_duplicate_error(hass, config, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -45,7 +45,7 @@ async def test_step_reauth(hass, config, config_entry, setup_notion):
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     with patch("homeassistant.components.notion.async_setup_entry", return_value=True):
@@ -54,7 +54,7 @@ async def test_step_reauth(hass, config, config_entry, setup_notion):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries()) == 1
 
@@ -64,7 +64,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -73,7 +73,7 @@ async def test_step_user(hass, config, setup_notion):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "user@host.com"
     assert result["data"] == {
         CONF_USERNAME: "user@host.com",

--- a/tests/components/nuki/test_config_flow.py
+++ b/tests/components/nuki/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -38,7 +38,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "75BCD15"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -67,7 +67,7 @@ async def test_form_invalid_auth(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -90,7 +90,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -113,7 +113,7 @@ async def test_form_unknown_exception(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -137,7 +137,7 @@ async def test_form_already_configured(hass):
             },
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "already_configured"
 
 
@@ -149,7 +149,7 @@ async def test_dhcp_flow(hass):
         context={"source": config_entries.SOURCE_DHCP},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
     with patch(
@@ -168,7 +168,7 @@ async def test_dhcp_flow(hass):
             },
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == "75BCD15"
         assert result2["data"] == {
             "host": "1.1.1.1",
@@ -189,7 +189,7 @@ async def test_dhcp_flow_already_configured(hass):
         context={"source": config_entries.SOURCE_DHCP},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -200,7 +200,7 @@ async def test_reauth_success(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=entry.data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -216,7 +216,7 @@ async def test_reauth_success(hass):
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "reauth_successful"
         assert entry.data[CONF_TOKEN] == "new-token"
 
@@ -228,7 +228,7 @@ async def test_reauth_invalid_auth(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=entry.data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -240,7 +240,7 @@ async def test_reauth_invalid_auth(hass):
             user_input={CONF_TOKEN: "new-token"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth_confirm"
         assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -252,7 +252,7 @@ async def test_reauth_cannot_connect(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=entry.data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -264,7 +264,7 @@ async def test_reauth_cannot_connect(hass):
             user_input={CONF_TOKEN: "new-token"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth_confirm"
         assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -276,7 +276,7 @@ async def test_reauth_unknown_exception(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=entry.data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -288,6 +288,6 @@ async def test_reauth_unknown_exception(hass):
             user_input={CONF_TOKEN: "new-token"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth_confirm"
         assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_form_zeroconf(hass):
             type="mock_type",
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -66,7 +66,7 @@ async def test_form_zeroconf(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "192.168.1.5:1234"
     assert result2["data"] == {
         CONF_HOST: "192.168.1.5",
@@ -84,7 +84,7 @@ async def test_form_user_one_ups(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     mock_pynut = _get_mock_pynutclient(
@@ -109,7 +109,7 @@ async def test_form_user_one_ups(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "1.1.1.1:2222"
     assert result2["data"] == {
         CONF_HOST: "1.1.1.1",
@@ -133,7 +133,7 @@ async def test_form_user_multiple_ups(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     mock_pynut = _get_mock_pynutclient(
@@ -156,7 +156,7 @@ async def test_form_user_multiple_ups(hass):
         )
 
     assert result2["step_id"] == "ups"
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "homeassistant.components.nut.PyNUTClient",
@@ -171,7 +171,7 @@ async def test_form_user_multiple_ups(hass):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "ups2@1.1.1.1:2222"
     assert result3["data"] == {
         CONF_HOST: "1.1.1.1",
@@ -194,7 +194,7 @@ async def test_form_user_one_ups_with_ignored_entry(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     mock_pynut = _get_mock_pynutclient(
@@ -219,7 +219,7 @@ async def test_form_user_one_ups_with_ignored_entry(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "1.1.1.1:2222"
     assert result2["data"] == {
         CONF_HOST: "1.1.1.1",
@@ -252,7 +252,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -272,7 +272,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -292,7 +292,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -329,7 +329,7 @@ async def test_abort_if_already_setup(hass):
             },
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "already_configured"
 
 
@@ -368,7 +368,7 @@ async def test_abort_if_already_setup_alias(hass):
         )
 
     assert result2["step_id"] == "ups"
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "homeassistant.components.nut.PyNUTClient",
@@ -379,7 +379,7 @@ async def test_abort_if_already_setup_alias(hass):
             {CONF_ALIAS: "ups1"},
         )
 
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result3["type"] == data_entry_flow.FlowResultType.ABORT
         assert result3["reason"] == "already_configured"
 
 
@@ -396,14 +396,14 @@ async def test_options_flow(hass):
     with patch("homeassistant.components.nut.async_setup_entry", return_value=True):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {
             CONF_SCAN_INTERVAL: 60,
         }
@@ -411,7 +411,7 @@ async def test_options_flow(hass):
     with patch("homeassistant.components.nut.async_setup_entry", return_value=True):
         result2 = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "init"
 
         result2 = await hass.config_entries.options.async_configure(
@@ -419,7 +419,7 @@ async def test_options_flow(hass):
             user_input={CONF_SCAN_INTERVAL: 12},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {
             CONF_SCAN_INTERVAL: 12,
         }

--- a/tests/components/octoprint/test_config_flow.py
+++ b/tests/components/octoprint/test_config_flow.py
@@ -230,7 +230,7 @@ async def test_show_zerconf_form(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_show_ssdp_form(hass: HomeAssistant) -> None:
@@ -296,7 +296,7 @@ async def test_show_ssdp_form(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_import_yaml(hass: HomeAssistant) -> None:
@@ -328,7 +328,7 @@ async def test_import_yaml(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert "errors" not in result
 
 
@@ -362,7 +362,7 @@ async def test_import_duplicate_yaml(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert len(request_app_key.mock_calls) == 0
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 

--- a/tests/components/omnilogic/test_config_flow.py
+++ b/tests/components/omnilogic/test_config_flow.py
@@ -129,7 +129,7 @@ async def test_option_flow(hass):
             data=None,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -137,6 +137,6 @@ async def test_option_flow(hass):
         user_input={"polling_interval": 9},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"]["polling_interval"] == 9

--- a/tests/components/ondilo_ico/test_config_flow.py
+++ b/tests/components/ondilo_ico/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_abort_if_existing_entry(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -73,7 +73,7 @@ async def test_flow_discovered_devices(hass):
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -91,7 +91,7 @@ async def test_flow_discovered_devices(hass):
             result["flow_id"], user_input={"auto": True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "device"
         assert len(result["data_schema"].schema[config_flow.CONF_HOST].container) == 3
 
@@ -99,7 +99,7 @@ async def test_flow_discovered_devices(hass):
             result["flow_id"], user_input={config_flow.CONF_HOST: f"{URN} ({HOST})"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "configure"
 
         with patch(
@@ -116,7 +116,7 @@ async def test_flow_discovered_devices(hass):
             await hass.async_block_till_done()
             assert len(mock_setup_entry.mock_calls) == 1
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == f"{URN} - {MAC}"
         assert result["data"] == {
             config_flow.CONF_NAME: URN,
@@ -135,7 +135,7 @@ async def test_flow_discovered_devices_ignore_configured_manual_input(hass):
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -153,7 +153,7 @@ async def test_flow_discovered_devices_ignore_configured_manual_input(hass):
             result["flow_id"], user_input={"auto": True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "device"
         assert len(result["data_schema"].schema[config_flow.CONF_HOST].container) == 2
 
@@ -162,7 +162,7 @@ async def test_flow_discovered_devices_ignore_configured_manual_input(hass):
             user_input={config_flow.CONF_HOST: config_flow.CONF_MANUAL_INPUT},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "configure"
 
 
@@ -174,7 +174,7 @@ async def test_flow_discovered_no_device(hass):
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -192,7 +192,7 @@ async def test_flow_discovered_no_device(hass):
             result["flow_id"], user_input={"auto": True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "configure"
 
 
@@ -216,7 +216,7 @@ async def test_flow_discovery_ignore_existing_and_abort(hass):
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -235,7 +235,7 @@ async def test_flow_discovery_ignore_existing_and_abort(hass):
         )
 
         # It should skip to manual entry if the only devices are already configured
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "configure"
 
         result = await hass.config_entries.flow.async_configure(
@@ -250,7 +250,7 @@ async def test_flow_discovery_ignore_existing_and_abort(hass):
         )
 
         # It should abort if already configured and entered manually
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_flow_manual_entry(hass):
@@ -259,7 +259,7 @@ async def test_flow_manual_entry(hass):
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -279,7 +279,7 @@ async def test_flow_manual_entry(hass):
             user_input={"auto": False},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "configure"
 
         with patch(
@@ -299,7 +299,7 @@ async def test_flow_manual_entry(hass):
             await hass.async_block_till_done()
             assert len(mock_setup_entry.mock_calls) == 1
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == f"{NAME} - {MAC}"
         assert result["data"] == {
             config_flow.CONF_NAME: NAME,
@@ -318,7 +318,7 @@ async def test_option_flow(hass):
         entry.entry_id, context={"show_advanced_options": True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "onvif_devices"
 
     result = await hass.config_entries.options.async_configure(
@@ -330,7 +330,7 @@ async def test_option_flow(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         config_flow.CONF_EXTRA_ARGUMENTS: "",
         config_flow.CONF_RTSP_TRANSPORT: list(config_flow.RTSP_TRANSPORTS)[1],

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -204,7 +204,7 @@ async def test_options_migration(hass):
             entry.entry_id, context={"source": config_entries.SOURCE_USER}, data=None
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -212,7 +212,7 @@ async def test_options_migration(hass):
             user_input={},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_READ_PRECISION] == PRECISION_TENTHS
         assert result["data"][CONF_SET_PRECISION] == PRECISION_TENTHS
         assert result["data"][CONF_FLOOR_TEMP] is True
@@ -243,7 +243,7 @@ async def test_options_form(hass):
     result = await hass.config_entries.options.async_init(
         entry.entry_id, context={"source": "test"}, data=None
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -256,7 +256,7 @@ async def test_options_form(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_READ_PRECISION] == PRECISION_HALVES
     assert result["data"][CONF_SET_PRECISION] == PRECISION_HALVES
     assert result["data"][CONF_TEMPORARY_OVRD_MODE] is True
@@ -270,7 +270,7 @@ async def test_options_form(hass):
         result["flow_id"], user_input={CONF_READ_PRECISION: 0}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_READ_PRECISION] == 0.0
     assert result["data"][CONF_SET_PRECISION] == PRECISION_HALVES
     assert result["data"][CONF_TEMPORARY_OVRD_MODE] is True
@@ -290,7 +290,7 @@ async def test_options_form(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_READ_PRECISION] == PRECISION_TENTHS
     assert result["data"][CONF_SET_PRECISION] == PRECISION_HALVES
     assert result["data"][CONF_TEMPORARY_OVRD_MODE] is False

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_duplicate_error(hass, config, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -32,7 +32,7 @@ async def test_invalid_api_key(hass, config):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
 
@@ -41,13 +41,13 @@ async def test_options_flow(hass, config_entry):
     with patch("homeassistant.components.openuv.async_setup_entry", return_value=True):
         await hass.config_entries.async_setup(config_entry.entry_id)
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_FROM_WINDOW: 3.5, CONF_TO_WINDOW: 2.0}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_FROM_WINDOW: 3.5, CONF_TO_WINDOW: 2.0}
 
 
@@ -56,13 +56,13 @@ async def test_step_user(hass, config, setup_openuv):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "51.528308, -0.3817765"
     assert result["data"] == {
         CONF_API_KEY: "abcde12345",

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_form(hass):
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == SOURCE_USER
         assert result["errors"] == {}
 
@@ -63,7 +63,7 @@ async def test_form(hass):
         await hass.async_block_till_done()
         assert entry.state == ConfigEntryState.NOT_LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == CONFIG[CONF_NAME]
         assert result["data"][CONF_LATITUDE] == CONFIG[CONF_LATITUDE]
         assert result["data"][CONF_LONGITUDE] == CONFIG[CONF_LONGITUDE]
@@ -90,14 +90,14 @@ async def test_form_options(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_MODE: "daily"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {
             CONF_MODE: "daily",
             CONF_LANGUAGE: DEFAULT_LANGUAGE,
@@ -109,14 +109,14 @@ async def test_form_options(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_MODE: "onecall_daily"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {
             CONF_MODE: "onecall_daily",
             CONF_LANGUAGE: DEFAULT_LANGUAGE,

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -106,7 +106,7 @@ async def test_form_invalid_auth(
         )
 
     assert result["step_id"] == config_entries.SOURCE_USER
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": error}
 
 
@@ -131,7 +131,7 @@ async def test_abort_on_duplicate_entry(hass: HomeAssistant) -> None:
             {"username": TEST_EMAIL, "password": TEST_PASSWORD},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
 
 
@@ -177,7 +177,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_DHCP},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
     with patch("pyoverkiz.client.OverkizClient.login", return_value=True), patch(
@@ -220,7 +220,7 @@ async def test_dhcp_flow_already_configured(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_DHCP},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -232,7 +232,7 @@ async def test_zeroconf_flow(hass):
         context={"source": config_entries.SOURCE_ZEROCONF},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
     with patch("pyoverkiz.client.OverkizClient.login", return_value=True), patch(
@@ -271,7 +271,7 @@ async def test_zeroconf_flow_already_configured(hass):
         context={"source": config_entries.SOURCE_ZEROCONF},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -295,7 +295,7 @@ async def test_reauth_success(hass):
         data=mock_entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("pyoverkiz.client.OverkizClient.login", return_value=True), patch(
@@ -311,7 +311,7 @@ async def test_reauth_success(hass):
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
         assert mock_entry.data["username"] == TEST_EMAIL
         assert mock_entry.data["password"] == TEST_PASSWORD2
@@ -337,7 +337,7 @@ async def test_reauth_wrong_account(hass):
         data=mock_entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("pyoverkiz.client.OverkizClient.login", return_value=True), patch(
@@ -353,5 +353,5 @@ async def test_reauth_wrong_account(hass):
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_wrong_account"

--- a/tests/components/ovo_energy/test_config_flow.py
+++ b/tests/components/ovo_energy/test_config_flow.py
@@ -22,7 +22,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -32,7 +32,7 @@ async def test_authorization_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -44,7 +44,7 @@ async def test_authorization_error(hass: HomeAssistant) -> None:
             FIXTURE_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -55,7 +55,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -67,7 +67,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
             FIXTURE_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -78,7 +78,7 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -93,7 +93,7 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
             FIXTURE_USER_INPUT,
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
     assert result2["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
 
@@ -110,7 +110,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -119,7 +119,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth"
         assert result2["errors"] == {"base": "authorization_error"}
 
@@ -136,7 +136,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -145,7 +145,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "reauth"
         assert result2["errors"] == {"base": "connection_error"}
 
@@ -167,7 +167,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
             data=FIXTURE_USER_INPUT,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth"
         assert result["errors"] == {"base": "authorization_error"}
 
@@ -184,5 +184,5 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "reauth_successful"

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -64,11 +64,11 @@ async def test_user(hass, webhook_id, secret):
     flow = await init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await flow.async_step_user({})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "OwnTracks"
     assert result["data"][CONF_WEBHOOK_ID] == WEBHOOK_ID
     assert result["data"][CONF_SECRET] == SECRET
@@ -98,7 +98,7 @@ async def test_abort_if_already_setup(hass):
 
     # Should fail, already setup (flow)
     result = await flow.async_step_user({})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -107,7 +107,7 @@ async def test_user_not_supports_encryption(hass, not_supports_encryption):
     flow = await init_config_flow(hass)
 
     result = await flow.async_step_user({})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert (
         result["description_placeholders"]["secret"]
         == "Encryption is not supported because nacl is not installed."
@@ -165,7 +165,7 @@ async def test_with_cloud_sub(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data={}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = result["result"]
     assert entry.data["cloudhook"]
     assert (
@@ -192,5 +192,5 @@ async def test_with_cloud_sub_not_connected(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data={}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cloud_not_connected"

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -219,12 +219,12 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_ALLOW_NOTIFY: True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {CONF_ALLOW_NOTIFY: True}

--- a/tests/components/picnic/test_config_flow.py
+++ b/tests/components/picnic/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_form(hass, picnic_api):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] is None
 
@@ -85,7 +85,7 @@ async def test_form_invalid_auth(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -108,7 +108,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -131,7 +131,7 @@ async def test_form_exception(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -158,7 +158,7 @@ async def test_form_already_configured(hass, picnic_api):
     )
     await hass.async_block_till_done()
 
-    assert result_configure["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result_configure["type"] == data_entry_flow.FlowResultType.ABORT
     assert result_configure["reason"] == "already_configured"
 
 
@@ -177,7 +177,7 @@ async def test_step_reauth(hass, picnic_api):
     result_init = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=conf
     )
-    assert result_init["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result_init["type"] == data_entry_flow.FlowResultType.FORM
     assert result_init["step_id"] == "user"
 
     with patch(
@@ -195,7 +195,7 @@ async def test_step_reauth(hass, picnic_api):
         await hass.async_block_till_done()
 
     # Check that the returned flow has type abort because of successful re-authentication
-    assert result_configure["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result_configure["type"] == data_entry_flow.FlowResultType.ABORT
     assert result_configure["reason"] == "reauth_successful"
 
     assert len(hass.config_entries.async_entries()) == 1
@@ -217,7 +217,7 @@ async def test_step_reauth_failed(hass):
     result_init = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=conf
     )
-    assert result_init["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result_init["type"] == data_entry_flow.FlowResultType.FORM
     assert result_init["step_id"] == "user"
 
     with patch(
@@ -256,7 +256,7 @@ async def test_step_reauth_different_account(hass, picnic_api):
     result_init = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=conf
     )
-    assert result_init["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result_init["type"] == data_entry_flow.FlowResultType.FORM
     assert result_init["step_id"] == "user"
 
     with patch(

--- a/tests/components/plaato/test_config_flow.py
+++ b/tests/components/plaato/test_config_flow.py
@@ -304,7 +304,7 @@ async def test_options(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
         result = await hass.config_entries.options.async_configure(
@@ -314,7 +314,7 @@ async def test_options(hass):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_SCAN_INTERVAL] == 10
 
         assert len(mock_setup_entry.mock_calls) == 1
@@ -339,7 +339,7 @@ async def test_options_webhook(hass, webhook_id):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "webhook"
         assert result["description_placeholders"] == {"webhook_url": ""}
 
@@ -350,7 +350,7 @@ async def test_options_webhook(hass, webhook_id):
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_WEBHOOK_ID] == CONF_WEBHOOK_ID
 
         assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/point/test_config_flow.py
+++ b/tests/components/point/test_config_flow.py
@@ -48,7 +48,7 @@ async def test_abort_if_no_implementation_registered(hass):
     flow.hass = hass
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_flows"
 
 
@@ -58,12 +58,12 @@ async def test_abort_if_already_setup(hass):
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_setup"
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_import()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_setup"
 
 
@@ -75,18 +75,18 @@ async def test_full_flow_implementation(
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await flow.async_step_user({"flow_impl": "test"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["description_placeholders"] == {
         "authorization_url": "https://example.com"
     }
 
     result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["refresh_args"] == {
         CONF_CLIENT_ID: "id",
         CONF_CLIENT_SECRET: "secret",
@@ -100,7 +100,7 @@ async def test_step_import(hass, mock_pypoint):  # pylint: disable=redefined-out
     flow = init_config_flow(hass)
 
     result = await flow.async_step_import()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -112,7 +112,7 @@ async def test_wrong_code_flow_implementation(
     flow = init_config_flow(hass)
 
     result = await flow.async_step_code("123ABC")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "auth_error"
 
 
@@ -121,7 +121,7 @@ async def test_not_pick_implementation_if_only_one(hass):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -130,7 +130,7 @@ async def test_abort_if_timeout_generating_auth_url(hass):
     flow = init_config_flow(hass, side_effect=asyncio.TimeoutError)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -139,7 +139,7 @@ async def test_abort_if_exception_generating_auth_url(hass):
     flow = init_config_flow(hass, side_effect=ValueError)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown_authorize_url_generation"
 
 
@@ -148,5 +148,5 @@ async def test_abort_no_code(hass):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_code()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_code"

--- a/tests/components/poolsense/test_config_flow.py
+++ b/tests/components/poolsense/test_config_flow.py
@@ -13,7 +13,7 @@ async def test_show_form(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
 
@@ -47,7 +47,7 @@ async def test_valid_credentials(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "test-email"
 
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -103,7 +103,7 @@ async def test_full_flow_implementation(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     # Step Creds results with form in Step Mode.
@@ -111,7 +111,7 @@ async def test_full_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     # Step Mode with User Input which is not manual, results in Step Link.
@@ -121,7 +121,7 @@ async def test_full_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_AUTO
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     # User Input results in created entry.
@@ -131,7 +131,7 @@ async def test_full_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TOKEN] == MOCK_CREDS
     assert result["data"]["devices"] == [MOCK_DEVICE]
     assert result["title"] == MOCK_TITLE
@@ -144,7 +144,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     # Step Creds results with form in Step Mode.
@@ -152,7 +152,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     # Step Mode with User Input which is not manual, results in Step Link.
@@ -163,7 +163,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_AUTO
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     # User Input results in created entry.
@@ -174,7 +174,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TOKEN] == MOCK_CREDS
     assert result["data"]["devices"] == [MOCK_DEVICE]
     assert result["title"] == MOCK_TITLE
@@ -196,7 +196,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     # Step Creds results with form in Step Mode.
@@ -204,7 +204,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     # Step Mode with User Input which is not manual, results in Step Link.
@@ -215,7 +215,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_AUTO
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     # Step Link
@@ -226,7 +226,7 @@ async def test_multiple_flow_implementation(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG_ADDITIONAL
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TOKEN] == MOCK_CREDS
     assert len(result["data"]["devices"]) == 1
     assert result["title"] == MOCK_TITLE
@@ -249,7 +249,7 @@ async def test_port_bind_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == reason
 
     with patch("pyps4_2ndscreen.Helper.port_bind", return_value=MOCK_TCP_PORT):
@@ -257,7 +257,7 @@ async def test_port_bind_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == reason
 
 
@@ -269,14 +269,14 @@ async def test_duplicate_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     with patch(
@@ -285,7 +285,7 @@ async def test_duplicate_abort(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_AUTO
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -299,14 +299,14 @@ async def test_additional_device(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     with patch(
@@ -322,7 +322,7 @@ async def test_additional_device(hass):
             result["flow_id"], user_input=MOCK_CONFIG_ADDITIONAL
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TOKEN] == MOCK_CREDS
     assert len(result["data"]["devices"]) == 1
     assert result["title"] == MOCK_TITLE
@@ -336,7 +336,7 @@ async def test_0_pin(hass):
             context={"source": "creds"},
             data={},
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     with patch(
@@ -348,7 +348,7 @@ async def test_0_pin(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], MOCK_AUTO
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
     mock_config = MOCK_CONFIG
@@ -372,14 +372,14 @@ async def test_no_devices_found_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     with patch("pyps4_2ndscreen.Helper.has_devices", return_value=[]):
@@ -387,7 +387,7 @@ async def test_no_devices_found_abort(hass):
             result["flow_id"], user_input=MOCK_AUTO
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
 
 
@@ -397,14 +397,14 @@ async def test_manual_mode(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     # Step Mode with User Input: manual, results in Step Link.
@@ -415,7 +415,7 @@ async def test_manual_mode(hass):
             result["flow_id"], user_input=MOCK_MANUAL
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
 
 
@@ -425,7 +425,7 @@ async def test_credential_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=None):
@@ -433,7 +433,7 @@ async def test_credential_abort(hass):
             result["flow_id"], user_input={}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "credential_error"
 
 
@@ -443,7 +443,7 @@ async def test_credential_timeout(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", side_effect=CredentialTimeout):
@@ -451,7 +451,7 @@ async def test_credential_timeout(hass):
             result["flow_id"], user_input={}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
     assert result["errors"] == {"base": "credential_timeout"}
 
@@ -462,14 +462,14 @@ async def test_wrong_pin_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     with patch(
@@ -483,7 +483,7 @@ async def test_wrong_pin_error(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
     assert result["errors"] == {"base": "login_failed"}
 
@@ -494,14 +494,14 @@ async def test_device_connection_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     with patch(
@@ -515,7 +515,7 @@ async def test_device_connection_error(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -526,20 +526,20 @@ async def test_manual_mode_no_ip_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "creds"
 
     with patch("pyps4_2ndscreen.Helper.get_creds", return_value=MOCK_CREDS):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"Config Mode": "Manual Entry"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mode"
     assert result["errors"] == {CONF_IP_ADDRESS: "no_ipaddress"}

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -43,7 +43,7 @@ MOCK_DATA = {CONF_TOKEN: MOCK_CREDS, "devices": [MOCK_DEVICE]}
 MOCK_FLOW_RESULT = {
     "version": VERSION,
     "handler": DOMAIN,
-    "type": data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+    "type": data_entry_flow.FlowResultType.CREATE_ENTRY,
     "title": "test_ps4",
     "data": MOCK_DATA,
     "options": {},
@@ -125,7 +125,7 @@ async def test_creating_entry_sets_up_media_player(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -43,12 +43,12 @@ async def test_config_flow(hass, pvpc_aioclient_mock: AiohttpClientMocker):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], tst_config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
         state = hass.states.get("sensor.test")
@@ -59,11 +59,11 @@ async def test_config_flow(hass, pvpc_aioclient_mock: AiohttpClientMocker):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], tst_config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert pvpc_aioclient_mock.call_count == 1
 
         # Check removal
@@ -75,12 +75,12 @@ async def test_config_flow(hass, pvpc_aioclient_mock: AiohttpClientMocker):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], tst_config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
         state = hass.states.get("sensor.test")
@@ -96,7 +96,7 @@ async def test_config_flow(hass, pvpc_aioclient_mock: AiohttpClientMocker):
         config_entry = current_entries[0]
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(

--- a/tests/components/qnap_qsw/test_config_flow.py
+++ b/tests/components/qnap_qsw/test_config_flow.py
@@ -48,7 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == SOURCE_USER
         assert result["errors"] == {}
 
@@ -62,7 +62,7 @@ async def test_form(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert (
             result["title"]
             == f"QNAP {SYSTEM_BOARD_MOCK[API_RESULT][API_PRODUCT]} {SYSTEM_BOARD_MOCK[API_RESULT][API_MAC_ADDR]}"
@@ -159,7 +159,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
 
     with patch(
@@ -206,7 +206,7 @@ async def test_dhcp_flow_error(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -223,7 +223,7 @@ async def test_dhcp_connection_error(hass: HomeAssistant):
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
 
     with patch(
@@ -254,7 +254,7 @@ async def test_dhcp_login_error(hass: HomeAssistant):
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
 
     with patch(

--- a/tests/components/radiotherm/test_config_flow.py
+++ b/tests/components/radiotherm/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "My Name"
     assert result2["data"] == {
         "host": "1.2.3.4",
@@ -72,7 +72,7 @@ async def test_form_unknown_error(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -93,7 +93,7 @@ async def test_form_cannot_connect(hass):
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {CONF_HOST: "cannot_connect"}
 
 
@@ -113,7 +113,7 @@ async def test_import(hass):
             data={CONF_HOST: "1.2.3.4"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "My Name"
     assert result["data"] == {CONF_HOST: "1.2.3.4"}
     assert len(mock_setup_entry.mock_calls) == 1
@@ -131,7 +131,7 @@ async def test_import_cannot_connect(hass):
             data={CONF_HOST: "1.2.3.4"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -153,7 +153,7 @@ async def test_dhcp_can_confirm(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
     assert result["description_placeholders"] == {
         "host": "1.2.3.4",
@@ -171,7 +171,7 @@ async def test_dhcp_can_confirm(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "My Name"
     assert result2["data"] == {
         "host": "1.2.3.4",
@@ -197,7 +197,7 @@ async def test_dhcp_fails_to_connect(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -226,7 +226,7 @@ async def test_dhcp_already_exists(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -243,7 +243,7 @@ async def test_user_unique_id_already_exists(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -261,5 +261,5 @@ async def test_user_unique_id_already_exists(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -16,7 +16,7 @@ async def test_duplicate_error(hass, config, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -95,13 +95,13 @@ async def test_options_flow(hass, config, config_entry):
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_ZONE_RUN_TIME: 600}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_ZONE_RUN_TIME: 600}
 
 
@@ -112,7 +112,7 @@ async def test_show_form(hass):
         context={"source": config_entries.SOURCE_USER},
         data=None,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -123,7 +123,7 @@ async def test_step_user(hass, config, setup_rainmachine):
         context={"source": config_entries.SOURCE_USER},
         data=config,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "12345"
     assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
@@ -158,7 +158,7 @@ async def test_step_homekit_zeroconf_ip_already_exists(
             ),
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -184,7 +184,7 @@ async def test_step_homekit_zeroconf_ip_change(hass, client, config_entry, sourc
             ),
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_IP_ADDRESS] == "192.168.1.2"
 
@@ -213,7 +213,7 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(
             ),
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -231,7 +231,7 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "12345"
     assert result2["data"] == {
         CONF_IP_ADDRESS: "192.168.1.100",
@@ -261,7 +261,7 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(hass, client):
             ),
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -281,5 +281,5 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(hass, client):
             ),
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_in_progress"

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_duplicate_error(hass, config, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -31,7 +31,7 @@ async def test_invalid_place_or_service_id(hass, config):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_place_or_service_id"}
 
 
@@ -42,13 +42,13 @@ async def test_options_flow(hass, config, config_entry):
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_FRIENDLY_NAME: True}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_FRIENDLY_NAME: True}
 
 
@@ -57,7 +57,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -67,6 +67,6 @@ async def test_step_user(hass, config, setup_recollect_waste):
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "12345, 12345"
     assert result["data"] == {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}

--- a/tests/components/renault/test_config_flow.py
+++ b/tests/components/renault/test_config_flow.py
@@ -38,7 +38,7 @@ async def test_config_flow_single_account(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     # Failed credentials
@@ -55,7 +55,7 @@ async def test_config_flow_single_account(
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_credentials"}
 
     renault_account = AsyncMock()
@@ -82,7 +82,7 @@ async def test_config_flow_single_account(
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "account_id_1"
     assert result["data"][CONF_USERNAME] == "email@test.com"
     assert result["data"][CONF_PASSWORD] == "test"
@@ -97,7 +97,7 @@ async def test_config_flow_no_account(hass: HomeAssistant, mock_setup_entry: Asy
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     # Account list empty
@@ -114,7 +114,7 @@ async def test_config_flow_no_account(hass: HomeAssistant, mock_setup_entry: Asy
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "kamereon_no_account"
 
     assert len(mock_setup_entry.mock_calls) == 0
@@ -127,7 +127,7 @@ async def test_config_flow_multiple_accounts(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     renault_account_1 = RenaultAccount(
@@ -153,7 +153,7 @@ async def test_config_flow_multiple_accounts(
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "kamereon"
 
     # Account selected
@@ -161,7 +161,7 @@ async def test_config_flow_multiple_accounts(
         result["flow_id"],
         user_input={CONF_KAMEREON_ACCOUNT_ID: "account_id_2"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "account_id_2"
     assert result["data"][CONF_USERNAME] == "email@test.com"
     assert result["data"][CONF_PASSWORD] == "test"
@@ -179,7 +179,7 @@ async def test_config_flow_duplicate(hass: HomeAssistant, mock_setup_entry: Asyn
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     renault_account = RenaultAccount(
@@ -199,7 +199,7 @@ async def test_config_flow_duplicate(hass: HomeAssistant, mock_setup_entry: Asyn
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
 
@@ -220,7 +220,7 @@ async def test_reauth(hass: HomeAssistant, config_entry: ConfigEntry):
         data=MOCK_CONFIG,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["description_placeholders"] == {CONF_USERNAME: "email@test.com"}
     assert result["errors"] == {}
 
@@ -234,7 +234,7 @@ async def test_reauth(hass: HomeAssistant, config_entry: ConfigEntry):
             user_input={CONF_PASSWORD: "any"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["description_placeholders"] == {CONF_USERNAME: "email@test.com"}
     assert result2["errors"] == {"base": "invalid_credentials"}
 
@@ -245,5 +245,5 @@ async def test_reauth(hass: HomeAssistant, config_entry: ConfigEntry):
             user_input={CONF_PASSWORD: "any"},
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -314,7 +314,7 @@ async def test_options_global(hass):
         user_input={"automatic_add": True, "protocols": SOME_PROTOCOLS},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -349,7 +349,7 @@ async def test_no_protocols(hass):
         user_input={"automatic_add": False, "protocols": []},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -404,7 +404,7 @@ async def test_options_add_device(hass):
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -558,7 +558,7 @@ async def test_options_replace_sensor_device(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -691,7 +691,7 @@ async def test_options_replace_control_device(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -772,7 +772,7 @@ async def test_options_add_and_configure_device(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -816,7 +816,7 @@ async def test_options_add_and_configure_device(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 
@@ -896,7 +896,7 @@ async def test_options_configure_rfy_cover_device(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
 

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -165,14 +165,14 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input=TEST_OPTIONS,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "risco_to_ha"
 
     result = await hass.config_entries.options.async_configure(
@@ -180,7 +180,7 @@ async def test_options_flow(hass):
         user_input=TEST_RISCO_TO_HA,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "ha_to_risco"
 
     with patch("homeassistant.components.risco.async_setup_entry", return_value=True):
@@ -189,7 +189,7 @@ async def test_options_flow(hass):
             user_input=TEST_HA_TO_RISCO,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options == {
         **TEST_OPTIONS,
         "risco_states_to_ha": TEST_RISCO_TO_HA,

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -128,7 +128,7 @@ async def test_form_user_discovery_and_password_fetch(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -137,7 +137,7 @@ async def test_form_user_discovery_and_password_fetch(hass):
         {CONF_HOST: MOCK_IP},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
     assert result2["step_id"] == "link"
 
@@ -157,7 +157,7 @@ async def test_form_user_discovery_and_password_fetch(hass):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "robot_name"
     assert result3["result"].unique_id == "BLID"
     assert result3["data"] == {
@@ -184,7 +184,7 @@ async def test_form_user_discovery_skips_known(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -204,7 +204,7 @@ async def test_form_user_no_devices_found_discovery_aborts_already_configured(ha
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -213,7 +213,7 @@ async def test_form_user_no_devices_found_discovery_aborts_already_configured(ha
         {CONF_HOST: MOCK_IP},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
 
 
@@ -233,7 +233,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -242,7 +242,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
         {CONF_HOST: None},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
     assert result2["step_id"] == "manual"
 
@@ -255,7 +255,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
         )
 
     await hass.async_block_till_done()
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"] is None
 
     with patch(
@@ -274,7 +274,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result4["title"] == "robot_name"
     assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
@@ -302,7 +302,7 @@ async def test_form_user_discover_fails_aborts_already_configured(hass):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -311,7 +311,7 @@ async def test_form_user_discover_fails_aborts_already_configured(hass):
         {CONF_HOST: MOCK_IP},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
 
 
@@ -328,7 +328,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -337,7 +337,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
         {CONF_HOST: None},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
     assert result2["step_id"] == "manual"
 
@@ -351,7 +351,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
         )
     await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "cannot_connect"
 
 
@@ -372,7 +372,7 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -384,7 +384,7 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass
             {CONF_HOST: MOCK_IP},
         )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
 
     with patch(
@@ -403,7 +403,7 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "robot_name"
     assert result3["result"].unique_id == "BLID"
     assert result3["data"] == {
@@ -433,7 +433,7 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(has
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -445,7 +445,7 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(has
             {CONF_HOST: MOCK_IP},
         )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
 
     with patch(
@@ -471,7 +471,7 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(has
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result4["title"] == "myroomba"
     assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
@@ -504,7 +504,7 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -516,7 +516,7 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
             {CONF_HOST: MOCK_IP},
         )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
 
     with patch(
@@ -542,7 +542,7 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
     assert result4["errors"] == {"base": "cannot_connect"}
     assert len(mock_setup_entry.mock_calls) == 0
 
@@ -563,7 +563,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(ha
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -572,7 +572,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(ha
         {CONF_HOST: MOCK_IP},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
     assert result2["step_id"] == "link"
 
@@ -599,7 +599,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(ha
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result4["title"] == "myroomba"
     assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
@@ -631,7 +631,7 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "link"
     assert result["description_placeholders"] == {"name": "robot_name"}
@@ -652,7 +652,7 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "robot_name"
     assert result2["result"].unique_id == "BLID"
     assert result2["data"] == {
@@ -684,7 +684,7 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -693,7 +693,7 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
         {},
     )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
     assert result2["step_id"] == "manual"
 
@@ -705,7 +705,7 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
             {CONF_HOST: MOCK_IP},
         )
     await hass.async_block_till_done()
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"] is None
 
     with patch(
@@ -724,7 +724,7 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result4["title"] == "robot_name"
     assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
@@ -757,7 +757,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_da
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "manual"
 
@@ -769,7 +769,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_da
             {CONF_HOST: MOCK_IP},
         )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is None
 
     with patch(
@@ -788,7 +788,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_da
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "robot_name"
     assert result3["result"].unique_id == "BLID"
     assert result3["data"] == {

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -185,7 +185,7 @@ async def test_duplicate_config(hass):
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "already_configured"
 
 

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -55,7 +55,7 @@ async def test_create_entry(hass):
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == "edc3eee7330e"
         assert result2["data"] == {
             CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
@@ -93,7 +93,7 @@ async def test_import_flow(hass) -> None:
             data=VALID_CONFIG_OLD,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "edc3eee7330e"
         assert result["data"][CONF_NAME] == "Sabnzbd"
         assert result["data"][CONF_API_KEY] == "edc3eee7330e4fdda04489e3fbc283d0"

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -75,7 +75,7 @@ async def test_form(hass, gen):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -93,7 +93,7 @@ async def test_title_without_name(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     settings = MOCK_SETTINGS.copy()
@@ -123,7 +123,7 @@ async def test_title_without_name(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "shelly1pm-12345"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -148,7 +148,7 @@ async def test_form_auth(hass, test_data):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -160,7 +160,7 @@ async def test_form_auth(hass, test_data):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -191,7 +191,7 @@ async def test_form_auth(hass, test_data):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] == "Test name"
     assert result3["data"] == {
         "host": "1.1.1.1",
@@ -221,7 +221,7 @@ async def test_form_errors_get_info(hass, error):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": base_error}
 
 
@@ -248,7 +248,7 @@ async def test_form_missing_model_key(hass):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "firmware_not_fully_provisioned"}
 
 
@@ -257,7 +257,7 @@ async def test_form_missing_model_key_auth_enabled(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -269,7 +269,7 @@ async def test_form_missing_model_key_auth_enabled(hass):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -286,7 +286,7 @@ async def test_form_missing_model_key_auth_enabled(hass):
             result2["flow_id"], {"password": "1234"}
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"] == {"base": "firmware_not_fully_provisioned"}
 
 
@@ -311,14 +311,14 @@ async def test_form_missing_model_key_zeroconf(hass, caplog):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "firmware_not_fully_provisioned"}
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["errors"] == {"base": "firmware_not_fully_provisioned"}
 
 
@@ -342,7 +342,7 @@ async def test_form_errors_test_connection(hass, error):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": base_error}
 
 
@@ -367,7 +367,7 @@ async def test_form_already_configured(hass):
             {"host": "1.1.1.1"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "already_configured"
 
     # Test config entry got updated with latest IP
@@ -416,7 +416,7 @@ async def test_user_setup_ignored_device(hass):
             {"host": "1.1.1.1"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Test config entry got updated with latest IP
     assert entry.data["host"] == "1.1.1.1"
@@ -439,7 +439,7 @@ async def test_form_firmware_unsupported(hass):
             {"host": "1.1.1.1"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "unsupported_firmware"
 
 
@@ -482,7 +482,7 @@ async def test_form_auth_errors_test_connection_gen1(hass, error):
             result2["flow_id"],
             {"username": "test username", "password": "test password"},
         )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"] == {"base": base_error}
 
 
@@ -524,7 +524,7 @@ async def test_form_auth_errors_test_connection_gen2(hass, error):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"password": "test password"}
         )
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"] == {"base": base_error}
 
 
@@ -548,7 +548,7 @@ async def test_zeroconf(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {}
         context = next(
             flow["context"]
@@ -569,7 +569,7 @@ async def test_zeroconf(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -614,7 +614,7 @@ async def test_zeroconf_sleeping_device(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {}
         context = next(
             flow["context"]
@@ -634,7 +634,7 @@ async def test_zeroconf_sleeping_device(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -677,7 +677,7 @@ async def test_zeroconf_sleeping_device_error(hass, error):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -698,7 +698,7 @@ async def test_zeroconf_already_configured(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
     # Test config entry got updated with latest IP
@@ -717,7 +717,7 @@ async def test_zeroconf_firmware_unsupported(hass):
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unsupported_firmware"
 
 
@@ -729,7 +729,7 @@ async def test_zeroconf_cannot_connect(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -745,7 +745,7 @@ async def test_zeroconf_require_auth(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {}
 
     with patch(
@@ -768,7 +768,7 @@ async def test_zeroconf_require_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",

--- a/tests/components/shopping_list/test_config_flow.py
+++ b/tests/components/shopping_list/test_config_flow.py
@@ -11,7 +11,7 @@ async def test_import(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_user(hass):
@@ -21,7 +21,7 @@ async def test_user(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -32,5 +32,5 @@ async def test_user_confirm(hass):
         DOMAIN, context={"source": SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].data == {}

--- a/tests/components/sia/test_config_flow.py
+++ b/tests/components/sia/test_config_flow.py
@@ -160,7 +160,9 @@ async def test_form_start_account(hass, flow_at_add_account_step):
 
 async def test_create(hass, entry_with_basic_config):
     """Test we create a entry through the form."""
-    assert entry_with_basic_config["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert (
+        entry_with_basic_config["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    )
     assert (
         entry_with_basic_config["title"]
         == f"SIA Alarm on port {BASIC_CONFIG[CONF_PORT]}"
@@ -173,7 +175,7 @@ async def test_create_additional_account(hass, entry_with_additional_account_con
     """Test we create a config with two accounts."""
     assert (
         entry_with_additional_account_config["type"]
-        == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        == data_entry_flow.FlowResultType.CREATE_ENTRY
     )
     assert (
         entry_with_additional_account_config["title"]
@@ -314,14 +316,14 @@ async def test_options_basic(hass):
     )
     await setup_sia(hass, config_entry)
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "options"
     assert result["last_step"]
 
     updated = await hass.config_entries.options.async_configure(
         result["flow_id"], BASIC_OPTIONS
     )
-    assert updated["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert updated["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert updated["data"] == {
         CONF_ACCOUNTS: {BASIC_CONFIG[CONF_ACCOUNT]: BASIC_OPTIONS}
     }
@@ -339,13 +341,13 @@ async def test_options_additional(hass):
     )
     await setup_sia(hass, config_entry)
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "options"
     assert not result["last_step"]
 
     updated = await hass.config_entries.options.async_configure(
         result["flow_id"], BASIC_OPTIONS
     )
-    assert updated["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert updated["type"] == data_entry_flow.FlowResultType.FORM
     assert updated["step_id"] == "options"
     assert updated["last_step"]

--- a/tests/components/simplepush/test_config_flow.py
+++ b/tests/components/simplepush/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_flow_successful(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input=MOCK_CONFIG,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "simplepush"
     assert result["data"] == MOCK_CONFIG
 
@@ -61,7 +61,7 @@ async def test_flow_with_password(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input=mock_config_pass,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "simplepush"
     assert result["data"] == mock_config_pass
 
@@ -84,7 +84,7 @@ async def test_flow_user_device_key_already_configured(hass: HomeAssistant) -> N
         result["flow_id"],
         user_input=MOCK_CONFIG,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -109,7 +109,7 @@ async def test_flow_user_name_already_configured(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input=MOCK_CONFIG,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -127,7 +127,7 @@ async def test_error_on_connection_failure(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=MOCK_CONFIG,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -139,6 +139,6 @@ async def test_flow_import(hass: HomeAssistant) -> None:
         data=MOCK_CONFIG,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "simplepush"
     assert result["data"] == MOCK_CONFIG

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -25,18 +25,18 @@ async def test_duplicate_error(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=credentials_config
     )
     assert result["step_id"] == "sms_2fa"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=sms_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -47,13 +47,13 @@ async def test_options_flow(hass, config_entry):
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_CODE: "4321"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_CODE: "4321"}
 
 
@@ -72,18 +72,18 @@ async def test_step_reauth(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config
     )
     assert result["step_id"] == "reauth_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=reauth_config
     )
     assert result["step_id"] == "sms_2fa"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=sms_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     assert len(hass.config_entries.async_entries()) == 2
@@ -112,12 +112,12 @@ async def test_step_reauth_errors(hass, config, error_string, exc, reauth_config
             DOMAIN, context={"source": SOURCE_REAUTH}, data=config
         )
         assert result["step_id"] == "reauth_confirm"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=reauth_config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": error_string}
 
@@ -149,18 +149,18 @@ async def test_step_reauth_from_scratch(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=credentials_config
     )
     assert result["step_id"] == "sms_2fa"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=sms_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     assert len(hass.config_entries.async_entries()) == 1
@@ -186,12 +186,12 @@ async def test_step_user_errors(hass, credentials_config, error_string, exc):
             DOMAIN, context={"source": SOURCE_USER}
         )
         assert result["step_id"] == "user"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=credentials_config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": error_string}
 
@@ -205,7 +205,7 @@ async def test_step_user_email_2fa(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Patch API.async_verify_2fa_email to first return pending, then return all done:
     api.async_verify_2fa_email.side_effect = [Verify2FAPending, None]
@@ -213,10 +213,10 @@ async def test_step_user_email_2fa(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=credentials_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS_DONE
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
@@ -236,7 +236,7 @@ async def test_step_user_email_2fa_timeout(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Patch API.async_verify_2fa_email to return pending:
     api.async_verify_2fa_email.side_effect = Verify2FAPending
@@ -244,14 +244,14 @@ async def test_step_user_email_2fa_timeout(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=credentials_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS_DONE
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
     assert result["step_id"] == "email_2fa_error"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "email_2fa_timed_out"
 
 
@@ -263,18 +263,18 @@ async def test_step_user_sms_2fa(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=credentials_config
     )
     assert result["step_id"] == "sms_2fa"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=sms_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.async_entries()) == 1
     [config_entry] = hass.config_entries.async_entries(DOMAIN)
@@ -300,13 +300,13 @@ async def test_step_user_sms_2fa_errors(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=credentials_config
     )
     assert result["step_id"] == "sms_2fa"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Simulate entering the incorrect SMS code:
     api.async_verify_2fa_sms.side_effect = InvalidCredentialsError
@@ -314,5 +314,5 @@ async def test_step_user_sms_2fa_errors(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=sms_config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"code": error_string}

--- a/tests/components/slack/test_config_flow.py
+++ b/tests/components/slack/test_config_flow.py
@@ -23,7 +23,7 @@ async def test_flow_user(
         result["flow_id"],
         user_input=CONF_INPUT,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEAM_NAME
     assert result["data"] == CONF_DATA
 
@@ -42,7 +42,7 @@ async def test_flow_user_already_configured(
         result["flow_id"],
         user_input=CONF_INPUT,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -56,7 +56,7 @@ async def test_flow_user_invalid_auth(
         context={"source": config_entries.SOURCE_USER},
         data=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -71,7 +71,7 @@ async def test_flow_user_cannot_connect(
         context={"source": config_entries.SOURCE_USER},
         data=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -87,7 +87,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_USER},
             data=CONF_DATA,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "unknown"}
 
@@ -103,7 +103,7 @@ async def test_flow_import(
         data=CONF_DATA,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEAM_NAME
     assert result["data"] == CONF_DATA
 
@@ -119,7 +119,7 @@ async def test_flow_import_no_name(
         data=CONF_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEAM_NAME
     assert result["data"] == CONF_DATA
 
@@ -136,5 +136,5 @@ async def test_flow_import_already_configured(
         data=CONF_DATA,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -46,7 +46,7 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
 
 
@@ -67,7 +67,7 @@ async def test_login_failure(hass: HomeAssistant, side_effect, error) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=SLEEPIQ_CONFIG
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": error}
 
@@ -90,7 +90,7 @@ async def test_success(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["data"][CONF_USERNAME] == SLEEPIQ_CONFIG[CONF_USERNAME]
     assert result2["data"][CONF_PASSWORD] == SLEEPIQ_CONFIG[CONF_PASSWORD]
     assert len(mock_setup_entry.mock_calls) == 1
@@ -128,5 +128,5 @@ async def test_reauth_password(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_show_user_form(hass):
     )
 
     assert result["step_id"] == "environment"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_show_user_host_form(hass):
@@ -39,14 +39,14 @@ async def test_show_user_host_form(hass):
         context={"source": SOURCE_USER},
     )
     assert result["step_id"] == "environment"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"environment": ENV_LOCAL}
     )
 
     assert result["step_id"] == ENV_LOCAL
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_show_zeroconf_connection_error_form(hass):
@@ -67,14 +67,14 @@ async def test_show_zeroconf_connection_error_form(hass):
         )
 
         assert result["description_placeholders"] == {CONF_SERIALNUMBER: "1006000212"}
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "zeroconf_confirm"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 0
 
@@ -97,14 +97,14 @@ async def test_show_zeroconf_connection_error_form_next_generation(hass):
         )
 
         assert result["description_placeholders"] == {CONF_SERIALNUMBER: "5001000212"}
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "zeroconf_confirm"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 0
 
@@ -119,19 +119,19 @@ async def test_connection_error(hass):
             context={"source": SOURCE_USER},
         )
         assert result["step_id"] == "environment"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"environment": ENV_LOCAL}
         )
         assert result["step_id"] == ENV_LOCAL
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
         assert result["reason"] == "cannot_connect"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_user_local_connection_error(hass):
@@ -148,19 +148,19 @@ async def test_user_local_connection_error(hass):
             context={"source": SOURCE_USER},
         )
         assert result["step_id"] == "environment"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"environment": ENV_LOCAL}
         )
         assert result["step_id"] == ENV_LOCAL
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
         assert result["reason"] == "cannot_connect"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_zeroconf_wrong_mdns(hass):
@@ -180,7 +180,7 @@ async def test_zeroconf_wrong_mdns(hass):
     )
 
     assert result["reason"] == "invalid_mdns"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_full_user_wrong_mdns(hass):
@@ -199,18 +199,18 @@ async def test_full_user_wrong_mdns(hass):
             context={"source": SOURCE_USER},
         )
         assert result["step_id"] == "environment"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"environment": ENV_LOCAL}
         )
         assert result["step_id"] == ENV_LOCAL
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "invalid_mdns"
 
 
@@ -239,18 +239,18 @@ async def test_user_device_exists_abort(hass):
             context={"source": SOURCE_USER},
         )
         assert result["step_id"] == "environment"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"environment": ENV_LOCAL}
         )
         assert result["step_id"] == ENV_LOCAL
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -289,7 +289,7 @@ async def test_zeroconf_device_exists_abort(hass):
                 properties={"_raw": {}},
             ),
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -310,7 +310,7 @@ async def test_cloud_device_exists_abort(hass):
         context={"source": SOURCE_USER},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured_device"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -339,7 +339,7 @@ async def test_zeroconf_abort_if_cloud_device_exists(hass):
             properties={"_raw": {}},
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured_device"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -371,7 +371,7 @@ async def test_zeroconf_confirm_abort_if_cloud_device_exists(hass):
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured_device"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -396,7 +396,7 @@ async def test_abort_cloud_flow_if_local_device_exists(hass):
         result["flow_id"], {"environment": ENV_CLOUD}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured_local_device"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -479,7 +479,7 @@ async def test_full_zeroconf_flow(hass):
                 properties={"_raw": {}},
             ),
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "zeroconf_confirm"
         assert result["description_placeholders"] == {CONF_SERIALNUMBER: "1006000212"}
 
@@ -487,7 +487,7 @@ async def test_full_zeroconf_flow(hass):
             result["flow_id"], {"host": "1.2.3.4"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "smappee1006000212"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -513,7 +513,7 @@ async def test_full_user_local_flow(hass):
             context={"source": SOURCE_USER},
         )
         assert result["step_id"] == "environment"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["description_placeholders"] is None
 
         result = await hass.config_entries.flow.async_configure(
@@ -521,12 +521,12 @@ async def test_full_user_local_flow(hass):
             {"environment": ENV_LOCAL},
         )
         assert result["step_id"] == ENV_LOCAL
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.2.3.4"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "smappee1006000212"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -555,7 +555,7 @@ async def test_full_zeroconf_flow_next_generation(hass):
                 properties={"_raw": {}},
             ),
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "zeroconf_confirm"
         assert result["description_placeholders"] == {CONF_SERIALNUMBER: "5001000212"}
 
@@ -563,7 +563,7 @@ async def test_full_zeroconf_flow_next_generation(hass):
             result["flow_id"], {"host": "1.2.3.4"}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "smappee5001000212"
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -27,7 +27,7 @@ async def test_import_shows_user_step(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -52,7 +52,7 @@ async def test_entry_created(hass, app, app_oauth_client, location, smartthings_
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -60,7 +60,7 @@ async def test_entry_created(hass, app, app_oauth_client, location, smartthings_
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -69,14 +69,14 @@ async def test_entry_created(hass, app, app_oauth_client, location, smartthings_
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_location"
 
     # Select location and advance to external auth
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_LOCATION_ID: location.location_id}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["step_id"] == "authorize"
     assert result["url"] == format_install_url(app.app_id, location.location_id)
 
@@ -85,7 +85,7 @@ async def test_entry_created(hass, app, app_oauth_client, location, smartthings_
 
     # Finish
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["app_id"] == app.app_id
     assert result["data"]["installed_app_id"] == installed_app_id
     assert result["data"]["location_id"] == location.location_id
@@ -123,7 +123,7 @@ async def test_entry_created_from_update_event(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -131,7 +131,7 @@ async def test_entry_created_from_update_event(
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -140,14 +140,14 @@ async def test_entry_created_from_update_event(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_location"
 
     # Select location and advance to external auth
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_LOCATION_ID: location.location_id}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["step_id"] == "authorize"
     assert result["url"] == format_install_url(app.app_id, location.location_id)
 
@@ -156,7 +156,7 @@ async def test_entry_created_from_update_event(
 
     # Finish
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["app_id"] == app.app_id
     assert result["data"]["installed_app_id"] == installed_app_id
     assert result["data"]["location_id"] == location.location_id
@@ -194,7 +194,7 @@ async def test_entry_created_existing_app_new_oauth_client(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -202,7 +202,7 @@ async def test_entry_created_existing_app_new_oauth_client(
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -211,14 +211,14 @@ async def test_entry_created_existing_app_new_oauth_client(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_location"
 
     # Select location and advance to external auth
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_LOCATION_ID: location.location_id}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["step_id"] == "authorize"
     assert result["url"] == format_install_url(app.app_id, location.location_id)
 
@@ -227,7 +227,7 @@ async def test_entry_created_existing_app_new_oauth_client(
 
     # Finish
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["app_id"] == app.app_id
     assert result["data"]["installed_app_id"] == installed_app_id
     assert result["data"]["location_id"] == location.location_id
@@ -278,7 +278,7 @@ async def test_entry_created_existing_app_copies_oauth_client(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -286,7 +286,7 @@ async def test_entry_created_existing_app_copies_oauth_client(
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -297,14 +297,14 @@ async def test_entry_created_existing_app_copies_oauth_client(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_location"
 
     # Select location and advance to external auth
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_LOCATION_ID: location.location_id}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["step_id"] == "authorize"
     assert result["url"] == format_install_url(app.app_id, location.location_id)
 
@@ -313,7 +313,7 @@ async def test_entry_created_existing_app_copies_oauth_client(
 
     # Finish
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["app_id"] == app.app_id
     assert result["data"]["installed_app_id"] == installed_app_id
     assert result["data"]["location_id"] == location.location_id
@@ -370,7 +370,7 @@ async def test_entry_created_with_cloudhook(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["description_placeholders"][
             "webhook_url"
@@ -379,7 +379,7 @@ async def test_entry_created_with_cloudhook(
 
         # Advance to PAT screen
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "pat"
         assert "token_url" in result["description_placeholders"]
         assert "component_url" in result["description_placeholders"]
@@ -388,14 +388,14 @@ async def test_entry_created_with_cloudhook(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_ACCESS_TOKEN: token}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "select_location"
 
         # Select location and advance to external auth
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_LOCATION_ID: location.location_id}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+        assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
         assert result["step_id"] == "authorize"
         assert result["url"] == format_install_url(app.app_id, location.location_id)
 
@@ -404,7 +404,7 @@ async def test_entry_created_with_cloudhook(
 
         # Finish
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"]["app_id"] == app.app_id
         assert result["data"]["installed_app_id"] == installed_app_id
         assert result["data"]["location_id"] == location.location_id
@@ -432,7 +432,7 @@ async def test_invalid_webhook_aborts(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "invalid_webhook_url"
     assert result["description_placeholders"][
         "webhook_url"
@@ -448,7 +448,7 @@ async def test_invalid_token_shows_error(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -456,7 +456,7 @@ async def test_invalid_token_shows_error(hass):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -465,7 +465,7 @@ async def test_invalid_token_shows_error(hass):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {CONF_ACCESS_TOKEN: "token_invalid_format"}
@@ -485,7 +485,7 @@ async def test_unauthorized_token_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -493,7 +493,7 @@ async def test_unauthorized_token_shows_error(hass, smartthings_mock):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -502,7 +502,7 @@ async def test_unauthorized_token_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {CONF_ACCESS_TOKEN: "token_unauthorized"}
@@ -522,7 +522,7 @@ async def test_forbidden_token_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -530,7 +530,7 @@ async def test_forbidden_token_shows_error(hass, smartthings_mock):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -539,7 +539,7 @@ async def test_forbidden_token_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {CONF_ACCESS_TOKEN: "token_forbidden"}
@@ -565,7 +565,7 @@ async def test_webhook_problem_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -573,7 +573,7 @@ async def test_webhook_problem_shows_error(hass, smartthings_mock):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -582,7 +582,7 @@ async def test_webhook_problem_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {"base": "webhook_error"}
@@ -607,7 +607,7 @@ async def test_api_error_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -615,7 +615,7 @@ async def test_api_error_shows_error(hass, smartthings_mock):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -624,7 +624,7 @@ async def test_api_error_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {"base": "app_setup_error"}
@@ -645,7 +645,7 @@ async def test_unknown_response_error_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -653,7 +653,7 @@ async def test_unknown_response_error_shows_error(hass, smartthings_mock):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -662,7 +662,7 @@ async def test_unknown_response_error_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {"base": "app_setup_error"}
@@ -679,7 +679,7 @@ async def test_unknown_error_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -687,7 +687,7 @@ async def test_unknown_error_shows_error(hass, smartthings_mock):
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -696,7 +696,7 @@ async def test_unknown_error_shows_error(hass, smartthings_mock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert result["data_schema"]({}) == {CONF_ACCESS_TOKEN: token}
     assert result["errors"] == {"base": "app_setup_error"}
@@ -721,7 +721,7 @@ async def test_no_available_locations_aborts(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["description_placeholders"][
         "webhook_url"
@@ -729,7 +729,7 @@ async def test_no_available_locations_aborts(
 
     # Advance to PAT screen
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pat"
     assert "token_url" in result["description_placeholders"]
     assert "component_url" in result["description_placeholders"]
@@ -738,5 +738,5 @@ async def test_no_available_locations_aborts(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_ACCESS_TOKEN: token}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_available_locations"

--- a/tests/components/smarttub/test_config_flow.py
+++ b/tests/components/smarttub/test_config_flow.py
@@ -73,14 +73,14 @@ async def test_reauth_success(hass, smarttub_api, account):
         data=mock_entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_EMAIL: "test-email3", CONF_PASSWORD: "test-password3"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert mock_entry.data[CONF_EMAIL] == "test-email3"
     assert mock_entry.data[CONF_PASSWORD] == "test-password3"
@@ -114,12 +114,12 @@ async def test_reauth_wrong_account(hass, smarttub_api, account):
         data=mock_entry2.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_EMAIL: "test-email1", CONF_PASSWORD: "test-password1"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/solaredge/test_config_flow.py
+++ b/tests/components/solaredge/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_user(hass: HomeAssistant, test_api: Mock) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "user"
 
     # test with all provided
@@ -40,7 +40,7 @@ async def test_user(hass: HomeAssistant, test_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_NAME: NAME, CONF_API_KEY: API_KEY, CONF_SITE_ID: SITE_ID},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result.get("title") == "solaredge_site_1_2_3"
 
     data = result.get("data")
@@ -62,7 +62,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant, test_api: str) -> Non
         context={"source": SOURCE_USER},
         data={CONF_NAME: "test", CONF_SITE_ID: SITE_ID, CONF_API_KEY: "test"},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("errors") == {CONF_SITE_ID: "already_configured"}
 
 
@@ -82,7 +82,7 @@ async def test_ignored_entry_does_not_cause_error(
         context={"source": SOURCE_USER},
         data={CONF_NAME: "test", CONF_SITE_ID: SITE_ID, CONF_API_KEY: "test"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "test"
 
     data = result["data"]
@@ -102,7 +102,7 @@ async def test_asserts(hass: HomeAssistant, test_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_NAME: NAME, CONF_API_KEY: API_KEY, CONF_SITE_ID: SITE_ID},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("errors") == {CONF_SITE_ID: "site_not_active"}
 
     # test with api_failure
@@ -112,7 +112,7 @@ async def test_asserts(hass: HomeAssistant, test_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_NAME: NAME, CONF_API_KEY: API_KEY, CONF_SITE_ID: SITE_ID},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("errors") == {CONF_SITE_ID: "invalid_api_key"}
 
     # test with ConnectionTimeout
@@ -122,7 +122,7 @@ async def test_asserts(hass: HomeAssistant, test_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_NAME: NAME, CONF_API_KEY: API_KEY, CONF_SITE_ID: SITE_ID},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("errors") == {CONF_SITE_ID: "could_not_connect"}
 
     # test with HTTPError
@@ -132,5 +132,5 @@ async def test_asserts(hass: HomeAssistant, test_api: Mock) -> None:
         context={"source": SOURCE_USER},
         data={CONF_NAME: NAME, CONF_API_KEY: API_KEY, CONF_SITE_ID: SITE_ID},
     )
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("errors") == {CONF_SITE_ID: "could_not_connect"}

--- a/tests/components/solarlog/test_config_flow.py
+++ b/tests/components/solarlog/test_config_flow.py
@@ -63,12 +63,12 @@ async def test_user(hass, test_connect):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # tets with all provided
     result = await flow.async_step_user({CONF_NAME: NAME, CONF_HOST: HOST})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "solarlog_test_1_2_3"
     assert result["data"][CONF_HOST] == HOST
 
@@ -79,19 +79,19 @@ async def test_import(hass, test_connect):
 
     # import with only host
     result = await flow.async_step_import({CONF_HOST: HOST})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "solarlog"
     assert result["data"][CONF_HOST] == HOST
 
     # import with only name
     result = await flow.async_step_import({CONF_NAME: NAME})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "solarlog_test_1_2_3"
     assert result["data"][CONF_HOST] == DEFAULT_HOST
 
     # import with host and name
     result = await flow.async_step_import({CONF_HOST: HOST, CONF_NAME: NAME})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "solarlog_test_1_2_3"
     assert result["data"][CONF_HOST] == HOST
 
@@ -107,19 +107,19 @@ async def test_abort_if_already_setup(hass, test_connect):
     result = await flow.async_step_import(
         {CONF_HOST: HOST, CONF_NAME: "solarlog_test_7_8_9"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     # Should fail, same HOST and NAME
     result = await flow.async_step_user({CONF_HOST: HOST, CONF_NAME: NAME})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "already_configured"}
 
     # SHOULD pass, diff HOST (without http://), different NAME
     result = await flow.async_step_import(
         {CONF_HOST: "2.2.2.2", CONF_NAME: "solarlog_test_7_8_9"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "solarlog_test_7_8_9"
     assert result["data"][CONF_HOST] == "http://2.2.2.2"
 
@@ -127,6 +127,6 @@ async def test_abort_if_already_setup(hass, test_connect):
     result = await flow.async_step_import(
         {CONF_HOST: "http://2.2.2.2", CONF_NAME: NAME}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "solarlog_test_1_2_3"
     assert result["data"][CONF_HOST] == "http://2.2.2.2"

--- a/tests/components/soma/test_config_flow.py
+++ b/tests/components/soma/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_form(hass):
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_import_abort(hass):
@@ -27,7 +27,7 @@ async def test_import_abort(hass):
     flow.hass = hass
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
     result = await flow.async_step_import()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_setup"
 
 
@@ -37,7 +37,7 @@ async def test_import_create(hass):
     flow.hass = hass
     with patch.object(SomaApi, "list_devices", return_value={"result": "success"}):
         result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_error_status(hass):
@@ -46,7 +46,7 @@ async def test_error_status(hass):
     flow.hass = hass
     with patch.object(SomaApi, "list_devices", return_value={"result": "error"}):
         result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "result_error"
 
 
@@ -56,7 +56,7 @@ async def test_key_error(hass):
     flow.hass = hass
     with patch.object(SomaApi, "list_devices", return_value={}):
         result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "connection_error"
 
 
@@ -66,7 +66,7 @@ async def test_exception(hass):
     flow.hass = hass
     with patch.object(SomaApi, "list_devices", side_effect=RequestException()):
         result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "connection_error"
 
 
@@ -77,4 +77,4 @@ async def test_full_flow(hass):
     flow.hass = hass
     with patch.object(SomaApi, "list_devices", return_value={"result": "success"}):
         result = await flow.async_step_user({"host": MOCK_HOST, "port": MOCK_PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/somfy_mylink/test_config_flow.py
+++ b/tests/components/somfy_mylink/test_config_flow.py
@@ -175,7 +175,7 @@ async def test_options_not_loaded(hass):
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 @pytest.mark.parametrize("reversed", [True, False])
@@ -204,7 +204,7 @@ async def test_options_with_targets(hass, reversed):
         await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result2 = await hass.config_entries.options.async_configure(
@@ -212,19 +212,19 @@ async def test_options_with_targets(hass, reversed):
             user_input={"target_id": "a"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         result3 = await hass.config_entries.options.async_configure(
             result2["flow_id"],
             user_input={"reverse": reversed},
         )
 
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result3["type"] == data_entry_flow.FlowResultType.FORM
 
         result4 = await hass.config_entries.options.async_configure(
             result3["flow_id"],
             user_input={"target_id": None},
         )
-        assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         assert config_entry.options == {
             CONF_REVERSED_TARGET_IDS: {"a": reversed},

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -26,10 +26,10 @@ async def test_creating_entry_sets_up_media_player(
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/speedtestdotnet/test_config_flow.py
+++ b/tests/components/speedtestdotnet/test_config_flow.py
@@ -21,13 +21,13 @@ async def test_flow_works(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         speedtestdotnet.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
@@ -42,7 +42,7 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -54,7 +54,7 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_SERVER_NAME: "Country1 - Sponsor1 - Server1",
         CONF_SERVER_ID: "1",
@@ -67,7 +67,7 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
 
     # test setting server name to "*Auto Detect"
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -79,7 +79,7 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_SERVER_NAME: "*Auto Detect",
         CONF_SERVER_ID: None,
@@ -89,7 +89,7 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
 
     # test setting the option to update periodically
     result2 = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "init"
 
     result2 = await hass.config_entries.options.async_configure(
@@ -114,5 +114,5 @@ async def test_integration_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         speedtestdotnet.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -32,7 +32,7 @@ async def test_user(hass, spider):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -45,7 +45,7 @@ async def test_user(hass, spider):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == DOMAIN
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
@@ -72,7 +72,7 @@ async def test_import(hass, spider):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == DOMAIN
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
@@ -91,7 +91,7 @@ async def test_abort_if_already_setup(hass, spider):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=SPIDER_USER_DATA
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
     # Should fail, config exist (flow)
@@ -99,5 +99,5 @@ async def test_abort_if_already_setup(hass, spider):
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=SPIDER_USER_DATA
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -30,14 +30,14 @@ async def test_abort_if_no_configuration(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=BLANK_ZEROCONF_INFO
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
@@ -49,7 +49,7 @@ async def test_zeroconf_abort_if_existing_entry(hass):
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=BLANK_ZEROCONF_INFO
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -79,7 +79,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         "https://accounts.spotify.com/authorize"
         "?response_type=code&client_id=client"
@@ -169,7 +169,7 @@ async def test_abort_if_spotify_error(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "connection_error"
 
 
@@ -305,7 +305,7 @@ async def test_reauth_account_mismatch(
         spotify_mock.return_value.current_user.return_value = {"id": "fake_id"}
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_account_mismatch"
 
 
@@ -315,5 +315,5 @@ async def test_abort_if_no_reauth_entry(hass):
         DOMAIN, context={"source": "reauth_confirm"}
     )
 
-    assert result.get("type") == data_entry_flow.RESULT_TYPE_ABORT
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
     assert result.get("reason") == "reauth_account_mismatch"

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -13,7 +13,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -104,7 +104,7 @@ async def test_config(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data=ENTRY_CONFIG,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         await hass.async_block_till_done()
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -116,5 +116,5 @@ async def test_integration_already_configured(hass):
     result = await hass.config_entries.flow.async_init(
         SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/steam_online/test_config_flow.py
+++ b/tests/components/steam_online/test_config_flow.py
@@ -40,7 +40,7 @@ async def test_flow_user(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input=CONF_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == ACCOUNT_NAME_1
         assert result["data"] == CONF_DATA
         assert result["options"] == CONF_OPTIONS
@@ -54,7 +54,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "cannot_connect"
 
@@ -66,7 +66,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "invalid_auth"
 
@@ -77,7 +77,7 @@ async def test_flow_user_invalid_account(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "invalid_account"
 
@@ -89,7 +89,7 @@ async def test_flow_user_unknown(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "unknown"
 
@@ -102,7 +102,7 @@ async def test_flow_user_already_configured(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -119,20 +119,20 @@ async def test_flow_reauth(hass: HomeAssistant) -> None:
             },
             data=CONF_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         new_conf = CONF_DATA | {CONF_API_KEY: "1234567890"}
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input=new_conf,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
         assert entry.data == new_conf
 
@@ -145,7 +145,7 @@ async def test_flow_import(hass: HomeAssistant) -> None:
             context={"source": SOURCE_IMPORT},
             data=CONF_IMPORT_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == ACCOUNT_NAME_1
         assert result["data"] == CONF_DATA
         assert result["options"] == CONF_IMPORT_OPTIONS
@@ -161,7 +161,7 @@ async def test_flow_import_already_configured(hass: HomeAssistant) -> None:
             context={"source": SOURCE_IMPORT},
             data=CONF_IMPORT_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -173,7 +173,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         result = await hass.config_entries.options.async_init(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -182,7 +182,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == CONF_OPTIONS_2
     assert len(er.async_get(hass).entities) == 2
 
@@ -195,7 +195,7 @@ async def test_options_flow_deselect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.options.async_init(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -203,7 +203,7 @@ async def test_options_flow_deselect(hass: HomeAssistant) -> None:
             user_input={CONF_ACCOUNTS: []},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_ACCOUNTS: {}}
     assert len(er.async_get(hass).entities) == 0
 
@@ -215,7 +215,7 @@ async def test_options_flow_timeout(hass: HomeAssistant) -> None:
         servicemock.side_effect = steam.api.HTTPTimeoutError
         result = await hass.config_entries.options.async_init(entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -224,7 +224,7 @@ async def test_options_flow_timeout(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == CONF_OPTIONS
 
 
@@ -234,7 +234,7 @@ async def test_options_flow_unauthorized(hass: HomeAssistant) -> None:
     with patch_interface_private():
         result = await hass.config_entries.options.async_init(entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -243,5 +243,5 @@ async def test_options_flow_unauthorized(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == CONF_OPTIONS

--- a/tests/components/syncthing/test_config_flow.py
+++ b/tests/components/syncthing/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_show_setup_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "user"
 
@@ -52,7 +52,7 @@ async def test_flow_successful(hass):
                 CONF_VERIFY_SSL: VERIFY_SSL,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "http://127.0.0.1:8384"
         assert result["data"][CONF_NAME] == NAME
         assert result["data"][CONF_URL] == URL
@@ -74,7 +74,7 @@ async def test_flow_already_configured(hass):
             data=MOCK_ENTRY,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -88,7 +88,7 @@ async def test_flow_invalid_auth(hass):
             data=MOCK_ENTRY,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"]["token"] == "invalid_auth"
 
 
@@ -102,5 +102,5 @@ async def test_flow_cannot_connect(hass):
             data=MOCK_ENTRY,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"]["base"] == "cannot_connect"

--- a/tests/components/syncthru/test_config_flow.py
+++ b/tests/components/syncthru/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_show_setup_form(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -65,7 +65,7 @@ async def test_already_configured_by_url(hass, aioclient_mock):
         data=FIXTURE_USER_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_URL] == FIXTURE_USER_INPUT[CONF_URL]
     assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
     assert result["result"].unique_id == udn
@@ -80,7 +80,7 @@ async def test_syncthru_not_supported(hass):
             data=FIXTURE_USER_INPUT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_URL: "syncthru_not_supported"}
 
@@ -96,7 +96,7 @@ async def test_unknown_state(hass):
             data=FIXTURE_USER_INPUT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_URL: "unknown_state"}
 
@@ -115,7 +115,7 @@ async def test_success(hass, aioclient_mock):
             data=FIXTURE_USER_INPUT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_URL] == FIXTURE_USER_INPUT[CONF_URL]
     await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
@@ -144,7 +144,7 @@ async def test_ssdp(hass, aioclient_mock):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
     assert CONF_URL in result["data_schema"].schema
     for k in result["data_schema"].schema:

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -120,7 +120,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=None
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # test with all provided
@@ -136,7 +136,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
             CONF_PASSWORD: PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -163,7 +163,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
             CONF_PASSWORD: PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL_2
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -185,7 +185,7 @@ async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "2sa"
 
     # Failed the first time because was too slow to enter the code
@@ -195,7 +195,7 @@ async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_OTP_CODE: "000000"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "2sa"
     assert result["errors"] == {CONF_OTP_CODE: "otp_failed"}
 
@@ -206,7 +206,7 @@ async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
         result["flow_id"], {CONF_OTP_CODE: "123456"}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -226,7 +226,7 @@ async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=None
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # test with all provided
@@ -242,7 +242,7 @@ async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock):
             CONF_PASSWORD: PASSWORD,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -288,7 +288,7 @@ async def test_reauth(hass: HomeAssistant, service: MagicMock):
                 CONF_PASSWORD: PASSWORD,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
 
         result = await hass.config_entries.flow.async_configure(
@@ -298,7 +298,7 @@ async def test_reauth(hass: HomeAssistant, service: MagicMock):
                 CONF_PASSWORD: PASSWORD,
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
 
 
@@ -323,7 +323,7 @@ async def test_reconfig_user(hass: HomeAssistant, service: MagicMock):
             context={"source": SOURCE_USER},
             data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reconfigure_successful"
 
 
@@ -338,7 +338,7 @@ async def test_login_failed(hass: HomeAssistant, service: MagicMock):
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_USERNAME: "invalid_auth"}
 
 
@@ -354,7 +354,7 @@ async def test_connection_failed(hass: HomeAssistant, service: MagicMock):
         data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
@@ -368,7 +368,7 @@ async def test_unknown_failed(hass: HomeAssistant, service: MagicMock):
         data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}
 
 
@@ -379,7 +379,7 @@ async def test_missing_data_after_login(hass: HomeAssistant, service_failed: Mag
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "missing_data"}
 
 
@@ -399,7 +399,7 @@ async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "link"
     assert result["errors"] == {}
 
@@ -407,7 +407,7 @@ async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
         result["flow_id"], {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == "192.168.1.5"
     assert result["data"][CONF_HOST] == "192.168.1.5"
@@ -450,7 +450,7 @@ async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 
 
@@ -482,7 +482,7 @@ async def test_skip_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -514,7 +514,7 @@ async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -535,7 +535,7 @@ async def test_options_flow(hass: HomeAssistant, service: MagicMock):
     assert config_entry.options == {}
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # Scan interval
@@ -544,7 +544,7 @@ async def test_options_flow(hass: HomeAssistant, service: MagicMock):
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options[CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
     assert config_entry.options[CONF_TIMEOUT] == DEFAULT_TIMEOUT
     assert config_entry.options[CONF_SNAPSHOT_QUALITY] == DEFAULT_SNAPSHOT_QUALITY
@@ -555,7 +555,7 @@ async def test_options_flow(hass: HomeAssistant, service: MagicMock):
         result["flow_id"],
         user_input={CONF_SCAN_INTERVAL: 2, CONF_TIMEOUT: 30, CONF_SNAPSHOT_QUALITY: 0},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options[CONF_SCAN_INTERVAL] == 2
     assert config_entry.options[CONF_TIMEOUT] == 30
     assert config_entry.options[CONF_SNAPSHOT_QUALITY] == 0

--- a/tests/components/synology_dsm/test_init.py
+++ b/tests/components/synology_dsm/test_init.py
@@ -52,7 +52,7 @@ async def test_reauth_triggered(hass: HomeAssistant):
         side_effect=SynologyDSMLoginInvalidException(USERNAME),
     ), patch(
         "homeassistant.components.synology_dsm.config_flow.SynologyDSMFlowHandler.async_step_reauth",
-        return_value={"type": data_entry_flow.RESULT_TYPE_FORM},
+        return_value={"type": data_entry_flow.FlowResultType.FORM},
     ) as mock_async_step_reauth:
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -102,7 +102,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -112,7 +112,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch(
@@ -129,7 +129,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "test-bridge"
     assert result2["data"] == FIXTURE_USER_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
@@ -141,7 +141,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch(
@@ -153,7 +153,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -164,7 +164,7 @@ async def test_form_connection_closed_cannot_connect(hass: HomeAssistant) -> Non
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -178,7 +178,7 @@ async def test_form_connection_closed_cannot_connect(hass: HomeAssistant) -> Non
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -189,7 +189,7 @@ async def test_form_timeout_cannot_connect(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -203,7 +203,7 @@ async def test_form_timeout_cannot_connect(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -214,7 +214,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -228,7 +228,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -239,7 +239,7 @@ async def test_form_uuid_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -253,7 +253,7 @@ async def test_form_uuid_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -264,7 +264,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -278,7 +278,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "unknown"}
 
@@ -289,7 +289,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": "reauth"}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "authenticate"
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -303,7 +303,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "authenticate"
     assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -314,7 +314,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": "reauth"}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "authenticate"
 
     with patch(
@@ -326,7 +326,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "authenticate"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -337,7 +337,7 @@ async def test_reauth_connection_closed_error(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": "reauth"}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "authenticate"
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -351,7 +351,7 @@ async def test_reauth_connection_closed_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "authenticate"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -367,7 +367,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": "reauth"}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "authenticate"
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -384,7 +384,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -399,7 +399,7 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
         data=FIXTURE_ZEROCONF,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert not result["errors"]
 
     with patch("systembridgeconnector.websocket_client.WebSocketClient.connect"), patch(
@@ -416,7 +416,7 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "1.1.1.1"
     assert result2["data"] == FIXTURE_ZEROCONF_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
@@ -431,7 +431,7 @@ async def test_zeroconf_cannot_connect(hass: HomeAssistant) -> None:
         data=FIXTURE_ZEROCONF,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert not result["errors"]
 
     with patch(
@@ -443,7 +443,7 @@ async def test_zeroconf_cannot_connect(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "authenticate"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -457,5 +457,5 @@ async def test_zeroconf_bad_zeroconf_info(hass: HomeAssistant) -> None:
         data=FIXTURE_ZEROCONF_BAD,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown"

--- a/tests/components/tautulli/test_config_flow.py
+++ b/tests/components/tautulli/test_config_flow.py
@@ -32,7 +32,7 @@ async def test_flow_user_single_instance_allowed(hass: HomeAssistant) -> None:
             context={"source": SOURCE_USER},
             data=CONF_IMPORT_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "single_instance_allowed"
 
 
@@ -41,7 +41,7 @@ async def test_flow_user(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -52,7 +52,7 @@ async def test_flow_user(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -64,7 +64,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "cannot_connect"
 
@@ -75,7 +75,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -87,7 +87,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -98,7 +98,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -110,7 +110,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "unknown"
 
@@ -121,7 +121,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -141,7 +141,7 @@ async def test_flow_reauth(
         },
         data=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
 
@@ -156,7 +156,7 @@ async def test_flow_reauth(
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
     assert entry.data == CONF_DATA
     assert len(mock_entry.mock_calls) == 1
@@ -182,7 +182,7 @@ async def test_flow_reauth_error(
             result["flow_id"],
             user_input={CONF_API_KEY: "efgh"},
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -191,5 +191,5 @@ async def test_flow_reauth_error(
             result["flow_id"],
             user_input={CONF_API_KEY: "efgh"},
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -62,12 +62,12 @@ async def test_abort_if_already_setup(hass):
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_setup"
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_import(None)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_setup"
 
 
@@ -76,16 +76,16 @@ async def test_full_flow_implementation(hass, mock_tellduslive):
     flow = init_config_flow(hass)
     flow.context = {"source": SOURCE_DISCOVERY}
     result = await flow.async_step_discovery(["localhost", "tellstick"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert len(flow._hosts) == 2
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await flow.async_step_user({"host": "localhost"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["description_placeholders"] == {
         "auth_url": "https://example.com",
@@ -93,7 +93,7 @@ async def test_full_flow_implementation(hass, mock_tellduslive):
     }
 
     result = await flow.async_step_auth("")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "localhost"
     assert result["data"]["host"] == "localhost"
     assert result["data"]["scan_interval"] == 60
@@ -105,7 +105,7 @@ async def test_step_import(hass, mock_tellduslive):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_import({CONF_HOST: DOMAIN, KEY_SCAN_INTERVAL: 0})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -116,7 +116,7 @@ async def test_step_import_add_host(hass, mock_tellduslive):
     result = await flow.async_step_import(
         {CONF_HOST: "localhost", KEY_SCAN_INTERVAL: 0}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -127,7 +127,7 @@ async def test_step_import_no_config_file(hass, mock_tellduslive):
     result = await flow.async_step_import(
         {CONF_HOST: "localhost", KEY_SCAN_INTERVAL: 0}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -142,7 +142,7 @@ async def test_step_import_load_json_matching_host(hass, mock_tellduslive):
         result = await flow.async_step_import(
             {CONF_HOST: "Cloud API", KEY_SCAN_INTERVAL: 0}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -157,7 +157,7 @@ async def test_step_import_load_json(hass, mock_tellduslive):
         result = await flow.async_step_import(
             {CONF_HOST: "localhost", KEY_SCAN_INTERVAL: SCAN_INTERVAL}
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "localhost"
     assert result["data"]["host"] == "localhost"
     assert result["data"]["scan_interval"] == 60
@@ -171,7 +171,7 @@ async def test_step_disco_no_local_api(hass, mock_tellduslive):
     flow.context = {"source": SOURCE_DISCOVERY}
 
     result = await flow.async_step_discovery(["localhost", "tellstick"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert len(flow._hosts) == 1
 
@@ -182,7 +182,7 @@ async def test_step_auth(hass, mock_tellduslive):
 
     await flow.async_step_auth()
     result = await flow.async_step_auth(["localhost", "tellstick"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Cloud API"
     assert result["data"]["host"] == "Cloud API"
     assert result["data"]["scan_interval"] == 60
@@ -199,7 +199,7 @@ async def test_wrong_auth_flow_implementation(hass, mock_tellduslive):
 
     await flow.async_step_auth()
     result = await flow.async_step_auth("")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -209,7 +209,7 @@ async def test_not_pick_host_if_only_one(hass, mock_tellduslive):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -218,7 +218,7 @@ async def test_abort_if_timeout_generating_auth_url(hass, mock_tellduslive):
     flow = init_config_flow(hass, side_effect=asyncio.TimeoutError)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -228,7 +228,7 @@ async def test_abort_no_auth_url(hass, mock_tellduslive):
     flow._get_auth_url = Mock(return_value=False)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown_authorize_url_generation"
 
 
@@ -237,7 +237,7 @@ async def test_abort_if_exception_generating_auth_url(hass, mock_tellduslive):
     flow = init_config_flow(hass, side_effect=ValueError)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unknown_authorize_url_generation"
 
 

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_duplicate_error(hass, config, config_entry):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -35,7 +35,7 @@ async def test_errors(hass, config, err, err_string):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=config
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": err_string}
 
 
@@ -44,7 +44,7 @@ async def test_step_import(hass, config, setup_tile):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "user@host.com"
     assert result["data"] == {
         CONF_USERNAME: "user@host.com",
@@ -60,13 +60,13 @@ async def test_step_reauth(hass, config, config_entry, setup_tile):
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_PASSWORD: "password"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries()) == 1
 
@@ -76,13 +76,13 @@ async def test_step_user(hass, config, setup_tile):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "user@host.com"
     assert result["data"] == {
         CONF_USERNAME: "user@host.com",

--- a/tests/components/tomorrowio/test_config_flow.py
+++ b/tests/components/tomorrowio/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_user_flow_minimum_fields(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
@@ -52,7 +52,7 @@ async def test_user_flow_minimum_fields(hass: HomeAssistant) -> None:
         user_input=_get_config_schema(hass, SOURCE_USER, MIN_CONFIG)(MIN_CONFIG),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
     assert result["data"][CONF_NAME] == DEFAULT_NAME
     assert result["data"][CONF_API_KEY] == API_KEY
@@ -77,7 +77,7 @@ async def test_user_flow_minimum_fields_in_zone(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
@@ -85,7 +85,7 @@ async def test_user_flow_minimum_fields_in_zone(hass: HomeAssistant) -> None:
         user_input=_get_config_schema(hass, SOURCE_USER, MIN_CONFIG)(MIN_CONFIG),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} - Home"
     assert result["data"][CONF_NAME] == f"{DEFAULT_NAME} - Home"
     assert result["data"][CONF_API_KEY] == API_KEY
@@ -111,7 +111,7 @@ async def test_user_flow_same_unique_ids(hass: HomeAssistant) -> None:
         data=user_input,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -127,7 +127,7 @@ async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
             data=_get_config_schema(hass, SOURCE_USER, MIN_CONFIG)(MIN_CONFIG),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -143,7 +143,7 @@ async def test_user_flow_invalid_api(hass: HomeAssistant) -> None:
             data=_get_config_schema(hass, SOURCE_USER, MIN_CONFIG)(MIN_CONFIG),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
 
@@ -159,7 +159,7 @@ async def test_user_flow_rate_limited(hass: HomeAssistant) -> None:
             data=_get_config_schema(hass, SOURCE_USER, MIN_CONFIG)(MIN_CONFIG),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {CONF_API_KEY: "rate_limited"}
 
 
@@ -175,7 +175,7 @@ async def test_user_flow_unknown_exception(hass: HomeAssistant) -> None:
             data=_get_config_schema(hass, SOURCE_USER, MIN_CONFIG)(MIN_CONFIG),
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "unknown"}
 
 
@@ -199,14 +199,14 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_TIMESTEP: 1}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_TIMESTEP] == 1
     assert entry.options[CONF_TIMESTEP] == 1
@@ -256,13 +256,13 @@ async def test_import_flow_v3(
         data=old_entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_API_KEY: "this is a test"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_API_KEY: "this is a test",
         CONF_LOCATION: {

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -37,7 +37,7 @@ async def test_abort_if_no_configuration(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_configuration"
 
 
@@ -51,7 +51,7 @@ async def test_full_flow_implementation(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # pylint: disable=protected-access
@@ -67,7 +67,7 @@ async def test_full_flow_implementation(
         result["flow_id"], {"implementation": "eneco"}
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result2["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result2["url"] == (
         "https://api.toon.eu/authorize"
         "?response_type=code&client_id=client"
@@ -141,7 +141,7 @@ async def test_no_agreements(
     with patch("toonapi.Toon.agreements", return_value=[]):
         result3 = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
     assert result3["reason"] == "no_agreements"
 
 
@@ -185,7 +185,7 @@ async def test_multiple_agreements(
     ):
         result3 = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result3["type"] == data_entry_flow.FlowResultType.FORM
         assert result3["step_id"] == "agreement"
 
         result4 = await hass.config_entries.flow.async_configure(
@@ -232,7 +232,7 @@ async def test_agreement_already_set_up(
     with patch("toonapi.Toon.agreements", return_value=[Agreement(agreement_id=123)]):
         result3 = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result3["type"] == data_entry_flow.FlowResultType.ABORT
         assert result3["reason"] == "already_configured"
 
 
@@ -271,7 +271,7 @@ async def test_toon_abort(
     with patch("toonapi.Toon.agreements", side_effect=ToonError):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
         assert result2["reason"] == "connection_error"
 
 
@@ -285,7 +285,7 @@ async def test_import(hass, current_request_with_host):
         DOMAIN, context={"source": SOURCE_IMPORT}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -333,7 +333,7 @@ async def test_import_migration(
     with patch("toonapi.Toon.agreements", return_value=[Agreement(agreement_id=123)]):
         result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1

--- a/tests/components/totalconnect/test_config_flow.py
+++ b/tests/components/totalconnect/test_config_flow.py
@@ -38,7 +38,7 @@ async def test_user(hass):
         data=None,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -65,7 +65,7 @@ async def test_user_show_locations(hass):
         )
 
         # first it should show the locations form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "locations"
         # client should have sent four requests for init
         assert mock_request.call_count == 4
@@ -75,7 +75,7 @@ async def test_user_show_locations(hass):
             result["flow_id"],
             user_input={CONF_USERCODES: "bad"},
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "locations"
         # client should have sent 5th request to validate usercode
         assert mock_request.call_count == 5
@@ -85,7 +85,7 @@ async def test_user_show_locations(hass):
             result2["flow_id"],
             user_input={CONF_USERCODES: "7890"},
         )
-        assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         # client should have sent another request to validate usercode
         assert mock_request.call_count == 6
 
@@ -106,7 +106,7 @@ async def test_abort_if_already_setup(hass):
             data=CONFIG_DATA,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -122,7 +122,7 @@ async def test_login_failed(hass):
             data=CONFIG_DATA,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
 
@@ -138,7 +138,7 @@ async def test_reauth(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=entry.data
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -152,7 +152,7 @@ async def test_reauth(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PASSWORD: "password"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "invalid_auth"}
 
@@ -162,7 +162,7 @@ async def test_reauth(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PASSWORD: "password"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
         await hass.async_block_till_done()
 
@@ -190,7 +190,7 @@ async def test_no_locations(hass):
             context={"source": SOURCE_USER},
             data=CONFIG_DATA_NO_USERCODES,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "no_locations"
         await hass.async_block_till_done()
 
@@ -221,14 +221,14 @@ async def test_options_flow(hass: HomeAssistant):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={AUTO_BYPASS: True}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {AUTO_BYPASS: True}
         await hass.async_block_till_done()
 

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -63,10 +63,10 @@ async def webhook_id_fixture(hass, client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     return result["result"].data["webhook_id"]

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_already_paired(hass, mock_entry_setup):
             result["flow_id"], {"host": "123.123.123.123", "security_code": "abcd"}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_authenticate"}
 
 
@@ -53,7 +53,7 @@ async def test_user_connection_successful(hass, mock_auth, mock_entry_setup):
 
     assert len(mock_entry_setup.mock_calls) == 1
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].data == {
         "host": "123.123.123.123",
         "gateway_id": "bla",
@@ -74,7 +74,7 @@ async def test_user_connection_timeout(hass, mock_auth, mock_entry_setup):
 
     assert len(mock_entry_setup.mock_calls) == 0
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "timeout"}
 
 
@@ -92,7 +92,7 @@ async def test_user_connection_bad_key(hass, mock_auth, mock_entry_setup):
 
     assert len(mock_entry_setup.mock_calls) == 0
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"security_code": "invalid_security_code"}
 
 
@@ -120,7 +120,7 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
 
     assert len(mock_entry_setup.mock_calls) == 1
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == "homekit-id"
     assert result["result"].data == {
         "host": "123.123.123.123",
@@ -149,7 +149,7 @@ async def test_discovery_duplicate_aborted(hass):
         ),
     )
 
-    assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow["type"] == data_entry_flow.FlowResultType.ABORT
     assert flow["reason"] == "already_configured"
 
     assert entry.data["host"] == "new-host"
@@ -165,7 +165,7 @@ async def test_import_duplicate_aborted(hass):
         data={"host": "some-host"},
     )
 
-    assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow["type"] == data_entry_flow.FlowResultType.ABORT
     assert flow["reason"] == "already_configured"
 
 
@@ -185,7 +185,7 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result2 = await hass.config_entries.flow.async_init(
         "tradfri",
@@ -201,7 +201,7 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
         ),
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_discovery_updates_unique_id(hass):
@@ -226,7 +226,7 @@ async def test_discovery_updates_unique_id(hass):
         ),
     )
 
-    assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow["type"] == data_entry_flow.FlowResultType.ABORT
     assert flow["reason"] == "already_configured"
 
     assert entry.unique_id == "homekit-id"

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -89,7 +89,7 @@ async def test_flow_user_config(hass, api):
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -101,7 +101,7 @@ async def test_flow_required_fields(hass, api):
         data={CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -116,7 +116,7 @@ async def test_flow_all_provided(hass, api):
         data=MOCK_ENTRY,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -137,10 +137,10 @@ async def test_options(hass):
     options_flow = flow.async_get_options_flow(entry)
 
     result = await options_flow.async_step_init()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     result = await options_flow.async_step_init({CONF_SCAN_INTERVAL: 10})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_SCAN_INTERVAL] == 10
 
 
@@ -171,7 +171,7 @@ async def test_host_already_configured(hass, api):
         context={"source": config_entries.SOURCE_USER},
         data=mock_entry_unique_port,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     mock_entry_unique_host = MOCK_ENTRY.copy()
     mock_entry_unique_host[CONF_HOST] = "192.168.1.101"
@@ -181,7 +181,7 @@ async def test_host_already_configured(hass, api):
         context={"source": config_entries.SOURCE_USER},
         data=mock_entry_unique_host,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_name_already_configured(hass, api):
@@ -218,7 +218,7 @@ async def test_error_on_wrong_credentials(hass, auth_error):
             CONF_PORT: PORT,
         }
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {
         CONF_USERNAME: "invalid_auth",
         CONF_PASSWORD: "invalid_auth",
@@ -238,7 +238,7 @@ async def test_error_on_connection_failure(hass, conn_error):
             CONF_PORT: PORT,
         }
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -255,7 +255,7 @@ async def test_error_on_unknown_error(hass, unknown_error):
             CONF_PORT: PORT,
         }
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -14,10 +14,10 @@ async def test_config_flow_registers_webhook(hass, hass_client_no_auth):
     result = await hass.config_entries.flow.async_init(
         "twilio", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     webhook_id = result["result"].data["webhook_id"]
 
     twilio_events = []

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -95,7 +95,7 @@ async def test_flow_works(hass, aioclient_mock, mock_discovery):
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["data_schema"]({CONF_USERNAME: "", CONF_PASSWORD: ""}) == {
         CONF_HOST: "unifi",
@@ -135,7 +135,7 @@ async def test_flow_works(hass, aioclient_mock, mock_discovery):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Site name"
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
@@ -161,7 +161,7 @@ async def test_flow_works_negative_discovery(hass, aioclient_mock, mock_discover
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["data_schema"]({CONF_USERNAME: "", CONF_PASSWORD: ""}) == {
         CONF_HOST: "",
@@ -178,7 +178,7 @@ async def test_flow_multiple_sites(hass, aioclient_mock):
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     aioclient_mock.get("https://1.2.3.4:1234", status=302)
@@ -212,7 +212,7 @@ async def test_flow_multiple_sites(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "site"
     assert result["data_schema"]({"site": "1"})
     assert result["data_schema"]({"site": "2"})
@@ -226,7 +226,7 @@ async def test_flow_raise_already_configured(hass, aioclient_mock):
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     aioclient_mock.clear_requests()
@@ -261,7 +261,7 @@ async def test_flow_raise_already_configured(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -281,7 +281,7 @@ async def test_flow_aborts_configuration_updated(hass, aioclient_mock):
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     aioclient_mock.get("https://1.2.3.4:1234", status=302)
@@ -315,7 +315,7 @@ async def test_flow_aborts_configuration_updated(hass, aioclient_mock):
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "configuration_updated"
 
 
@@ -325,7 +325,7 @@ async def test_flow_fails_user_credentials_faulty(hass, aioclient_mock):
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     aioclient_mock.get("https://1.2.3.4:1234", status=302)
@@ -342,7 +342,7 @@ async def test_flow_fails_user_credentials_faulty(hass, aioclient_mock):
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "faulty_credentials"}
 
 
@@ -352,7 +352,7 @@ async def test_flow_fails_controller_unavailable(hass, aioclient_mock):
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     aioclient_mock.get("https://1.2.3.4:1234", status=302)
@@ -369,7 +369,7 @@ async def test_flow_fails_controller_unavailable(hass, aioclient_mock):
             },
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "service_unavailable"}
 
 
@@ -389,7 +389,7 @@ async def test_reauth_flow_update_configuration(hass, aioclient_mock):
         data=config_entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
     aioclient_mock.clear_requests()
@@ -424,7 +424,7 @@ async def test_reauth_flow_update_configuration(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert config_entry.data[CONF_HOST] == "1.2.3.4"
     assert config_entry.data[CONF_USERNAME] == "new_name"
@@ -447,7 +447,7 @@ async def test_advanced_option_flow(hass, aioclient_mock):
         config_entry.entry_id, context={"show_advanced_options": True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "device_tracker"
     assert not result["last_step"]
     assert set(
@@ -465,7 +465,7 @@ async def test_advanced_option_flow(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "client_control"
     assert not result["last_step"]
 
@@ -478,7 +478,7 @@ async def test_advanced_option_flow(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "statistics_sensors"
     assert result["last_step"]
 
@@ -490,7 +490,7 @@ async def test_advanced_option_flow(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_TRACK_CLIENTS: False,
         CONF_TRACK_WIRED_CLIENTS: False,
@@ -521,7 +521,7 @@ async def test_simple_option_flow(hass, aioclient_mock):
         config_entry.entry_id, context={"show_advanced_options": False}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "simple_options"
     assert result["last_step"]
 
@@ -534,7 +534,7 @@ async def test_simple_option_flow(hass, aioclient_mock):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_TRACK_CLIENTS: False,
         CONF_TRACK_DEVICES: False,

--- a/tests/components/upcloud/test_config_flow.py
+++ b/tests/components/upcloud/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_show_set_form(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -37,7 +37,7 @@ async def test_connection_error(hass, requests_mock):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -56,7 +56,7 @@ async def test_login_error(hass, requests_mock):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -68,7 +68,7 @@ async def test_success(hass, requests_mock):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
 
@@ -82,7 +82,7 @@ async def test_options(hass):
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_flow_ssdp(hass: HomeAssistant):
         context={"source": config_entries.SOURCE_SSDP},
         data=TEST_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "ssdp_confirm"
 
     # Confirm via step ssdp_confirm.
@@ -53,7 +53,7 @@ async def test_flow_ssdp(hass: HomeAssistant):
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEST_FRIENDLY_NAME
     assert result["data"] == {
         CONFIG_ENTRY_ST: TEST_ST,
@@ -81,7 +81,7 @@ async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "incomplete_discovery"
 
 
@@ -102,7 +102,7 @@ async def test_flow_ssdp_non_igd_device(hass: HomeAssistant):
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "non_igd_device"
 
 
@@ -120,7 +120,7 @@ async def test_flow_ssdp_no_mac_address(hass: HomeAssistant):
         context={"source": config_entries.SOURCE_SSDP},
         data=TEST_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "ssdp_confirm"
 
     # Confirm via step ssdp_confirm.
@@ -128,7 +128,7 @@ async def test_flow_ssdp_no_mac_address(hass: HomeAssistant):
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEST_FRIENDLY_NAME
     assert result["data"] == {
         CONFIG_ENTRY_ST: TEST_ST,
@@ -167,7 +167,7 @@ async def test_flow_ssdp_discovery_changed_udn(hass: HomeAssistant):
         context={"source": config_entries.SOURCE_SSDP},
         data=new_discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "config_entry_updated"
 
 
@@ -207,7 +207,7 @@ async def test_flow_ssdp_discovery_changed_udn_but_st_differs(hass: HomeAssistan
             context={"source": config_entries.SOURCE_SSDP},
             data=new_discovery,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "ssdp_confirm"
 
     # UDN + ST different: New discovery via step ssdp.
@@ -225,7 +225,7 @@ async def test_flow_ssdp_discovery_changed_udn_but_st_differs(hass: HomeAssistan
             context={"source": config_entries.SOURCE_SSDP},
             data=new_discovery,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "ssdp_confirm"
 
 
@@ -256,7 +256,7 @@ async def test_flow_ssdp_discovery_changed_location(hass: HomeAssistant):
         context={"source": config_entries.SOURCE_SSDP},
         data=new_discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     # Test if location is updated.
@@ -285,7 +285,7 @@ async def test_flow_ssdp_discovery_ignored_entry(hass: HomeAssistant):
         context={"source": config_entries.SOURCE_SSDP},
         data=TEST_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -316,7 +316,7 @@ async def test_flow_ssdp_discovery_changed_udn_ignored_entry(hass: HomeAssistant
         context={"source": config_entries.SOURCE_SSDP},
         data=new_discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "discovery_ignored"
 
 
@@ -332,7 +332,7 @@ async def test_flow_user(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Confirmed via step user.
@@ -340,7 +340,7 @@ async def test_flow_user(hass: HomeAssistant):
         result["flow_id"],
         user_input={"unique_id": TEST_USN},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == TEST_FRIENDLY_NAME
     assert result["data"] == {
         CONFIG_ENTRY_ST: TEST_ST,
@@ -362,5 +362,5 @@ async def test_flow_user_no_discovery(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -66,20 +66,20 @@ async def test_user(hass: HomeAssistant):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await flow.async_step_user(
         {CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "velbus_test_serial"
     assert result["data"][CONF_PORT] == PORT_SERIAL
 
     result = await flow.async_step_user(
         {CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "velbus_test_tcp"
     assert result["data"][CONF_PORT] == PORT_TCP
 
@@ -92,13 +92,13 @@ async def test_user_fail(hass: HomeAssistant):
     result = await flow.async_step_user(
         {CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_PORT: "cannot_connect"}
 
     result = await flow.async_step_user(
         {CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_PORT: "cannot_connect"}
 
 
@@ -108,7 +108,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user({CONF_PORT: PORT_TCP, CONF_NAME: "velbus test"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"port": "already_configured"}
 
 
@@ -121,14 +121,14 @@ async def test_flow_usb(hass: HomeAssistant):
         context={CONF_SOURCE: SOURCE_USB},
         data=DISCOVERY_INFO,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # test an already configured discovery
     entry = MockConfigEntry(
@@ -141,7 +141,7 @@ async def test_flow_usb(hass: HomeAssistant):
         context={CONF_SOURCE: SOURCE_USB},
         data=DISCOVERY_INFO,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -154,5 +154,5 @@ async def test_flow_usb_failed(hass: HomeAssistant):
         context={CONF_SOURCE: SOURCE_USB},
         data=DISCOVERY_INFO,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"

--- a/tests/components/vera/test_config_flow.py
+++ b/tests/components/vera/test_config_flow.py
@@ -138,7 +138,7 @@ async def test_options(hass):
     result = await hass.config_entries.options.async_init(
         entry.entry_id, context={"source": "test"}, data=None
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -148,7 +148,7 @@ async def test_options(hass):
             CONF_EXCLUDE: "8,9;10  11 12_13bb14",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_LIGHTS: [1, 2, 3, 4, 5, 6, 7],
         CONF_EXCLUDE: [8, 9, 10, 11, 12, 13, 14],

--- a/tests/components/vesync/test_config_flow.py
+++ b/tests/components/vesync/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_abort_already_setup(hass):
     )
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -29,7 +29,7 @@ async def test_invalid_login_error(hass):
     with patch("pyvesync.vesync.VeSync.login", return_value=False):
         result = await flow.async_step_user(user_input=test_dict)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
 
@@ -38,11 +38,11 @@ async def test_config_flow_user_input(hass):
     flow = config_flow.VeSyncFlowHandler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     with patch("pyvesync.vesync.VeSync.login", return_value=True):
         result = await flow.async_step_user(
             {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_USERNAME] == "user"
         assert result["data"][CONF_PASSWORD] == "pass"

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert len(result["errors"]) == 0
 
     with patch(
@@ -38,7 +38,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "ViCare"
     assert result2["data"] == ENTRY_CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
@@ -64,7 +64,7 @@ async def test_invalid_login(hass) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -81,7 +81,7 @@ async def test_form_dhcp(hass):
             macaddress=MOCK_MAC,
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -102,7 +102,7 @@ async def test_form_dhcp(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "ViCare"
     assert result2["data"] == ENTRY_CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
@@ -125,7 +125,7 @@ async def test_dhcp_single_instance_allowed(hass):
             macaddress=MOCK_MAC,
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -141,5 +141,5 @@ async def test_user_input_single_instance_allowed(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch("vilfo.Client.ping", return_value=None), patch(
@@ -29,7 +29,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testadmin.vilfo.com"
     assert result2["data"] == {
         "host": "testadmin.vilfo.com",
@@ -56,7 +56,7 @@ async def test_form_invalid_auth(hass):
             {"host": "testadmin.vilfo.com", "access_token": "test-token"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -74,7 +74,7 @@ async def test_form_cannot_connect(hass):
             {"host": "testadmin.vilfo.com", "access_token": "test-token"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch("vilfo.Client.ping", side_effect=vilfo.exceptions.VilfoException), patch(
@@ -85,7 +85,7 @@ async def test_form_cannot_connect(hass):
             {"host": "testadmin.vilfo.com", "access_token": "test-token"},
         )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"] == {"base": "cannot_connect"}
 
 
@@ -128,8 +128,8 @@ async def test_form_already_configured(hass):
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
         )
 
-    assert first_flow_result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert second_flow_result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert first_flow_result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert second_flow_result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert second_flow_result2["reason"] == "already_configured"
 
 

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -66,14 +66,14 @@ async def test_user_flow_minimum_fields(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_SPEAKER_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -91,14 +91,14 @@ async def test_user_flow_all_fields(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -117,19 +117,19 @@ async def test_speaker_options_flow(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_SPEAKER_CONFIG
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = result["result"]
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_VOLUME_STEP: VOLUME_STEP}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
     assert CONF_APPS not in result["data"]
@@ -145,12 +145,12 @@ async def test_tv_options_flow_no_apps(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = result["result"]
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     options = {CONF_VOLUME_STEP: VOLUME_STEP}
@@ -160,7 +160,7 @@ async def test_tv_options_flow_no_apps(
         result["flow_id"], user_input=options
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
     assert CONF_APPS not in result["data"]
@@ -176,12 +176,12 @@ async def test_tv_options_flow_with_apps(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = result["result"]
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     options = {CONF_VOLUME_STEP: VOLUME_STEP}
@@ -191,7 +191,7 @@ async def test_tv_options_flow_with_apps(
         result["flow_id"], user_input=options
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
     assert CONF_APPS in result["data"]
@@ -208,13 +208,13 @@ async def test_tv_options_flow_start_with_volume(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
     await hass.async_block_till_done()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = result["result"]
 
     result = await hass.config_entries.options.async_init(
         entry.entry_id, data={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert entry.options
     assert entry.options == {CONF_VOLUME_STEP: VOLUME_STEP}
@@ -223,7 +223,7 @@ async def test_tv_options_flow_start_with_volume(
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     options = {CONF_VOLUME_STEP: VOLUME_STEP}
@@ -233,7 +233,7 @@ async def test_tv_options_flow_start_with_volume(
         result["flow_id"], user_input=options
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
     assert CONF_APPS in result["data"]
@@ -260,7 +260,7 @@ async def test_user_host_already_configured(
         DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "existing_config_entry_found"}
 
 
@@ -284,7 +284,7 @@ async def test_user_serial_number_already_exists(
         DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "existing_config_entry_found"}
 
 
@@ -296,7 +296,7 @@ async def test_user_error_on_could_not_connect(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
@@ -308,7 +308,7 @@ async def test_user_error_on_could_not_connect_invalid_token(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -323,19 +323,19 @@ async def test_user_tv_pairing_no_apps(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_TV_CONFIG_NO_TOKEN
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pair_tv"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_PIN_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pairing_complete"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -354,7 +354,7 @@ async def test_user_start_pairing_failure(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_TV_CONFIG_NO_TOKEN
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -370,14 +370,14 @@ async def test_user_invalid_pin(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_TV_CONFIG_NO_TOKEN
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pair_tv"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_PIN_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pair_tv"
     assert result["errors"] == {CONF_PIN: "complete_pairing_failed"}
 
@@ -399,7 +399,7 @@ async def test_user_ignore(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_SPEAKER_CONFIG
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_import_flow_minimum_fields(
@@ -416,7 +416,7 @@ async def test_import_flow_minimum_fields(
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
     assert result["data"][CONF_NAME] == DEFAULT_NAME
     assert result["data"][CONF_HOST] == HOST
@@ -436,7 +436,7 @@ async def test_import_flow_all_fields(
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -463,7 +463,7 @@ async def test_import_entity_already_configured(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=fail_entry
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured_device"
 
 
@@ -481,7 +481,7 @@ async def test_import_flow_update_options(
     await hass.async_block_till_done()
 
     assert result["result"].options == {CONF_VOLUME_STEP: DEFAULT_VOLUME_STEP}
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry_id = result["result"].entry_id
 
     updated_config = MOCK_SPEAKER_CONFIG.copy()
@@ -492,7 +492,7 @@ async def test_import_flow_update_options(
         data=vol.Schema(VIZIO_SCHEMA)(updated_config),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "updated_entry"
     config_entry = hass.config_entries.async_get_entry(entry_id)
     assert config_entry.options[CONF_VOLUME_STEP] == VOLUME_STEP + 1
@@ -512,7 +512,7 @@ async def test_import_flow_update_name_and_apps(
     await hass.async_block_till_done()
 
     assert result["result"].data[CONF_NAME] == NAME
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry_id = result["result"].entry_id
 
     updated_config = MOCK_IMPORT_VALID_TV_CONFIG.copy()
@@ -524,7 +524,7 @@ async def test_import_flow_update_name_and_apps(
         data=vol.Schema(VIZIO_SCHEMA)(updated_config),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "updated_entry"
     config_entry = hass.config_entries.async_get_entry(entry_id)
     assert config_entry.data[CONF_NAME] == NAME2
@@ -546,7 +546,7 @@ async def test_import_flow_update_remove_apps(
     await hass.async_block_till_done()
 
     assert result["result"].data[CONF_NAME] == NAME
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     config_entry = hass.config_entries.async_get_entry(result["result"].entry_id)
     assert CONF_APPS in config_entry.data
     assert CONF_APPS in config_entry.options
@@ -559,7 +559,7 @@ async def test_import_flow_update_remove_apps(
         data=vol.Schema(VIZIO_SCHEMA)(updated_config),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "updated_entry"
     assert CONF_APPS not in config_entry.data
     assert CONF_APPS not in config_entry.options
@@ -576,26 +576,26 @@ async def test_import_needs_pairing(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_TV_CONFIG_NO_TOKEN
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_TV_CONFIG_NO_TOKEN
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pair_tv"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_PIN_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pairing_complete_import"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -616,7 +616,7 @@ async def test_import_with_apps_needs_pairing(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=import_config
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Mock inputting info without apps to make sure apps get stored
@@ -625,19 +625,19 @@ async def test_import_with_apps_needs_pairing(
         user_input=_get_config_schema(MOCK_TV_CONFIG_NO_TOKEN)(MOCK_TV_CONFIG_NO_TOKEN),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pair_tv"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_PIN_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pairing_complete_import"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
@@ -659,7 +659,7 @@ async def test_import_flow_additional_configs(
     await hass.async_block_till_done()
 
     assert result["result"].data[CONF_NAME] == NAME
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     config_entry = hass.config_entries.async_get_entry(result["result"].entry_id)
     assert CONF_APPS in config_entry.data
     assert CONF_APPS not in config_entry.options
@@ -688,7 +688,7 @@ async def test_import_error(
         data=vol.Schema(VIZIO_SCHEMA)(fail_entry),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Ensure error gets logged
     vizio_log_list = [
@@ -719,7 +719,7 @@ async def test_import_ignore(
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_zeroconf_flow(
@@ -735,7 +735,7 @@ async def test_zeroconf_flow(
     )
 
     # Form should always show even if all required properties are discovered
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Apply discovery updates to entry to mimic when user hits submit without changing
@@ -752,7 +752,7 @@ async def test_zeroconf_flow(
         result["flow_id"], user_input=user_input
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_NAME] == NAME
@@ -781,7 +781,7 @@ async def test_zeroconf_flow_already_configured(
     )
 
     # Flow should abort because device is already setup
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -808,7 +808,7 @@ async def test_zeroconf_flow_with_port_in_host(
     )
 
     # Flow should abort because device is already setup
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -825,7 +825,7 @@ async def test_zeroconf_dupe_fail(
     )
 
     # Form should always show even if all required properties are discovered
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
@@ -834,7 +834,7 @@ async def test_zeroconf_dupe_fail(
     )
 
     # Flow should abort because device is already setup
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -858,7 +858,7 @@ async def test_zeroconf_ignore(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_zeroconf_no_unique_id(
@@ -873,7 +873,7 @@ async def test_zeroconf_no_unique_id(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -898,7 +898,7 @@ async def test_zeroconf_abort_when_ignored(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -927,7 +927,7 @@ async def test_zeroconf_flow_already_configured_hostname(
     )
 
     # Flow should abort because device is already setup
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -952,7 +952,7 @@ async def test_import_flow_already_configured_hostname(
     )
 
     # Flow should abort because device was updated
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "updated_entry"
 
     assert entry.data[CONF_HOST] == HOST

--- a/tests/components/vulcan/test_config_flow.py
+++ b/tests/components/vulcan/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_show_form(hass):
 
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
 
 
@@ -56,7 +56,7 @@ async def test_config_flow_auth_success(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"] is None
 
@@ -70,7 +70,7 @@ async def test_config_flow_auth_success(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -93,7 +93,7 @@ async def test_config_flow_auth_success_with_multiple_students(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"] is None
 
@@ -102,7 +102,7 @@ async def test_config_flow_auth_success_with_multiple_students(
         {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_student"
     assert result["errors"] == {}
 
@@ -115,7 +115,7 @@ async def test_config_flow_auth_success_with_multiple_students(
             {"student": "0"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -141,7 +141,7 @@ async def test_config_flow_reauth_success(
         const.DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
 
@@ -154,7 +154,7 @@ async def test_config_flow_reauth_success(
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -180,7 +180,7 @@ async def test_config_flow_reauth_without_matching_entries(
         const.DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
 
@@ -189,7 +189,7 @@ async def test_config_flow_reauth_without_matching_entries(
         {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_matching_entries"
 
 
@@ -202,7 +202,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
     with patch(
@@ -215,7 +215,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "invalid_token"}
 
@@ -229,7 +229,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "expired_token"}
 
@@ -243,7 +243,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "invalid_pin"}
 
@@ -257,7 +257,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "invalid_symbol"}
 
@@ -271,7 +271,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "cannot_connect"}
 
@@ -285,7 +285,7 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "unknown"}
 
@@ -310,7 +310,7 @@ async def test_multiple_config_entries(mock_account, mock_keystore, mock_student
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -319,7 +319,7 @@ async def test_multiple_config_entries(mock_account, mock_keystore, mock_student
         {"use_saved_credentials": False},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"] is None
 
@@ -332,7 +332,7 @@ async def test_multiple_config_entries(mock_account, mock_keystore, mock_student
             {CONF_TOKEN: "token", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 2
 
@@ -353,7 +353,7 @@ async def test_multiple_config_entries_using_saved_credentials(mock_student, has
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -366,7 +366,7 @@ async def test_multiple_config_entries_using_saved_credentials(mock_student, has
             {"use_saved_credentials": True},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 2
 
@@ -387,7 +387,7 @@ async def test_multiple_config_entries_using_saved_credentials_2(mock_student, h
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -396,7 +396,7 @@ async def test_multiple_config_entries_using_saved_credentials_2(mock_student, h
         {"use_saved_credentials": True},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_student"
     assert result["errors"] == {}
 
@@ -409,7 +409,7 @@ async def test_multiple_config_entries_using_saved_credentials_2(mock_student, h
             {"student": "0"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 2
 
@@ -438,7 +438,7 @@ async def test_multiple_config_entries_using_saved_credentials_3(mock_student, h
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -447,7 +447,7 @@ async def test_multiple_config_entries_using_saved_credentials_3(mock_student, h
         {"use_saved_credentials": True},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_saved_credentials"
     assert result["errors"] is None
 
@@ -460,7 +460,7 @@ async def test_multiple_config_entries_using_saved_credentials_3(mock_student, h
             {"credentials": "123"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 3
 
@@ -489,7 +489,7 @@ async def test_multiple_config_entries_using_saved_credentials_4(mock_student, h
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -498,7 +498,7 @@ async def test_multiple_config_entries_using_saved_credentials_4(mock_student, h
         {"use_saved_credentials": True},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_saved_credentials"
     assert result["errors"] is None
 
@@ -507,7 +507,7 @@ async def test_multiple_config_entries_using_saved_credentials_4(mock_student, h
         {"credentials": "123"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "select_student"
     assert result["errors"] == {}
 
@@ -520,7 +520,7 @@ async def test_multiple_config_entries_using_saved_credentials_4(mock_student, h
             {"student": "0"},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Jan Kowalski"
     assert len(mock_setup_entry.mock_calls) == 3
 
@@ -545,7 +545,7 @@ async def test_multiple_config_entries_without_valid_saved_credentials(hass):
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -557,7 +557,7 @@ async def test_multiple_config_entries_without_valid_saved_credentials(hass):
         "homeassistant.components.vulcan.config_flow.Vulcan.get_students",
         side_effect=UnauthorizedCertificateException,
     ):
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "select_saved_credentials"
         assert result["errors"] is None
 
@@ -566,7 +566,7 @@ async def test_multiple_config_entries_without_valid_saved_credentials(hass):
             {"credentials": "123"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "expired_credentials"}
 
@@ -593,7 +593,7 @@ async def test_multiple_config_entries_using_saved_credentials_with_connections_
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -605,7 +605,7 @@ async def test_multiple_config_entries_using_saved_credentials_with_connections_
         "homeassistant.components.vulcan.config_flow.Vulcan.get_students",
         side_effect=ClientConnectionError,
     ):
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "select_saved_credentials"
         assert result["errors"] is None
 
@@ -614,7 +614,7 @@ async def test_multiple_config_entries_using_saved_credentials_with_connections_
             {"credentials": "123"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "select_saved_credentials"
         assert result["errors"] == {"base": "cannot_connect"}
 
@@ -639,7 +639,7 @@ async def test_multiple_config_entries_using_saved_credentials_with_unknown_erro
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -651,7 +651,7 @@ async def test_multiple_config_entries_using_saved_credentials_with_unknown_erro
         "homeassistant.components.vulcan.config_flow.Vulcan.get_students",
         side_effect=Exception,
     ):
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "select_saved_credentials"
         assert result["errors"] is None
 
@@ -660,7 +660,7 @@ async def test_multiple_config_entries_using_saved_credentials_with_unknown_erro
             {"credentials": "123"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "unknown"}
 
@@ -688,7 +688,7 @@ async def test_student_already_exists(mock_account, mock_keystore, mock_student,
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "add_next_config_entry"
     assert result["errors"] == {}
 
@@ -697,7 +697,7 @@ async def test_student_already_exists(mock_account, mock_keystore, mock_student,
         {"use_saved_credentials": True},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "all_student_already_configured"
 
 
@@ -713,7 +713,7 @@ async def test_config_flow_auth_invalid_token(mock_keystore, hass):
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] is None
 
@@ -722,7 +722,7 @@ async def test_config_flow_auth_invalid_token(mock_keystore, hass):
             {CONF_TOKEN: "3S20000", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "invalid_token"}
 
@@ -739,7 +739,7 @@ async def test_config_flow_auth_invalid_region(mock_keystore, hass):
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] is None
 
@@ -748,7 +748,7 @@ async def test_config_flow_auth_invalid_region(mock_keystore, hass):
             {CONF_TOKEN: "3S10000", CONF_REGION: "invalid_region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "invalid_symbol"}
 
@@ -765,7 +765,7 @@ async def test_config_flow_auth_invalid_pin(mock_keystore, hass):
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] is None
 
@@ -774,7 +774,7 @@ async def test_config_flow_auth_invalid_pin(mock_keystore, hass):
             {CONF_TOKEN: "3S10000", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "invalid_pin"}
 
@@ -791,7 +791,7 @@ async def test_config_flow_auth_expired_token(mock_keystore, hass):
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] is None
 
@@ -800,7 +800,7 @@ async def test_config_flow_auth_expired_token(mock_keystore, hass):
             {CONF_TOKEN: "3S10000", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "expired_token"}
 
@@ -817,7 +817,7 @@ async def test_config_flow_auth_connection_error(mock_keystore, hass):
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] is None
 
@@ -826,7 +826,7 @@ async def test_config_flow_auth_connection_error(mock_keystore, hass):
             {CONF_TOKEN: "3S10000", CONF_REGION: "region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "cannot_connect"}
 
@@ -843,7 +843,7 @@ async def test_config_flow_auth_unknown_error(mock_keystore, hass):
             const.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] is None
 
@@ -852,6 +852,6 @@ async def test_config_flow_auth_unknown_error(mock_keystore, hass):
             {CONF_TOKEN: "3S10000", CONF_REGION: "invalid_region", CONF_PIN: "000000"},
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "auth"
         assert result["errors"] == {"base": "unknown"}

--- a/tests/components/wallbox/test_config_flow.py
+++ b/tests/components/wallbox/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
     flow.hass = hass
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -106,13 +106,13 @@ async def test_options_flow(hass: HomeAssistant, config_entry):
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_SHOW_ON_MAP: False}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_SHOW_ON_MAP: False}
 
 

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_minimum_fields(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -38,7 +38,7 @@ async def test_minimum_fields(hass):
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == DEFAULT_NAME
     assert result2["data"] == {
         CONF_NAME: DEFAULT_NAME,
@@ -60,7 +60,7 @@ async def test_options(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -76,7 +76,7 @@ async def test_options(hass):
             CONF_VEHICLE_TYPE: "taxi",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"] == {
         CONF_AVOID_FERRIES: True,
@@ -122,7 +122,7 @@ async def test_import(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.data == {
@@ -148,7 +148,7 @@ async def test_dupe(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -157,13 +157,13 @@ async def test_dupe(hass):
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -172,7 +172,7 @@ async def test_dupe(hass):
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.usefixtures("invalidate_config_entry")
@@ -181,12 +181,12 @@ async def test_invalid_config_entry(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         MOCK_CONFIG,
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -18,5 +18,5 @@ async def test_not_discovered(hass: HomeAssistant) -> None:
     with patch("homeassistant.components.wemo.config_flow.pywemo") as mock_pywemo:
         mock_pywemo.discover_devices.return_value = []
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"

--- a/tests/components/wiffi/test_config_flow.py
+++ b/tests/components/wiffi/test_config_flow.py
@@ -125,13 +125,13 @@ async def test_option_flow(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_TIMEOUT: 9}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_TIMEOUT] == 9

--- a/tests/components/withings/common.py
+++ b/tests/components/withings/common.py
@@ -199,7 +199,7 @@ class ComponentFactory:
                 "redirect_uri": "http://127.0.0.1:8080/auth/external/callback",
             },
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+        assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
         assert result["url"] == (
             "https://account.withings.com/oauth2_user/authorize2?"
             f"response_type=code&client_id={self._client_id}&"

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -38,7 +38,7 @@ async def test_show_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -52,7 +52,7 @@ async def test_device_step_form(hass):
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=INPUT_CONFIG
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "device"
 
 
@@ -71,7 +71,7 @@ async def test_create_entry(hass):
             {"device_name": CONFIG[DEVICE_NAME]},
         )
 
-    assert result_create_entry["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result_create_entry["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result_create_entry["title"] == CONFIG[DEVICE_NAME]
     assert result_create_entry["data"] == CONFIG
 
@@ -138,5 +138,5 @@ async def test_already_configured_error(hass):
             {"device_name": CONFIG[DEVICE_NAME]},
         )
 
-    assert result_create_entry["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result_create_entry["type"] == data_entry_flow.FlowResultType.ABORT
     assert result_create_entry["reason"] == "already_configured"

--- a/tests/components/ws66i/test_config_flow.py
+++ b/tests/components/ws66i/test_config_flow.py
@@ -126,7 +126,7 @@ async def test_options_flow(hass):
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
@@ -141,7 +141,7 @@ async def test_options_flow(hass):
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options[CONF_SOURCES] == {
             "1": "one",
             "2": "too",

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_abort_if_existing_entry(hass):
     result = await hass.config_entries.flow.async_init(
         "xbox", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -872,7 +872,7 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -882,7 +882,7 @@ async def test_options_flow(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         const.CONF_CLOUD_SUBDEVICES: True,
     }
@@ -912,7 +912,7 @@ async def test_options_flow_incomplete(hass):
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -921,7 +921,7 @@ async def test_options_flow_incomplete(hass):
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {"base": "cloud_credentials_incomplete"}
 

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -128,13 +128,13 @@ async def test_user_input_device_not_found(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"host": "none"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -146,13 +146,13 @@ async def test_user_input_non_yamaha_device_found(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"host": "127.0.0.1"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "no_musiccast_device"}
 
 
@@ -176,7 +176,7 @@ async def test_user_input_device_already_existing(
         {"host": "192.168.188.18"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
 
 
@@ -188,13 +188,13 @@ async def test_user_input_unknown_error(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"host": "127.0.0.1"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -209,13 +209,13 @@ async def test_user_input_device_found(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"host": "127.0.0.1"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert isinstance(result2["result"], ConfigEntry)
     assert result2["data"] == {
         "host": "127.0.0.1",
@@ -235,13 +235,13 @@ async def test_user_input_device_found_no_ssdp(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"host": "127.0.0.1"},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert isinstance(result2["result"], ConfigEntry)
     assert result2["data"] == {
         "host": "127.0.0.1",
@@ -269,7 +269,7 @@ async def test_ssdp_discovery_failed(hass, mock_ssdp_no_yamaha, mock_get_source_
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "yxc_control_url_missing"
 
 
@@ -291,7 +291,7 @@ async def test_ssdp_discovery_successful_add_device(
         ),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "confirm"
 
@@ -300,7 +300,7 @@ async def test_ssdp_discovery_successful_add_device(
         {},
     )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert isinstance(result2["result"], ConfigEntry)
     assert result2["data"] == {
         "host": "127.0.0.1",
@@ -332,7 +332,7 @@ async def test_ssdp_discovery_existing_device_update(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert mock_entry.data[CONF_HOST] == "127.0.0.1"
     assert mock_entry.data["upnp_description"] == "http://127.0.0.1/desc.xml"

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -22,7 +22,7 @@ async def test_abort_if_no_configuration(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
@@ -32,7 +32,7 @@ async def test_abort_if_existing_entry(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -60,7 +60,7 @@ async def test_full_flow(
             "redirect_uri": "https://example.com/auth/external/callback",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -126,7 +126,7 @@ async def test_abort_if_authorization_timeout(hass, current_request_with_host):
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -203,6 +203,6 @@ async def test_reauthentication(
     assert token_data["refresh_token"] == "mock-refresh-token"
     assert token_data["type"] == "Bearer"
     assert token_data["expires_in"] == 60
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(mock_setup.mock_calls) == 1

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -51,7 +51,7 @@ async def test_single_entry_allowed(hass, discovery_flow_conf):
     MockConfigEntry(domain="test").add_to_hass(hass)
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -62,7 +62,7 @@ async def test_user_no_devices_found(hass, discovery_flow_conf):
     flow.context = {"source": config_entries.SOURCE_USER}
     result = await flow.async_step_confirm(user_input={})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
 
 
@@ -75,7 +75,7 @@ async def test_user_has_confirmation(hass, discovery_flow_conf):
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     progress = hass.config_entries.flow.async_progress()
@@ -88,7 +88,7 @@ async def test_user_has_confirmation(hass, discovery_flow_conf):
     }
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.parametrize(
@@ -110,7 +110,7 @@ async def test_discovery_single_instance(hass, discovery_flow_conf, source):
     MockConfigEntry(domain="test").add_to_hass(hass)
     result = await getattr(flow, f"async_step_{source}")({})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -132,11 +132,11 @@ async def test_discovery_confirmation(hass, discovery_flow_conf, source):
 
     result = await getattr(flow, f"async_step_{source}")({})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await flow.async_step_confirm({})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,7 @@ async def test_discovery_during_onboarding(hass, discovery_flow_conf, source):
     ):
         result = await getattr(flow, f"async_step_{source}")({})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_multiple_discoveries(hass, discovery_flow_conf):
@@ -170,13 +170,13 @@ async def test_multiple_discoveries(hass, discovery_flow_conf):
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Second discovery
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_only_one_in_progress(hass, discovery_flow_conf):
@@ -187,21 +187,21 @@ async def test_only_one_in_progress(hass, discovery_flow_conf):
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # User starts flow
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Discovery flow has not been aborted
     assert len(hass.config_entries.flow.async_progress()) == 2
 
     # Discovery should be aborted once user confirms
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(hass.config_entries.flow.async_progress()) == 0
 
 
@@ -213,14 +213,14 @@ async def test_import_abort_discovery(hass, discovery_flow_conf):
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Start import flow
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_IMPORT}, data={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Discovery flow has been aborted
     assert len(hass.config_entries.flow.async_progress()) == 0
@@ -234,7 +234,7 @@ async def test_import_no_confirmation(hass, discovery_flow_conf):
     discovery_flow_conf["discovered"] = True
 
     result = await flow.async_step_import(None)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_import_single_instance(hass, discovery_flow_conf):
@@ -246,7 +246,7 @@ async def test_import_single_instance(hass, discovery_flow_conf):
     MockConfigEntry(domain="test").add_to_hass(hass)
 
     result = await flow.async_step_import(None)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_ignored_discoveries(hass, discovery_flow_conf):
@@ -256,7 +256,7 @@ async def test_ignored_discoveries(hass, discovery_flow_conf):
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     flow = next(
         (
@@ -278,7 +278,7 @@ async def test_ignored_discoveries(hass, discovery_flow_conf):
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
 async def test_webhook_single_entry_allowed(hass, webhook_flow_conf):
@@ -289,7 +289,7 @@ async def test_webhook_single_entry_allowed(hass, webhook_flow_conf):
     MockConfigEntry(domain="test_single").add_to_hass(hass)
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -302,7 +302,7 @@ async def test_webhook_multiple_entries_allowed(hass, webhook_flow_conf):
     hass.config.api = Mock(base_url="http://example.com")
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_webhook_config_flow_registers_webhook(hass, webhook_flow_conf):
@@ -316,7 +316,7 @@ async def test_webhook_config_flow_registers_webhook(hass, webhook_flow_conf):
     )
     result = await flow.async_step_user(user_input={})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["webhook_id"] is not None
 
 
@@ -341,7 +341,7 @@ async def test_webhook_create_cloudhook(hass, webhook_flow_conf):
     result = await hass.config_entries.flow.async_init(
         "test_single", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "hass_nabucasa.cloudhooks.Cloudhooks.async_create",
@@ -358,7 +358,7 @@ async def test_webhook_create_cloudhook(hass, webhook_flow_conf):
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["description_placeholders"]["webhook_url"] == "https://example.com"
     assert len(mock_create.mock_calls) == 1
     assert len(async_setup_entry.mock_calls) == 1
@@ -395,7 +395,7 @@ async def test_webhook_create_cloudhook_aborts_not_connected(hass, webhook_flow_
     result = await hass.config_entries.flow.async_init(
         "test_single", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "hass_nabucasa.cloudhooks.Cloudhooks.async_create",
@@ -413,7 +413,7 @@ async def test_webhook_create_cloudhook_aborts_not_connected(hass, webhook_flow_
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cloud_not_connected"
 
 

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -110,7 +110,7 @@ async def test_abort_if_no_implementation(hass, flow_handler):
     flow = flow_handler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_configuration"
 
 
@@ -121,7 +121,7 @@ async def test_missing_credentials_for_domain(hass, flow_handler):
 
     with patch("homeassistant.loader.APPLICATION_CREDENTIALS", [TEST_DOMAIN]):
         result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
@@ -139,7 +139,7 @@ async def test_abort_if_authorization_timeout(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -157,7 +157,7 @@ async def test_abort_if_no_url_available(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_url_available"
 
 
@@ -179,7 +179,7 @@ async def test_abort_if_oauth_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -195,7 +195,7 @@ async def test_abort_if_oauth_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -219,7 +219,7 @@ async def test_abort_if_oauth_error(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_error"
 
 
@@ -241,7 +241,7 @@ async def test_abort_if_oauth_rejected(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -257,7 +257,7 @@ async def test_abort_if_oauth_rejected(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -273,7 +273,7 @@ async def test_abort_if_oauth_rejected(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "user_rejected_authorize"
     assert result["description_placeholders"] == {"error": "access_denied"}
 
@@ -291,7 +291,7 @@ async def test_step_discovery(hass, flow_handler, local_impl):
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
 
@@ -308,7 +308,7 @@ async def test_abort_discovered_multiple(hass, flow_handler, local_impl):
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     result = await hass.config_entries.flow.async_init(
@@ -317,7 +317,7 @@ async def test_abort_discovered_multiple(hass, flow_handler, local_impl):
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -340,7 +340,7 @@ async def test_abort_discovered_existing_entries(hass, flow_handler, local_impl)
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -362,7 +362,7 @@ async def test_full_flow(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -378,7 +378,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"

--- a/tests/helpers/test_helper_config_entry_flow.py
+++ b/tests/helpers/test_helper_config_entry_flow.py
@@ -38,7 +38,7 @@ def manager():
 
         async def async_finish_flow(self, flow, result):
             """Test finish flow."""
-            if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
                 result["source"] = flow.context.get("source")
                 entries.append(result)
             return result
@@ -110,11 +110,11 @@ async def test_config_flow_advanced_option(
 
     # Start flow in basic mode
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == ["option1"]
 
     result = await manager.async_configure(result["flow_id"], {"option1": "blabla"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "a very reasonable default",
@@ -126,7 +126,7 @@ async def test_config_flow_advanced_option(
 
     # Start flow in advanced mode
     result = await manager.async_init("test", context={"show_advanced_options": True})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -136,7 +136,7 @@ async def test_config_flow_advanced_option(
     result = await manager.async_configure(
         result["flow_id"], {"advanced_no_default": "abc123", "option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "a very reasonable default",
@@ -149,7 +149,7 @@ async def test_config_flow_advanced_option(
 
     # Start flow in advanced mode
     result = await manager.async_init("test", context={"show_advanced_options": True})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -164,7 +164,7 @@ async def test_config_flow_advanced_option(
             "option1": "blabla",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "not default",
@@ -216,13 +216,13 @@ async def test_options_flow_advanced_option(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == ["option1"]
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "not default",
         "advanced_no_default": "abc123",
@@ -236,7 +236,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -246,7 +246,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"advanced_no_default": "def456", "option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "a very reasonable default",
         "advanced_no_default": "def456",
@@ -260,7 +260,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -275,7 +275,7 @@ async def test_options_flow_advanced_option(
             "option1": "blabla",
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "also not default",
         "advanced_no_default": "abc123",

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -713,14 +713,14 @@ async def test_discovery_notification(hass):
         )
 
         flow1 = await hass.config_entries.flow.async_configure(flow1["flow_id"], {})
-        assert flow1["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert flow1["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_discovery")
         assert state is not None
 
         flow2 = await hass.config_entries.flow.async_configure(flow2["flow_id"], {})
-        assert flow2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert flow2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_discovery")
@@ -780,14 +780,14 @@ async def test_reauth_notification(hass):
         )
 
         flow1 = await hass.config_entries.flow.async_configure(flow1["flow_id"], {})
-        assert flow1["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert flow1["type"] == data_entry_flow.FlowResultType.ABORT
 
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_reconfigure")
         assert state is not None
 
         flow2 = await hass.config_entries.flow.async_configure(flow2["flow_id"], {})
-        assert flow2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert flow2["type"] == data_entry_flow.FlowResultType.ABORT
 
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_reconfigure")
@@ -1059,7 +1059,7 @@ async def test_entry_options(hass, manager):
 
     await manager.options.async_finish_flow(
         flow,
-        {"data": {"second": True}, "type": data_entry_flow.RESULT_TYPE_CREATE_ENTRY},
+        {"data": {"second": True}, "type": data_entry_flow.FlowResultType.CREATE_ENTRY},
     )
 
     assert entry.data == {"first": True}
@@ -1092,7 +1092,7 @@ async def test_entry_options_abort(hass, manager):
     flow.handler = entry.entry_id  # Used to keep reference to config entry
 
     assert await manager.options.async_finish_flow(
-        flow, {"type": data_entry_flow.RESULT_TYPE_ABORT, "reason": "test"}
+        flow, {"type": data_entry_flow.FlowResultType.ABORT, "reason": "test"}
     )
 
 
@@ -1574,7 +1574,7 @@ async def test_unique_id_existing_entry(hass, manager):
             "comp", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries("comp")
     assert len(entries) == 1
@@ -1860,14 +1860,14 @@ async def test_unique_id_in_progress(hass, manager):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         # Will be canceled
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_in_progress"
 
 
@@ -1898,14 +1898,14 @@ async def test_finish_flow_aborts_progress(hass, manager):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         # Will finish and cancel other one.
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}, data={}
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -1931,7 +1931,7 @@ async def test_unique_id_ignore(hass, manager):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result2 = await manager.flow.async_init(
             "comp",
@@ -1939,7 +1939,7 @@ async def test_unique_id_ignore(hass, manager):
             data={"unique_id": "mock-unique-id", "title": "Ignored Title"},
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -1992,7 +1992,7 @@ async def test_manual_add_overrides_ignored_entry(hass, manager):
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["additional"] == "data"
     assert len(async_reload.mock_calls) == 0
@@ -2169,7 +2169,7 @@ async def test_unignore_step_form(hass, manager):
             context={"source": config_entries.SOURCE_IGNORE},
             data={"unique_id": "mock-unique-id", "title": "Ignored Title"},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         entry = hass.config_entries.async_entries("comp")[0]
         assert entry.source == "ignore"
@@ -2214,7 +2214,7 @@ async def test_unignore_create_entry(hass, manager):
             context={"source": config_entries.SOURCE_IGNORE},
             data={"unique_id": "mock-unique-id", "title": "Ignored Title"},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         entry = hass.config_entries.async_entries("comp")[0]
         assert entry.source == "ignore"
@@ -2256,7 +2256,7 @@ async def test_unignore_default_impl(hass, manager):
             context={"source": config_entries.SOURCE_IGNORE},
             data={"unique_id": "mock-unique-id", "title": "Ignored Title"},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
         entry = hass.config_entries.async_entries("comp")[0]
         assert entry.source == "ignore"
@@ -2321,7 +2321,7 @@ async def test_partial_flows_hidden(hass, manager):
         # When it's complete it should now be visible in async_progress and have triggered
         # discovery notifications
         result = await init_task
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert len(hass.config_entries.flow.async_progress()) == 1
 
         await hass.async_block_till_done()
@@ -2531,7 +2531,7 @@ async def test_flow_with_default_discovery(hass, manager, discovery_source):
         result = await manager.flow.async_init(
             "comp", context={"source": discovery_source[0]}, data=discovery_source[1]
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 1
@@ -2544,7 +2544,7 @@ async def test_flow_with_default_discovery(hass, manager, discovery_source):
         result2 = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -2575,7 +2575,7 @@ async def test_flow_with_default_discovery_with_unique_id(hass, manager):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -2600,7 +2600,7 @@ async def test_default_discovery_abort_existing_entries(hass, manager):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -2626,13 +2626,13 @@ async def test_default_discovery_in_progress(hass, manager):
             context={"source": config_entries.SOURCE_DISCOVERY},
             data={"unique_id": "mock-unique-id"},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         # Second discovery without a unique ID
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -2660,7 +2660,7 @@ async def test_default_discovery_abort_on_new_unique_flow(hass, manager):
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
         # Second discovery brings in a unique ID
         result = await manager.flow.async_init(
@@ -2668,7 +2668,7 @@ async def test_default_discovery_abort_on_new_unique_flow(hass, manager):
             context={"source": config_entries.SOURCE_DISCOVERY},
             data={"unique_id": "mock-unique-id"},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     # Ensure the first one is cancelled and we end up with just the last one
     flows = hass.config_entries.flow.async_progress()
@@ -2702,7 +2702,7 @@ async def test_default_discovery_abort_on_user_flow_complete(hass, manager):
         flow1 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert flow1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert flow1["type"] == data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 1
@@ -2711,14 +2711,14 @@ async def test_default_discovery_abort_on_user_flow_complete(hass, manager):
         flow2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert flow2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert flow2["type"] == data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 2
 
         # Complete the manual flow
         result = await hass.config_entries.flow.async_configure(flow2["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Ensure the first flow is gone now
     flows = hass.config_entries.flow.async_progress()
@@ -2780,7 +2780,7 @@ async def test_flow_same_device_multiple_sources(hass, manager):
         result2 = await manager.flow.async_configure(
             flows[0]["flow_id"], user_input={"fake": "data"}
         )
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -34,7 +34,7 @@ def manager():
 
         async def async_finish_flow(self, flow, result):
             """Test finish flow."""
-            if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
                 result["source"] = flow.context.get("source")
                 entries.append(result)
             return result
@@ -100,7 +100,7 @@ async def test_configure_two_steps(manager):
 
     form = await manager.async_configure(form["flow_id"], ["INIT-DATA"])
     form = await manager.async_configure(form["flow_id"], ["SECOND-DATA"])
-    assert form["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert form["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(manager.async_progress()) == 0
     assert len(manager.mock_created_entries) == 1
     result = manager.mock_created_entries[0]
@@ -122,7 +122,7 @@ async def test_show_form(manager):
             )
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert form["type"] == data_entry_flow.FlowResultType.FORM
     assert form["data_schema"] is schema
     assert form["errors"] == {"username": "Should be unique."}
 
@@ -218,7 +218,7 @@ async def test_finish_callback_change_result_type(hass):
 
         async def async_finish_flow(self, flow, result):
             """Redirect to init form if count <= 1."""
-            if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
                 if result["data"] is None or result["data"].get("count", 0) <= 1:
                     return flow.async_show_form(
                         step_id="init", data_schema=vol.Schema({"count": int})
@@ -230,16 +230,16 @@ async def test_finish_callback_change_result_type(hass):
     manager = FlowManager(hass)
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await manager.async_configure(result["flow_id"], {"count": 0})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert "result" not in result
 
     result = await manager.async_configure(result["flow_id"], {"count": 2})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"] == 2
 
 
@@ -269,7 +269,7 @@ async def test_external_step(hass, manager):
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
     assert manager.async_get(result["flow_id"])["handler"] == "test"
@@ -277,7 +277,7 @@ async def test_external_step(hass, manager):
     # Mimic external step
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP_DONE
+    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP_DONE
 
     await hass.async_block_till_done()
     assert len(events) == 1
@@ -289,7 +289,7 @@ async def test_external_step(hass, manager):
 
     # Frontend refreshses the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
 
@@ -326,7 +326,7 @@ async def test_show_progress(hass, manager):
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -335,7 +335,7 @@ async def test_show_progress(hass, manager):
     # Mimic task one done and moving to task two
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
 
     await hass.async_block_till_done()
@@ -349,7 +349,7 @@ async def test_show_progress(hass, manager):
     # Mimic task two done and continuing step
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS_DONE
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
 
     await hass.async_block_till_done()
     assert len(events) == 2
@@ -361,7 +361,7 @@ async def test_show_progress(hass, manager):
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
 
@@ -374,7 +374,7 @@ async def test_abort_flow_exception(manager):
             raise data_entry_flow.AbortFlow("mock-reason", {"placeholder": "yo"})
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert form["type"] == data_entry_flow.FlowResultType.ABORT
     assert form["reason"] == "mock-reason"
     assert form["description_placeholders"] == {"placeholder": "yo"}
 
@@ -432,7 +432,7 @@ async def test_async_has_matching_flow(
         context={"source": config_entries.SOURCE_HOMEKIT},
         data={"properties": {"id": "aa:bb:cc:dd:ee:ff"}},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -528,5 +528,5 @@ async def test_show_menu(hass, manager, menu_options):
     result = await manager.async_configure(
         result["flow_id"], {"next_step_id": "target1"}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "target1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Result of 

`sd 'data_entry_flow.RESULT_TYPE_(FORM|CREATE_ENTRY|ABORT|EXTERNAL_STEP|EXTERNAL_STEP_DONE|SHOW_PROGRESS|SHOW_PROGRESS_DONE|_MENU)' 'data_entry_flow.FlowResultType.$1' $(fd -e py)`

And next `black` and voila, PR.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
