### PR TITLE
Fix ZHA light brightness jumping around during transitions

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -129,6 +129,7 @@ CONF_DATABASE = "database_path"
 CONF_DEFAULT_LIGHT_TRANSITION = "default_light_transition"
 CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_ENHANCED_LIGHT_TRANSITION = "enhanced_light_transition"
+CONF_ENABLE_LIGHT_TRANSITIONING_FLAG = "light_transitioning_flag"
 CONF_ALWAYS_PREFER_XY_COLOR_MODE = "always_prefer_xy_color_mode"
 CONF_ENABLE_IDENTIFY_ON_JOIN = "enable_identify_on_join"
 CONF_ENABLE_QUIRKS = "enable_quirks"
@@ -146,6 +147,7 @@ CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
         vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=False): cv.boolean,
+        vol.Required(CONF_ENABLE_LIGHT_TRANSITIONING_FLAG, default=True): cv.boolean,
         vol.Required(CONF_ALWAYS_PREFER_XY_COLOR_MODE, default=True): cv.boolean,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
         vol.Optional(

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -1,7 +1,9 @@
 """Lights on Zigbee Home Automation networks."""
 from __future__ import annotations
 
+import asyncio
 from collections import Counter
+from collections.abc import Callable
 from datetime import timedelta
 import functools
 import itertools
@@ -26,14 +28,14 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 
 from .core import discovery, helpers
 from .core.const import (
@@ -61,6 +63,10 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_ON_OFF_TRANSITION = 1  # most bulbs default to a 1-second turn on/off transition
+DEFAULT_EXTRA_TRANSITION_DELAY_SHORT = 0.25
+DEFAULT_EXTRA_TRANSITION_DELAY_LONG = 2.0
+DEFAULT_LONG_TRANSITION_TIME = 10
 DEFAULT_MIN_BRIGHTNESS = 2
 
 UPDATE_COLORLOOP_ACTION = 0x1
@@ -75,6 +81,8 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.LIGHT)
 GROUP_MATCH = functools.partial(ZHA_ENTITIES.group_match, Platform.LIGHT)
 PARALLEL_UPDATES = 0
 SIGNAL_LIGHT_GROUP_STATE_CHANGED = "zha_light_group_state_changed"
+SIGNAL_LIGHT_GROUP_TRANSITION_START = "zha_light_group_transition_start"
+SIGNAL_LIGHT_GROUP_TRANSITION_FINISHED = "zha_light_group_transition_finished"
 DEFAULT_MIN_TRANSITION_MANUFACTURERS = {"Sengled"}
 
 COLOR_MODES_GROUP_LIGHT = {ColorMode.COLOR_TEMP, ColorMode.XY}
@@ -111,6 +119,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
     def __init__(self, *args, **kwargs):
         """Initialize the light."""
+        self._zha_device: ZHADevice = None
         super().__init__(*args, **kwargs)
         self._attr_min_mireds: int | None = 153
         self._attr_max_mireds: int | None = 500
@@ -126,6 +135,8 @@ class BaseLight(LogMixin, light.LightEntity):
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
+        self._transitioning: bool = False
+        self._transition_listener: Callable[[], None] | None = None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -151,6 +162,12 @@ class BaseLight(LogMixin, light.LightEntity):
         on at `on_level` Zigbee attribute value, regardless of the last set
         level
         """
+        if self._transitioning:
+            self.debug(
+                "received level %s while transitioning - skipping update",
+                value,
+            )
+            return
         value = max(0, min(254, value))
         self._attr_brightness = value
         self.async_write_ha_state()
@@ -169,6 +186,36 @@ class BaseLight(LogMixin, light.LightEntity):
         temperature = kwargs.get(light.ATTR_COLOR_TEMP)
         xy_color = kwargs.get(light.ATTR_XY_COLOR)
         hs_color = kwargs.get(light.ATTR_HS_COLOR)
+
+        set_transition_flag = (
+            brightness_supported(self._attr_supported_color_modes)
+            or temperature is not None
+            or xy_color is not None
+            or hs_color is not None
+        )
+        transition_time = (
+            (
+                duration / 10 + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+                if (
+                    (brightness is not None or transition is not None)
+                    and brightness_supported(self._attr_supported_color_modes)
+                    or (self._off_with_transition and self._off_brightness is not None)
+                    or temperature is not None
+                    or xy_color is not None
+                    or hs_color is not None
+                )
+                else DEFAULT_ON_OFF_TRANSITION + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+            )
+            if set_transition_flag
+            else 0
+        )
+
+        # If we need to pause attribute report parsing, we'll do so here.
+        # After successful calls, we later start a timer to unset the flag after transition_time.
+        # On an error on the first move to level call, we unset the flag immediately if no previous timer is running.
+        # On an error on subsequent calls, we start the transition timer, as a brightness call might have come through.
+        if set_transition_flag:
+            self.async_transition_set_flag()
 
         # If the light is currently off but a turn_on call with a color/temperature is sent,
         # the light needs to be turned on first at a low brightness level where the light is immediately transitioned
@@ -230,6 +277,10 @@ class BaseLight(LogMixin, light.LightEntity):
             )
             t_log["move_to_level_with_on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+                # First 'move to level' call failed, so if the transitioning delay isn't running from a previous call,
+                # the flag can be unset immediately
+                if set_transition_flag and not self._transition_listener:
+                    self.async_transition_complete()
                 self.debug("turned on: %s", t_log)
                 return
             # Currently only setting it to "on", as the correct level state will be set at the second move_to_level call
@@ -245,6 +296,10 @@ class BaseLight(LogMixin, light.LightEntity):
             )
             t_log["move_to_level_with_on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+                # First 'move to level' call failed, so if the transitioning delay isn't running from a previous call,
+                # the flag can be unset immediately
+                if set_transition_flag and not self._transition_listener:
+                    self.async_transition_complete()
                 self.debug("turned on: %s", t_log)
                 return
             self._attr_state = bool(level)
@@ -261,6 +316,9 @@ class BaseLight(LogMixin, light.LightEntity):
             result = await self._on_off_channel.on()
             t_log["on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+                # 'On' call failed, but as brightness may still transition (for FORCE_ON lights),
+                # we start the timer to unset the flag after the transition_time if necessary.
+                self.async_transition_start_timer(transition_time)
                 self.debug("turned on: %s", t_log)
                 return
             self._attr_state = True
@@ -273,6 +331,8 @@ class BaseLight(LogMixin, light.LightEntity):
             new_color_provided_while_off,
             t_log,
         ):
+            # Color calls failed, but as brightness may still transition, we start the timer to unset the flag
+            self.async_transition_start_timer(transition_time)
             self.debug("turned on: %s", t_log)
             return
 
@@ -286,6 +346,10 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_state = bool(level)
             if level:
                 self._attr_brightness = level
+
+        # Our light is guaranteed to have just started the transitioning process if necessary,
+        # so we start the delay for the transition (to stop parsing attribute reports after the completed transition).
+        self.async_transition_start_timer(transition_time)
 
         if effect == light.EFFECT_COLORLOOP:
             result = await self._color_channel.color_loop_set(
@@ -329,6 +393,14 @@ class BaseLight(LogMixin, light.LightEntity):
         transition = kwargs.get(light.ATTR_TRANSITION)
         supports_level = brightness_supported(self._attr_supported_color_modes)
 
+        transition_time = (
+            transition or self._DEFAULT_MIN_TRANSITION_TIME
+            if transition is not None
+            else DEFAULT_ON_OFF_TRANSITION
+        ) + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+        # Start pausing attribute report parsing
+        self.async_transition_set_flag()
+
         # is not none looks odd here but it will override built in bulb transition times if we pass 0 in here
         if transition is not None and supports_level:
             result = await self._level_channel.move_to_level_with_on_off(
@@ -336,6 +408,9 @@ class BaseLight(LogMixin, light.LightEntity):
             )
         else:
             result = await self._on_off_channel.off()
+
+        # Pause parsing attribute reports until transition is complete
+        self.async_transition_start_timer(transition_time)
         self.debug("turned off: %s", result)
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
             return
@@ -420,6 +495,54 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_hs_color = None
 
         return True
+
+    @callback
+    def async_transition_set_flag(self) -> None:
+        """Set _transitioning to True."""
+        self.debug("setting transitioning flag to True")
+        self._transitioning = True
+        if isinstance(self, LightGroup):
+            async_dispatcher_send(
+                self.hass,
+                SIGNAL_LIGHT_GROUP_TRANSITION_START,
+                {"entity_ids": self._entity_ids},
+            )
+        if self._transition_listener is not None:
+            self._transition_listener()
+
+    @callback
+    def async_transition_start_timer(self, transition_time) -> None:
+        """Start a timer to unset _transitioning after transition_time if necessary."""
+        if not transition_time:
+            return
+        # For longer transitions, we want to extend the timer a bit more
+        if transition_time >= DEFAULT_LONG_TRANSITION_TIME:
+            transition_time += DEFAULT_EXTRA_TRANSITION_DELAY_LONG
+        self.debug("starting transitioning timer for %s", transition_time)
+        self._transition_listener = async_call_later(
+            self._zha_device.hass,
+            transition_time,
+            self.async_transition_complete,
+        )
+
+    @callback
+    def async_transition_complete(self, _=None) -> None:
+        """Set _transitioning to False and write HA state."""
+        self.debug("transition complete - future attribute reports will write HA state")
+        self._transitioning = False
+        if self._transition_listener:
+            self._transition_listener()
+            self._transition_listener = None
+        self.async_write_ha_state()
+        if isinstance(self, LightGroup):
+            async_dispatcher_send(
+                self.hass,
+                SIGNAL_LIGHT_GROUP_TRANSITION_FINISHED,
+                {"entity_ids": self._entity_ids},
+            )
+            if self._debounced_member_refresh is not None:
+                self.debug("transition complete - refreshing group member states")
+                asyncio.create_task(self._debounced_member_refresh.async_call())
 
 
 @STRICT_MATCH(channel_names=CHANNEL_ON_OFF, aux_channels={CHANNEL_COLOR, CHANNEL_LEVEL})
@@ -530,6 +653,12 @@ class Light(BaseLight, ZhaEntity):
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
+        if self._transitioning:
+            self.debug(
+                "received onoff %s while transitioning - skipping update",
+                value,
+            )
+            return
         self._attr_state = bool(value)
         if value:
             self._off_with_transition = False
@@ -554,6 +683,38 @@ class Light(BaseLight, ZhaEntity):
             None,
             SIGNAL_LIGHT_GROUP_STATE_CHANGED,
             self._maybe_force_refresh,
+            signal_override=True,
+        )
+
+        @callback
+        def transition_on(signal):
+            """Handle a transition start event from a group."""
+            if self.entity_id in signal["entity_ids"]:
+                self.debug(
+                    "group transition started - setting member transitioning flag"
+                )
+                self._transitioning = True
+
+        self.async_accept_signal(
+            None,
+            SIGNAL_LIGHT_GROUP_TRANSITION_START,
+            transition_on,
+            signal_override=True,
+        )
+
+        @callback
+        def transition_off(signal):
+            """Handle a transition finished event from a group."""
+            if self.entity_id in signal["entity_ids"]:
+                self.debug(
+                    "group transition completed - unsetting member transitioning flag"
+                )
+                self._transitioning = False
+
+        self.async_accept_signal(
+            None,
+            SIGNAL_LIGHT_GROUP_TRANSITION_FINISHED,
+            transition_off,
             signal_override=True,
         )
 
@@ -674,16 +835,25 @@ class Light(BaseLight, ZhaEntity):
 
     async def async_update(self):
         """Update to the latest state."""
+        if self._transitioning:
+            self.debug("skipping async_update while transitioning")
+            return
         await self.async_get_state()
 
     async def _refresh(self, time):
         """Call async_get_state at an interval."""
+        if self._transitioning:
+            self.debug("skipping _refresh while transitioning")
+            return
         await self.async_get_state()
         self.async_write_ha_state()
 
     async def _maybe_force_refresh(self, signal):
         """Force update the state if the signal contains the entity id for this entity."""
         if self.entity_id in signal["entity_ids"]:
+            if self._transitioning:
+                self.debug("skipping _maybe_force_refresh while transitioning")
+                return
             await self.async_get_state()
             self.async_write_ha_state()
 
@@ -777,12 +947,31 @@ class LightGroup(BaseLight, ZhaGroupEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
         await super().async_turn_on(**kwargs)
+        if self._transitioning:
+            return
         await self._debounced_member_refresh.async_call()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
         await super().async_turn_off(**kwargs)
+        if self._transitioning:
+            return
         await self._debounced_member_refresh.async_call()
+
+    @callback
+    def async_state_changed_listener(self, event: Event):
+        """Handle child updates."""
+        if self._transitioning:
+            self.debug("skipping group entity state update during transition")
+            return
+        super().async_state_changed_listener(event)
+
+    async def async_update_ha_state(self, force_refresh: bool = False) -> None:
+        """Update Home Assistant with current state of entity."""
+        if self._transitioning:
+            self.debug("skipping group entity state update during transition")
+            return
+        await super().async_update_ha_state(force_refresh)
 
     async def async_update(self) -> None:
         """Query all members and determine the light group state."""

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -38,6 +38,7 @@
     "zha_options": {
       "title": "Global Options",
       "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
+      "light_transitioning_flag": "Enable enhanced brightness slider during light transition",
       "always_prefer_xy_color_mode": "Always prefer XY color mode",
       "enable_identify_on_join": "Enable identify effect when devices join the network",
       "default_light_transition": "Default light transition time (seconds)",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -46,12 +46,13 @@
             "title": "Alarm Control Panel Options"
         },
         "zha_options": {
+            "always_prefer_xy_color_mode": "Always prefer XY color mode",
             "consider_unavailable_battery": "Consider battery powered devices unavailable after (seconds)",
             "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",
             "default_light_transition": "Default light transition time (seconds)",
             "enable_identify_on_join": "Enable identify effect when devices join the network",
             "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
-            "always_prefer_xy_color_mode": "Always prefer XY color mode",
+            "light_transitioning_flag": "Enable enhanced brightness slider during light transition",
             "title": "Global Options"
         }
     },

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -1,5 +1,6 @@
 """Common test objects."""
 import asyncio
+from datetime import timedelta
 import math
 from unittest.mock import AsyncMock, Mock
 
@@ -8,6 +9,9 @@ import zigpy.zcl.foundation as zcl_f
 
 import homeassistant.components.zha.core.const as zha_const
 from homeassistant.helpers import entity_registry
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
 
 
 def patch_cluster(cluster):
@@ -231,4 +235,11 @@ async def async_wait_for_updates(hass):
     await hass.async_block_till_done()
     await asyncio.sleep(0)
     await asyncio.sleep(0)
+    await hass.async_block_till_done()
+
+
+async def async_shift_time(hass):
+    """Shift time to cause call later tasks to run."""
+    next_update = dt_util.utcnow() + timedelta(seconds=11)
+    async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -22,6 +22,7 @@ import homeassistant.util.dt as dt_util
 from .common import (
     async_enable_traffic,
     async_find_group_entity_id,
+    async_shift_time,
     async_test_rejoin,
     find_entity_id,
     get_zha_gateway,
@@ -346,6 +347,7 @@ async def test_light(
         await async_test_level_on_off_from_hass(
             hass, cluster_on_off, cluster_level, entity_id
         )
+        await async_shift_time(hass)
 
         # test getting a brightness change from the network
         await async_test_on_from_light(hass, cluster_on_off, entity_id)
@@ -1190,6 +1192,8 @@ async def async_test_level_on_off_from_hass(
 
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
+    await async_shift_time(hass)
+
     # turn on via UI
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
@@ -1209,6 +1213,8 @@ async def async_test_level_on_off_from_hass(
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
+
+    await async_shift_time(hass)
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -1407,10 +1413,14 @@ async def test_zha_group_light_entity(
     # test turning the lights on and off from the HA
     await async_test_on_off_from_hass(hass, group_cluster_on_off, group_entity_id)
 
+    await async_shift_time(hass)
+
     # test short flashing the lights from the HA
     await async_test_flash_from_hass(
         hass, group_cluster_identify, group_entity_id, FLASH_SHORT
     )
+
+    await async_shift_time(hass)
 
     # test turning the lights on and off from the light
     await async_test_on_off_from_light(hass, dev1_cluster_on_off, group_entity_id)
@@ -1423,6 +1433,8 @@ async def test_zha_group_light_entity(
         group_entity_id,
         expected_default_transition=1,  # a Sengled light is in that group and needs a minimum 0.1s transition
     )
+
+    await async_shift_time(hass)
 
     # test getting a brightness change from the network
     await async_test_on_from_light(hass, dev1_cluster_on_off, group_entity_id)
@@ -1442,6 +1454,8 @@ async def test_zha_group_light_entity(
     await async_test_flash_from_hass(
         hass, group_cluster_identify, group_entity_id, FLASH_LONG
     )
+
+    await async_shift_time(hass)
 
     assert len(zha_group.members) == 2
     # test some of the group logic to make sure we key off states correctly


### PR DESCRIPTION
## Proposed change
This PR will fix brightness sliders of ZHA lights jumping around when attribute reports are received during the transition phase of a light.

Here are two short videos (one with the changes and the other one without):


Without the changes:

https://user-images.githubusercontent.com/6409465/181120620-44764d05-d6b3-4314-8c96-ef22378a1858.mp4

With the changes:

https://user-images.githubusercontent.com/6409465/181120628-23b23d04-c1b4-4342-b8b5-102082798faa.mp4

The issue can easily be reproduced when using an attribute reporting light. In the example, I've used a newer Zigbee 3.0 Philips Hue light. I've also set the default ZHA transition time to 1 second (instead of the default 0 seconds) in the ZHA config panel. The issue also occurs when using the default 0 seconds transition time, although it mostly seems to cause the slider to only jump back once when changing the brightness (turn on/off is still as bad, as the lights have a default 1 second on/off transition).

Please feel free to ask questions or leave any comments/feedback regarding this change.

## Type of change
(Most) Zigbee lights send attribute reports (current state including brightness) whenever their state changes. Annoyingly, this also happens multiple times during transitions.
Most HA integrations show their target brightness during transition (ESPHome, Zigbee2MQTT, (mostly) the Philips Hue integration, ...).
ZHA currently doesn't do this. This means that when a light is at 1% brightness and the user then moves the slider to 100% brightness, the brightness slider will briefly be at 100%, then jump back to something like 12%, then to 60%, ..., 95%, and then finally to 100%. On mobile phones/tablets, this is especially annoying. It's also jarring when using a PC though.

With these changes, ZHA will now mostly ignore attribute reports that are sent during the transition phase of a light (and another half a second after that). Instead, the light brightness slider will stay at the target value during the whole transition time.
Since most Zigbee lights (Hue, IKEA, Gledopto Pro, ...) have a turn on and turn off transition of about 1 second which will happen if ``on``/``off`` on the ``OnOff`` cluster is called, we will always wait at least 1 second (+ half a second). (I've seen lights that have a turn on/off transition shorter than 1 second but never longer than 1 second).
If, in the service call, a longer transition is given, so the ``on``/``off`` calls aren't used, but the ``move_to_level_with_on_off`` is used instead, we will wait the specified duration (+ half a second).
Completely ignoring the attribute reports during the transition phase also fixes an issue where the brightness slider would jump around when the light state is changed again (color or else).
Furthermore, this PR will also stop polling of lights during transition phases.

~~Because there doesn't seem to be a clear way on how brightness during light transitions should be handled in HA and feedback in https://github.com/home-assistant/core/pull/48777/files#r609991422, attribute reports for transition times equal or longer than ``MAX_IGNORE_TRANSITION_TIME`` (currently 10 seconds) will still be fully parsed and written to state. Those long transition times can basically only be produced by service calls and some people find it nice to see the brightness slider moving over longer durations.~~
This isn't included at the PR at the moment, should it be included again?

This PR should also make it possible to implement parsing of attribute reports for color/temperature in the future without disrupting the user experience.

ZHA groups also set their member transitioning flag to true (called "linking" in some other places of this PR/comments). This fixes many issues (especially with lights that don’t send attribute reports or when using transitions for ZHA groups). See my latest comments regarding this. I’ll update this description later.

Lastly, this PR also adds a config option to disable the new behavior. (Or should the new behavior be opt-in?)
​
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The initial implementation was done by @dmulcahey here: https://github.com/dmulcahey/home-assistant/commits/dm/zha-light-transition-fix (Thanks!)
The old PR https://github.com/home-assistant/core/pull/48777/ also tried to fix the same issue.

I think there are also some GitHub comments and forum posts about this issue, although I can't seem to find them at the moment.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
