### PR TITLE
Fix climacell/tomorrowio config flow test failure

### DIFF
--- a/homeassistant/components/climacell/weather.py
+++ b/homeassistant/components/climacell/weather.py
@@ -148,17 +148,16 @@ class BaseClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return additional state attributes."""
-        wind_gust = self.wind_gust
-        wind_gust = round(
-            speed_convert(self.wind_gust, SPEED_MILES_PER_HOUR, self._wind_speed_unit),
-            4,
-        )
         cloud_cover = self.cloud_cover
-        return {
+        attrs = {
             ATTR_CLOUD_COVER: cloud_cover,
-            ATTR_WIND_GUST: wind_gust,
             ATTR_PRECIPITATION_TYPE: self.precipitation_type,
         }
+        if (wind_gust := self.wind_gust) is not None:
+            attrs[ATTR_WIND_GUST] = round(
+                speed_convert(wind_gust, SPEED_MILES_PER_HOUR, self._wind_speed_unit), 4
+            )
+        return attrs
 
     @property
     @abstractmethod


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes
```
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 892, in _async_registry_updated
    self.async_write_ha_state()
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 532, in async_write_ha_state
    self._async_write_ha_state()
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 573, in _async_write_ha_state
    attr.update(self.extra_state_attributes or {})
  File "/Users/bdraco/home-assistant/homeassistant/components/climacell/weather.py", line 153, in extra_state_attributes
    speed_convert(self.wind_gust, SPEED_MILES_PER_HOUR, self._wind_speed_unit),
  File "/Users/bdraco/home-assistant/homeassistant/util/speed.py", line 58, in convert
    raise TypeError(f"{value} is not of numeric type")
TypeError: None is not of numeric type
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
