### PR TITLE
Add coverage for lutron caseta bridges to hkc

### DIFF
--- a/tests/components/homekit_controller/fixtures/lutron_caseta_bridge.json
+++ b/tests/components/homekit_controller/fixtures/lutron_caseta_bridge.json
@@ -1,0 +1,178 @@
+[
+  {
+    "aid": 1,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 85899345921,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 137438953473,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Lutron Electronics Co., Inc",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 141733920769,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "L-BDG2-WH",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 150323855361,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Smart Bridge 2",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 206158430209,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "12344331",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 352187318273,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "08.08",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 2,
+        "type": "000000A2-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000037-0000-1000-8000-0026BB765291",
+            "iid": 236223201282,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.1.0",
+            "description": "Version",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 21474836482,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 85899345921,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 137438953473,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Lutron Electronics Co., Inc",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 141733920769,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "PD-FSQN-XX",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 150323855361,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Cas\u00e9ta\u00ae Wireless Fan Speed Control",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 206158430209,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "39024290",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 352187318273,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "001.005",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 2,
+        "type": "00000040-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000029-0000-1000-8000-0026BB765291",
+            "iid": 176093659138,
+            "perms": ["pr", "pw", "ev"],
+            "format": "float",
+            "value": 0,
+            "description": "Rotation Speed",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 25
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 150323855362,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Cas\u00e9ta\u00ae Wireless Fan Speed Control",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000025-0000-1000-8000-0026BB765291",
+            "iid": 158913789954,
+            "perms": ["pr", "pw", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "On"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/components/homekit_controller/specific_devices/test_lutron_caseta_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_lutron_caseta_bridge.py
@@ -1,0 +1,55 @@
+"""Tests for handling accessories on a Lutron Caseta bridge via HomeKit."""
+
+from homeassistant.const import STATE_OFF
+
+from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
+    DeviceTestInfo,
+    EntityTestInfo,
+    assert_devices_and_entities_created,
+    setup_accessories_from_file,
+    setup_test_accessories,
+)
+
+
+async def test_lutron_caseta_bridge_setup(hass):
+    """Test that a Lutron Caseta bridge can be correctly setup in HA via HomeKit."""
+    accessories = await setup_accessories_from_file(hass, "lutron_caseta_bridge.json")
+    await setup_test_accessories(hass, accessories)
+
+    await assert_devices_and_entities_created(
+        hass,
+        DeviceTestInfo(
+            unique_id=HUB_TEST_ACCESSORY_ID,
+            name="Smart Bridge 2",
+            model="L-BDG2-WH",
+            manufacturer="Lutron Electronics Co., Inc",
+            sw_version="08.08",
+            hw_version="",
+            serial_number="12344331",
+            devices=[
+                DeviceTestInfo(
+                    name="Cas\u00e9ta\u00ae Wireless Fan Speed Control",
+                    model="PD-FSQN-XX",
+                    manufacturer="Lutron Electronics Co., Inc",
+                    sw_version="001.005",
+                    hw_version="",
+                    serial_number="39024290",
+                    unique_id="00:00:00:00:00:00:aid:21474836482",
+                    devices=[],
+                    entities=[
+                        EntityTestInfo(
+                            entity_id="fan.caseta_r_wireless_fan_speed_control",
+                            friendly_name="Caséta® Wireless Fan Speed Control",
+                            unique_id="homekit-39024290-2",
+                            unit_of_measurement=None,
+                            supported_features=1,
+                            state=STATE_OFF,
+                            capabilities={"preset_modes": None},
+                        )
+                    ],
+                ),
+            ],
+            entities=[],
+        ),
+    )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I wanted to make sure the fan changes didn't have any unexpected side effects so I linked a lutron bridge with a fan to HKC to provide some addition manual testing for #74440

Since I did that, I figured it was worth capturing the bridge into a test. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
