### PR TITLE
2022.7.2

### DIFF
--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cloud",
   "name": "Home Assistant Cloud",
   "documentation": "https://www.home-assistant.io/integrations/cloud",
-  "requirements": ["hass-nabucasa==0.54.0"],
+  "requirements": ["hass-nabucasa==0.54.1"],
   "dependencies": ["http", "webhook"],
   "after_dependencies": ["google_assistant", "alexa"],
   "codeowners": ["@home-assistant/cloud"],

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==96"],
+  "requirements": ["pydeconz==97"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -113,7 +113,7 @@ class FreeboxRouter:
         # According to the doc `syst_datas["sensors"]` is temperature sensors in celsius degree.
         # Name and id of sensors may vary under Freebox devices.
         for sensor in syst_datas["sensors"]:
-            self.sensors_temperature[sensor["name"]] = sensor["value"]
+            self.sensors_temperature[sensor["name"]] = sensor.get("value")
 
         # Connection sensors
         connection_datas: dict[str, Any] = await self._api.connection.get_status()

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -159,7 +159,7 @@ class FreeboxDiskSensor(FreeboxSensor):
         self._disk = disk
         self._partition = partition
         self._attr_name = f"{partition['label']} {description.name}"
-        self._unique_id = f"{self._router.mac} {description.key} {self._disk['id']} {self._partition['id']}"
+        self._attr_unique_id = f"{self._router.mac} {description.key} {self._disk['id']} {self._partition['id']}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/here_travel_time/strings.json
+++ b/homeassistant/components/here_travel_time/strings.json
@@ -8,6 +8,13 @@
           "mode": "Travel Mode"
         }
       },
+      "origin_menu": {
+        "title": "Choose Origin",
+        "menu_options": {
+          "origin_coordinates": "Using a map location",
+          "origin_entity": "Using an entity"
+        }
+      },
       "origin_coordinates": {
         "title": "Choose Origin",
         "data": {

--- a/homeassistant/components/here_travel_time/translations/en.json
+++ b/homeassistant/components/here_travel_time/translations/en.json
@@ -39,6 +39,13 @@
                 },
                 "title": "Choose Origin"
             },
+            "origin_menu": {
+                "menu_options": {
+                    "origin_coordinates": "Using a map location",
+                    "origin_entity": "Using an entity"
+                },
+                "title": "Choose Origin"
+            },
             "user": {
                 "data": {
                     "api_key": "API Key",

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -183,7 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_IP_ADDRESS],
             entry.data[CONF_PASSWORD],
             port=entry.data[CONF_PORT],
-            ssl=entry.data.get(CONF_SSL, DEFAULT_SSL),
+            use_ssl=entry.data.get(CONF_SSL, DEFAULT_SSL),
         )
     except RainMachineError as err:
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -32,7 +32,7 @@ async def async_get_controller(
     websession = aiohttp_client.async_get_clientsession(hass)
     client = Client(session=websession)
     try:
-        await client.load_local(ip_address, password, port=port, ssl=ssl)
+        await client.load_local(ip_address, password, port=port, use_ssl=ssl)
     except RainMachineError:
         return None
     else:

--- a/homeassistant/components/rainmachine/manifest.json
+++ b/homeassistant/components/rainmachine/manifest.json
@@ -3,7 +3,7 @@
   "name": "RainMachine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rainmachine",
-  "requirements": ["regenmaschine==2022.06.1"],
+  "requirements": ["regenmaschine==2022.07.0"],
   "codeowners": ["@bachya"],
   "iot_class": "local_polling",
   "homekit": {

--- a/homeassistant/components/unifi_direct/device_tracker.py
+++ b/homeassistant/components/unifi_direct/device_tracker.py
@@ -80,7 +80,7 @@ class UnifiDeviceScanner(DeviceScanner):
     def _connect(self):
         """Connect to the Unifi AP SSH server."""
 
-        self.ssh = pxssh.pxssh()
+        self.ssh = pxssh.pxssh(options={"HostKeyAlgorithms": "ssh-rsa"})
         try:
             self.ssh.login(
                 self.host, self.username, password=self.password, port=self.port

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -141,7 +141,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._color_channel = None
         self._identify_channel = None
         self._default_transition = None
-        self._color_mode = ColorMode.UNKNOWN  # Set by sub classes
+        self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -158,11 +158,6 @@ class BaseLight(LogMixin, light.LightEntity):
         if self._state is None:
             return False
         return self._state
-
-    @property
-    def color_mode(self):
-        """Return the color mode of this light."""
-        return self._color_mode
 
     @property
     def brightness(self):
@@ -309,7 +304,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)
                 return
-            self._color_mode = ColorMode.COLOR_TEMP
+            self._attr_color_mode = ColorMode.COLOR_TEMP
             self._color_temp = temperature
             self._hs_color = None
 
@@ -323,7 +318,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)
                 return
-            self._color_mode = ColorMode.HS
+            self._attr_color_mode = ColorMode.HS
             self._hs_color = hs_color
             self._color_temp = None
 
@@ -451,13 +446,13 @@ class Light(BaseLight, ZhaEntity):
             self._attr_supported_color_modes
         )
         if len(self._attr_supported_color_modes) == 1:
