### PR TITLE
Identify the active ZHA coordinator device in API responses

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1234,8 +1234,8 @@ build.json @home-assistant/supervisor
 /tests/components/zeroconf/ @bdraco
 /homeassistant/components/zerproc/ @emlove
 /tests/components/zerproc/ @emlove
-/homeassistant/components/zha/ @dmulcahey @adminiuga
-/tests/components/zha/ @dmulcahey @adminiuga
+/homeassistant/components/zha/ @dmulcahey @adminiuga @puddly
+/tests/components/zha/ @dmulcahey @adminiuga @puddly
 /homeassistant/components/zodiac/ @JulienTant
 /tests/components/zodiac/ @JulienTant
 /homeassistant/components/zone/ @home-assistant/core

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -109,15 +109,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        connections={
-            (
-                dr.CONNECTION_ZIGBEE,
-                str(zha_gateway.application_controller.state.node_info.ieee),
-            )
-        },
-        identifiers={
-            (DOMAIN, str(zha_gateway.application_controller.state.node_info.ieee))
-        },
+        connections={(dr.CONNECTION_ZIGBEE, str(zha_gateway.coordinator_ieee))},
+        identifiers={(DOMAIN, str(zha_gateway.coordinator_ieee))},
         name="Zigbee Coordinator",
         manufacturer="ZHA",
         model=zha_gateway.radio_description,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -110,9 +110,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={
-            (dr.CONNECTION_ZIGBEE, str(zha_gateway.application_controller.ieee))
+            (
+                dr.CONNECTION_ZIGBEE,
+                str(zha_gateway.application_controller.state.node_info.ieee),
+            )
         },
-        identifiers={(DOMAIN, str(zha_gateway.application_controller.ieee))},
+        identifiers={
+            (DOMAIN, str(zha_gateway.application_controller.state.node_info.ieee))
+        },
         name="Zigbee Coordinator",
         manufacturer="ZHA",
         model=zha_gateway.radio_description,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1091,10 +1091,7 @@ def async_load_api(hass: HomeAssistant) -> None:
         zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
         ieee: EUI64 = service.data[ATTR_IEEE]
         zha_device: ZHADevice | None = zha_gateway.get_device(ieee)
-        if zha_device is not None and (
-            zha_device.is_coordinator
-            and zha_device.ieee == zha_gateway.application_controller.ieee
-        ):
+        if zha_device is not None and zha_device.is_active_coordinator:
             _LOGGER.info("Removing the coordinator (%s) is not allowed", ieee)
             return
         _LOGGER.info("Removing node %s", ieee)

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -17,6 +17,7 @@ import zigpy_znp.zigbee.application
 from homeassistant.const import Platform
 import homeassistant.helpers.config_validation as cv
 
+ATTR_ACTIVE_COORDINATOR = "active_coordinator"
 ATTR_ARGS = "args"
 ATTR_ATTRIBUTE = "attribute"
 ATTR_ATTRIBUTE_ID = "attribute_id"

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from . import channels
 from .const import (
+    ATTR_ACTIVE_COORDINATOR,
     ATTR_ARGS,
     ATTR_ATTRIBUTE,
     ATTR_AVAILABLE,
@@ -252,11 +253,19 @@ class ZHADevice(LogMixin):
 
     @property
     def is_coordinator(self) -> bool | None:
-        """Return true if this device represents the coordinator."""
+        """Return true if this device represents a coordinator."""
         if self._zigpy_device.node_desc is None:
             return None
 
         return self._zigpy_device.node_desc.is_coordinator
+
+    @property
+    def is_active_coordinator(self) -> bool:
+        """Return true if this device is the active coordinator."""
+        if not self.is_coordinator:
+            return False
+
+        return self.ieee == self.gateway.application_controller.state.node_info.ieee
 
     @property
     def is_end_device(self) -> bool | None:
@@ -507,6 +516,7 @@ class ZHADevice(LogMixin):
         """Get ZHA device information."""
         device_info: dict[str, Any] = {}
         device_info.update(self.device_info)
+        device_info[ATTR_ACTIVE_COORDINATOR] = self.is_active_coordinator
         device_info["entities"] = [
             {
                 "entity_id": entity_ref.reference_id,

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -265,7 +265,7 @@ class ZHADevice(LogMixin):
         if not self.is_coordinator:
             return False
 
-        return self.ieee == self.gateway.application_controller.state.node_info.ieee
+        return self.ieee == self.gateway.coordinator_ieee
 
     @property
     def is_end_device(self) -> bool | None:

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -184,7 +184,7 @@ class ZHAGateway:
         self.application_controller.groups.add_listener(self)
         self._hass.data[DATA_ZHA][DATA_ZHA_GATEWAY] = self
         self._hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID] = str(
-            self.application_controller.ieee
+            self.application_controller.state.node_info.ieee
         )
         self.async_load_devices()
         self.async_load_groups()
@@ -194,7 +194,7 @@ class ZHAGateway:
         """Restore ZHA devices from zigpy application state."""
         for zigpy_device in self.application_controller.devices.values():
             zha_device = self._async_get_or_create_device(zigpy_device, restored=True)
-            if zha_device.ieee == self.application_controller.ieee:
+            if zha_device.ieee == self.application_controller.state.node_info.ieee:
                 self.coordinator_zha_device = zha_device
             zha_dev_entry = self.zha_storage.devices.get(str(zigpy_device.ieee))
             delta_msg = "not known"

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -183,9 +183,7 @@ class ZHAGateway:
         self.application_controller.add_listener(self)
         self.application_controller.groups.add_listener(self)
         self._hass.data[DATA_ZHA][DATA_ZHA_GATEWAY] = self
-        self._hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID] = str(
-            self.application_controller.state.node_info.ieee
-        )
+        self._hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID] = str(self.coordinator_ieee)
         self.async_load_devices()
         self.async_load_groups()
 
