### PR TITLE
Migrate CO2 Signal to new entity naming style

### DIFF
--- a/homeassistant/components/co2signal/__init__.py
+++ b/homeassistant/components/co2signal/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_COUNTRY_CODE, DOMAIN
-from .util import get_extra_name
 
 PLATFORMS = [Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
@@ -72,10 +71,6 @@ class CO2SignalCoordinator(DataUpdateCoordinator[CO2SignalResponse]):
     def entry_id(self) -> str:
         """Return entry ID."""
         return self._entry.entry_id
-
-    def get_extra_name(self) -> str | None:
-        """Return the extra name describing the location if not home."""
-        return get_extra_name(self._entry.data)
 
     async def _async_update_data(self) -> CO2SignalResponse:
         """Fetch the latest data from the source."""

--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import cast
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CO2SignalCoordinator
@@ -22,12 +25,9 @@ SCAN_INTERVAL = timedelta(minutes=3)
 
 
 @dataclass
-class CO2SensorEntityDescription:
+class CO2SensorEntityDescription(SensorEntityDescription):
     """Provide a description of a CO2 sensor."""
 
-    key: str
-    name: str
-    unit_of_measurement: str | None = None
     # For backwards compat, allow description to override unique ID key to use
     unique_id: str | None = None
 
@@ -42,7 +42,7 @@ SENSORS = (
     CO2SensorEntityDescription(
         key="fossilFuelPercentage",
         name="Grid fossil fuel percentage",
-        unit_of_measurement=PERCENTAGE,
+        native_unit_of_measurement=PERCENTAGE,
     ),
 )
 
@@ -58,21 +58,18 @@ async def async_setup_entry(
 class CO2Sensor(CoordinatorEntity[CO2SignalCoordinator], SensorEntity):
     """Implementation of the CO2Signal sensor."""
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    entity_description: CO2SensorEntityDescription
+    _attr_has_entity_name = True
     _attr_icon = "mdi:molecule-co2"
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self, coordinator: CO2SignalCoordinator, description: CO2SensorEntityDescription
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._description = description
+        self.entity_description = description
 
-        name = description.name
-        if extra_name := coordinator.get_extra_name():
-            name = f"{extra_name} - {name}"
-
-        self._attr_name = name
         self._attr_extra_state_attributes = {
             "country_code": coordinator.data["countryCode"],
             ATTR_ATTRIBUTION: ATTRIBUTION,
@@ -92,19 +89,22 @@ class CO2Sensor(CoordinatorEntity[CO2SignalCoordinator], SensorEntity):
     def available(self) -> bool:
         """Return True if entity is available."""
         return (
-            super().available and self._description.key in self.coordinator.data["data"]
+            super().available
+            and self.entity_description.key in self.coordinator.data["data"]
         )
 
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> float | None:
         """Return sensor state."""
-        if (value := self.coordinator.data["data"][self._description.key]) is None:  # type: ignore[literal-required]
+        if (value := self.coordinator.data["data"][self.entity_description.key]) is None:  # type: ignore[literal-required]
             return None
         return round(value, 2)
 
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
-        if self._description.unit_of_measurement:
-            return self._description.unit_of_measurement
-        return cast(str, self.coordinator.data["units"].get(self._description.key))
+        if self.entity_description.unit_of_measurement:
+            return self.entity_description.unit_of_measurement
+        return cast(
+            str, self.coordinator.data["units"].get(self.entity_description.key)
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the CO2 Signal integration to use the new entity naming style and sets the flag.

ref #73217

<img width="674" alt="CleanShot 2022-07-08 at 09 16 38@2x" src="https://user-images.githubusercontent.com/195327/177938238-9c0f1d24-7dfe-4bf5-b446-15c98e03d38a.png">


Turned out this integration used entity descriptions... but not really?
Adjusted it to use them correctly, so this naming stuff actually works :)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
