### PR TITLE
Make UniFi utilise forward_entry_setups

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -46,7 +46,7 @@ from .const import (
     DEFAULT_POE_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
 )
-from .controller import UniFiController, get_controller
+from .controller import UniFiController, get_unifi_controller
 from .errors import AuthenticationRequired, CannotConnect
 
 DEFAULT_PORT = 443
@@ -99,16 +99,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
             }
 
             try:
-                controller = await get_controller(
-                    self.hass,
-                    host=self.config[CONF_HOST],
-                    username=self.config[CONF_USERNAME],
-                    password=self.config[CONF_PASSWORD],
-                    port=self.config[CONF_PORT],
-                    site=self.config[CONF_SITE_ID],
-                    verify_ssl=self.config[CONF_VERIFY_SSL],
-                )
-
+                controller = await get_unifi_controller(self.hass, self.config)
                 sites = await controller.sites()
 
             except AuthenticationRequired:

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import socket
+from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse
 
@@ -99,7 +100,9 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
             }
 
             try:
-                controller = await get_unifi_controller(self.hass, self.config)
+                controller = await get_unifi_controller(
+                    self.hass, MappingProxyType(self.config)
+                )
                 sites = await controller.sites()
 
             except AuthenticationRequired:

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -30,7 +30,7 @@ from homeassistant.components.unifi.const import (
 from homeassistant.components.unifi.controller import (
     PLATFORMS,
     RETRY_TIMER,
-    get_controller,
+    get_unifi_controller,
 )
 from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect
 from homeassistant.const import (
@@ -271,7 +271,7 @@ async def test_controller_mac(hass, aioclient_mock):
 async def test_controller_not_accessible(hass):
     """Retry to login gets scheduled when connection fails."""
     with patch(
-        "homeassistant.components.unifi.controller.get_controller",
+        "homeassistant.components.unifi.controller.get_unifi_controller",
         side_effect=CannotConnect,
     ):
         await setup_unifi_integration(hass)
@@ -281,7 +281,7 @@ async def test_controller_not_accessible(hass):
 async def test_controller_trigger_reauth_flow(hass):
     """Failed authentication trigger a reauthentication flow."""
     with patch(
-        "homeassistant.components.unifi.controller.get_controller",
+        "homeassistant.components.unifi.controller.get_unifi_controller",
         side_effect=AuthenticationRequired,
     ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
         await setup_unifi_integration(hass)
@@ -292,7 +292,7 @@ async def test_controller_trigger_reauth_flow(hass):
 async def test_controller_unknown_error(hass):
     """Unknown errors are handled."""
     with patch(
-        "homeassistant.components.unifi.controller.get_controller",
+        "homeassistant.components.unifi.controller.get_unifi_controller",
         side_effect=Exception,
     ):
         await setup_unifi_integration(hass)
@@ -470,22 +470,22 @@ async def test_reconnect_mechanism_exceptions(
         mock_reconnect.assert_called_once()
 
 
-async def test_get_controller(hass):
+async def test_get_unifi_controller(hass):
     """Successful call."""
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
         "aiounifi.Controller.login", return_value=True
     ):
-        assert await get_controller(hass, **CONTROLLER_DATA)
+        assert await get_unifi_controller(hass, CONTROLLER_DATA)
 
 
-async def test_get_controller_verify_ssl_false(hass):
+async def test_get_unifi_controller_verify_ssl_false(hass):
     """Successful call with verify ssl set to false."""
     controller_data = dict(CONTROLLER_DATA)
     controller_data[CONF_VERIFY_SSL] = False
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
         "aiounifi.Controller.login", return_value=True
     ):
-        assert await get_controller(hass, **controller_data)
+        assert await get_unifi_controller(hass, controller_data)
 
 
 @pytest.mark.parametrize(
@@ -501,9 +501,11 @@ async def test_get_controller_verify_ssl_false(hass):
         (aiounifi.AiounifiException, AuthenticationRequired),
     ],
 )
-async def test_get_controller_fails_to_connect(hass, side_effect, raised_exception):
-    """Check that get_controller can handle controller being unavailable."""
+async def test_get_unifi_controller_fails_to_connect(
+    hass, side_effect, raised_exception
+):
+    """Check that get_unifi_controller can handle controller being unavailable."""
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
         "aiounifi.Controller.login", side_effect=side_effect
     ), pytest.raises(raised_exception):
