### PR TITLE
Convert eq3btsmart to use config flow

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -1,1 +1,40 @@
 """The eq3btsmart component."""
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+PLATFORMS = [Platform.CLIMATE]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up eq3 environment."""
+    if (conf := config.get("climate")) is None:
+        return True
+    # TODO: note hard coded pieces, how to properly initialize from the old platform-based config?
+    # This just misuses the config data to pass the name along for the config flow.
+    for config_entry in conf:
+        for name, data in config_entry["devices"].items():
+            data["name"] = name
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data=data,
+                ),
+            )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up songpal media player."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload songpal media player."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -137,7 +137,7 @@ class EQ3BTSmartThermostat(ClimateEntity):
         # TODO: should the default name contain some hint what the value is about?
         # For example, eQ-3 Thermostat (serial) ?
         self._name = device.device_serial
-        self._mac = device._conn._mac
+        self._mac = device.mac
         self._thermostat = device
 
     @property

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 
 import async_timeout
-from bluepy.btle import BTLEException  # pylint: disable=import-error
 import eq3bt as eq3  # pylint: disable=import-error
 import voluptuous as vol
 
@@ -119,7 +118,7 @@ async def async_setup_entry(
             # and the firmware version prior creating the entity
             await hass.async_add_executor_job(device.query_id)
     except (Exception, asyncio.TimeoutError) as ex:
-        _LOGGER.warning("[%s] Unable to connect", mac)
+        _LOGGER.warning("[%s] Unable to connect: %s", mac, ex)
         raise PlatformNotReady from ex
 
     entity = EQ3BTSmartThermostat(device)
@@ -258,5 +257,5 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
         try:
             self._thermostat.update()
-        except BTLEException as ex:
+        except eq3.BackendException as ex:
             _LOGGER.warning("Updating the state failed: %s", ex)

--- a/homeassistant/components/eq3btsmart/config_flow.py
+++ b/homeassistant/components/eq3btsmart/config_flow.py
@@ -45,7 +45,7 @@ class EQ3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             thermostat = eq3.Thermostat(mac)
             # TODO is this the correct way to execute synchronous calls in a config flow?
             await self.hass.async_add_executor_job(thermostat.update)
-        except Exception as ex:
+        except eq3.BackendException as ex:
             _LOGGER.debug("Connection failed: %s", ex)
             return self.async_show_form(
                 step_id="user",

--- a/homeassistant/components/eq3btsmart/config_flow.py
+++ b/homeassistant/components/eq3btsmart/config_flow.py
@@ -1,0 +1,117 @@
+"""Config flow to configure eq3 component."""
+from __future__ import annotations
+
+import logging
+
+import eq3bt as eq3  # pylint: disable=import-error
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_MAC
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EQ3Config:
+    """Device Configuration."""
+
+    def __init__(self, mac):
+        """Initialize Configuration."""
+        self.mac = mac
+
+
+class EQ3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """EQ3 configuration flow."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize the flow."""
+        self.conf: EQ3Config | None = None
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema({vol.Required(CONF_MAC): str}),
+            )
+
+        mac = user_input[CONF_MAC]
+        try:
+            thermostat = eq3.Thermostat(mac)
+            # TODO is this the correct way to execute synchronous calls in a config flow?
+            await self.hass.async_add_executor_job(thermostat.update)
+        except Exception as ex:
+            _LOGGER.debug("Connection failed: %s", ex)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_MAC, default=user_input.get(CONF_MAC, "")
+                        ): str,
+                    }
+                ),
+                errors={"base": "cannot_connect"},
+            )
+
+        self.conf = EQ3Config(mac)
+
+        return await self.async_step_init(user_input)
+
+    async def async_step_bluetooth(self, info):
+        """Handle bluetooth discovery."""
+
+        # TODO: would it be better to use the service_uuids instead of the name for matching?
+        # BluetoothServiceInfo(name='CC-RT-BLE', address='00:1A:22:xx:xx:xx', rssi=-64,
+        # manufacturer_data={0: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00'}, service_data={},
+        # service_uuids=['3e135142-654f-9090-134a-a6ff5bb77046'])
+
+        _LOGGER.debug("Discovered eQ3 thermostat using bluetooth: %s", info)
+        self.conf = EQ3Config(info.address)
+
+        return await self.async_step_init()
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        self._async_abort_entries_match({CONF_MAC: self.conf.mac})
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="init",
+                description_placeholders={
+                    CONF_MAC: self.conf.mac,
+                },
+            )
+
+        await self.async_set_unique_id(format_mac(self.conf.mac))
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=self.conf.mac,
+            data={CONF_MAC: self.conf.mac},
+        )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        # TODO: what's the proper way to convert from platform-based?
+        # Currently, EQ3Config contains only information about a single device
+        # but the platform configuration has a list of all configured devices.
+        _LOGGER.info("Got config: %s", user_input)
+
+        mac = user_input[CONF_MAC]
+        # TODO: is it worth trying to keep backwards compatibility with names?
+        # name = user_input[CONF_NAME]
+        thermostat = eq3.Thermostat(mac)
+
+        # TODO: is this the correct way to execute synchronous calls in a config flow?
+        # TODO: should we simply import the configuration always and let the retry process handle PlatforNotReady?
+        await self.hass.async_add_executor_job(thermostat.update)
+
+        self.conf = EQ3Config(mac)
+
+        return await self.async_step_init(user_input)

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -1,5 +1,6 @@
 """Constants for EQ3 Bluetooth Smart Radiator Valves."""
 