@@ -194,7 +192,7 @@ class ZHAGateway:
         """Restore ZHA devices from zigpy application state."""
         for zigpy_device in self.application_controller.devices.values():
             zha_device = self._async_get_or_create_device(zigpy_device, restored=True)
-            if zha_device.ieee == self.application_controller.state.node_info.ieee:
+            if zha_device.ieee == self.coordinator_ieee:
                 self.coordinator_zha_device = zha_device
             zha_dev_entry = self.zha_storage.devices.get(str(zigpy_device.ieee))
             delta_msg = "not known"
@@ -447,6 +445,11 @@ class ZHAGateway:
                 "cleaning up entity registry entry for entity: %s", entry.entity_id
             )
             self.ha_entity_registry.async_remove(entry.entity_id)
+
+    @property
+    def coordinator_ieee(self) -> EUI64:
+        """Return the active coordinator's IEEE address."""
+        return self.application_controller.state.node_info.ieee
 
     @property
     def devices(self) -> dict[EUI64, ZHADevice]:

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -76,7 +76,7 @@
       "known_devices": ["Bitron Video AV2010/10"]
     }
   ],
-  "codeowners": ["@dmulcahey", "@adminiuga"],
+  "codeowners": ["@dmulcahey", "@adminiuga", "@puddly"],
   "zeroconf": [
     {
       "type": "_esphomelib._tcp.local.",

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -6,7 +6,9 @@ from unittest.mock import patch
 
 import pytest
 import zigpy.profiles.zha
+import zigpy.types
 import zigpy.zcl.clusters.general as general
+import zigpy.zdo.types as zdo_t
 
 from homeassistant.components.zha.core.const import (
     CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
@@ -42,7 +44,7 @@ def required_platforms_only():
 def zigpy_device(zigpy_device_mock):
     """Device tracker zigpy device."""
 
-    def _dev(with_basic_channel: bool = True):
+    def _dev(with_basic_channel: bool = True, **kwargs):
         in_clusters = [general.OnOff.cluster_id]
         if with_basic_channel:
             in_clusters.append(general.Basic.cluster_id)
@@ -54,7 +56,7 @@ def zigpy_device(zigpy_device_mock):
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
             }
         }
-        return zigpy_device_mock(endpoints)
+        return zigpy_device_mock(endpoints, **kwargs)
 
     return _dev
 
@@ -321,3 +323,31 @@ async def test_device_restore_availability(
         assert hass.states.get(entity_id).state == STATE_OFF
     else:
         assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_device_is_active_coordinator(hass, zha_device_joined, zigpy_device):
+    """Test that the current coordinator is uniquely detected."""
+
+    current_coord_dev = zigpy_device(ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000)
+    current_coord_dev.node_desc = current_coord_dev.node_desc.replace(
+        logical_type=zdo_t.LogicalType.Coordinator
+    )
+
+    old_coord_dev = zigpy_device(ieee="aa:bb:cc:dd:ee:ff:00:12", nwk=0x0000)
+    old_coord_dev.node_desc = old_coord_dev.node_desc.replace(
+        logical_type=zdo_t.LogicalType.Coordinator
+    )
+
+    # The two coordinators have different IEEE addresses
+    assert current_coord_dev.ieee != old_coord_dev.ieee
+
+    current_coordinator = await zha_device_joined(current_coord_dev)
+    stale_coordinator = await zha_device_joined(old_coord_dev)
+
+    # Ensure the current ApplicationController's IEEE matches our coordinator's
+    current_coordinator.gateway.application_controller.state.node_info.ieee = (
+        current_coord_dev.ieee
+    )
+
+    assert current_coordinator.is_active_coordinator
+    assert not stale_coordinator.is_active_coordinator


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Users who switch coordinators but keep their `zigbee.db` will be stuck with a stale coordinator entry for their old hardware that cannot be deleted from the frontend.

This change adds the necessary key to the device API response for the frontend to distinguish between the currently coordinator and old coordinators.

I've also added myself as a ZHA code owner.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
