### PR TITLE
Add Plugwise number platform

### DIFF
--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -25,6 +25,7 @@ UNIT_LUMEN: Final = "lm"
 PLATFORMS_GATEWAY: Final[list[str]] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SELECT,
     Platform.SWITCH,

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -26,8 +26,8 @@ PLATFORMS_GATEWAY: Final[list[str]] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.NUMBER,
-    Platform.SENSOR,
     Platform.SELECT,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 ZEROCONF_MAP: Final[dict[str, str]] = {

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["plugwise==0.18.5"],
+  "requirements": ["plugwise==0.18.6"],
   "codeowners": ["@CoMPaTech", "@bouwew", "@brefra", "@frenck"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true,

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -1,0 +1,104 @@
+"""Number platform for Plugwise integration."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from plugwise import Smile
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import PlugwiseDataUpdateCoordinator
+from .entity import PlugwiseEntity
+
+
+@dataclass
+class PlugwiseEntityDescriptionMixin:
+    """Mixin values for Plugwse entities."""
+
+    command: Callable[[Smile, float], Awaitable[Any]]
+
+
+@dataclass
+class PlugwiseNumberEntityDescription(
+    NumberEntityDescription, PlugwiseEntityDescriptionMixin
+):
+    """Class describing Plugwise Number entities."""
+
+
+NUMBER_TYPES = (
+    PlugwiseNumberEntityDescription(
+        key="maximum_boiler_temperature",
+        command=lambda api, value: api.set_max_boiler_temperature(value),
+        device_class=NumberDeviceClass.TEMPERATURE,
+        name="Maximum Boiler Temperature Setpoint",
+        icon="mdi:thermometer",
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        native_min_value=25,
+        native_max_value=95,
+        native_step=5,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Plugwise number platform."""
+
+    coordinator: PlugwiseDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
+    entities: list[PlugwiseNumberEntity] = []
+    for device_id, device in coordinator.data.devices.items():
+        for description in NUMBER_TYPES:
+            if description.key in device:
+                entities.append(
+                    PlugwiseNumberEntity(coordinator, device_id, description)
+                )
+
+    async_add_entities(entities)
+
+
+class PlugwiseNumberEntity(PlugwiseEntity, NumberEntity):
+    """Representation of a Plugwise number."""
+
+    entity_description: PlugwiseNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: PlugwiseDataUpdateCoordinator,
+        device_id: str,
+        description: PlugwiseNumberEntityDescription,
+    ) -> None:
+        """Initiate Plugwise Number."""
+        super().__init__(coordinator, device_id)
+        self.entity_description = description
+        self._attr_unique_id = f"{device_id}-{description.key}"
+        self._attr_name = (f"{self.device['name']} {description.name}").lstrip()
+        self._attr_mode = NumberMode.BOX
+
+    @property
+    def native_value(self) -> float:
+        """Return the present setpoint value."""
+        return self.device[self.entity_description.key]
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Change to the new setpoint value."""
+        await self.entity_description.command(self.coordinator.api, value)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
 
 from plugwise import Smile
 
@@ -14,6 +13,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -27,7 +27,7 @@ from .entity import PlugwiseEntity
 class PlugwiseEntityDescriptionMixin:
     """Mixin values for Plugwse entities."""
 
-    command: Callable[[Smile, float], Awaitable[Any]]
+    command: Callable[[Smile, float], Awaitable[None]]
 
 
 @dataclass
@@ -43,11 +43,11 @@ NUMBER_TYPES = (
         command=lambda api, value: api.set_max_boiler_temperature(value),
         device_class=NumberDeviceClass.TEMPERATURE,
         name="Maximum Boiler Temperature Setpoint",
-        icon="mdi:thermometer",
         entity_category=EntityCategory.CONFIG,
         native_min_value=25,
         native_max_value=95,
         native_step=5,
+        native_unit_of_measurement=TEMP_CELSIUS,
     ),
 )
 

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -45,7 +45,6 @@ NUMBER_TYPES = (
         name="Maximum Boiler Temperature Setpoint",
         icon="mdi:thermometer",
         entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
         native_min_value=25,
         native_max_value=95,
         native_step=5,

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -44,9 +44,6 @@ NUMBER_TYPES = (
         device_class=NumberDeviceClass.TEMPERATURE,
         name="Maximum Boiler Temperature Setpoint",
         entity_category=EntityCategory.CONFIG,
-        native_min_value=25,
-        native_max_value=95,
-        native_step=5,
         native_unit_of_measurement=TEMP_CELSIUS,
     ),
 )
@@ -93,9 +90,24 @@ class PlugwiseNumberEntity(PlugwiseEntity, NumberEntity):
         self._attr_mode = NumberMode.BOX
 
     @property
+    def native_step(self) -> float:
+        """Return the setpoint step value."""
+        return max(self.device["resolution"], 1)
+
+    @property
     def native_value(self) -> float:
         """Return the present setpoint value."""
         return self.device[self.entity_description.key]
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the setpoint min. value."""
+        return self.device["lower_bound"]
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the setpoint max. value."""
+        return self.device["upper_bound"]
 
     async def async_set_native_value(self, value: float) -> None:
         """Change to the new setpoint value."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1251,7 +1251,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.18.5
+plugwise==0.18.6
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -859,7 +859,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.18.5
+plugwise==0.18.6
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plugwise/fixtures/anna_heatpump/all_data.json
+++ b/tests/components/plugwise/fixtures/anna_heatpump/all_data.json
@@ -13,6 +13,9 @@
       "model": "Generic heater",
       "name": "OpenTherm",
       "vendor": "Techneco",
+      "lower_bound": 0.0,
+      "upper_bound": 100.0,
+      "resolution": 1.0,
       "maximum_boiler_temperature": 60.0,
       "binary_sensors": {
         "dhw_state": false,

--- a/tests/components/plugwise/test_number.py
+++ b/tests/components/plugwise/test_number.py
@@ -1,0 +1,40 @@
+"""Tests for the Plugwise Number integration."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_anna_number_entities(
+    hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry
+) -> None:
+    """Test creation of a number."""
+    state = hass.states.get("number.opentherm_maximum_boiler_temperature_setpoint")
+    assert state
+    assert float(state.state) == 60.0
+
+
+async def test_anna_max_boiler_temp_change(
+    hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry
+) -> None:
+    """Test changing of number entities."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.opentherm_maximum_boiler_temperature_setpoint",
+            ATTR_VALUE: 65,
+        },
+        blocking=True,
+    )
+
+    assert mock_smile_anna.set_max_boiler_temperature.call_count == 1
+    mock_smile_anna.set_max_boiler_temperature.assert_called_with(65)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the `maximum_boiler_temperature_setpoint` number, allowing the user to change this boiler-setpoint via Core.
Tests are also included.

Also, the plugwise backend was updated to v0.18.6: https://github.com/plugwise/python-plugwise/releases/tag/v0.18.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23313

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
