### PR TITLE
Migrate Guardian to new entity naming style

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -379,7 +379,6 @@ class GuardianEntity(CoordinatorEntity):
         self, entry: ConfigEntry, description: EntityDescription
     ) -> None:
         """Initialize."""
-        self._attr_device_info = DeviceInfo(manufacturer="Elexa")
         self._attr_extra_state_attributes = {}
         self._entry = entry
         self.entity_description = description
@@ -408,6 +407,8 @@ class PairedSensorEntity(GuardianEntity):
         paired_sensor_uid = coordinator.data["uid"]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, paired_sensor_uid)},
+            manufacturer="Elexa",
+            model=coordinator.data["codename"],
             name=f"Guardian Paired Sensor {paired_sensor_uid}",
             via_device=(DOMAIN, entry.data[CONF_UID]),
         )
@@ -433,6 +434,7 @@ class ValveControllerEntity(GuardianEntity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.data[CONF_UID])},
+            manufacturer="Elexa",
             model=coordinators[API_SYSTEM_DIAGNOSTICS].data["firmware"],
             name=f"Guardian Valve Controller {entry.data[CONF_UID]}",
         )

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -373,6 +373,8 @@ class PairedSensorManager:
 class GuardianEntity(CoordinatorEntity):
     """Define a base Guardian entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(  # pylint: disable=super-init-not-called
         self, entry: ConfigEntry, description: EntityDescription
     ) -> None:
@@ -409,9 +411,6 @@ class PairedSensorEntity(GuardianEntity):
             name=f"Guardian Paired Sensor {paired_sensor_uid}",
             via_device=(DOMAIN, entry.data[CONF_UID]),
         )
-        self._attr_name = (
-            f"Guardian Paired Sensor {paired_sensor_uid}: {description.name}"
-        )
         self._attr_unique_id = f"{paired_sensor_uid}_{description.key}"
         self.coordinator = coordinator
 
@@ -437,7 +436,6 @@ class ValveControllerEntity(GuardianEntity):
             model=coordinators[API_SYSTEM_DIAGNOSTICS].data["firmware"],
             name=f"Guardian Valve Controller {entry.data[CONF_UID]}",
         )
-        self._attr_name = f"Guardian {entry.data[CONF_UID]}: {description.name}"
         self._attr_unique_id = f"{entry.data[CONF_UID]}_{description.key}"
         self.coordinators = coordinators
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -379,7 +379,10 @@ class GuardianEntity(CoordinatorEntity):
         self, entry: ConfigEntry, description: EntityDescription
     ) -> None:
         """Initialize."""
-        self._attr_device_info = DeviceInfo(manufacturer="Elexa")
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data[CONF_UID])},
+            name=f"Guardian Valve Controller {entry.data[CONF_UID]}",
+        )
         self._attr_extra_state_attributes = {}
         self._entry = entry
         self.entity_description = description
@@ -406,11 +409,9 @@ class PairedSensorEntity(GuardianEntity):
         super().__init__(entry, description)
 
         paired_sensor_uid = coordinator.data["uid"]
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, paired_sensor_uid)},
-            name=f"Guardian Paired Sensor {paired_sensor_uid}",
-            via_device=(DOMAIN, entry.data[CONF_UID]),
-        )
+        self._attr_device_info["identifiers"].add((DOMAIN, paired_sensor_uid))
+        self._attr_device_info["name"] = f"Guardian Paired Sensor {paired_sensor_uid}"
+        self._attr_device_info["via_device"] = (DOMAIN, entry.data[CONF_UID])
         self._attr_unique_id = f"{paired_sensor_uid}_{description.key}"
         self.coordinator = coordinator
 
@@ -431,11 +432,9 @@ class ValveControllerEntity(GuardianEntity):
         """Initialize."""
         super().__init__(entry, description)
 
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_UID])},
-            model=coordinators[API_SYSTEM_DIAGNOSTICS].data["firmware"],
-            name=f"Guardian Valve Controller {entry.data[CONF_UID]}",
-        )
+        self._attr_device_info["model"] = coordinators[API_SYSTEM_DIAGNOSTICS].data[
+            "firmware"
+        ]
         self._attr_unique_id = f"{entry.data[CONF_UID]}_{description.key}"
         self.coordinators = coordinators
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -379,10 +379,7 @@ class GuardianEntity(CoordinatorEntity):
         self, entry: ConfigEntry, description: EntityDescription
     ) -> None:
         """Initialize."""
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_UID])},
-            name=f"Guardian Valve Controller {entry.data[CONF_UID]}",
-        )
+        self._attr_device_info = DeviceInfo(manufacturer="Elexa")
         self._attr_extra_state_attributes = {}
         self._entry = entry
         self.entity_description = description
@@ -409,9 +406,11 @@ class PairedSensorEntity(GuardianEntity):
         super().__init__(entry, description)
 
         paired_sensor_uid = coordinator.data["uid"]
-        self._attr_device_info["identifiers"].add((DOMAIN, paired_sensor_uid))
-        self._attr_device_info["name"] = f"Guardian Paired Sensor {paired_sensor_uid}"
-        self._attr_device_info["via_device"] = (DOMAIN, entry.data[CONF_UID])
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, paired_sensor_uid)},
+            name=f"Guardian Paired Sensor {paired_sensor_uid}",
+            via_device=(DOMAIN, entry.data[CONF_UID]),
+        )
         self._attr_unique_id = f"{paired_sensor_uid}_{description.key}"
         self.coordinator = coordinator
 
@@ -432,9 +431,11 @@ class ValveControllerEntity(GuardianEntity):
         """Initialize."""
         super().__init__(entry, description)
 
-        self._attr_device_info["model"] = coordinators[API_SYSTEM_DIAGNOSTICS].data[
-            "firmware"
-        ]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data[CONF_UID])},
+            model=coordinators[API_SYSTEM_DIAGNOSTICS].data["firmware"],
+            name=f"Guardian Valve Controller {entry.data[CONF_UID]}",
+        )
         self._attr_unique_id = f"{entry.data[CONF_UID]}_{description.key}"
         self.coordinators = coordinators
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR migrates the Guardian integration to the new entity naming style.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/73217
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
