### PR TITLE
Attempt to fix flaky test by waiting for setup to complete

### DIFF
--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -89,6 +89,7 @@ def get_frame(name):
 async def test_normal_logs(hass, simple_queue, hass_ws_client):
     """Test that debug and info are not logged."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
 
     _LOGGER.debug("debug")
     _LOGGER.info("info")
@@ -102,6 +103,8 @@ async def test_normal_logs(hass, simple_queue, hass_ws_client):
 async def test_exception(hass, simple_queue, hass_ws_client):
     """Test that exceptions are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _generate_and_log_exception("exception message", "log message")
     await _async_block_until_queue_empty(hass, simple_queue)
     log = find_log(await get_error_log(hass_ws_client), "ERROR")
@@ -112,6 +115,8 @@ async def test_exception(hass, simple_queue, hass_ws_client):
 async def test_warning(hass, simple_queue, hass_ws_client):
     """Test that warning are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _LOGGER.warning("warning message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
@@ -122,6 +127,8 @@ async def test_warning(hass, simple_queue, hass_ws_client):
 async def test_error(hass, simple_queue, hass_ws_client):
     """Test that errors are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _LOGGER.error("error message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
@@ -132,6 +139,8 @@ async def test_error(hass, simple_queue, hass_ws_client):
 async def test_config_not_fire_event(hass, simple_queue):
     """Test that errors are not posted as events with default config."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     events = []
 
     @callback
@@ -152,6 +161,8 @@ async def test_error_posted_as_event(hass, simple_queue):
     await async_setup_component(
         hass, system_log.DOMAIN, {"system_log": {"max_entries": 2, "fire_event": True}}
     )
+    await hass.async_block_till_done()
+
     events = async_capture_events(hass, system_log.EVENT_SYSTEM_LOG)
 
     _LOGGER.error("error message")
@@ -164,6 +175,8 @@ async def test_error_posted_as_event(hass, simple_queue):
 async def test_critical(hass, simple_queue, hass_ws_client):
     """Test that critical are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _LOGGER.critical("critical message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
@@ -174,6 +187,8 @@ async def test_critical(hass, simple_queue, hass_ws_client):
 async def test_remove_older_logs(hass, simple_queue, hass_ws_client):
     """Test that older logs are rotated out."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _LOGGER.error("error message 1")
     _LOGGER.error("error message 2")
     _LOGGER.error("error message 3")
@@ -192,6 +207,8 @@ def log_msg(nr=2):
 async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     """Test that duplicate log entries are dedupe."""
     await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
     _LOGGER.error("error message 1")
     log_msg()
     log_msg("2-2")
@@ -234,6 +251,8 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
 async def test_clear_logs(hass, simple_queue, hass_ws_client):
     """Test that the log can be cleared via a service call."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _LOGGER.error("error message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
@@ -247,6 +266,8 @@ async def test_clear_logs(hass, simple_queue, hass_ws_client):
 async def test_write_log(hass):
     """Test that error propagates to logger."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     logger = MagicMock()
     with patch("logging.getLogger", return_value=logger) as mock_logging:
         await hass.services.async_call(
@@ -260,6 +281,8 @@ async def test_write_log(hass):
 async def test_write_choose_logger(hass):
     """Test that correct logger is chosen."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     with patch("logging.getLogger") as mock_logging:
         await hass.services.async_call(
             system_log.DOMAIN,
@@ -273,6 +296,8 @@ async def test_write_choose_logger(hass):
 async def test_write_choose_level(hass):
     """Test that correct logger is chosen."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     logger = MagicMock()
     with patch("logging.getLogger", return_value=logger):
         await hass.services.async_call(
@@ -287,6 +312,8 @@ async def test_write_choose_level(hass):
 async def test_unknown_path(hass, simple_queue, hass_ws_client):
     """Test error logged from unknown path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     _LOGGER.findCaller = MagicMock(return_value=("unknown_path", 0, None, None))
     _LOGGER.error("error message")
     await _async_block_until_queue_empty(hass, simple_queue)
@@ -317,6 +344,8 @@ async def async_log_error_from_test_path(hass, path, sq):
 async def test_homeassistant_path(hass, simple_queue, hass_ws_client):
     """Test error logged from Home Assistant path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     with patch(
         "homeassistant.components.system_log.HOMEASSISTANT_PATH",
         new=["venv_path/homeassistant"],
@@ -331,6 +360,8 @@ async def test_homeassistant_path(hass, simple_queue, hass_ws_client):
 async def test_config_path(hass, simple_queue, hass_ws_client):
     """Test error logged from config path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    await hass.async_block_till_done()
+
     with patch.object(hass.config, "config_dir", new="config"):
         await async_log_error_from_test_path(
             hass, "config/custom_component/test.py", simple_queue


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Wait for setup to complete before trying to assert on log messages. The idea is that the integration setup should finish (and any associated log messages) so that when the test looks at warnings it should only find warnings that it created itself during the test.

Test failure is:
```
_____________________________ test_warning[pyloop] _____________________________
[gw1] linux -- Python 3.9.13 /home/runner/work/core/core/venv/bin/python3
hass = <homeassistant.core.HomeAssistant object at 0x7f0efc785790>
simple_queue = <_queue.SimpleQueue object at 0x7f0f100aaea0>
hass_ws_client = <function hass_ws_client.<locals>.create_client at 0x7f0f123fb040>
    async def test_warning(hass, simple_queue, hass_ws_client):
        """Test that warning are logged and retrieved correctly."""
        await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
        _LOGGER.warning("warning message")
        await _async_block_until_queue_empty(hass, simple_queue)
        log = find_log(await get_error_log(hass_ws_client), "WARNING")
>       assert_log(log, "", "warning message", "WARNING")
tests/components/system_log/test_init.py:119: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
log = {'count': 1, 'exception': '', 'first_occurred': 16572[90](https://github.com/home-assistant/core/runs/7253180094?check_suite_focus=true#step:10:91)[92](https://github.com/home-assistant/core/runs/7253180094?check_suite_focus=true#step:10:93)8.7554243, 'level': 'WARNING', ...}
exception = '', message = ['warning message'], level = 'WARNING'
    def assert_log(log, exception, message, level):
        """Assert that specified values are in a specific log entry."""
        if not isinstance(message, list):
            message = [message]
>       assert log["name"] == "test_logger"
E       AssertionError: assert 'asyncio' == 'test_logger'
E         - test_logger
E         + asyncio
```

With these log messages:
```
WARNING:test_logger:warning message
WARNING:asyncio:Executing <Task pending name='Task-13849' coro=<test_warning() running at /home/runner/work/core/core/tests/components/system_log/test_init.py:116> cb=[_run_until_complete_cb() at /opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/asyncio/base_events.py:184] created at /opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/asyncio/base_events.py:626> took 0.160 seconds
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
