### PR TITLE
Migrate devolo Home Network to new entity naming

### DIFF
--- a/homeassistant/components/devolo_home_network/entity.py
+++ b/homeassistant/components/devolo_home_network/entity.py
@@ -15,6 +15,8 @@ from .const import DOMAIN
 class DevoloEntity(CoordinatorEntity):
     """Representation of a devolo home network device."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self, coordinator: DataUpdateCoordinator, device: Device, device_name: str
     ) -> None:

--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -25,10 +25,11 @@ from tests.common import async_fire_time_changed
 async def test_binary_sensor_setup(hass: HomeAssistant):
     """Test default setup of the binary sensor component."""
     entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.{CONNECTED_TO_ROUTER}") is None
+    assert hass.states.get(f"{DOMAIN}.{device_name}_{CONNECTED_TO_ROUTER}") is None
 
     await hass.config_entries.async_unload(entry.entry_id)
 
@@ -36,8 +37,9 @@ async def test_binary_sensor_setup(hass: HomeAssistant):
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_device")
 async def test_update_attached_to_router(hass: HomeAssistant):
     """Test state change of a attached_to_router binary sensor device."""
-    state_key = f"{DOMAIN}.{CONNECTED_TO_ROUTER}"
     entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
+    state_key = f"{DOMAIN}.{device_name}_{CONNECTED_TO_ROUTER}"
 
     er = entity_registry.async_get(hass)
 

--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -9,7 +9,12 @@ from homeassistant.components.devolo_home_network.const import (
     CONNECTED_TO_ROUTER,
     LONG_UPDATE_INTERVAL,
 )
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity import EntityCategory
@@ -49,6 +54,7 @@ async def test_update_attached_to_router(hass: HomeAssistant):
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{entry.title} Connected to router"
 
     assert er.async_get(state_key).entity_category == EntityCategory.DIAGNOSTIC
 

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.devolo_home_network.const import (
     SHORT_UPDATE_INTERVAL,
 )
 from homeassistant.components.sensor import DOMAIN, SensorStateClass
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity import EntityCategory
@@ -47,6 +47,9 @@ async def test_update_connected_wifi_clients(hass: HomeAssistant):
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == "1"
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME] == f"{entry.title} Connected Wifi clients"
+    )
     assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
 
     # Emulate device failure
@@ -85,6 +88,10 @@ async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == "1"
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME]
+        == f"{entry.title} Neighboring Wifi networks"
+    )
     assert er.async_get(state_key).entity_category is EntityCategory.DIAGNOSTIC
 
     # Emulate device failure
@@ -123,6 +130,9 @@ async def test_update_connected_plc_devices(hass: HomeAssistant):
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == "1"
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME] == f"{entry.title} Connected PLC devices"
+    )
     assert er.async_get(state_key).entity_category is EntityCategory.DIAGNOSTIC
 
     # Emulate device failure

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -24,12 +24,13 @@ from tests.common import async_fire_time_changed
 async def test_sensor_setup(hass: HomeAssistant):
     """Test default setup of the sensor component."""
     entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.connected_wifi_clients") is not None
-    assert hass.states.get(f"{DOMAIN}.connected_plc_devices") is None
-    assert hass.states.get(f"{DOMAIN}.neighboring_wifi_networks") is None
+    assert hass.states.get(f"{DOMAIN}.{device_name}_connected_wifi_clients") is not None
+    assert hass.states.get(f"{DOMAIN}.{device_name}_connected_plc_devices") is None
+    assert hass.states.get(f"{DOMAIN}.{device_name}_neighboring_wifi_networks") is None
 
     await hass.config_entries.async_unload(entry.entry_id)
 
@@ -37,9 +38,9 @@ async def test_sensor_setup(hass: HomeAssistant):
 @pytest.mark.usefixtures("mock_device")
 async def test_update_connected_wifi_clients(hass: HomeAssistant):
     """Test state change of a connected_wifi_clients sensor device."""
-    state_key = f"{DOMAIN}.connected_wifi_clients"
-
     entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
+    state_key = f"{DOMAIN}.{device_name}_connected_wifi_clients"
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
@@ -74,8 +75,9 @@ async def test_update_connected_wifi_clients(hass: HomeAssistant):
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_device")
 async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
     """Test state change of a neighboring_wifi_networks sensor device."""
-    state_key = f"{DOMAIN}.neighboring_wifi_networks"
     entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
+    state_key = f"{DOMAIN}.{device_name}_neighboring_wifi_networks"
     er = entity_registry.async_get(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -111,8 +113,9 @@ async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_device")
 async def test_update_connected_plc_devices(hass: HomeAssistant):
     """Test state change of a connected_plc_devices sensor device."""
-    state_key = f"{DOMAIN}.connected_plc_devices"
     entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
+    state_key = f"{DOMAIN}.{device_name}_connected_plc_devices"
     er = entity_registry.async_get(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate devolo Home Network to new entity naming style. This slightly changes the way, I named entities before. However, this is the nicer approach. Do I need a kind of migration or anything?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