+DOMAIN = "eq3btsmart"
 PRESET_PERMANENT_HOLD = "permanent_hold"
 PRESET_NO_HOLD = "no_hold"
 PRESET_OPEN = "open"

--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -5,5 +5,7 @@
   "requirements": ["construct==2.10.56", "python-eq3bt==0.1.11"],
   "codeowners": ["@rytilahti"],
   "iot_class": "local_polling",
-  "loggers": ["bluepy", "eq3bt"]
+  "loggers": ["bluepy", "eq3bt"],
+  "config_flow": true,
+  "bluetooth": [{ "local_name": "CC-RT-BLE" }]
 }

--- a/homeassistant/components/eq3btsmart/translations/en.json
+++ b/homeassistant/components/eq3btsmart/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect"
+        },
+        "flow_title": "EQ3 thermostat ({mac})",
+        "step": {
+            "init": {
+                "description": "Do you want to set up eQ-3 Thermostat ({mac})?"
+            },
+            "user": {
+                "data": {
+                    "mac": "MAC address"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 BLUETOOTH: list[dict[str, str | int]] = [
     {
+        "domain": "eq3btsmart",
+        "local_name": "CC-RT-BLE"
+    },
+    {
         "domain": "switchbot",
         "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -98,6 +98,7 @@ FLOWS = {
         "enphase_envoy",
         "environment_canada",
         "epson",
+        "eq3btsmart",
         "esphome",
         "evil_genius_labs",
         "ezviz",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This change deprecates the old platform-style YAML configuration in favor of using UI to configure the integration.
The old configuration is imported and an error is displayed notifying users to remove the now-deprecated configuration items from the YAML file.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Inspired by #74653, this converts eq3btsmart to use config flows for configuration, and also adds autodetection based on bluetooth name identifier to launch the flow on discovered devices.

This is a draft and there are several TODOs in the code that need to be figured out before merging this.
This PR requires installing python-eq3bt from git master.

TBD:
- [ ] Fix the TODOs listed in the code
- [x] Improve the backend library to avoid using internals
- [x] Improve the backend library to avoid raising bluepy specific exceptions (tangentially related to https://github.com/rytilahti/python-eq3bt/issues/50)
- [ ] Add tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