-        await get_controller(hass, **CONTROLLER_DATA)
+        await get_unifi_controller(hass, CONTROLLER_DATA)

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -281,7 +281,7 @@ async def test_controller_not_accessible(hass):
 async def test_controller_trigger_reauth_flow(hass):
     """Failed authentication trigger a reauthentication flow."""
     with patch(
-        "homeassistant.components.unifi.controller.get_unifi_controller",
+        "homeassistant.components.unifi.get_unifi_controller",
         side_effect=AuthenticationRequired,
     ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
         await setup_unifi_integration(hass)

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -51,7 +51,7 @@ async def test_controller_mac(hass):
         mock_controller.return_value.api.url = "https://123:443"
         assert await unifi.async_setup_entry(hass, entry) is True
 
-    assert len(mock_controller.mock_calls) == 2
+    assert len(mock_controller.mock_calls) == 26
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -1,10 +1,10 @@
 """Test UniFi Network integration setup process."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from homeassistant.components import unifi
 from homeassistant.components.unifi import async_flatten_entry_data
 from homeassistant.components.unifi.const import CONF_CONTROLLER, DOMAIN as UNIFI_DOMAIN
-from homeassistant.helpers import device_registry as dr
+from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect
 from homeassistant.setup import async_setup_component
 
 from .test_controller import (
@@ -29,40 +29,27 @@ async def test_successful_config_entry(hass, aioclient_mock):
     assert hass.data[UNIFI_DOMAIN]
 
 
-async def test_controller_fail_setup(hass):
-    """Test that a failed setup still stores controller."""
-    with patch("homeassistant.components.unifi.UniFiController") as mock_controller:
-        mock_controller.return_value.async_setup = AsyncMock(return_value=False)
+async def test_setup_entry_fails_config_entry_not_ready(hass):
+    """Failed authentication trigger a reauthentication flow."""
+    with patch(
+        "homeassistant.components.unifi.get_unifi_controller",
+        side_effect=CannotConnect,
+    ):
         await setup_unifi_integration(hass)
 
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_controller_mac(hass):
-    """Test that configured options for a host are loaded via config entry."""
-    entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN, data=ENTRY_CONFIG, unique_id="1", entry_id=1
-    )
-    entry.add_to_hass(hass)
+async def test_setup_entry_fails_trigger_reauth_flow(hass):
+    """Failed authentication trigger a reauthentication flow."""
+    with patch(
+        "homeassistant.components.unifi.get_unifi_controller",
+        side_effect=AuthenticationRequired,
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
+        await setup_unifi_integration(hass)
+        mock_flow_init.assert_called_once()
 
-    with patch("homeassistant.components.unifi.UniFiController") as mock_controller:
-        mock_controller.return_value.async_setup = AsyncMock(return_value=True)
-        mock_controller.return_value.mac = "mac1"
-        mock_controller.return_value.api.url = "https://123:443"
-        assert await unifi.async_setup_entry(hass, entry) is True
-
-    assert len(mock_controller.mock_calls) == 26
-
-    device_registry = dr.async_get(hass)
-    device = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, "mac1")},
-    )
-    assert device.configuration_url == "https://123:443"
-    assert device.manufacturer == "Ubiquiti Networks"
-    assert device.model == "UniFi Network"
-    assert device.name == "UniFi Network"
-    assert device.sw_version is None
+    assert hass.data[UNIFI_DOMAIN] == {}
 
 
 async def test_flatten_entry_data(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Take inspiration from improvements in deCONZ integration
Move setup logic and exception handling to async_setup_entry
Make get_unifi_controller take the config_entry.data dictionary


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #73806
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
