### PR TITLE
Migrate deCONZ Group and Scenes to new entity naming style

### DIFF
--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -120,6 +120,8 @@ class DeconzDevice(DeconzBase, Entity):
 class DeconzSceneMixin(DeconzDevice):
     """Representation of a deCONZ scene."""
 
+    _attr_has_entity_name = True
+
     _device: PydeconzScene
 
     def __init__(
@@ -130,7 +132,9 @@ class DeconzSceneMixin(DeconzDevice):
         """Set up a scene."""
         super().__init__(device, gateway)
 
-        self._attr_name = device.full_name
+        self.group = self.gateway.api.groups[device.group_id]
+
+        self._attr_name = device.name
         self._group_identifier = self.get_parent_identifier()
 
     def get_device_identifier(self) -> str:
@@ -139,7 +143,7 @@ class DeconzSceneMixin(DeconzDevice):
 
     def get_parent_identifier(self) -> str:
         """Describe a unique identifier for group this scene belongs to."""
-        return f"{self.gateway.bridgeid}-{self._device.group_deconz_id}"
+        return f"{self.gateway.bridgeid}-{self.group.deconz_id}"
 
     @property
     def unique_id(self) -> str:
@@ -149,4 +153,10 @@ class DeconzSceneMixin(DeconzDevice):
     @property
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
-        return DeviceInfo(identifiers={(DECONZ_DOMAIN, self._group_identifier)})
+        return DeviceInfo(
+            identifiers={(DECONZ_DOMAIN, self._group_identifier)},
+            manufacturer="Dresden Elektronik",
+            model="deCONZ group",
+            name=self.group.name,
+            via_device=(DECONZ_DOMAIN, self.gateway.api.config.bridge_id),
+        )

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -289,12 +289,16 @@ class DeconzLight(DeconzBaseLight[Light]):
 class DeconzGroup(DeconzBaseLight[Group]):
     """Representation of a deCONZ group."""
 
+    _attr_has_entity_name = True
+
     _device: Group
 
     def __init__(self, device: Group, gateway: DeconzGateway) -> None:
         """Set up group and create an unique id."""
         self._unique_id = f"{gateway.bridgeid}-{device.deconz_id}"
         super().__init__(device, gateway)
+
+        self._attr_name = ""
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -298,7 +298,7 @@ class DeconzGroup(DeconzBaseLight[Group]):
         self._unique_id = f"{gateway.bridgeid}-{device.deconz_id}"
         super().__init__(device, gateway)
 
-        self._attr_name = ""
+        self._attr_name = None
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate the virtual devices (groups and scenes) of deCONZ integration to use the new entity naming style and set the flag.
(https://github.com/home-assistant/core/pull/73217)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