-            self._color_mode = next(iter(self._attr_supported_color_modes))
+            self._attr_color_mode = next(iter(self._attr_supported_color_modes))
         else:  # Light supports color_temp + hs, determine which mode the light is in
             assert self._color_channel
             if self._color_channel.color_mode == Color.ColorMode.Color_temperature:
-                self._color_mode = ColorMode.COLOR_TEMP
+                self._attr_color_mode = ColorMode.COLOR_TEMP
             else:
-                self._color_mode = ColorMode.HS
+                self._attr_color_mode = ColorMode.HS
 
         if self._identify_channel:
             self._supported_features |= light.LightEntityFeature.FLASH
@@ -518,7 +513,7 @@ class Light(BaseLight, ZhaEntity):
         if "off_brightness" in last_state.attributes:
             self._off_brightness = last_state.attributes["off_brightness"]
         if "color_mode" in last_state.attributes:
-            self._color_mode = ColorMode(last_state.attributes["color_mode"])
+            self._attr_color_mode = ColorMode(last_state.attributes["color_mode"])
         if "color_temp" in last_state.attributes:
             self._color_temp = last_state.attributes["color_temp"]
         if "hs_color" in last_state.attributes:
@@ -558,13 +553,13 @@ class Light(BaseLight, ZhaEntity):
 
             if (color_mode := results.get("color_mode")) is not None:
                 if color_mode == Color.ColorMode.Color_temperature:
-                    self._color_mode = ColorMode.COLOR_TEMP
+                    self._attr_color_mode = ColorMode.COLOR_TEMP
                     color_temp = results.get("color_temperature")
                     if color_temp is not None and color_mode:
                         self._color_temp = color_temp
                         self._hs_color = None
                 else:
-                    self._color_mode = ColorMode.HS
+                    self._attr_color_mode = ColorMode.HS
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
@@ -650,7 +645,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
-        self._color_mode = None
+        self._attr_color_mode = None
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 7
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ aiohttp_cors==0.7.0
 astral==2.2
 async-upnp-client==0.31.2
 async_timeout==4.0.2
-atomicwrites==1.4.0
+atomicwrites-homeassistant==1.4.1
 attrs==21.2.0
 awesomeversion==22.6.0
 bcrypt==3.1.7
@@ -14,7 +14,7 @@ certifi>=2021.5.30
 ciso8601==2.2.0
 cryptography==36.0.2
 fnvhash==0.1.0
-hass-nabucasa==0.54.0
+hass-nabucasa==0.54.1
 home-assistant-frontend==20220707.0
 httpx==0.23.0
 ifaddr==0.1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     "astral==2.2",
     "async_timeout==4.0.2",
     "attrs==21.2.0",
-    "atomicwrites==1.4.0",
+    "atomicwrites-homeassistant==1.4.1",
     "awesomeversion==22.6.0",
     "bcrypt==3.1.7",
     "certifi>=2021.5.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.7.1"
+version     = "2022.7.2"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp==3.8.1
 astral==2.2
 async_timeout==4.0.2
 attrs==21.2.0
