### PR TITLE
Add option to include attachments from remote URL to Discord notifications

### DIFF
--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -178,11 +178,7 @@ class DiscordNotificationService(BaseNotificationService):
             for channelid in kwargs[ATTR_TARGET]:
                 channelid = int(channelid)
                 # Must create new instances of File for each channel.
-                files = (
-                    [nextcord.File(image, filename) for image, filename in images]
-                    if images
-                    else []
-                )
+                files = [nextcord.File(image, filename) for image, filename in images]
                 try:
                     channel = cast(
                         Messageable, await discord_bot.fetch_channel(channelid)

--- a/tests/components/discord/conftest.py
+++ b/tests/components/discord/conftest.py
@@ -1,0 +1,46 @@
+"""Discord notification test helpers."""
+from http import HTTPStatus
+
+import pytest
+from requests_mock.mocker import Mocker
+
+from homeassistant.components.discord.notify import DiscordNotificationService
+from homeassistant.core import HomeAssistant
+
+MESSAGE = "Testing Discord Messenger platform"
+CONTENT = b"TestContent"
+URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
+TARGET = "1234567890"
+
+
+@pytest.fixture
+def discord_notification_service(hass: HomeAssistant) -> DiscordNotificationService:
+    """Set up discord notification service."""
+    hass.config.allowlist_external_urls.add(URL_ATTACHMENT)
+    token = "token"
+    return DiscordNotificationService(hass, token)
+
+
+@pytest.fixture
+def discord_requests_mock_factory(requests_mock: Mocker) -> Mocker:
+    """Create Discord service mock from factory."""
+
+    def _discord_requests_mock_factory(content_length_header: str = None) -> Mocker:
+        if content_length_header is not None:
+            requests_mock.register_uri(
+                "GET",
+                URL_ATTACHMENT,
+                status_code=HTTPStatus.OK,
+                content=CONTENT,
+                headers={"Content-Length": content_length_header},
+            )
+        else:
+            requests_mock.register_uri(
+                "GET",
+                URL_ATTACHMENT,
+                status_code=HTTPStatus.OK,
+                content=CONTENT,
+            )
+        return requests_mock
+
+    return _discord_requests_mock_factory

--- a/tests/components/discord/conftest.py
+++ b/tests/components/discord/conftest.py
@@ -2,10 +2,11 @@
 from http import HTTPStatus
 
 import pytest
-from requests_mock.mocker import Mocker
 
 from homeassistant.components.discord.notify import DiscordNotificationService
 from homeassistant.core import HomeAssistant
+
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MESSAGE = "Testing Discord Messenger platform"
 CONTENT = b"TestContent"
@@ -22,25 +23,27 @@ def discord_notification_service(hass: HomeAssistant) -> DiscordNotificationServ
 
 
 @pytest.fixture
-def discord_requests_mock_factory(requests_mock: Mocker) -> Mocker:
+def discord_aiohttp_mock_factory(
+    aioclient_mock: AiohttpClientMocker,
+) -> AiohttpClientMocker:
     """Create Discord service mock from factory."""
 
-    def _discord_requests_mock_factory(content_length_header: str = None) -> Mocker:
+    def _discord_aiohttp_mock_factory(
+        content_length_header: str = None,
+    ) -> AiohttpClientMocker:
         if content_length_header is not None:
-            requests_mock.register_uri(
-                "GET",
+            aioclient_mock.get(
                 URL_ATTACHMENT,
-                status_code=HTTPStatus.OK,
+                status=HTTPStatus.OK,
                 content=CONTENT,
                 headers={"Content-Length": content_length_header},
             )
         else:
-            requests_mock.register_uri(
-                "GET",
+            aioclient_mock.get(
                 URL_ATTACHMENT,
-                status_code=HTTPStatus.OK,
+                status=HTTPStatus.OK,
                 content=CONTENT,
             )
-        return requests_mock
+        return aioclient_mock
 
-    return _discord_requests_mock_factory
+    return _discord_aiohttp_mock_factory

--- a/tests/components/discord/conftest.py
+++ b/tests/components/discord/conftest.py
@@ -18,8 +18,7 @@ TARGET = "1234567890"
 def discord_notification_service(hass: HomeAssistant) -> DiscordNotificationService:
     """Set up discord notification service."""
     hass.config.allowlist_external_urls.add(URL_ATTACHMENT)
-    token = "token"
-    return DiscordNotificationService(hass, token)
+    return DiscordNotificationService(hass, "token")
 
 
 @pytest.fixture
@@ -29,14 +28,11 @@ def discord_aiohttp_mock_factory(
     """Create Discord service mock from factory."""
 
     def _discord_aiohttp_mock_factory(
-        content_length_header: str = None,
+        headers: dict[str, str] = None,
     ) -> AiohttpClientMocker:
-        if content_length_header is not None:
+        if headers is not None:
             aioclient_mock.get(
-                URL_ATTACHMENT,
-                status=HTTPStatus.OK,
-                content=CONTENT,
-                headers={"Content-Length": content_length_header},
+                URL_ATTACHMENT, status=HTTPStatus.OK, content=CONTENT, headers=headers
             )
         else:
             aioclient_mock.get(

--- a/tests/components/discord/test_notify.py
+++ b/tests/components/discord/test_notify.py
@@ -1,0 +1,111 @@
+"""Test Discord notify."""
+import logging
+
+import pytest
+from requests_mock.mocker import Mocker
+
+from homeassistant.components.discord.notify import DiscordNotificationService
+
+from .conftest import CONTENT, MESSAGE, URL_ATTACHMENT
+
+
+async def test_send_message_without_target_logs_error(
+    discord_notification_service: DiscordNotificationService,
+    discord_requests_mock_factory: Mocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test send message."""
+    discord_requests_mock = discord_requests_mock_factory()
+    with caplog.at_level(
+        logging.ERROR, logger="homeassistant.components.discord.notify"
+    ):
+        await discord_notification_service.async_send_message(MESSAGE)
+    assert "No target specified" in caplog.text
+    assert not discord_requests_mock.called
+
+
+def test_get_file_from_url_with_true_verify(
+    discord_notification_service: DiscordNotificationService,
+    discord_requests_mock_factory: Mocker,
+) -> None:
+    """Test getting a file from a URL."""
+    discord_requests_mock = discord_requests_mock_factory(str(len(CONTENT)))
+    result = discord_notification_service.get_file_from_url(
+        URL_ATTACHMENT, True, len(CONTENT)
+    )
+
+    assert discord_requests_mock.called
+    assert discord_requests_mock.call_count == 1
+    assert discord_requests_mock.last_request.verify is True
+    assert result == bytearray(CONTENT)
+
+
+def test_get_file_from_url_with_false_verify(
+    discord_notification_service: DiscordNotificationService,
+    discord_requests_mock_factory: Mocker,
+) -> None:
+    """Test getting a file from a URL."""
+    discord_requests_mock = discord_requests_mock_factory(str(len(CONTENT)))
+    result = discord_notification_service.get_file_from_url(
+        URL_ATTACHMENT, False, len(CONTENT)
+    )
+
+    assert discord_requests_mock.called
+    assert discord_requests_mock.call_count == 1
+    assert discord_requests_mock.last_request.verify is False
+    assert result == bytearray(CONTENT)
+
+
+def test_get_file_from_url_not_on_allowlist(
+    discord_notification_service: DiscordNotificationService,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test getting file from URL that isn't on the allowlist."""
+    url = "http://dodgyurl.com"
+    with caplog.at_level(
+        logging.WARNING, logger="homeassistant.components.discord.notify"
+    ):
+        result = discord_notification_service.get_file_from_url(url, True, len(CONTENT))
+
+    assert f"URL not allowed: {url}" in caplog.text
+    assert result is None
+
+
+def test_get_file_from_url_with_large_attachment(
+    discord_notification_service: DiscordNotificationService,
+    discord_requests_mock_factory: Mocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test getting file from URL with large attachment (per Content-Length header) throws error."""
+    discord_requests_mock = discord_requests_mock_factory(str(len(CONTENT) + 1))
+    with caplog.at_level(
+        logging.WARNING, logger="homeassistant.components.discord.notify"
+    ):
+        result = discord_notification_service.get_file_from_url(
+            URL_ATTACHMENT, True, len(CONTENT)
+        )
+
+    assert discord_requests_mock.called
+    assert discord_requests_mock.call_count == 1
+    assert "Attachment too large (Content-Length reports" in caplog.text
+    assert result is None
+
+
+def test_get_file_from_url_with_large_attachment_no_header(
+    discord_notification_service: DiscordNotificationService,
+    discord_requests_mock_factory: Mocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test getting file from URL with large attachment (per content length) throws error."""
+    discord_requests_mock = discord_requests_mock_factory()
+    with caplog.at_level(
+        logging.WARNING, logger="homeassistant.components.discord.notify"
+    ):
+        result = discord_notification_service.get_file_from_url(
+            URL_ATTACHMENT, True, len(CONTENT) - 1
+        )
+
+    assert discord_requests_mock.called
+    assert discord_requests_mock.call_count == 1
+    assert "Attachment too large (Stream reports" in caplog.text
+    assert result is None

--- a/tests/components/discord/test_notify.py
+++ b/tests/components/discord/test_notify.py
@@ -2,61 +2,44 @@
 import logging
 
 import pytest
-from requests_mock.mocker import Mocker
 
 from homeassistant.components.discord.notify import DiscordNotificationService
 
 from .conftest import CONTENT, MESSAGE, URL_ATTACHMENT
 
+from tests.test_util.aiohttp import AiohttpClientMocker
+
 
 async def test_send_message_without_target_logs_error(
     discord_notification_service: DiscordNotificationService,
-    discord_requests_mock_factory: Mocker,
+    discord_aiohttp_mock_factory: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test send message."""
-    discord_requests_mock = discord_requests_mock_factory()
+    discord_aiohttp_mock = discord_aiohttp_mock_factory()
     with caplog.at_level(
         logging.ERROR, logger="homeassistant.components.discord.notify"
     ):
         await discord_notification_service.async_send_message(MESSAGE)
     assert "No target specified" in caplog.text
-    assert not discord_requests_mock.called
+    assert discord_aiohttp_mock.call_count == 0
 
 
-def test_get_file_from_url_with_true_verify(
+async def test_get_file_from_url(
     discord_notification_service: DiscordNotificationService,
-    discord_requests_mock_factory: Mocker,
+    discord_aiohttp_mock_factory: AiohttpClientMocker,
 ) -> None:
     """Test getting a file from a URL."""
-    discord_requests_mock = discord_requests_mock_factory(str(len(CONTENT)))
-    result = discord_notification_service.get_file_from_url(
+    discord_aiohttp_mock = discord_aiohttp_mock_factory(str(len(CONTENT)))
+    result = await discord_notification_service.async_get_file_from_url(
         URL_ATTACHMENT, True, len(CONTENT)
     )
 
-    assert discord_requests_mock.called
-    assert discord_requests_mock.call_count == 1
-    assert discord_requests_mock.last_request.verify is True
+    assert discord_aiohttp_mock.call_count == 1
     assert result == bytearray(CONTENT)
 
 
-def test_get_file_from_url_with_false_verify(
-    discord_notification_service: DiscordNotificationService,
-    discord_requests_mock_factory: Mocker,
-) -> None:
-    """Test getting a file from a URL."""
-    discord_requests_mock = discord_requests_mock_factory(str(len(CONTENT)))
-    result = discord_notification_service.get_file_from_url(
-        URL_ATTACHMENT, False, len(CONTENT)
-    )
-
-    assert discord_requests_mock.called
-    assert discord_requests_mock.call_count == 1
-    assert discord_requests_mock.last_request.verify is False
-    assert result == bytearray(CONTENT)
-
-
-def test_get_file_from_url_not_on_allowlist(
+async def test_get_file_from_url_not_on_allowlist(
     discord_notification_service: DiscordNotificationService,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -65,47 +48,47 @@ def test_get_file_from_url_not_on_allowlist(
     with caplog.at_level(
         logging.WARNING, logger="homeassistant.components.discord.notify"
     ):
-        result = discord_notification_service.get_file_from_url(url, True, len(CONTENT))
+        result = await discord_notification_service.async_get_file_from_url(
+            url, True, len(CONTENT)
+        )
 
     assert f"URL not allowed: {url}" in caplog.text
     assert result is None
 
 
-def test_get_file_from_url_with_large_attachment(
+async def test_get_file_from_url_with_large_attachment(
     discord_notification_service: DiscordNotificationService,
-    discord_requests_mock_factory: Mocker,
+    discord_aiohttp_mock_factory: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test getting file from URL with large attachment (per Content-Length header) throws error."""
-    discord_requests_mock = discord_requests_mock_factory(str(len(CONTENT) + 1))
+    discord_aiohttp_mock = discord_aiohttp_mock_factory(str(len(CONTENT) + 1))
     with caplog.at_level(
         logging.WARNING, logger="homeassistant.components.discord.notify"
     ):
-        result = discord_notification_service.get_file_from_url(
+        result = await discord_notification_service.async_get_file_from_url(
             URL_ATTACHMENT, True, len(CONTENT)
         )
 
-    assert discord_requests_mock.called
-    assert discord_requests_mock.call_count == 1
+    assert discord_aiohttp_mock.call_count == 1
     assert "Attachment too large (Content-Length reports" in caplog.text
     assert result is None
 
 
-def test_get_file_from_url_with_large_attachment_no_header(
+async def test_get_file_from_url_with_large_attachment_no_header(
     discord_notification_service: DiscordNotificationService,
-    discord_requests_mock_factory: Mocker,
+    discord_aiohttp_mock_factory: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test getting file from URL with large attachment (per content length) throws error."""
-    discord_requests_mock = discord_requests_mock_factory()
+    discord_aiohttp_mock = discord_aiohttp_mock_factory()
     with caplog.at_level(
         logging.WARNING, logger="homeassistant.components.discord.notify"
     ):
-        result = discord_notification_service.get_file_from_url(
+        result = await discord_notification_service.async_get_file_from_url(
             URL_ATTACHMENT, True, len(CONTENT) - 1
         )
 
-    assert discord_requests_mock.called
-    assert discord_requests_mock.call_count == 1
+    assert discord_aiohttp_mock.call_count == 1
     assert "Attachment too large (Stream reports" in caplog.text
     assert result is None

--- a/tests/components/discord/test_notify.py
+++ b/tests/components/discord/test_notify.py
@@ -30,7 +30,8 @@ async def test_get_file_from_url(
     discord_aiohttp_mock_factory: AiohttpClientMocker,
 ) -> None:
     """Test getting a file from a URL."""
-    discord_aiohttp_mock = discord_aiohttp_mock_factory(str(len(CONTENT)))
+    headers = {"Content-Length": str(len(CONTENT))}
+    discord_aiohttp_mock = discord_aiohttp_mock_factory(headers)
     result = await discord_notification_service.async_get_file_from_url(
         URL_ATTACHMENT, True, len(CONTENT)
     )
@@ -62,7 +63,8 @@ async def test_get_file_from_url_with_large_attachment(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test getting file from URL with large attachment (per Content-Length header) throws error."""
-    discord_aiohttp_mock = discord_aiohttp_mock_factory(str(len(CONTENT) + 1))
+    headers = {"Content-Length": str(len(CONTENT) + 1)}
+    discord_aiohttp_mock = discord_aiohttp_mock_factory(headers)
     with caplog.at_level(
         logging.WARNING, logger="homeassistant.components.discord.notify"
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extends the Discord Notify integration to be able to download files from a remote URL so as to attach to Discord messages (currently it can only attach files that are already on the local disk). An example use case is to attach snapshots and video clips from a camera's API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23335

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
