### PR TITLE
Bump atomicwrites dependency to fix #74751

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ aiohttp_cors==0.7.0
 astral==2.2
 async-upnp-client==0.31.2
 async_timeout==4.0.2
-atomicwrites==1.4.0
+atomicwrites==1.4.1
 attrs==21.2.0
 awesomeversion==22.6.0
 bcrypt==3.1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     "astral==2.2",
     "async_timeout==4.0.2",
     "attrs==21.2.0",
-    "atomicwrites==1.4.0",
+    "atomicwrites==1.4.1",
     "awesomeversion==22.6.0",
     "bcrypt==3.1.7",
     "certifi>=2021.5.30",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp==3.8.1
 astral==2.2
 async_timeout==4.0.2
 attrs==21.2.0
-atomicwrites==1.4.0
+atomicwrites==1.4.1
 awesomeversion==22.6.0
 bcrypt==3.1.7
 certifi>=2021.5.30


### PR DESCRIPTION
## Proposed change
Bump atomicwrites dependency to fix #74751
https://github.com/untitaker/python-atomicwrites/issues/61

## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #74751
- 
## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