-atomicwrites==1.4.0
+atomicwrites-homeassistant==1.4.1
 awesomeversion==22.6.0
 bcrypt==3.1.7
 certifi>=2021.5.30

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -795,7 +795,7 @@ habitipy==0.2.0
 hangups==0.4.18
 
 # homeassistant.components.cloud
-hass-nabucasa==0.54.0
+hass-nabucasa==0.54.1
 
 # homeassistant.components.splunk
 hass_splunk==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2065,7 +2065,7 @@ raincloudy==0.0.7
 raspyrfm-client==1.2.8
 
 # homeassistant.components.rainmachine
-regenmaschine==2022.06.1
+regenmaschine==2022.07.0
 
 # homeassistant.components.renault
 renault-api==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1444,7 +1444,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==96
+pydeconz==97
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1376,7 +1376,7 @@ radios==0.1.1
 radiotherm==2.1.0
 
 # homeassistant.components.rainmachine
-regenmaschine==2022.06.1
+regenmaschine==2022.07.0
 
 # homeassistant.components.renault
 renault-api==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -574,7 +574,7 @@ habitipy==0.2.0
 hangups==0.4.18
 
 # homeassistant.components.cloud
-hass-nabucasa==0.54.0
+hass-nabucasa==0.54.1
 
 # homeassistant.components.tasmota
 hatasmota==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -974,7 +974,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==96
