### PR TITLE
Add service results/return values

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -25,10 +25,6 @@ from homeassistant.helpers.typing import ConfigType
 
 DOMAIN = "rest_command"
 
-RESULT_EVENT = f"{DOMAIN}_result"
-
-SERVICE_NAME = "invoke"
-
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 10
@@ -58,10 +54,6 @@ COMMAND_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: cv.schema_with_slug_keys(COMMAND_SCHEMA)}, extra=vol.ALLOW_EXTRA
 )
-
-SERVICE_CONF_REQUEST_ID = "request_id"
-
-SERVICE_SCHEMA = vol.Schema({vol.Optional(SERVICE_CONF_REQUEST_ID): cv.string})
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -146,8 +138,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                             "url": str(response.url),
                         },
                     }
-                    if "request_id" in service.data:
-                        event_data["request_id"] = service.data["request_id"]
 
                     hass.bus.async_fire(
                         EVENT_SERVICE_RESULT, event_data, context=service.context
@@ -179,9 +169,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 )
 
         # register services
-        hass.services.async_register(
-            DOMAIN, name, async_service_handler, SERVICE_SCHEMA
-        )
+        hass.services.async_register(DOMAIN, name, async_service_handler)
 
     for command, command_config in config[DOMAIN].items():
         async_register_rest_command(command, command_config)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -268,6 +268,7 @@ CONF_ZONE: Final = "zone"
 
 # #### EVENTS ####
 EVENT_CALL_SERVICE: Final = "call_service"
+EVENT_SERVICE_RESULT: Final = "service_result"
 EVENT_COMPONENT_LOADED: Final = "component_loaded"
 EVENT_CORE_CONFIG_UPDATE: Final = "core_config_updated"
 EVENT_HOMEASSISTANT_CLOSE: Final = "homeassistant_close"

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -670,8 +670,12 @@ class _ScriptRun:
 
         trace_set_result(params=params, running_script=running_script, limit=limit)
 
-        # Create a child context in order to allow service results to be associated to this call
-        subcontext = Context(user_id=self._context.user_id, parent_id=self._context.id)
+        # Create a marker context instance to identify individual callw' return values
+        subcontext = Context(
+            user_id=self._context.user_id,
+            parent_id=self._context.parent_id,
+            id=self._context.id,
+        )
 
         def handle_result(event: Event) -> None:
             self._variables["service"] = event.data

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -680,7 +680,10 @@ class _ScriptRun:
             return event.context is subcontext
 
         result_listener_cancel = self._hass.bus.async_listen(
-            EVENT_SERVICE_RESULT, handle_result, service_result_filter, True
+            EVENT_SERVICE_RESULT,
+            callback(handle_result),
+            callback(service_result_filter),
+            True,
         )
 
         try:

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,6 +38,7 @@ from homeassistant.config import async_process_component_config
 from homeassistant.const import (
     DEVICE_DEFAULT_NAME,
     EVENT_HOMEASSISTANT_CLOSE,
+    EVENT_SERVICE_RESULT,
     EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
@@ -325,7 +326,9 @@ async def async_test_home_assistant(loop, load_registries=True):
     return hass
 
 
-def async_mock_service(hass, domain, service, schema=None):
+def async_mock_service(
+    hass, domain, service, schema=None, result: dict[str, Any] | None = None
+):
     """Set up a fake service & return a calls log list to this service."""
     calls = []
 
@@ -333,6 +336,9 @@ def async_mock_service(hass, domain, service, schema=None):
     def mock_service_log(call):  # pylint: disable=unnecessary-lambda
         """Mock service call."""
         calls.append(call)
+        """Pass along results"""
+        if result is not None:
+            hass.bus.async_fire(EVENT_SERVICE_RESULT, result, context=call.context)
 
     hass.services.async_register(domain, service, mock_service_log, schema=schema)
 

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -244,6 +244,10 @@ class AiohttpClientMockResponse:
         """Return content."""
         return mock_stream(self.response)
 
+    def get_encoding(self):
+        """Get encoding."""
+        return "utf-8"
+
     async def read(self):
         """Return mock response."""
         return self.response


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added a way for service calls to provide a return value or 'result', making it available as a script variable after the service completes.  To make this immediately useful, updated the rest_command integration to return the http response, which allows one to avoid having to use a rest_sensor for one-off requests.

Scripts and other services need only raise a "service_result" event with their return payload before they finish execution in order for this value to be passed along to the caller.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
