### PR TITLE
Support notification_id in notify.persistent_notification

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -19,7 +19,6 @@ from .const import (  # noqa: F401
     ATTR_TITLE,
     DOMAIN,
     NOTIFY_SERVICE_SCHEMA,
-    PERSISTENT_NOTIFICATION_SERVICE_SCHEMA,
     SERVICE_NOTIFY,
     SERVICE_PERSISTENT_NOTIFICATION,
 )
@@ -70,13 +69,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             title_tpl.hass = hass
             title = title_tpl.async_render(parse_result=False)
 
-        pn.async_create(hass, message.async_render(parse_result=False), title)
+        notification_id = None
+        if data := service.data.get(ATTR_DATA):
+            notification_id = data.get(pn.ATTR_NOTIFICATION_ID)
+
+        pn.async_create(
+            hass, message.async_render(parse_result=False), title, notification_id
+        )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_PERSISTENT_NOTIFICATION,
         persistent_notification,
-        schema=PERSISTENT_NOTIFICATION_SERVICE_SCHEMA,
+        schema=NOTIFY_SERVICE_SCHEMA,
     )
 
     return True

--- a/homeassistant/components/notify/const.py
+++ b/homeassistant/components/notify/const.py
@@ -31,10 +31,3 @@ NOTIFY_SERVICE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_DATA): dict,
     }
 )
-
-PERSISTENT_NOTIFICATION_SERVICE_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_MESSAGE): cv.template,
-        vol.Optional(ATTR_TITLE): cv.template,
-    }
-)

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -51,3 +51,11 @@ persistent_notification:
       example: "Your Garage Door Friend"
       selector:
         text:
+    data:
+      name: Data
+      description:
+        Extended information for notification. Optional depending on the
+        platform.
+      example: platform specific
+      selector:
+        object:

--- a/tests/components/notify/test_persistent_notification.py
+++ b/tests/components/notify/test_persistent_notification.py
@@ -25,3 +25,42 @@ async def test_async_send_message(hass: HomeAssistant) -> None:
 
     assert notification["message"] == "Hello"
     assert notification["title"] == "Test notification"
+
+
+async def test_async_supports_notification_id(hass: HomeAssistant):
+    """Test that notify.persistent_notification supports notification_id."""
+    await async_setup_component(hass, pn.DOMAIN, {"core": {}})
+    await async_setup_component(hass, notify.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    message = {
+        "message": "Hello",
+        "title": "Test notification",
+        "data": {"notification_id": "my_id"},
+    }
+    await hass.services.async_call(
+        notify.DOMAIN, notify.SERVICE_PERSISTENT_NOTIFICATION, message
+    )
+    await hass.async_block_till_done()
+
+    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
+    assert len(entity_ids) == 1
+
+    # Send second message with same ID
+
+    message = {
+        "message": "Goodbye",
+        "title": "Notification was updated",
+        "data": {"notification_id": "my_id"},
+    }
+    await hass.services.async_call(
+        notify.DOMAIN, notify.SERVICE_PERSISTENT_NOTIFICATION, message
+    )
+    await hass.async_block_till_done()
+
+    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
+    assert len(entity_ids) == 1
+
+    state = hass.states.get(entity_ids[0])
+    assert state.attributes.get("message") == "Goodbye"
+    assert state.attributes.get("title") == "Notification was updated"

--- a/tests/components/notify/test_persistent_notification.py
+++ b/tests/components/notify/test_persistent_notification.py
@@ -27,7 +27,7 @@ async def test_async_send_message(hass: HomeAssistant) -> None:
     assert notification["title"] == "Test notification"
 
 
-async def test_async_supports_notification_id(hass: HomeAssistant):
+async def test_async_supports_notification_id(hass: HomeAssistant) -> None:
     """Test that notify.persistent_notification supports notification_id."""
     await async_setup_component(hass, pn.DOMAIN, {"core": {}})
     await async_setup_component(hass, notify.DOMAIN, {})
@@ -43,8 +43,8 @@ async def test_async_supports_notification_id(hass: HomeAssistant):
     )
     await hass.async_block_till_done()
 
-    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
-    assert len(entity_ids) == 1
+    notifications = async_get_persistent_notifications(hass)
+    assert len(notifications) == 1
 
     # Send second message with same ID
 
@@ -58,9 +58,9 @@ async def test_async_supports_notification_id(hass: HomeAssistant):
     )
     await hass.async_block_till_done()
 
-    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
-    assert len(entity_ids) == 1
+    notifications = async_get_persistent_notifications(hass)
+    assert len(notifications) == 1
 
-    state = hass.states.get(entity_ids[0])
-    assert state.attributes.get("message") == "Goodbye"
-    assert state.attributes.get("title") == "Notification was updated"
+    notification = notifications[list(notifications)[0]]
+    assert notification["message"] == "Goodbye"
+    assert notification["title"] == "Notification was updated"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Adds support for notification_id as a data field. As discussed in issue https://github.com/home-assistant/core/issues/68811, this is relevant in some scenarios such as when using the Alert integration, which you would prefer to update the existing notification instead of potentially creating a large number of persistent_notification entities.

Code wise this is pretty straightforward. Rather than updating the voluptuous schema for this service, I've just used the existing notify schema to make this act the same as the real platform implementations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68811
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23336

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