+pydeconz==97
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -816,6 +816,37 @@ async def test_dont_add_sensor_if_state_is_none(
     assert len(hass.states.async_all()) == 0
 
 
+async def test_air_quality_sensor_without_ppb(hass, aioclient_mock):
+    """Test sensor with scaled data is not created if state is None."""
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 2,
+                "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
+                "lastseen": "2020-11-20T22:48Z",
+                "manufacturername": "BOSCH",
+                "modelid": "AIR",
+                "name": "BOSCH Air quality sensor",
+                "state": {
+                    "airquality": "poor",
+                    "lastupdated": "2020-11-20T22:48:00.209",
+                },
+                "swversion": "20200402",
+                "type": "ZHAAirQuality",
+                "uniqueid": "00:00:00:00:00:00:00:00-02-fdef",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 1
+
+
 async def test_add_battery_later(hass, aioclient_mock, mock_deconz_websocket):
     """Test that a sensor without an initial battery state creates a battery sensor once state exist."""
     data = {

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -1,12 +1,10 @@
 """The tests for the Demo component."""
-from contextlib import suppress
 import json
-import os
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.demo import DOMAIN
-from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import list_statistic_ids
 from homeassistant.helpers.json import JSONEncoder
@@ -22,11 +20,10 @@ def mock_history(hass):
 
 
 @pytest.fixture(autouse=True)
-def demo_cleanup(hass):
-    """Clean up device tracker demo file."""
-    yield
-    with suppress(FileNotFoundError):
-        os.remove(hass.config.path(YAML_DEVICES))
+def mock_device_tracker_update_config(hass):
+    """Prevent device tracker from creating known devices file."""
+    with patch("homeassistant.components.device_tracker.legacy.update_config"):
+        yield
 
 
 async def test_setting_up_demo(hass):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -28,6 +28,8 @@ from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from . import common
+
 from tests.common import (
     assert_setup_component,
     async_fire_time_changed,
@@ -35,7 +37,6 @@ from tests.common import (
     mock_restore_cache,
     patch_yaml_files,
 )
-from tests.components.device_tracker import common
 
 TEST_PLATFORM = {device_tracker.DOMAIN: {CONF_PLATFORM: "test"}}
 
@@ -165,6 +166,7 @@ async def test_setup_without_yaml_file(hass, enable_custom_integrations):
     """Test with no YAML file."""
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
 
 
 async def test_gravatar(hass):
@@ -210,10 +212,11 @@ async def test_gravatar_and_picture(hass):
 @patch("homeassistant.components.demo.device_tracker.setup_scanner", autospec=True)
 async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
     """Test discovery of device_tracker demo platform."""
-    await discovery.async_load_platform(
-        hass, device_tracker.DOMAIN, "demo", {"test_key": "test_val"}, {"bla": {}}
-    )
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.device_tracker.legacy.update_config"):
+        await discovery.async_load_platform(
+            hass, device_tracker.DOMAIN, "demo", {"test_key": "test_val"}, {"bla": {}}
+        )
+        await hass.async_block_till_done()
     assert device_tracker.DOMAIN in hass.config.components
     assert mock_demo_setup_scanner.called
     assert mock_demo_setup_scanner.call_args[0] == (

--- a/tests/components/freebox/const.py
+++ b/tests/components/freebox/const.py
@@ -22,6 +22,7 @@ DATA_SYSTEM_GET_CONFIG = {
     "fans": [{"id": "fan0_speed", "name": "Ventilateur 1", "value": 2130}],
     "sensors": [
         {"id": "temp_hdd", "name": "Disque dur", "value": 40},
+        {"id": "temp_hdd2", "name": "Disque dur 2"},
         {"id": "temp_sw", "name": "Température Switch", "value": 50},
         {"id": "temp_cpum", "name": "Température CPU M", "value": 60},
         {"id": "temp_cpub", "name": "Température CPU B", "value": 56},
@@ -123,7 +124,42 @@ DATA_STORAGE_GET_DISKS = [
                 "path": "L0Rpc3F1ZSBkdXI=",
             }
         ],
-    }
+    },
+    {
+        "idle_duration": 8290,
+        "read_error_requests": 0,
+        "read_requests": 2326826,
+        "spinning": False,
+        "table_type": "gpt",
+        "firmware": "0001",
+        "type": "sata",
+        "idle": True,
+        "connector": 0,
+        "id": 2000,
+        "write_error_requests": 0,
+        "state": "enabled",
+        "write_requests": 122733632,
+        "total_bytes": 2000000000000,
+        "model": "ST2000LM015-2E8174",
+        "active_duration": 0,
+        "temp": 0,
+        "serial": "WDZYJ27Q",
+        "partitions": [
+            {
+                "fstype": "ext4",
+                "total_bytes": 1960000000000,
+                "label": "Disque 2",
+                "id": 2001,
+                "internal": False,
+                "fsck_result": "no_run_yet",
+                "state": "mounted",
+                "disk_id": 2000,
+                "free_bytes": 1880000000000,
+                "used_bytes": 85410000000,
+                "path": "L0Rpc3F1ZSAy",
+            }
+        ],
+    },
 ]
 
 # switch


### PR DESCRIPTION
- Add missing strings for here_travel_time ([@eifinger] - [#74641]) ([here_travel_time docs])
- Add ssh-rsa as acceptable an host key algorithm ([@siyuan-nz] - [#74684]) ([unifi_direct docs])
- Fix ZHA group not setting the correct color mode ([@TheJulianJES] - [#74687]) ([zha docs])
- Bump deconz dependency to fix #74523 ([@Kane610] - [#74710]) ([deconz docs])
- Bump atomicwrites ([@balloob] - [#74758])
- Bump regenmaschine to 2022.07.0 ([@bachya] - [#74680]) ([rainmachine docs])
- Fix error with HDD temperature report in Freebox integration ([@BenoitAnastay] - [#74718]) ([freebox docs])

[#74641]: https://github.com/home-assistant/core/pull/74641
[#74680]: https://github.com/home-assistant/core/pull/74680
[#74684]: https://github.com/home-assistant/core/pull/74684
[#74687]: https://github.com/home-assistant/core/pull/74687
[#74710]: https://github.com/home-assistant/core/pull/74710
[#74718]: https://github.com/home-assistant/core/pull/74718
[#74758]: https://github.com/home-assistant/core/pull/74758
[@BenoitAnastay]: https://github.com/BenoitAnastay
[@Kane610]: https://github.com/Kane610
[@TheJulianJES]: https://github.com/TheJulianJES
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@eifinger]: https://github.com/eifinger
[@siyuan-nz]: https://github.com/siyuan-nz
[deconz docs]: https://www.home-assistant.io/integrations/deconz/
[freebox docs]: https://www.home-assistant.io/integrations/freebox/
[here_travel_time docs]: https://www.home-assistant.io/integrations/here_travel_time/
[rainmachine docs]: https://www.home-assistant.io/integrations/rainmachine/
[unifi_direct docs]: https://www.home-assistant.io/integrations/unifi_direct/
[zha docs]: https://www.home-assistant.io/integrations/zha/