### PR TITLE
Update systembridgeconnector to 3.3.2

### DIFF
--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -93,7 +93,7 @@ class SystemBridgeDataUpdateCoordinator(
         if not self.websocket_client.connected:
             await self._setup_websocket()
 
-        await self.websocket_client.get_data(modules)
+        self.hass.async_create_task(self.websocket_client.get_data(modules))
 
     async def async_handle_module(
         self,
@@ -107,9 +107,7 @@ class SystemBridgeDataUpdateCoordinator(
 
     async def _listen_for_data(self) -> None:
         """Listen for events from the WebSocket."""
-
         try:
-            await self.websocket_client.register_data_listener(MODULES)
             await self.websocket_client.listen(callback=self.async_handle_module)
         except AuthenticationException as exception:
             self.last_update_success = False
@@ -175,6 +173,9 @@ class SystemBridgeDataUpdateCoordinator(
             self.async_update_listeners()
 
         self.hass.async_create_task(self._listen_for_data())
+
+        await self.websocket_client.register_data_listener(MODULES)
+
         self.last_update_success = True
         self.async_update_listeners()
 

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridgeconnector==3.1.5"],
+  "requirements": ["systembridgeconnector==3.3.2"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._tcp.local."],
   "after_dependencies": ["zeroconf"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2268,7 +2268,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridgeconnector==3.1.5
+systembridgeconnector==3.3.2
 
 # homeassistant.components.tailscale
 tailscale==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1516,7 +1516,7 @@ sunwatcher==0.2.1
 surepy==0.7.2
 
 # homeassistant.components.system_bridge
-systembridgeconnector==3.1.5
+systembridgeconnector==3.3.2
 
 # homeassistant.components.tailscale
 tailscale==0.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates `systembridgeconnector` to latest version.

Fix for #74698 from [3.3.0](https://github.com/timmo001/system-bridge/releases/tag/3.3.0)

Due to changes in [3.3.1](https://github.com/timmo001/system-bridge/releases/tag/3.3.1), the coordinator needed a change to make sure the listener is active before registering as a listener.

For context, 3.3.0 had the fix, but this release contained a reference to the wrong package, so updating to the latest and implementing the small fix above was needed.

Full Changes:

https://github.com/timmo001/system-bridge/compare/3.1.5...3.3.2 _(Monorepo so changes will not just be this package)_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)

<!--
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74698

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] 🥈 Silver

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
