### PR TITLE
Fix ZHA group not setting the correct color mode

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -141,7 +141,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._color_channel = None
         self._identify_channel = None
         self._default_transition = None
-        self._color_mode = ColorMode.UNKNOWN  # Set by sub classes
+        self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -158,11 +158,6 @@ class BaseLight(LogMixin, light.LightEntity):
         if self._state is None:
             return False
         return self._state
-
-    @property
-    def color_mode(self):
-        """Return the color mode of this light."""
-        return self._color_mode
 
     @property
     def brightness(self):
@@ -309,7 +304,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)
                 return
-            self._color_mode = ColorMode.COLOR_TEMP
+            self._attr_color_mode = ColorMode.COLOR_TEMP
             self._color_temp = temperature
             self._hs_color = None
 
@@ -323,7 +318,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)
                 return
-            self._color_mode = ColorMode.HS
+            self._attr_color_mode = ColorMode.HS
             self._hs_color = hs_color
             self._color_temp = None
 
@@ -451,13 +446,13 @@ class Light(BaseLight, ZhaEntity):
             self._attr_supported_color_modes
         )
         if len(self._attr_supported_color_modes) == 1:
-            self._color_mode = next(iter(self._attr_supported_color_modes))
+            self._attr_color_mode = next(iter(self._attr_supported_color_modes))
         else:  # Light supports color_temp + hs, determine which mode the light is in
             assert self._color_channel
             if self._color_channel.color_mode == Color.ColorMode.Color_temperature:
-                self._color_mode = ColorMode.COLOR_TEMP
+                self._attr_color_mode = ColorMode.COLOR_TEMP
             else:
-                self._color_mode = ColorMode.HS
+                self._attr_color_mode = ColorMode.HS
 
         if self._identify_channel:
             self._supported_features |= light.LightEntityFeature.FLASH
@@ -518,7 +513,7 @@ class Light(BaseLight, ZhaEntity):
         if "off_brightness" in last_state.attributes:
             self._off_brightness = last_state.attributes["off_brightness"]
         if "color_mode" in last_state.attributes:
-            self._color_mode = ColorMode(last_state.attributes["color_mode"])
+            self._attr_color_mode = ColorMode(last_state.attributes["color_mode"])
         if "color_temp" in last_state.attributes:
             self._color_temp = last_state.attributes["color_temp"]
         if "hs_color" in last_state.attributes:
@@ -558,13 +553,13 @@ class Light(BaseLight, ZhaEntity):
 
             if (color_mode := results.get("color_mode")) is not None:
                 if color_mode == Color.ColorMode.Color_temperature:
-                    self._color_mode = ColorMode.COLOR_TEMP
+                    self._attr_color_mode = ColorMode.COLOR_TEMP
                     color_temp = results.get("color_temperature")
                     if color_temp is not None and color_mode:
                         self._color_temp = color_temp
                         self._hs_color = None
                 else:
-                    self._color_mode = ColorMode.HS
+                    self._attr_color_mode = ColorMode.HS
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
@@ -650,7 +645,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
-        self._color_mode = None
+        self._attr_color_mode = None
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
@@ -711,7 +706,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             effects_count = Counter(itertools.chain(all_effects))
             self._effect = effects_count.most_common(1)[0][0]
 
-        self._color_mode = None
+        self._attr_color_mode = None
         all_color_modes = list(
             helpers.find_state_attributes(on_states, ATTR_COLOR_MODE)
         )
@@ -722,7 +717,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
                 color_mode_count[ColorMode.ONOFF] = -1
             if ColorMode.BRIGHTNESS in color_mode_count:
                 color_mode_count[ColorMode.BRIGHTNESS] = 0
-            self._color_mode = color_mode_count.most_common(1)[0][0]
+            self._attr_color_mode = color_mode_count.most_common(1)[0][0]
 
         self._attr_supported_color_modes = None
         all_supported_color_modes = list(

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -711,7 +711,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             effects_count = Counter(itertools.chain(all_effects))
             self._effect = effects_count.most_common(1)[0][0]
 
-        self._attr_color_mode = None
+        self._color_mode = None
         all_color_modes = list(
             helpers.find_state_attributes(on_states, ATTR_COLOR_MODE)
         )
@@ -722,7 +722,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
                 color_mode_count[ColorMode.ONOFF] = -1
             if ColorMode.BRIGHTNESS in color_mode_count:
                 color_mode_count[ColorMode.BRIGHTNESS] = 0
-            self._attr_color_mode = color_mode_count.most_common(1)[0][0]
+            self._color_mode = color_mode_count.most_common(1)[0][0]
 
         self._attr_supported_color_modes = None
         all_supported_color_modes = list(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correctly set the color mode of a ZHA group.

The issue can be easily reproduced by doing the following:
1. set a ZHA group to a color temperature
2. individually set the group members to a (HS) color
3. observe the ZHA group still having ``color_temp`` as the color mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
https://github.com/home-assistant/core/pull/70970 introduced code where ``self._attr_color_mode`` gets set to the color mode (instead of ``self._color_mode``).
However, ``BaseLight`` returns ``self._color_mode`` as the color mode. (So ``self._attr_color_mode`` is ignored)
This PR removes ``self._color_mode`` and the associated property so that we rely on the property and attribute from the base class.

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
