### PR TITLE
Add diagnostics to bmw_connected_drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/diagnostics.py
+++ b/homeassistant/components/bmw_connected_drive/diagnostics.py
@@ -1,0 +1,116 @@
+"""Diagnostics support for the BMW Connected Drive integration."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any
+
+from bimmer_connected.utils import MyBMWJSONEncoder
+
+from homeassistant.components.diagnostics.util import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import CONF_REFRESH_TOKEN, DOMAIN
+
+if TYPE_CHECKING:
+    from bimmer_connected.vehicle import MyBMWVehicle
+
+    from .coordinator import BMWDataUpdateCoordinator
+
+TO_REDACT_INFO = [CONF_USERNAME, CONF_PASSWORD, CONF_REFRESH_TOKEN]
+TO_REDACT_DATA = [
+    "lat",
+    "latitude",
+    "lon",
+    "longitude",
+    "heading",
+    "vin",
+    "licensePlate",
+    "name",
+    "city",
+    "street",
+    "streetNumber",
+    "postalCode",
+    "phone",
+    "formatted",
+    "subtitle",
+]
+
+
+async def async_get_fingerprints(
+    coordinator: "BMWDataUpdateCoordinator",
+) -> dict[str, Any]:
+    """Return pre-redacted fingerprints (i.e. the raw API responses)."""
+
+    fingerprints = {}
+
+    try:
+        # Use the library's fingerprint function to store all relevant
+        # HTTP requests into a temporary directory and load from there
+        with TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            coordinator.account.config.log_response_path = tempdir_path
+            await coordinator.account.get_vehicles()
+            for logfile in tempdir_path.iterdir():
+                with open(logfile, "rb") as fp:
+                    fingerprints[logfile.name] = json.load(fp)
+    finally:
+        # Make sure that log_response_path is always set to None afterwards
+        coordinator.account.config.log_response_path = None
+
+    return fingerprints
+
+
+def vehicle_to_dict(vehicle: MyBMWVehicle) -> dict:
+    """Convert a MyBMWVehicle to a dictionary using MyBMWJSONEncoder."""
+    retval: dict = json.loads(json.dumps(vehicle, cls=MyBMWJSONEncoder))
+    return retval
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: BMWDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    diagnostics_data = {
+        "info": async_redact_data(config_entry.data, TO_REDACT_INFO),
+        "data": [
+            async_redact_data(vehicle_to_dict(vehicle), TO_REDACT_DATA)
+            for vehicle in coordinator.account.vehicles
+        ],
+        "fingerprint": async_redact_data(
+            await async_get_fingerprints(coordinator), TO_REDACT_DATA
+        ),
+    }
+
+    return diagnostics_data
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a device."""
+    coordinator: BMWDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    vin = next(iter(device.identifiers))[1]
+    vehicle = coordinator.account.get_vehicle(vin)
+
+    if not vehicle:
+        raise HomeAssistantError("Vehicle not found")
+
+    diagnostics_data = {
+        "info": async_redact_data(config_entry.data, TO_REDACT_INFO),
+        "data": async_redact_data(vehicle_to_dict(vehicle), TO_REDACT_DATA),
+        # Always have to get the full fingerprint as the VIN is redacted beforehand by the library
+        "fingerprint": async_redact_data(
+            await async_get_fingerprints(coordinator), TO_REDACT_DATA
+        ),
+    }
+
+    return diagnostics_data

--- a/homeassistant/components/bmw_connected_drive/diagnostics.py
+++ b/homeassistant/components/bmw_connected_drive/diagnostics.py
@@ -11,7 +11,6 @@ from homeassistant.components.diagnostics.util import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import CONF_REFRESH_TOKEN, DOMAIN
@@ -40,7 +39,7 @@ TO_REDACT_DATA = [
 ]
 
 
-def vehicle_to_dict(vehicle: MyBMWVehicle) -> dict:
+def vehicle_to_dict(vehicle: MyBMWVehicle | None) -> dict:
     """Convert a MyBMWVehicle to a dictionary using MyBMWJSONEncoder."""
     retval: dict = json.loads(json.dumps(vehicle, cls=MyBMWJSONEncoder))
     return retval
@@ -83,9 +82,6 @@ async def async_get_device_diagnostics(
 
     vin = next(iter(device.identifiers))[1]
     vehicle = coordinator.account.get_vehicle(vin)
-
-    if not vehicle:
-        raise HomeAssistantError("Vehicle not found")
 
     diagnostics_data = {
         "info": async_redact_data(config_entry.data, TO_REDACT_INFO),

--- a/homeassistant/components/bmw_connected_drive/diagnostics.py
+++ b/homeassistant/components/bmw_connected_drive/diagnostics.py
@@ -59,7 +59,7 @@ async def async_get_config_entry_diagnostics(
             for vehicle in coordinator.account.vehicles
         ],
         "fingerprint": async_redact_data(
-            await coordinator.account.get_fingerprints(), TO_REDACT_DATA
+            coordinator.account.get_stored_responses(), TO_REDACT_DATA
         ),
     }
 
@@ -83,7 +83,7 @@ async def async_get_device_diagnostics(
         "data": async_redact_data(vehicle_to_dict(vehicle), TO_REDACT_DATA),
         # Always have to get the full fingerprint as the VIN is redacted beforehand by the library
         "fingerprint": async_redact_data(
-            await coordinator.account.get_fingerprints(), TO_REDACT_DATA
+            coordinator.account.get_stored_responses(), TO_REDACT_DATA
         ),
     }
 

--- a/homeassistant/components/bmw_connected_drive/diagnostics.py
+++ b/homeassistant/components/bmw_connected_drive/diagnostics.py
@@ -30,7 +30,6 @@ TO_REDACT_DATA = [
     "heading",
     "vin",
     "licensePlate",
-    "name",
     "city",
     "street",
     "streetNumber",

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -40,7 +40,9 @@ FIXTURE_CONFIG_ENTRY = {
 }
 
 
-async def mock_vehicles_from_fixture(account: MyBMWAccount) -> None:
+async def mock_vehicles_from_fixture(
+    account: MyBMWAccount, force_init: bool = False
+) -> None:
     """Load MyBMWVehicle from fixtures and add them to the account."""
 
     fixture_path = Path(get_fixture_path("", integration=BMW_DOMAIN))

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -3,7 +3,9 @@
 import json
 from pathlib import Path
 
-from bimmer_connected.account import MyBMWAccount
+from bimmer_connected.api.authentication import MyBMWAuthentication
+import httpx
+import respx
 
 from homeassistant import config_entries
 from homeassistant.components.bmw_connected_drive.const import (
@@ -13,7 +15,6 @@ from homeassistant.components.bmw_connected_drive.const import (
 )
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, get_fixture_path, load_fixture
 
@@ -39,51 +40,48 @@ FIXTURE_CONFIG_ENTRY = {
     "unique_id": f"{FIXTURE_USER_INPUT[CONF_REGION]}-{FIXTURE_USER_INPUT[CONF_REGION]}",
 }
 
+FIXTURE_PATH = Path(get_fixture_path("", integration=BMW_DOMAIN))
 
-async def mock_vehicles_from_fixture(
-    account: MyBMWAccount, force_init: bool = False
-) -> None:
-    """Load MyBMWVehicle from fixtures and add them to the account."""
 
-    fixture_path = Path(get_fixture_path("", integration=BMW_DOMAIN))
+def vehicles_sideeffect(request: httpx.Request) -> httpx.Response:
+    """Return /vehicles response based on x-user-agent."""
+    x_user_agent = request.headers.get("x-user-agent", "").split(";")
+    brand = x_user_agent[1]
+    vehicles = []
+    for vehicle_file in FIXTURE_PATH.rglob(f"vehicles_v2_{brand}_*.json"):
+        vehicles.extend(json.loads(load_fixture(vehicle_file, integration=BMW_DOMAIN)))
+    return httpx.Response(200, json=vehicles)
 
-    fixture_vehicles_bmw = list(fixture_path.rglob("vehicles_v2_bmw_*.json"))
-    fixture_vehicles_mini = list(fixture_path.rglob("vehicles_v2_mini_*.json"))
 
-    # Load vehicle base lists as provided by vehicles/v2 API
-    vehicles = {
-        "bmw": [
-            vehicle
-            for bmw_file in fixture_vehicles_bmw
-            for vehicle in json.loads(load_fixture(bmw_file, integration=BMW_DOMAIN))
-        ],
-        "mini": [
-            vehicle
-            for mini_file in fixture_vehicles_mini
-            for vehicle in json.loads(load_fixture(mini_file, integration=BMW_DOMAIN))
-        ],
-    }
-    fetched_at = utcnow()
-
-    # Create a vehicle with base + specific state as provided by state/VIN API
-    for vehicle_base in [vehicle for brand in vehicles.values() for vehicle in brand]:
-        vehicle_state_path = (
-            Path("vehicles")
-            / vehicle_base["attributes"]["bodyType"]
-            / f"state_{vehicle_base['vin']}_0.json"
+def vehicle_state_sideeffect(request: httpx.Request, vin: str) -> httpx.Response:
+    """Return /vehicles/VIN/state response."""
+    state_file = next(FIXTURE_PATH.rglob(f"state_{vin}_*.json"))
+    try:
+        return httpx.Response(
+            200, json=json.loads(load_fixture(state_file, integration=BMW_DOMAIN))
         )
-        vehicle_state = json.loads(
-            load_fixture(
-                vehicle_state_path,
-                integration=BMW_DOMAIN,
-            )
-        )
+    except KeyError:
+        return httpx.Response(404)
 
-        account.add_vehicle(
-            vehicle_base,
-            vehicle_state,
-            fetched_at,
-        )
+
+def mock_vehicles() -> respx.Router:
+    """Return mocked adapter for vehicles."""
+    router = respx.mock(assert_all_called=False)
+
+    # Get vehicle list
+    router.get("/eadrax-vcs/v2/vehicles").mock(side_effect=vehicles_sideeffect)
+
+    # Get vehicle state
+    router.get(path__regex=r"^/eadrax-vcs/v2/vehicles/(?P<vin>\w+)/state").mock(
+        side_effect=vehicle_state_sideeffect
+    )
+
+    return router
+
+
+async def mock_login(auth: MyBMWAuthentication) -> None:
+    """Mock a successful login."""
+    auth.access_token = "SOME_ACCESS_TOKEN"
 
 
 async def setup_mocked_integration(hass: HomeAssistant) -> MockConfigEntry:

--- a/tests/components/bmw_connected_drive/conftest.py
+++ b/tests/components/bmw_connected_drive/conftest.py
@@ -1,12 +1,15 @@
 """Fixtures for BMW tests."""
 
-from bimmer_connected.account import MyBMWAccount
+from bimmer_connected.api.authentication import MyBMWAuthentication
 import pytest
 
-from . import mock_vehicles_from_fixture
+from . import mock_login, mock_vehicles
 
 
 @pytest.fixture
 async def bmw_fixture(monkeypatch):
-    """Patch the vehicle fixtures into a MyBMWAccount."""
-    monkeypatch.setattr(MyBMWAccount, "get_vehicles", mock_vehicles_from_fixture)
+    """Patch the MyBMW Login and mock HTTP calls."""
+    monkeypatch.setattr(MyBMWAuthentication, "login", mock_login)
+
+    with mock_vehicles():
+        yield mock_vehicles

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
@@ -51,6 +51,8 @@
           "mappingStatus": "CONFIRMED"
         },
         "vin": "**REDACTED**",
+        "is_metric": true,
+        "fetched_at": "2022-07-10T11:00:00+00:00",
         "capabilities": {
           "climateFunction": "AIR_CONDITIONING",
           "climateNow": true,
@@ -254,9 +256,7 @@
             "leftFront": "CLOSED",
             "rightFront": "CLOSED"
           }
-        },
-        "is_metric": true,
-        "fetched_at": "2022-07-10T11:00:00+00:00"
+        }
       },
       "fuel_and_battery": {
         "remaining_range_fuel": [105, "km"],
@@ -289,49 +289,49 @@
         "door_lock_state": "UNLOCKED",
         "lids": [
           {
-            "name": "**REDACTED**",
+            "name": "hood",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "leftFront",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "leftRear",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "rightFront",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "rightRear",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "trunk",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "sunRoof",
             "state": "CLOSED",
             "is_closed": true
           }
         ],
         "windows": [
           {
-            "name": "**REDACTED**",
+            "name": "leftFront",
             "state": "CLOSED",
             "is_closed": true
           },
           {
-            "name": "**REDACTED**",
+            "name": "rightFront",
             "state": "CLOSED",
             "is_closed": true
           }
@@ -516,10 +516,274 @@
       "is_vehicle_tracking_enabled": false,
       "lsc_type": "ACTIVATED",
       "mileage": [137009, "km"],
-      "name": "**REDACTED**",
+      "name": "i3 (+ REX)",
       "timestamp": "2022-07-10T09:25:53+00:00",
       "vin": "**REDACTED**"
     }
   ],
-  "fingerprint": []
+  "fingerprint": [
+    {
+      "filename": "bmw-vehicles_.json",
+      "content": [
+        {
+          "appVehicleType": "CONNECTED",
+          "attributes": {
+            "a4aType": "USB_ONLY",
+            "bodyType": "I01",
+            "brand": "BMW_I",
+            "color": 4284110934,
+            "countryOfOrigin": "CZ",
+            "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
+            "driverGuideInfo": {
+              "androidAppScheme": "com.bmwgroup.driversguide.row",
+              "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
+              "iosAppScheme": "bmwdriversguide:///open",
+              "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
+            },
+            "headUnitType": "NBT",
+            "hmiVersion": "ID4",
+            "lastFetched": "2022-07-10T09:25:53.104Z",
+            "model": "i3 (+ REX)",
+            "softwareVersionCurrent": {
+              "iStep": 510,
+              "puStep": {
+                "month": 11,
+                "year": 21
+              },
+              "seriesCluster": "I001"
+            },
+            "softwareVersionExFactory": {
+              "iStep": 502,
+              "puStep": {
+                "month": 3,
+                "year": 15
+              },
+              "seriesCluster": "I001"
+            },
+            "year": 2015
+          },
+          "mappingInfo": {
+            "isAssociated": false,
+            "isLmmEnabled": false,
+            "isPrimaryUser": true,
+            "mappingStatus": "CONFIRMED"
+          },
+          "vin": "**REDACTED**"
+        }
+      ]
+    },
+    {
+      "filename": "mini-vehicles_.json",
+      "content": []
+    },
+    {
+      "filename": "bmw-vehicles_WBY0FINGERPRINT01_state_.json",
+      "content": {
+        "capabilities": {
+          "climateFunction": "AIR_CONDITIONING",
+          "climateNow": true,
+          "climateTimerTrigger": "DEPARTURE_TIMER",
+          "horn": true,
+          "isBmwChargingSupported": true,
+          "isCarSharingSupported": false,
+          "isChargeNowForBusinessSupported": false,
+          "isChargingHistorySupported": true,
+          "isChargingHospitalityEnabled": false,
+          "isChargingLoudnessEnabled": false,
+          "isChargingPlanSupported": true,
+          "isChargingPowerLimitEnabled": false,
+          "isChargingSettingsEnabled": false,
+          "isChargingTargetSocEnabled": false,
+          "isClimateTimerSupported": true,
+          "isCustomerEsimSupported": false,
+          "isDCSContractManagementSupported": true,
+          "isDataPrivacyEnabled": false,
+          "isEasyChargeEnabled": false,
+          "isEvGoChargingSupported": false,
+          "isMiniChargingSupported": false,
+          "isNonLscFeatureEnabled": false,
+          "isRemoteEngineStartSupported": false,
+          "isRemoteHistoryDeletionSupported": false,
+          "isRemoteHistorySupported": true,
+          "isRemoteParkingSupported": false,
+          "isRemoteServicesActivationRequired": false,
+          "isRemoteServicesBookingRequired": false,
+          "isScanAndChargeSupported": false,
+          "isSustainabilitySupported": false,
+          "isWifiHotspotServiceSupported": false,
+          "lastStateCallState": "ACTIVATED",
+          "lights": true,
+          "lock": true,
+          "remoteChargingCommands": {},
+          "sendPoi": true,
+          "specialThemeSupport": [],
+          "unlock": true,
+          "vehicleFinder": false,
+          "vehicleStateSource": "LAST_STATE_CALL"
+        },
+        "state": {
+          "chargingProfile": {
+            "chargingControlType": "WEEKLY_PLANNER",
+            "chargingMode": "DELAYED_CHARGING",
+            "chargingPreference": "CHARGING_WINDOW",
+            "chargingSettings": {
+              "hospitality": "NO_ACTION",
+              "idcc": "NO_ACTION",
+              "targetSoc": 100
+            },
+            "climatisationOn": false,
+            "departureTimes": [
+              {
+                "action": "DEACTIVATE",
+                "id": 1,
+                "timeStamp": {
+                  "hour": 7,
+                  "minute": 35
+                },
+                "timerWeekDays": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY"
+                ]
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 2,
+                "timeStamp": {
+                  "hour": 18,
+                  "minute": 0
+                },
+                "timerWeekDays": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY",
+                  "SATURDAY",
+                  "SUNDAY"
+                ]
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 3,
+                "timeStamp": {
+                  "hour": 7,
+                  "minute": 0
+                },
+                "timerWeekDays": []
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 4,
+                "timerWeekDays": []
+              }
+            ],
+            "reductionOfChargeCurrent": {
+              "end": {
+                "hour": 1,
+                "minute": 30
+              },
+              "start": {
+                "hour": 18,
+                "minute": 1
+              }
+            }
+          },
+          "checkControlMessages": [],
+          "climateTimers": [
+            {
+              "departureTime": {
+                "hour": 6,
+                "minute": 40
+              },
+              "isWeeklyTimer": true,
+              "timerAction": "ACTIVATE",
+              "timerWeekDays": ["THURSDAY", "SUNDAY"]
+            },
+            {
+              "departureTime": {
+                "hour": 12,
+                "minute": 50
+              },
+              "isWeeklyTimer": false,
+              "timerAction": "ACTIVATE",
+              "timerWeekDays": ["MONDAY"]
+            },
+            {
+              "departureTime": {
+                "hour": 18,
+                "minute": 59
+              },
+              "isWeeklyTimer": true,
+              "timerAction": "DEACTIVATE",
+              "timerWeekDays": ["WEDNESDAY"]
+            }
+          ],
+          "combustionFuelLevel": {
+            "range": 105,
+            "remainingFuelLiters": 6,
+            "remainingFuelPercent": 65
+          },
+          "currentMileage": 137009,
+          "doorsState": {
+            "combinedSecurityState": "UNLOCKED",
+            "combinedState": "CLOSED",
+            "hood": "CLOSED",
+            "leftFront": "CLOSED",
+            "leftRear": "CLOSED",
+            "rightFront": "CLOSED",
+            "rightRear": "CLOSED",
+            "trunk": "CLOSED"
+          },
+          "driverPreferences": {
+            "lscPrivacyMode": "OFF"
+          },
+          "electricChargingState": {
+            "chargingConnectionType": "CONDUCTIVE",
+            "chargingLevelPercent": 82,
+            "chargingStatus": "WAITING_FOR_CHARGING",
+            "chargingTarget": 100,
+            "isChargerConnected": true,
+            "range": 174
+          },
+          "isLeftSteering": true,
+          "isLscSupported": true,
+          "lastFetched": "2022-06-22T14:24:23.982Z",
+          "lastUpdatedAt": "2022-06-22T13:58:52Z",
+          "range": 174,
+          "requiredServices": [
+            {
+              "dateTime": "2022-10-01T00:00:00.000Z",
+              "description": "Next service due by the specified date.",
+              "status": "OK",
+              "type": "BRAKE_FLUID"
+            },
+            {
+              "dateTime": "2023-05-01T00:00:00.000Z",
+              "description": "Next vehicle check due after the specified distance or date.",
+              "status": "OK",
+              "type": "VEHICLE_CHECK"
+            },
+            {
+              "dateTime": "2023-05-01T00:00:00.000Z",
+              "description": "Next state inspection due by the specified date.",
+              "status": "OK",
+              "type": "VEHICLE_TUV"
+            }
+          ],
+          "roofState": {
+            "roofState": "CLOSED",
+            "roofStateType": "SUN_ROOF"
+          },
+          "windowsState": {
+            "combinedState": "CLOSED",
+            "leftFront": "CLOSED",
+            "rightFront": "CLOSED"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
@@ -1,0 +1,651 @@
+{
+  "info": {
+    "username": "**REDACTED**",
+    "password": "**REDACTED**",
+    "region": "rest_of_world",
+    "refresh_token": "**REDACTED**"
+  },
+  "data": [
+    {
+      "data": {
+        "appVehicleType": "CONNECTED",
+        "attributes": {
+          "a4aType": "USB_ONLY",
+          "bodyType": "I01",
+          "brand": "BMW_I",
+          "color": 4284110934,
+          "countryOfOrigin": "CZ",
+          "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
+          "driverGuideInfo": {
+            "androidAppScheme": "com.bmwgroup.driversguide.row",
+            "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
+            "iosAppScheme": "bmwdriversguide:///open",
+            "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
+          },
+          "headUnitType": "NBT",
+          "hmiVersion": "ID4",
+          "lastFetched": "2022-07-10T09:25:53.104Z",
+          "model": "i3 (+ REX)",
+          "softwareVersionCurrent": {
+            "iStep": 510,
+            "puStep": { "month": 11, "year": 21 },
+            "seriesCluster": "I001"
+          },
+          "softwareVersionExFactory": {
+            "iStep": 502,
+            "puStep": { "month": 3, "year": 15 },
+            "seriesCluster": "I001"
+          },
+          "year": 2015
+        },
+        "mappingInfo": {
+          "isAssociated": false,
+          "isLmmEnabled": false,
+          "isPrimaryUser": true,
+          "mappingStatus": "CONFIRMED"
+        },
+        "vin": "**REDACTED**",
+        "capabilities": {
+          "climateFunction": "AIR_CONDITIONING",
+          "climateNow": true,
+          "climateTimerTrigger": "DEPARTURE_TIMER",
+          "horn": true,
+          "isBmwChargingSupported": true,
+          "isCarSharingSupported": false,
+          "isChargeNowForBusinessSupported": false,
+          "isChargingHistorySupported": true,
+          "isChargingHospitalityEnabled": false,
+          "isChargingLoudnessEnabled": false,
+          "isChargingPlanSupported": true,
+          "isChargingPowerLimitEnabled": false,
+          "isChargingSettingsEnabled": false,
+          "isChargingTargetSocEnabled": false,
+          "isClimateTimerSupported": true,
+          "isCustomerEsimSupported": false,
+          "isDCSContractManagementSupported": true,
+          "isDataPrivacyEnabled": false,
+          "isEasyChargeEnabled": false,
+          "isEvGoChargingSupported": false,
+          "isMiniChargingSupported": false,
+          "isNonLscFeatureEnabled": false,
+          "isRemoteEngineStartSupported": false,
+          "isRemoteHistoryDeletionSupported": false,
+          "isRemoteHistorySupported": true,
+          "isRemoteParkingSupported": false,
+          "isRemoteServicesActivationRequired": false,
+          "isRemoteServicesBookingRequired": false,
+          "isScanAndChargeSupported": false,
+          "isSustainabilitySupported": false,
+          "isWifiHotspotServiceSupported": false,
+          "lastStateCallState": "ACTIVATED",
+          "lights": true,
+          "lock": true,
+          "remoteChargingCommands": {},
+          "sendPoi": true,
+          "specialThemeSupport": [],
+          "unlock": true,
+          "vehicleFinder": false,
+          "vehicleStateSource": "LAST_STATE_CALL"
+        },
+        "state": {
+          "chargingProfile": {
+            "chargingControlType": "WEEKLY_PLANNER",
+            "chargingMode": "DELAYED_CHARGING",
+            "chargingPreference": "CHARGING_WINDOW",
+            "chargingSettings": {
+              "hospitality": "NO_ACTION",
+              "idcc": "NO_ACTION",
+              "targetSoc": 100
+            },
+            "climatisationOn": false,
+            "departureTimes": [
+              {
+                "action": "DEACTIVATE",
+                "id": 1,
+                "timeStamp": { "hour": 7, "minute": 35 },
+                "timerWeekDays": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY"
+                ]
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 2,
+                "timeStamp": { "hour": 18, "minute": 0 },
+                "timerWeekDays": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY",
+                  "SATURDAY",
+                  "SUNDAY"
+                ]
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 3,
+                "timeStamp": { "hour": 7, "minute": 0 },
+                "timerWeekDays": []
+              },
+              { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
+            ],
+            "reductionOfChargeCurrent": {
+              "end": { "hour": 1, "minute": 30 },
+              "start": { "hour": 18, "minute": 1 }
+            }
+          },
+          "checkControlMessages": [],
+          "climateTimers": [
+            {
+              "departureTime": { "hour": 6, "minute": 40 },
+              "isWeeklyTimer": true,
+              "timerAction": "ACTIVATE",
+              "timerWeekDays": ["THURSDAY", "SUNDAY"]
+            },
+            {
+              "departureTime": { "hour": 12, "minute": 50 },
+              "isWeeklyTimer": false,
+              "timerAction": "ACTIVATE",
+              "timerWeekDays": ["MONDAY"]
+            },
+            {
+              "departureTime": { "hour": 18, "minute": 59 },
+              "isWeeklyTimer": true,
+              "timerAction": "DEACTIVATE",
+              "timerWeekDays": ["WEDNESDAY"]
+            }
+          ],
+          "combustionFuelLevel": {
+            "range": 105,
+            "remainingFuelLiters": 6,
+            "remainingFuelPercent": 65
+          },
+          "currentMileage": 137009,
+          "doorsState": {
+            "combinedSecurityState": "UNLOCKED",
+            "combinedState": "CLOSED",
+            "hood": "CLOSED",
+            "leftFront": "CLOSED",
+            "leftRear": "CLOSED",
+            "rightFront": "CLOSED",
+            "rightRear": "CLOSED",
+            "trunk": "CLOSED"
+          },
+          "driverPreferences": { "lscPrivacyMode": "OFF" },
+          "electricChargingState": {
+            "chargingConnectionType": "CONDUCTIVE",
+            "chargingLevelPercent": 82,
+            "chargingStatus": "WAITING_FOR_CHARGING",
+            "chargingTarget": 100,
+            "isChargerConnected": true,
+            "range": 174
+          },
+          "isLeftSteering": true,
+          "isLscSupported": true,
+          "lastFetched": "2022-06-22T14:24:23.982Z",
+          "lastUpdatedAt": "2022-06-22T13:58:52Z",
+          "range": 174,
+          "requiredServices": [
+            {
+              "dateTime": "2022-10-01T00:00:00.000Z",
+              "description": "Next service due by the specified date.",
+              "status": "OK",
+              "type": "BRAKE_FLUID"
+            },
+            {
+              "dateTime": "2023-05-01T00:00:00.000Z",
+              "description": "Next vehicle check due after the specified distance or date.",
+              "status": "OK",
+              "type": "VEHICLE_CHECK"
+            },
+            {
+              "dateTime": "2023-05-01T00:00:00.000Z",
+              "description": "Next state inspection due by the specified date.",
+              "status": "OK",
+              "type": "VEHICLE_TUV"
+            }
+          ],
+          "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
+          "windowsState": {
+            "combinedState": "CLOSED",
+            "leftFront": "CLOSED",
+            "rightFront": "CLOSED"
+          }
+        },
+        "is_metric": true,
+        "fetched_at": "2022-07-10T11:00:00+00:00"
+      },
+      "fuel_and_battery": {
+        "remaining_range_fuel": [105, "km"],
+        "remaining_range_electric": [174, "km"],
+        "remaining_range_total": [279, "km"],
+        "remaining_fuel": [6, "L"],
+        "remaining_fuel_percent": 65,
+        "remaining_battery_percent": 82,
+        "charging_status": "WAITING_FOR_CHARGING",
+        "charging_start_time_no_tz": "2022-07-10T18:01:00",
+        "charging_end_time": null,
+        "is_charger_connected": true,
+        "account_timezone": {
+          "_std_offset": "0:00:00",
+          "_dst_offset": "0:00:00",
+          "_dst_saved": "0:00:00",
+          "_hasdst": false,
+          "_tznames": ["UTC", "UTC"]
+        },
+        "charging_start_time": "2022-07-10T18:01:00+00:00"
+      },
+      "vehicle_location": {
+        "location": { "latitude": null, "longitude": null },
+        "heading": null,
+        "vehicle_update_timestamp": "2022-07-10T09:25:53+00:00",
+        "account_region": "row",
+        "remote_service_position": null
+      },
+      "doors_and_windows": {
+        "door_lock_state": "UNLOCKED",
+        "lids": [
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+        ],
+        "windows": [
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+        ],
+        "all_lids_closed": true,
+        "all_windows_closed": true,
+        "open_lids": [],
+        "open_windows": []
+      },
+      "condition_based_services": {
+        "messages": [
+          {
+            "service_type": "BRAKE_FLUID",
+            "state": "OK",
+            "due_date": "2022-10-01T00:00:00+00:00",
+            "due_distance": [null, null]
+          },
+          {
+            "service_type": "VEHICLE_CHECK",
+            "state": "OK",
+            "due_date": "2023-05-01T00:00:00+00:00",
+            "due_distance": [null, null]
+          },
+          {
+            "service_type": "VEHICLE_TUV",
+            "state": "OK",
+            "due_date": "2023-05-01T00:00:00+00:00",
+            "due_distance": [null, null]
+          }
+        ],
+        "is_service_required": false
+      },
+      "check_control_messages": {
+        "messages": [],
+        "has_check_control_messages": false
+      },
+      "charging_profile": {
+        "is_pre_entry_climatization_enabled": false,
+        "timer_type": "WEEKLY_PLANNER",
+        "departure_times": [
+          {
+            "_timer_dict": {
+              "action": "DEACTIVATE",
+              "id": 1,
+              "timeStamp": { "hour": 7, "minute": 35 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY"
+              ]
+            },
+            "action": "DEACTIVATE",
+            "start_time": "07:35:00",
+            "timer_id": 1,
+            "weekdays": ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+          },
+          {
+            "_timer_dict": {
+              "action": "DEACTIVATE",
+              "id": 2,
+              "timeStamp": { "hour": 18, "minute": 0 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY",
+                "SATURDAY",
+                "SUNDAY"
+              ]
+            },
+            "action": "DEACTIVATE",
+            "start_time": "18:00:00",
+            "timer_id": 2,
+            "weekdays": [
+              "MONDAY",
+              "TUESDAY",
+              "WEDNESDAY",
+              "THURSDAY",
+              "FRIDAY",
+              "SATURDAY",
+              "SUNDAY"
+            ]
+          },
+          {
+            "_timer_dict": {
+              "action": "DEACTIVATE",
+              "id": 3,
+              "timeStamp": { "hour": 7, "minute": 0 },
+              "timerWeekDays": []
+            },
+            "action": "DEACTIVATE",
+            "start_time": "07:00:00",
+            "timer_id": 3,
+            "weekdays": []
+          },
+          {
+            "_timer_dict": {
+              "action": "DEACTIVATE",
+              "id": 4,
+              "timerWeekDays": []
+            },
+            "action": "DEACTIVATE",
+            "start_time": null,
+            "timer_id": 4,
+            "weekdays": []
+          }
+        ],
+        "preferred_charging_window": {
+          "_window_dict": {
+            "end": { "hour": 1, "minute": 30 },
+            "start": { "hour": 18, "minute": 1 }
+          },
+          "end_time": "01:30:00",
+          "start_time": "18:01:00"
+        },
+        "charging_preferences": "CHARGING_WINDOW",
+        "charging_mode": "DELAYED_CHARGING"
+      },
+      "available_attributes": [
+        "gps_position",
+        "vin",
+        "remaining_range_total",
+        "mileage",
+        "charging_time_remaining",
+        "charging_end_time",
+        "charging_time_label",
+        "charging_status",
+        "connection_status",
+        "remaining_battery_percent",
+        "remaining_range_electric",
+        "last_charging_end_result",
+        "remaining_fuel",
+        "remaining_range_fuel",
+        "remaining_fuel_percent",
+        "condition_based_services",
+        "check_control_messages",
+        "door_lock_state",
+        "timestamp",
+        "lids",
+        "windows"
+      ],
+      "brand": "bmw",
+      "drive_train": "ELECTRIC_WITH_RANGE_EXTENDER",
+      "drive_train_attributes": [
+        "remaining_range_total",
+        "mileage",
+        "charging_time_remaining",
+        "charging_end_time",
+        "charging_time_label",
+        "charging_status",
+        "connection_status",
+        "remaining_battery_percent",
+        "remaining_range_electric",
+        "last_charging_end_result",
+        "remaining_fuel",
+        "remaining_range_fuel",
+        "remaining_fuel_percent"
+      ],
+      "has_combustion_drivetrain": true,
+      "has_electric_drivetrain": true,
+      "is_charging_plan_supported": true,
+      "is_lsc_enabled": true,
+      "is_vehicle_active": false,
+      "is_vehicle_tracking_enabled": false,
+      "lsc_type": "ACTIVATED",
+      "mileage": [137009, "km"],
+      "name": "**REDACTED**",
+      "timestamp": "2022-07-10T09:25:53+00:00",
+      "vin": "**REDACTED**"
+    }
+  ],
+  "fingerprint": {
+    "vehicles_v2_mini_0.json": [],
+    "state_WBY00000000REXI01_0.json": {
+      "capabilities": {
+        "climateFunction": "AIR_CONDITIONING",
+        "climateNow": true,
+        "climateTimerTrigger": "DEPARTURE_TIMER",
+        "horn": true,
+        "isBmwChargingSupported": true,
+        "isCarSharingSupported": false,
+        "isChargeNowForBusinessSupported": false,
+        "isChargingHistorySupported": true,
+        "isChargingHospitalityEnabled": false,
+        "isChargingLoudnessEnabled": false,
+        "isChargingPlanSupported": true,
+        "isChargingPowerLimitEnabled": false,
+        "isChargingSettingsEnabled": false,
+        "isChargingTargetSocEnabled": false,
+        "isClimateTimerSupported": true,
+        "isCustomerEsimSupported": false,
+        "isDCSContractManagementSupported": true,
+        "isDataPrivacyEnabled": false,
+        "isEasyChargeEnabled": false,
+        "isEvGoChargingSupported": false,
+        "isMiniChargingSupported": false,
+        "isNonLscFeatureEnabled": false,
+        "isRemoteEngineStartSupported": false,
+        "isRemoteHistoryDeletionSupported": false,
+        "isRemoteHistorySupported": true,
+        "isRemoteParkingSupported": false,
+        "isRemoteServicesActivationRequired": false,
+        "isRemoteServicesBookingRequired": false,
+        "isScanAndChargeSupported": false,
+        "isSustainabilitySupported": false,
+        "isWifiHotspotServiceSupported": false,
+        "lastStateCallState": "ACTIVATED",
+        "lights": true,
+        "lock": true,
+        "remoteChargingCommands": {},
+        "sendPoi": true,
+        "specialThemeSupport": [],
+        "unlock": true,
+        "vehicleFinder": false,
+        "vehicleStateSource": "LAST_STATE_CALL"
+      },
+      "state": {
+        "chargingProfile": {
+          "chargingControlType": "WEEKLY_PLANNER",
+          "chargingMode": "DELAYED_CHARGING",
+          "chargingPreference": "CHARGING_WINDOW",
+          "chargingSettings": {
+            "hospitality": "NO_ACTION",
+            "idcc": "NO_ACTION",
+            "targetSoc": 100
+          },
+          "climatisationOn": false,
+          "departureTimes": [
+            {
+              "action": "DEACTIVATE",
+              "id": 1,
+              "timeStamp": { "hour": 7, "minute": 35 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY"
+              ]
+            },
+            {
+              "action": "DEACTIVATE",
+              "id": 2,
+              "timeStamp": { "hour": 18, "minute": 0 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY",
+                "SATURDAY",
+                "SUNDAY"
+              ]
+            },
+            {
+              "action": "DEACTIVATE",
+              "id": 3,
+              "timeStamp": { "hour": 7, "minute": 0 },
+              "timerWeekDays": []
+            },
+            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
+          ],
+          "reductionOfChargeCurrent": {
+            "end": { "hour": 1, "minute": 30 },
+            "start": { "hour": 18, "minute": 1 }
+          }
+        },
+        "checkControlMessages": [],
+        "climateTimers": [
+          {
+            "departureTime": { "hour": 6, "minute": 40 },
+            "isWeeklyTimer": true,
+            "timerAction": "ACTIVATE",
+            "timerWeekDays": ["THURSDAY", "SUNDAY"]
+          },
+          {
+            "departureTime": { "hour": 12, "minute": 50 },
+            "isWeeklyTimer": false,
+            "timerAction": "ACTIVATE",
+            "timerWeekDays": ["MONDAY"]
+          },
+          {
+            "departureTime": { "hour": 18, "minute": 59 },
+            "isWeeklyTimer": true,
+            "timerAction": "DEACTIVATE",
+            "timerWeekDays": ["WEDNESDAY"]
+          }
+        ],
+        "combustionFuelLevel": {
+          "range": 105,
+          "remainingFuelLiters": 6,
+          "remainingFuelPercent": 65
+        },
+        "currentMileage": 137009,
+        "doorsState": {
+          "combinedSecurityState": "UNLOCKED",
+          "combinedState": "CLOSED",
+          "hood": "CLOSED",
+          "leftFront": "CLOSED",
+          "leftRear": "CLOSED",
+          "rightFront": "CLOSED",
+          "rightRear": "CLOSED",
+          "trunk": "CLOSED"
+        },
+        "driverPreferences": { "lscPrivacyMode": "OFF" },
+        "electricChargingState": {
+          "chargingConnectionType": "CONDUCTIVE",
+          "chargingLevelPercent": 82,
+          "chargingStatus": "WAITING_FOR_CHARGING",
+          "chargingTarget": 100,
+          "isChargerConnected": true,
+          "range": 174
+        },
+        "isLeftSteering": true,
+        "isLscSupported": true,
+        "lastFetched": "2022-06-22T14:24:23.982Z",
+        "lastUpdatedAt": "2022-06-22T13:58:52Z",
+        "range": 174,
+        "requiredServices": [
+          {
+            "dateTime": "2022-10-01T00:00:00.000Z",
+            "description": "Next service due by the specified date.",
+            "status": "OK",
+            "type": "BRAKE_FLUID"
+          },
+          {
+            "dateTime": "2023-05-01T00:00:00.000Z",
+            "description": "Next vehicle check due after the specified distance or date.",
+            "status": "OK",
+            "type": "VEHICLE_CHECK"
+          },
+          {
+            "dateTime": "2023-05-01T00:00:00.000Z",
+            "description": "Next state inspection due by the specified date.",
+            "status": "OK",
+            "type": "VEHICLE_TUV"
+          }
+        ],
+        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
+        "windowsState": {
+          "combinedState": "CLOSED",
+          "leftFront": "CLOSED",
+          "rightFront": "CLOSED"
+        }
+      }
+    },
+    "vehicles_v2_bmw_0.json": [
+      {
+        "appVehicleType": "CONNECTED",
+        "attributes": {
+          "a4aType": "USB_ONLY",
+          "bodyType": "I01",
+          "brand": "BMW_I",
+          "color": 4284110934,
+          "countryOfOrigin": "CZ",
+          "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
+          "driverGuideInfo": {
+            "androidAppScheme": "com.bmwgroup.driversguide.row",
+            "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
+            "iosAppScheme": "bmwdriversguide:///open",
+            "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
+          },
+          "headUnitType": "NBT",
+          "hmiVersion": "ID4",
+          "lastFetched": "2022-07-10T09:25:53.104Z",
+          "model": "i3 (+ REX)",
+          "softwareVersionCurrent": {
+            "iStep": 510,
+            "puStep": { "month": 11, "year": 21 },
+            "seriesCluster": "I001"
+          },
+          "softwareVersionExFactory": {
+            "iStep": 502,
+            "puStep": { "month": 3, "year": 15 },
+            "seriesCluster": "I001"
+          },
+          "year": 2015
+        },
+        "mappingInfo": {
+          "isAssociated": false,
+          "isLmmEnabled": false,
+          "isPrimaryUser": true,
+          "mappingStatus": "CONFIRMED"
+        },
+        "vin": "**REDACTED**"
+      }
+    ]
+  }
+}

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
@@ -28,18 +28,12 @@
           "model": "i3 (+ REX)",
           "softwareVersionCurrent": {
             "iStep": 510,
-            "puStep": {
-              "month": 11,
-              "year": 21
-            },
+            "puStep": { "month": 11, "year": 21 },
             "seriesCluster": "I001"
           },
           "softwareVersionExFactory": {
             "iStep": 502,
-            "puStep": {
-              "month": 3,
-              "year": 15
-            },
+            "puStep": { "month": 3, "year": 15 },
             "seriesCluster": "I001"
           },
           "year": 2015
@@ -110,10 +104,7 @@
               {
                 "action": "DEACTIVATE",
                 "id": 1,
-                "timeStamp": {
-                  "hour": 7,
-                  "minute": 35
-                },
+                "timeStamp": { "hour": 7, "minute": 35 },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -125,10 +116,7 @@
               {
                 "action": "DEACTIVATE",
                 "id": 2,
-                "timeStamp": {
-                  "hour": 18,
-                  "minute": 0
-                },
+                "timeStamp": { "hour": 18, "minute": 0 },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -142,54 +130,32 @@
               {
                 "action": "DEACTIVATE",
                 "id": 3,
-                "timeStamp": {
-                  "hour": 7,
-                  "minute": 0
-                },
+                "timeStamp": { "hour": 7, "minute": 0 },
                 "timerWeekDays": []
               },
-              {
-                "action": "DEACTIVATE",
-                "id": 4,
-                "timerWeekDays": []
-              }
+              { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
             ],
             "reductionOfChargeCurrent": {
-              "end": {
-                "hour": 1,
-                "minute": 30
-              },
-              "start": {
-                "hour": 18,
-                "minute": 1
-              }
+              "end": { "hour": 1, "minute": 30 },
+              "start": { "hour": 18, "minute": 1 }
             }
           },
           "checkControlMessages": [],
           "climateTimers": [
             {
-              "departureTime": {
-                "hour": 6,
-                "minute": 40
-              },
+              "departureTime": { "hour": 6, "minute": 40 },
               "isWeeklyTimer": true,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["THURSDAY", "SUNDAY"]
             },
             {
-              "departureTime": {
-                "hour": 12,
-                "minute": 50
-              },
+              "departureTime": { "hour": 12, "minute": 50 },
               "isWeeklyTimer": false,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["MONDAY"]
             },
             {
-              "departureTime": {
-                "hour": 18,
-                "minute": 59
-              },
+              "departureTime": { "hour": 18, "minute": 59 },
               "isWeeklyTimer": true,
               "timerAction": "DEACTIVATE",
               "timerWeekDays": ["WEDNESDAY"]
@@ -211,9 +177,7 @@
             "rightRear": "CLOSED",
             "trunk": "CLOSED"
           },
-          "driverPreferences": {
-            "lscPrivacyMode": "OFF"
-          },
+          "driverPreferences": { "lscPrivacyMode": "OFF" },
           "electricChargingState": {
             "chargingConnectionType": "CONDUCTIVE",
             "chargingLevelPercent": 82,
@@ -247,10 +211,7 @@
               "type": "VEHICLE_TUV"
             }
           ],
-          "roofState": {
-            "roofState": "CLOSED",
-            "roofStateType": "SUN_ROOF"
-          },
+          "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
           "windowsState": {
             "combinedState": "CLOSED",
             "leftFront": "CLOSED",
@@ -288,53 +249,17 @@
       "doors_and_windows": {
         "door_lock_state": "UNLOCKED",
         "lids": [
-          {
-            "name": "hood",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "leftFront",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "leftRear",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "rightFront",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "rightRear",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "trunk",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "sunRoof",
-            "state": "CLOSED",
-            "is_closed": true
-          }
+          { "name": "hood", "state": "CLOSED", "is_closed": true },
+          { "name": "leftFront", "state": "CLOSED", "is_closed": true },
+          { "name": "leftRear", "state": "CLOSED", "is_closed": true },
+          { "name": "rightFront", "state": "CLOSED", "is_closed": true },
+          { "name": "rightRear", "state": "CLOSED", "is_closed": true },
+          { "name": "trunk", "state": "CLOSED", "is_closed": true },
+          { "name": "sunRoof", "state": "CLOSED", "is_closed": true }
         ],
         "windows": [
-          {
-            "name": "leftFront",
-            "state": "CLOSED",
-            "is_closed": true
-          },
-          {
-            "name": "rightFront",
-            "state": "CLOSED",
-            "is_closed": true
-          }
+          { "name": "leftFront", "state": "CLOSED", "is_closed": true },
+          { "name": "rightFront", "state": "CLOSED", "is_closed": true }
         ],
         "all_lids_closed": true,
         "all_windows_closed": true,
@@ -376,10 +301,7 @@
             "_timer_dict": {
               "action": "DEACTIVATE",
               "id": 1,
-              "timeStamp": {
-                "hour": 7,
-                "minute": 35
-              },
+              "timeStamp": { "hour": 7, "minute": 35 },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -397,10 +319,7 @@
             "_timer_dict": {
               "action": "DEACTIVATE",
               "id": 2,
-              "timeStamp": {
-                "hour": 18,
-                "minute": 0
-              },
+              "timeStamp": { "hour": 18, "minute": 0 },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -428,10 +347,7 @@
             "_timer_dict": {
               "action": "DEACTIVATE",
               "id": 3,
-              "timeStamp": {
-                "hour": 7,
-                "minute": 0
-              },
+              "timeStamp": { "hour": 7, "minute": 0 },
               "timerWeekDays": []
             },
             "action": "DEACTIVATE",
@@ -453,14 +369,8 @@
         ],
         "preferred_charging_window": {
           "_window_dict": {
-            "end": {
-              "hour": 1,
-              "minute": 30
-            },
-            "start": {
-              "hour": 18,
-              "minute": 1
-            }
+            "end": { "hour": 1, "minute": 30 },
+            "start": { "hour": 18, "minute": 1 }
           },
           "end_time": "01:30:00",
           "start_time": "18:01:00"
@@ -523,7 +433,7 @@
   ],
   "fingerprint": [
     {
-      "filename": "bmw-vehicles_.json",
+      "filename": "bmw-vehicles.json",
       "content": [
         {
           "appVehicleType": "CONNECTED",
@@ -546,18 +456,12 @@
             "model": "i3 (+ REX)",
             "softwareVersionCurrent": {
               "iStep": 510,
-              "puStep": {
-                "month": 11,
-                "year": 21
-              },
+              "puStep": { "month": 11, "year": 21 },
               "seriesCluster": "I001"
             },
             "softwareVersionExFactory": {
               "iStep": 502,
-              "puStep": {
-                "month": 3,
-                "year": 15
-              },
+              "puStep": { "month": 3, "year": 15 },
               "seriesCluster": "I001"
             },
             "year": 2015
@@ -572,12 +476,9 @@
         }
       ]
     },
+    { "filename": "mini-vehicles.json", "content": [] },
     {
-      "filename": "mini-vehicles_.json",
-      "content": []
-    },
-    {
-      "filename": "bmw-vehicles_WBY0FINGERPRINT01_state_.json",
+      "filename": "bmw-vehicles_state_WBY0FINGERPRINT01.json",
       "content": {
         "capabilities": {
           "climateFunction": "AIR_CONDITIONING",
@@ -636,10 +537,7 @@
               {
                 "action": "DEACTIVATE",
                 "id": 1,
-                "timeStamp": {
-                  "hour": 7,
-                  "minute": 35
-                },
+                "timeStamp": { "hour": 7, "minute": 35 },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -651,10 +549,7 @@
               {
                 "action": "DEACTIVATE",
                 "id": 2,
-                "timeStamp": {
-                  "hour": 18,
-                  "minute": 0
-                },
+                "timeStamp": { "hour": 18, "minute": 0 },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -668,54 +563,32 @@
               {
                 "action": "DEACTIVATE",
                 "id": 3,
-                "timeStamp": {
-                  "hour": 7,
-                  "minute": 0
-                },
+                "timeStamp": { "hour": 7, "minute": 0 },
                 "timerWeekDays": []
               },
-              {
-                "action": "DEACTIVATE",
-                "id": 4,
-                "timerWeekDays": []
-              }
+              { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
             ],
             "reductionOfChargeCurrent": {
-              "end": {
-                "hour": 1,
-                "minute": 30
-              },
-              "start": {
-                "hour": 18,
-                "minute": 1
-              }
+              "end": { "hour": 1, "minute": 30 },
+              "start": { "hour": 18, "minute": 1 }
             }
           },
           "checkControlMessages": [],
           "climateTimers": [
             {
-              "departureTime": {
-                "hour": 6,
-                "minute": 40
-              },
+              "departureTime": { "hour": 6, "minute": 40 },
               "isWeeklyTimer": true,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["THURSDAY", "SUNDAY"]
             },
             {
-              "departureTime": {
-                "hour": 12,
-                "minute": 50
-              },
+              "departureTime": { "hour": 12, "minute": 50 },
               "isWeeklyTimer": false,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["MONDAY"]
             },
             {
-              "departureTime": {
-                "hour": 18,
-                "minute": 59
-              },
+              "departureTime": { "hour": 18, "minute": 59 },
               "isWeeklyTimer": true,
               "timerAction": "DEACTIVATE",
               "timerWeekDays": ["WEDNESDAY"]
@@ -737,9 +610,7 @@
             "rightRear": "CLOSED",
             "trunk": "CLOSED"
           },
-          "driverPreferences": {
-            "lscPrivacyMode": "OFF"
-          },
+          "driverPreferences": { "lscPrivacyMode": "OFF" },
           "electricChargingState": {
             "chargingConnectionType": "CONDUCTIVE",
             "chargingLevelPercent": 82,
@@ -773,10 +644,7 @@
               "type": "VEHICLE_TUV"
             }
           ],
-          "roofState": {
-            "roofState": "CLOSED",
-            "roofStateType": "SUN_ROOF"
-          },
+          "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
           "windowsState": {
             "combinedState": "CLOSED",
             "leftFront": "CLOSED",

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_config_entry.json
@@ -28,12 +28,18 @@
           "model": "i3 (+ REX)",
           "softwareVersionCurrent": {
             "iStep": 510,
-            "puStep": { "month": 11, "year": 21 },
+            "puStep": {
+              "month": 11,
+              "year": 21
+            },
             "seriesCluster": "I001"
           },
           "softwareVersionExFactory": {
             "iStep": 502,
-            "puStep": { "month": 3, "year": 15 },
+            "puStep": {
+              "month": 3,
+              "year": 15
+            },
             "seriesCluster": "I001"
           },
           "year": 2015
@@ -102,7 +108,10 @@
               {
                 "action": "DEACTIVATE",
                 "id": 1,
-                "timeStamp": { "hour": 7, "minute": 35 },
+                "timeStamp": {
+                  "hour": 7,
+                  "minute": 35
+                },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -114,7 +123,10 @@
               {
                 "action": "DEACTIVATE",
                 "id": 2,
-                "timeStamp": { "hour": 18, "minute": 0 },
+                "timeStamp": {
+                  "hour": 18,
+                  "minute": 0
+                },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -128,32 +140,54 @@
               {
                 "action": "DEACTIVATE",
                 "id": 3,
-                "timeStamp": { "hour": 7, "minute": 0 },
+                "timeStamp": {
+                  "hour": 7,
+                  "minute": 0
+                },
                 "timerWeekDays": []
               },
-              { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
+              {
+                "action": "DEACTIVATE",
+                "id": 4,
+                "timerWeekDays": []
+              }
             ],
             "reductionOfChargeCurrent": {
-              "end": { "hour": 1, "minute": 30 },
-              "start": { "hour": 18, "minute": 1 }
+              "end": {
+                "hour": 1,
+                "minute": 30
+              },
+              "start": {
+                "hour": 18,
+                "minute": 1
+              }
             }
           },
           "checkControlMessages": [],
           "climateTimers": [
             {
-              "departureTime": { "hour": 6, "minute": 40 },
+              "departureTime": {
+                "hour": 6,
+                "minute": 40
+              },
               "isWeeklyTimer": true,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["THURSDAY", "SUNDAY"]
             },
             {
-              "departureTime": { "hour": 12, "minute": 50 },
+              "departureTime": {
+                "hour": 12,
+                "minute": 50
+              },
               "isWeeklyTimer": false,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["MONDAY"]
             },
             {
-              "departureTime": { "hour": 18, "minute": 59 },
+              "departureTime": {
+                "hour": 18,
+                "minute": 59
+              },
               "isWeeklyTimer": true,
               "timerAction": "DEACTIVATE",
               "timerWeekDays": ["WEDNESDAY"]
@@ -175,7 +209,9 @@
             "rightRear": "CLOSED",
             "trunk": "CLOSED"
           },
-          "driverPreferences": { "lscPrivacyMode": "OFF" },
+          "driverPreferences": {
+            "lscPrivacyMode": "OFF"
+          },
           "electricChargingState": {
             "chargingConnectionType": "CONDUCTIVE",
             "chargingLevelPercent": 82,
@@ -209,7 +245,10 @@
               "type": "VEHICLE_TUV"
             }
           ],
-          "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
+          "roofState": {
+            "roofState": "CLOSED",
+            "roofStateType": "SUN_ROOF"
+          },
           "windowsState": {
             "combinedState": "CLOSED",
             "leftFront": "CLOSED",
@@ -240,7 +279,7 @@
         "charging_start_time": "2022-07-10T18:01:00+00:00"
       },
       "vehicle_location": {
-        "location": { "latitude": null, "longitude": null },
+        "location": null,
         "heading": null,
         "vehicle_update_timestamp": "2022-07-10T09:25:53+00:00",
         "account_region": "row",
@@ -249,17 +288,53 @@
       "doors_and_windows": {
         "door_lock_state": "UNLOCKED",
         "lids": [
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          }
         ],
         "windows": [
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-          { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          },
+          {
+            "name": "**REDACTED**",
+            "state": "CLOSED",
+            "is_closed": true
+          }
         ],
         "all_lids_closed": true,
         "all_windows_closed": true,
@@ -301,7 +376,10 @@
             "_timer_dict": {
               "action": "DEACTIVATE",
               "id": 1,
-              "timeStamp": { "hour": 7, "minute": 35 },
+              "timeStamp": {
+                "hour": 7,
+                "minute": 35
+              },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -319,7 +397,10 @@
             "_timer_dict": {
               "action": "DEACTIVATE",
               "id": 2,
-              "timeStamp": { "hour": 18, "minute": 0 },
+              "timeStamp": {
+                "hour": 18,
+                "minute": 0
+              },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -347,7 +428,10 @@
             "_timer_dict": {
               "action": "DEACTIVATE",
               "id": 3,
-              "timeStamp": { "hour": 7, "minute": 0 },
+              "timeStamp": {
+                "hour": 7,
+                "minute": 0
+              },
               "timerWeekDays": []
             },
             "action": "DEACTIVATE",
@@ -369,8 +453,14 @@
         ],
         "preferred_charging_window": {
           "_window_dict": {
-            "end": { "hour": 1, "minute": 30 },
-            "start": { "hour": 18, "minute": 1 }
+            "end": {
+              "hour": 1,
+              "minute": 30
+            },
+            "start": {
+              "hour": 18,
+              "minute": 1
+            }
           },
           "end_time": "01:30:00",
           "start_time": "18:01:00"
@@ -431,221 +521,5 @@
       "vin": "**REDACTED**"
     }
   ],
-  "fingerprint": {
-    "vehicles_v2_mini_0.json": [],
-    "state_WBY00000000REXI01_0.json": {
-      "capabilities": {
-        "climateFunction": "AIR_CONDITIONING",
-        "climateNow": true,
-        "climateTimerTrigger": "DEPARTURE_TIMER",
-        "horn": true,
-        "isBmwChargingSupported": true,
-        "isCarSharingSupported": false,
-        "isChargeNowForBusinessSupported": false,
-        "isChargingHistorySupported": true,
-        "isChargingHospitalityEnabled": false,
-        "isChargingLoudnessEnabled": false,
-        "isChargingPlanSupported": true,
-        "isChargingPowerLimitEnabled": false,
-        "isChargingSettingsEnabled": false,
-        "isChargingTargetSocEnabled": false,
-        "isClimateTimerSupported": true,
-        "isCustomerEsimSupported": false,
-        "isDCSContractManagementSupported": true,
-        "isDataPrivacyEnabled": false,
-        "isEasyChargeEnabled": false,
-        "isEvGoChargingSupported": false,
-        "isMiniChargingSupported": false,
-        "isNonLscFeatureEnabled": false,
-        "isRemoteEngineStartSupported": false,
-        "isRemoteHistoryDeletionSupported": false,
-        "isRemoteHistorySupported": true,
-        "isRemoteParkingSupported": false,
-        "isRemoteServicesActivationRequired": false,
-        "isRemoteServicesBookingRequired": false,
-        "isScanAndChargeSupported": false,
-        "isSustainabilitySupported": false,
-        "isWifiHotspotServiceSupported": false,
-        "lastStateCallState": "ACTIVATED",
-        "lights": true,
-        "lock": true,
-        "remoteChargingCommands": {},
-        "sendPoi": true,
-        "specialThemeSupport": [],
-        "unlock": true,
-        "vehicleFinder": false,
-        "vehicleStateSource": "LAST_STATE_CALL"
-      },
-      "state": {
-        "chargingProfile": {
-          "chargingControlType": "WEEKLY_PLANNER",
-          "chargingMode": "DELAYED_CHARGING",
-          "chargingPreference": "CHARGING_WINDOW",
-          "chargingSettings": {
-            "hospitality": "NO_ACTION",
-            "idcc": "NO_ACTION",
-            "targetSoc": 100
-          },
-          "climatisationOn": false,
-          "departureTimes": [
-            {
-              "action": "DEACTIVATE",
-              "id": 1,
-              "timeStamp": { "hour": 7, "minute": 35 },
-              "timerWeekDays": [
-                "MONDAY",
-                "TUESDAY",
-                "WEDNESDAY",
-                "THURSDAY",
-                "FRIDAY"
-              ]
-            },
-            {
-              "action": "DEACTIVATE",
-              "id": 2,
-              "timeStamp": { "hour": 18, "minute": 0 },
-              "timerWeekDays": [
-                "MONDAY",
-                "TUESDAY",
-                "WEDNESDAY",
-                "THURSDAY",
-                "FRIDAY",
-                "SATURDAY",
-                "SUNDAY"
-              ]
-            },
-            {
-              "action": "DEACTIVATE",
-              "id": 3,
-              "timeStamp": { "hour": 7, "minute": 0 },
-              "timerWeekDays": []
-            },
-            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
-          ],
-          "reductionOfChargeCurrent": {
-            "end": { "hour": 1, "minute": 30 },
-            "start": { "hour": 18, "minute": 1 }
-          }
-        },
-        "checkControlMessages": [],
-        "climateTimers": [
-          {
-            "departureTime": { "hour": 6, "minute": 40 },
-            "isWeeklyTimer": true,
-            "timerAction": "ACTIVATE",
-            "timerWeekDays": ["THURSDAY", "SUNDAY"]
-          },
-          {
-            "departureTime": { "hour": 12, "minute": 50 },
-            "isWeeklyTimer": false,
-            "timerAction": "ACTIVATE",
-            "timerWeekDays": ["MONDAY"]
-          },
-          {
-            "departureTime": { "hour": 18, "minute": 59 },
-            "isWeeklyTimer": true,
-            "timerAction": "DEACTIVATE",
-            "timerWeekDays": ["WEDNESDAY"]
-          }
-        ],
-        "combustionFuelLevel": {
-          "range": 105,
-          "remainingFuelLiters": 6,
-          "remainingFuelPercent": 65
-        },
-        "currentMileage": 137009,
-        "doorsState": {
-          "combinedSecurityState": "UNLOCKED",
-          "combinedState": "CLOSED",
-          "hood": "CLOSED",
-          "leftFront": "CLOSED",
-          "leftRear": "CLOSED",
-          "rightFront": "CLOSED",
-          "rightRear": "CLOSED",
-          "trunk": "CLOSED"
-        },
-        "driverPreferences": { "lscPrivacyMode": "OFF" },
-        "electricChargingState": {
-          "chargingConnectionType": "CONDUCTIVE",
-          "chargingLevelPercent": 82,
-          "chargingStatus": "WAITING_FOR_CHARGING",
-          "chargingTarget": 100,
-          "isChargerConnected": true,
-          "range": 174
-        },
-        "isLeftSteering": true,
-        "isLscSupported": true,
-        "lastFetched": "2022-06-22T14:24:23.982Z",
-        "lastUpdatedAt": "2022-06-22T13:58:52Z",
-        "range": 174,
-        "requiredServices": [
-          {
-            "dateTime": "2022-10-01T00:00:00.000Z",
-            "description": "Next service due by the specified date.",
-            "status": "OK",
-            "type": "BRAKE_FLUID"
-          },
-          {
-            "dateTime": "2023-05-01T00:00:00.000Z",
-            "description": "Next vehicle check due after the specified distance or date.",
-            "status": "OK",
-            "type": "VEHICLE_CHECK"
-          },
-          {
-            "dateTime": "2023-05-01T00:00:00.000Z",
-            "description": "Next state inspection due by the specified date.",
-            "status": "OK",
-            "type": "VEHICLE_TUV"
-          }
-        ],
-        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
-        "windowsState": {
-          "combinedState": "CLOSED",
-          "leftFront": "CLOSED",
-          "rightFront": "CLOSED"
-        }
-      }
-    },
-    "vehicles_v2_bmw_0.json": [
-      {
-        "appVehicleType": "CONNECTED",
-        "attributes": {
-          "a4aType": "USB_ONLY",
-          "bodyType": "I01",
-          "brand": "BMW_I",
-          "color": 4284110934,
-          "countryOfOrigin": "CZ",
-          "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
-          "driverGuideInfo": {
-            "androidAppScheme": "com.bmwgroup.driversguide.row",
-            "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
-            "iosAppScheme": "bmwdriversguide:///open",
-            "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
-          },
-          "headUnitType": "NBT",
-          "hmiVersion": "ID4",
-          "lastFetched": "2022-07-10T09:25:53.104Z",
-          "model": "i3 (+ REX)",
-          "softwareVersionCurrent": {
-            "iStep": 510,
-            "puStep": { "month": 11, "year": 21 },
-            "seriesCluster": "I001"
-          },
-          "softwareVersionExFactory": {
-            "iStep": 502,
-            "puStep": { "month": 3, "year": 15 },
-            "seriesCluster": "I001"
-          },
-          "year": 2015
-        },
-        "mappingInfo": {
-          "isAssociated": false,
-          "isLmmEnabled": false,
-          "isPrimaryUser": true,
-          "mappingStatus": "CONFIRMED"
-        },
-        "vin": "**REDACTED**"
-      }
-    ]
-  }
+  "fingerprint": []
 }

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
@@ -27,18 +27,12 @@
         "model": "i3 (+ REX)",
         "softwareVersionCurrent": {
           "iStep": 510,
-          "puStep": {
-            "month": 11,
-            "year": 21
-          },
+          "puStep": { "month": 11, "year": 21 },
           "seriesCluster": "I001"
         },
         "softwareVersionExFactory": {
           "iStep": 502,
-          "puStep": {
-            "month": 3,
-            "year": 15
-          },
+          "puStep": { "month": 3, "year": 15 },
           "seriesCluster": "I001"
         },
         "year": 2015
@@ -109,10 +103,7 @@
             {
               "action": "DEACTIVATE",
               "id": 1,
-              "timeStamp": {
-                "hour": 7,
-                "minute": 35
-              },
+              "timeStamp": { "hour": 7, "minute": 35 },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -124,10 +115,7 @@
             {
               "action": "DEACTIVATE",
               "id": 2,
-              "timeStamp": {
-                "hour": 18,
-                "minute": 0
-              },
+              "timeStamp": { "hour": 18, "minute": 0 },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -141,54 +129,32 @@
             {
               "action": "DEACTIVATE",
               "id": 3,
-              "timeStamp": {
-                "hour": 7,
-                "minute": 0
-              },
+              "timeStamp": { "hour": 7, "minute": 0 },
               "timerWeekDays": []
             },
-            {
-              "action": "DEACTIVATE",
-              "id": 4,
-              "timerWeekDays": []
-            }
+            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
           ],
           "reductionOfChargeCurrent": {
-            "end": {
-              "hour": 1,
-              "minute": 30
-            },
-            "start": {
-              "hour": 18,
-              "minute": 1
-            }
+            "end": { "hour": 1, "minute": 30 },
+            "start": { "hour": 18, "minute": 1 }
           }
         },
         "checkControlMessages": [],
         "climateTimers": [
           {
-            "departureTime": {
-              "hour": 6,
-              "minute": 40
-            },
+            "departureTime": { "hour": 6, "minute": 40 },
             "isWeeklyTimer": true,
             "timerAction": "ACTIVATE",
             "timerWeekDays": ["THURSDAY", "SUNDAY"]
           },
           {
-            "departureTime": {
-              "hour": 12,
-              "minute": 50
-            },
+            "departureTime": { "hour": 12, "minute": 50 },
             "isWeeklyTimer": false,
             "timerAction": "ACTIVATE",
             "timerWeekDays": ["MONDAY"]
           },
           {
-            "departureTime": {
-              "hour": 18,
-              "minute": 59
-            },
+            "departureTime": { "hour": 18, "minute": 59 },
             "isWeeklyTimer": true,
             "timerAction": "DEACTIVATE",
             "timerWeekDays": ["WEDNESDAY"]
@@ -210,9 +176,7 @@
           "rightRear": "CLOSED",
           "trunk": "CLOSED"
         },
-        "driverPreferences": {
-          "lscPrivacyMode": "OFF"
-        },
+        "driverPreferences": { "lscPrivacyMode": "OFF" },
         "electricChargingState": {
           "chargingConnectionType": "CONDUCTIVE",
           "chargingLevelPercent": 82,
@@ -246,10 +210,7 @@
             "type": "VEHICLE_TUV"
           }
         ],
-        "roofState": {
-          "roofState": "CLOSED",
-          "roofStateType": "SUN_ROOF"
-        },
+        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
         "windowsState": {
           "combinedState": "CLOSED",
           "leftFront": "CLOSED",
@@ -287,53 +248,17 @@
     "doors_and_windows": {
       "door_lock_state": "UNLOCKED",
       "lids": [
-        {
-          "name": "hood",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "leftFront",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "leftRear",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "rightFront",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "rightRear",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "trunk",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "sunRoof",
-          "state": "CLOSED",
-          "is_closed": true
-        }
+        { "name": "hood", "state": "CLOSED", "is_closed": true },
+        { "name": "leftFront", "state": "CLOSED", "is_closed": true },
+        { "name": "leftRear", "state": "CLOSED", "is_closed": true },
+        { "name": "rightFront", "state": "CLOSED", "is_closed": true },
+        { "name": "rightRear", "state": "CLOSED", "is_closed": true },
+        { "name": "trunk", "state": "CLOSED", "is_closed": true },
+        { "name": "sunRoof", "state": "CLOSED", "is_closed": true }
       ],
       "windows": [
-        {
-          "name": "leftFront",
-          "state": "CLOSED",
-          "is_closed": true
-        },
-        {
-          "name": "rightFront",
-          "state": "CLOSED",
-          "is_closed": true
-        }
+        { "name": "leftFront", "state": "CLOSED", "is_closed": true },
+        { "name": "rightFront", "state": "CLOSED", "is_closed": true }
       ],
       "all_lids_closed": true,
       "all_windows_closed": true,
@@ -375,10 +300,7 @@
           "_timer_dict": {
             "action": "DEACTIVATE",
             "id": 1,
-            "timeStamp": {
-              "hour": 7,
-              "minute": 35
-            },
+            "timeStamp": { "hour": 7, "minute": 35 },
             "timerWeekDays": [
               "MONDAY",
               "TUESDAY",
@@ -396,10 +318,7 @@
           "_timer_dict": {
             "action": "DEACTIVATE",
             "id": 2,
-            "timeStamp": {
-              "hour": 18,
-              "minute": 0
-            },
+            "timeStamp": { "hour": 18, "minute": 0 },
             "timerWeekDays": [
               "MONDAY",
               "TUESDAY",
@@ -427,10 +346,7 @@
           "_timer_dict": {
             "action": "DEACTIVATE",
             "id": 3,
-            "timeStamp": {
-              "hour": 7,
-              "minute": 0
-            },
+            "timeStamp": { "hour": 7, "minute": 0 },
             "timerWeekDays": []
           },
           "action": "DEACTIVATE",
@@ -452,14 +368,8 @@
       ],
       "preferred_charging_window": {
         "_window_dict": {
-          "end": {
-            "hour": 1,
-            "minute": 30
-          },
-          "start": {
-            "hour": 18,
-            "minute": 1
-          }
+          "end": { "hour": 1, "minute": 30 },
+          "start": { "hour": 18, "minute": 1 }
         },
         "end_time": "01:30:00",
         "start_time": "18:01:00"
@@ -521,7 +431,7 @@
   },
   "fingerprint": [
     {
-      "filename": "bmw-vehicles_.json",
+      "filename": "bmw-vehicles.json",
       "content": [
         {
           "appVehicleType": "CONNECTED",
@@ -544,18 +454,12 @@
             "model": "i3 (+ REX)",
             "softwareVersionCurrent": {
               "iStep": 510,
-              "puStep": {
-                "month": 11,
-                "year": 21
-              },
+              "puStep": { "month": 11, "year": 21 },
               "seriesCluster": "I001"
             },
             "softwareVersionExFactory": {
               "iStep": 502,
-              "puStep": {
-                "month": 3,
-                "year": 15
-              },
+              "puStep": { "month": 3, "year": 15 },
               "seriesCluster": "I001"
             },
             "year": 2015
@@ -570,12 +474,9 @@
         }
       ]
     },
+    { "filename": "mini-vehicles.json", "content": [] },
     {
-      "filename": "mini-vehicles_.json",
-      "content": []
-    },
-    {
-      "filename": "bmw-vehicles_WBY0FINGERPRINT01_state_.json",
+      "filename": "bmw-vehicles_state_WBY0FINGERPRINT01.json",
       "content": {
         "capabilities": {
           "climateFunction": "AIR_CONDITIONING",
@@ -634,10 +535,7 @@
               {
                 "action": "DEACTIVATE",
                 "id": 1,
-                "timeStamp": {
-                  "hour": 7,
-                  "minute": 35
-                },
+                "timeStamp": { "hour": 7, "minute": 35 },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -649,10 +547,7 @@
               {
                 "action": "DEACTIVATE",
                 "id": 2,
-                "timeStamp": {
-                  "hour": 18,
-                  "minute": 0
-                },
+                "timeStamp": { "hour": 18, "minute": 0 },
                 "timerWeekDays": [
                   "MONDAY",
                   "TUESDAY",
@@ -666,54 +561,32 @@
               {
                 "action": "DEACTIVATE",
                 "id": 3,
-                "timeStamp": {
-                  "hour": 7,
-                  "minute": 0
-                },
+                "timeStamp": { "hour": 7, "minute": 0 },
                 "timerWeekDays": []
               },
-              {
-                "action": "DEACTIVATE",
-                "id": 4,
-                "timerWeekDays": []
-              }
+              { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
             ],
             "reductionOfChargeCurrent": {
-              "end": {
-                "hour": 1,
-                "minute": 30
-              },
-              "start": {
-                "hour": 18,
-                "minute": 1
-              }
+              "end": { "hour": 1, "minute": 30 },
+              "start": { "hour": 18, "minute": 1 }
             }
           },
           "checkControlMessages": [],
           "climateTimers": [
             {
-              "departureTime": {
-                "hour": 6,
-                "minute": 40
-              },
+              "departureTime": { "hour": 6, "minute": 40 },
               "isWeeklyTimer": true,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["THURSDAY", "SUNDAY"]
             },
             {
-              "departureTime": {
-                "hour": 12,
-                "minute": 50
-              },
+              "departureTime": { "hour": 12, "minute": 50 },
               "isWeeklyTimer": false,
               "timerAction": "ACTIVATE",
               "timerWeekDays": ["MONDAY"]
             },
             {
-              "departureTime": {
-                "hour": 18,
-                "minute": 59
-              },
+              "departureTime": { "hour": 18, "minute": 59 },
               "isWeeklyTimer": true,
               "timerAction": "DEACTIVATE",
               "timerWeekDays": ["WEDNESDAY"]
@@ -735,9 +608,7 @@
             "rightRear": "CLOSED",
             "trunk": "CLOSED"
           },
-          "driverPreferences": {
-            "lscPrivacyMode": "OFF"
-          },
+          "driverPreferences": { "lscPrivacyMode": "OFF" },
           "electricChargingState": {
             "chargingConnectionType": "CONDUCTIVE",
             "chargingLevelPercent": 82,
@@ -771,10 +642,7 @@
               "type": "VEHICLE_TUV"
             }
           ],
-          "roofState": {
-            "roofState": "CLOSED",
-            "roofStateType": "SUN_ROOF"
-          },
+          "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
           "windowsState": {
             "combinedState": "CLOSED",
             "leftFront": "CLOSED",

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
@@ -27,12 +27,18 @@
         "model": "i3 (+ REX)",
         "softwareVersionCurrent": {
           "iStep": 510,
-          "puStep": { "month": 11, "year": 21 },
+          "puStep": {
+            "month": 11,
+            "year": 21
+          },
           "seriesCluster": "I001"
         },
         "softwareVersionExFactory": {
           "iStep": 502,
-          "puStep": { "month": 3, "year": 15 },
+          "puStep": {
+            "month": 3,
+            "year": 15
+          },
           "seriesCluster": "I001"
         },
         "year": 2015
@@ -101,7 +107,10 @@
             {
               "action": "DEACTIVATE",
               "id": 1,
-              "timeStamp": { "hour": 7, "minute": 35 },
+              "timeStamp": {
+                "hour": 7,
+                "minute": 35
+              },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -113,7 +122,10 @@
             {
               "action": "DEACTIVATE",
               "id": 2,
-              "timeStamp": { "hour": 18, "minute": 0 },
+              "timeStamp": {
+                "hour": 18,
+                "minute": 0
+              },
               "timerWeekDays": [
                 "MONDAY",
                 "TUESDAY",
@@ -127,32 +139,54 @@
             {
               "action": "DEACTIVATE",
               "id": 3,
-              "timeStamp": { "hour": 7, "minute": 0 },
+              "timeStamp": {
+                "hour": 7,
+                "minute": 0
+              },
               "timerWeekDays": []
             },
-            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
+            {
+              "action": "DEACTIVATE",
+              "id": 4,
+              "timerWeekDays": []
+            }
           ],
           "reductionOfChargeCurrent": {
-            "end": { "hour": 1, "minute": 30 },
-            "start": { "hour": 18, "minute": 1 }
+            "end": {
+              "hour": 1,
+              "minute": 30
+            },
+            "start": {
+              "hour": 18,
+              "minute": 1
+            }
           }
         },
         "checkControlMessages": [],
         "climateTimers": [
           {
-            "departureTime": { "hour": 6, "minute": 40 },
+            "departureTime": {
+              "hour": 6,
+              "minute": 40
+            },
             "isWeeklyTimer": true,
             "timerAction": "ACTIVATE",
             "timerWeekDays": ["THURSDAY", "SUNDAY"]
           },
           {
-            "departureTime": { "hour": 12, "minute": 50 },
+            "departureTime": {
+              "hour": 12,
+              "minute": 50
+            },
             "isWeeklyTimer": false,
             "timerAction": "ACTIVATE",
             "timerWeekDays": ["MONDAY"]
           },
           {
-            "departureTime": { "hour": 18, "minute": 59 },
+            "departureTime": {
+              "hour": 18,
+              "minute": 59
+            },
             "isWeeklyTimer": true,
             "timerAction": "DEACTIVATE",
             "timerWeekDays": ["WEDNESDAY"]
@@ -174,7 +208,9 @@
           "rightRear": "CLOSED",
           "trunk": "CLOSED"
         },
-        "driverPreferences": { "lscPrivacyMode": "OFF" },
+        "driverPreferences": {
+          "lscPrivacyMode": "OFF"
+        },
         "electricChargingState": {
           "chargingConnectionType": "CONDUCTIVE",
           "chargingLevelPercent": 82,
@@ -208,7 +244,10 @@
             "type": "VEHICLE_TUV"
           }
         ],
-        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
+        "roofState": {
+          "roofState": "CLOSED",
+          "roofStateType": "SUN_ROOF"
+        },
         "windowsState": {
           "combinedState": "CLOSED",
           "leftFront": "CLOSED",
@@ -239,7 +278,7 @@
       "charging_start_time": "2022-07-10T18:01:00+00:00"
     },
     "vehicle_location": {
-      "location": { "latitude": null, "longitude": null },
+      "location": null,
       "heading": null,
       "vehicle_update_timestamp": "2022-07-10T09:25:53+00:00",
       "account_region": "row",
@@ -248,17 +287,53 @@
     "doors_and_windows": {
       "door_lock_state": "UNLOCKED",
       "lids": [
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        }
       ],
       "windows": [
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
-        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        },
+        {
+          "name": "**REDACTED**",
+          "state": "CLOSED",
+          "is_closed": true
+        }
       ],
       "all_lids_closed": true,
       "all_windows_closed": true,
@@ -300,7 +375,10 @@
           "_timer_dict": {
             "action": "DEACTIVATE",
             "id": 1,
-            "timeStamp": { "hour": 7, "minute": 35 },
+            "timeStamp": {
+              "hour": 7,
+              "minute": 35
+            },
             "timerWeekDays": [
               "MONDAY",
               "TUESDAY",
@@ -318,7 +396,10 @@
           "_timer_dict": {
             "action": "DEACTIVATE",
             "id": 2,
-            "timeStamp": { "hour": 18, "minute": 0 },
+            "timeStamp": {
+              "hour": 18,
+              "minute": 0
+            },
             "timerWeekDays": [
               "MONDAY",
               "TUESDAY",
@@ -346,7 +427,10 @@
           "_timer_dict": {
             "action": "DEACTIVATE",
             "id": 3,
-            "timeStamp": { "hour": 7, "minute": 0 },
+            "timeStamp": {
+              "hour": 7,
+              "minute": 0
+            },
             "timerWeekDays": []
           },
           "action": "DEACTIVATE",
@@ -368,8 +452,14 @@
       ],
       "preferred_charging_window": {
         "_window_dict": {
-          "end": { "hour": 1, "minute": 30 },
-          "start": { "hour": 18, "minute": 1 }
+          "end": {
+            "hour": 1,
+            "minute": 30
+          },
+          "start": {
+            "hour": 18,
+            "minute": 1
+          }
         },
         "end_time": "01:30:00",
         "start_time": "18:01:00"
@@ -429,221 +519,5 @@
     "timestamp": "2022-07-10T09:25:53+00:00",
     "vin": "**REDACTED**"
   },
-  "fingerprint": {
-    "vehicles_v2_mini_0.json": [],
-    "state_WBY00000000REXI01_0.json": {
-      "capabilities": {
-        "climateFunction": "AIR_CONDITIONING",
-        "climateNow": true,
-        "climateTimerTrigger": "DEPARTURE_TIMER",
-        "horn": true,
-        "isBmwChargingSupported": true,
-        "isCarSharingSupported": false,
-        "isChargeNowForBusinessSupported": false,
-        "isChargingHistorySupported": true,
-        "isChargingHospitalityEnabled": false,
-        "isChargingLoudnessEnabled": false,
-        "isChargingPlanSupported": true,
-        "isChargingPowerLimitEnabled": false,
-        "isChargingSettingsEnabled": false,
-        "isChargingTargetSocEnabled": false,
-        "isClimateTimerSupported": true,
-        "isCustomerEsimSupported": false,
-        "isDCSContractManagementSupported": true,
-        "isDataPrivacyEnabled": false,
-        "isEasyChargeEnabled": false,
-        "isEvGoChargingSupported": false,
-        "isMiniChargingSupported": false,
-        "isNonLscFeatureEnabled": false,
-        "isRemoteEngineStartSupported": false,
-        "isRemoteHistoryDeletionSupported": false,
-        "isRemoteHistorySupported": true,
-        "isRemoteParkingSupported": false,
-        "isRemoteServicesActivationRequired": false,
-        "isRemoteServicesBookingRequired": false,
-        "isScanAndChargeSupported": false,
-        "isSustainabilitySupported": false,
-        "isWifiHotspotServiceSupported": false,
-        "lastStateCallState": "ACTIVATED",
-        "lights": true,
-        "lock": true,
-        "remoteChargingCommands": {},
-        "sendPoi": true,
-        "specialThemeSupport": [],
-        "unlock": true,
-        "vehicleFinder": false,
-        "vehicleStateSource": "LAST_STATE_CALL"
-      },
-      "state": {
-        "chargingProfile": {
-          "chargingControlType": "WEEKLY_PLANNER",
-          "chargingMode": "DELAYED_CHARGING",
-          "chargingPreference": "CHARGING_WINDOW",
-          "chargingSettings": {
-            "hospitality": "NO_ACTION",
-            "idcc": "NO_ACTION",
-            "targetSoc": 100
-          },
-          "climatisationOn": false,
-          "departureTimes": [
-            {
-              "action": "DEACTIVATE",
-              "id": 1,
-              "timeStamp": { "hour": 7, "minute": 35 },
-              "timerWeekDays": [
-                "MONDAY",
-                "TUESDAY",
-                "WEDNESDAY",
-                "THURSDAY",
-                "FRIDAY"
-              ]
-            },
-            {
-              "action": "DEACTIVATE",
-              "id": 2,
-              "timeStamp": { "hour": 18, "minute": 0 },
-              "timerWeekDays": [
-                "MONDAY",
-                "TUESDAY",
-                "WEDNESDAY",
-                "THURSDAY",
-                "FRIDAY",
-                "SATURDAY",
-                "SUNDAY"
-              ]
-            },
-            {
-              "action": "DEACTIVATE",
-              "id": 3,
-              "timeStamp": { "hour": 7, "minute": 0 },
-              "timerWeekDays": []
-            },
-            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
-          ],
-          "reductionOfChargeCurrent": {
-            "end": { "hour": 1, "minute": 30 },
-            "start": { "hour": 18, "minute": 1 }
-          }
-        },
-        "checkControlMessages": [],
-        "climateTimers": [
-          {
-            "departureTime": { "hour": 6, "minute": 40 },
-            "isWeeklyTimer": true,
-            "timerAction": "ACTIVATE",
-            "timerWeekDays": ["THURSDAY", "SUNDAY"]
-          },
-          {
-            "departureTime": { "hour": 12, "minute": 50 },
-            "isWeeklyTimer": false,
-            "timerAction": "ACTIVATE",
-            "timerWeekDays": ["MONDAY"]
-          },
-          {
-            "departureTime": { "hour": 18, "minute": 59 },
-            "isWeeklyTimer": true,
-            "timerAction": "DEACTIVATE",
-            "timerWeekDays": ["WEDNESDAY"]
-          }
-        ],
-        "combustionFuelLevel": {
-          "range": 105,
-          "remainingFuelLiters": 6,
-          "remainingFuelPercent": 65
-        },
-        "currentMileage": 137009,
-        "doorsState": {
-          "combinedSecurityState": "UNLOCKED",
-          "combinedState": "CLOSED",
-          "hood": "CLOSED",
-          "leftFront": "CLOSED",
-          "leftRear": "CLOSED",
-          "rightFront": "CLOSED",
-          "rightRear": "CLOSED",
-          "trunk": "CLOSED"
-        },
-        "driverPreferences": { "lscPrivacyMode": "OFF" },
-        "electricChargingState": {
-          "chargingConnectionType": "CONDUCTIVE",
-          "chargingLevelPercent": 82,
-          "chargingStatus": "WAITING_FOR_CHARGING",
-          "chargingTarget": 100,
-          "isChargerConnected": true,
-          "range": 174
-        },
-        "isLeftSteering": true,
-        "isLscSupported": true,
-        "lastFetched": "2022-06-22T14:24:23.982Z",
-        "lastUpdatedAt": "2022-06-22T13:58:52Z",
-        "range": 174,
-        "requiredServices": [
-          {
-            "dateTime": "2022-10-01T00:00:00.000Z",
-            "description": "Next service due by the specified date.",
-            "status": "OK",
-            "type": "BRAKE_FLUID"
-          },
-          {
-            "dateTime": "2023-05-01T00:00:00.000Z",
-            "description": "Next vehicle check due after the specified distance or date.",
-            "status": "OK",
-            "type": "VEHICLE_CHECK"
-          },
-          {
-            "dateTime": "2023-05-01T00:00:00.000Z",
-            "description": "Next state inspection due by the specified date.",
-            "status": "OK",
-            "type": "VEHICLE_TUV"
-          }
-        ],
-        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
-        "windowsState": {
-          "combinedState": "CLOSED",
-          "leftFront": "CLOSED",
-          "rightFront": "CLOSED"
-        }
-      }
-    },
-    "vehicles_v2_bmw_0.json": [
-      {
-        "appVehicleType": "CONNECTED",
-        "attributes": {
-          "a4aType": "USB_ONLY",
-          "bodyType": "I01",
-          "brand": "BMW_I",
-          "color": 4284110934,
-          "countryOfOrigin": "CZ",
-          "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
-          "driverGuideInfo": {
-            "androidAppScheme": "com.bmwgroup.driversguide.row",
-            "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
-            "iosAppScheme": "bmwdriversguide:///open",
-            "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
-          },
-          "headUnitType": "NBT",
-          "hmiVersion": "ID4",
-          "lastFetched": "2022-07-10T09:25:53.104Z",
-          "model": "i3 (+ REX)",
-          "softwareVersionCurrent": {
-            "iStep": 510,
-            "puStep": { "month": 11, "year": 21 },
-            "seriesCluster": "I001"
-          },
-          "softwareVersionExFactory": {
-            "iStep": 502,
-            "puStep": { "month": 3, "year": 15 },
-            "seriesCluster": "I001"
-          },
-          "year": 2015
-        },
-        "mappingInfo": {
-          "isAssociated": false,
-          "isLmmEnabled": false,
-          "isPrimaryUser": true,
-          "mappingStatus": "CONFIRMED"
-        },
-        "vin": "**REDACTED**"
-      }
-    ]
-  }
+  "fingerprint": []
 }

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
@@ -1,0 +1,649 @@
+{
+  "info": {
+    "username": "**REDACTED**",
+    "password": "**REDACTED**",
+    "region": "rest_of_world",
+    "refresh_token": "**REDACTED**"
+  },
+  "data": {
+    "data": {
+      "appVehicleType": "CONNECTED",
+      "attributes": {
+        "a4aType": "USB_ONLY",
+        "bodyType": "I01",
+        "brand": "BMW_I",
+        "color": 4284110934,
+        "countryOfOrigin": "CZ",
+        "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
+        "driverGuideInfo": {
+          "androidAppScheme": "com.bmwgroup.driversguide.row",
+          "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
+          "iosAppScheme": "bmwdriversguide:///open",
+          "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
+        },
+        "headUnitType": "NBT",
+        "hmiVersion": "ID4",
+        "lastFetched": "2022-07-10T09:25:53.104Z",
+        "model": "i3 (+ REX)",
+        "softwareVersionCurrent": {
+          "iStep": 510,
+          "puStep": { "month": 11, "year": 21 },
+          "seriesCluster": "I001"
+        },
+        "softwareVersionExFactory": {
+          "iStep": 502,
+          "puStep": { "month": 3, "year": 15 },
+          "seriesCluster": "I001"
+        },
+        "year": 2015
+      },
+      "mappingInfo": {
+        "isAssociated": false,
+        "isLmmEnabled": false,
+        "isPrimaryUser": true,
+        "mappingStatus": "CONFIRMED"
+      },
+      "vin": "**REDACTED**",
+      "capabilities": {
+        "climateFunction": "AIR_CONDITIONING",
+        "climateNow": true,
+        "climateTimerTrigger": "DEPARTURE_TIMER",
+        "horn": true,
+        "isBmwChargingSupported": true,
+        "isCarSharingSupported": false,
+        "isChargeNowForBusinessSupported": false,
+        "isChargingHistorySupported": true,
+        "isChargingHospitalityEnabled": false,
+        "isChargingLoudnessEnabled": false,
+        "isChargingPlanSupported": true,
+        "isChargingPowerLimitEnabled": false,
+        "isChargingSettingsEnabled": false,
+        "isChargingTargetSocEnabled": false,
+        "isClimateTimerSupported": true,
+        "isCustomerEsimSupported": false,
+        "isDCSContractManagementSupported": true,
+        "isDataPrivacyEnabled": false,
+        "isEasyChargeEnabled": false,
+        "isEvGoChargingSupported": false,
+        "isMiniChargingSupported": false,
+        "isNonLscFeatureEnabled": false,
+        "isRemoteEngineStartSupported": false,
+        "isRemoteHistoryDeletionSupported": false,
+        "isRemoteHistorySupported": true,
+        "isRemoteParkingSupported": false,
+        "isRemoteServicesActivationRequired": false,
+        "isRemoteServicesBookingRequired": false,
+        "isScanAndChargeSupported": false,
+        "isSustainabilitySupported": false,
+        "isWifiHotspotServiceSupported": false,
+        "lastStateCallState": "ACTIVATED",
+        "lights": true,
+        "lock": true,
+        "remoteChargingCommands": {},
+        "sendPoi": true,
+        "specialThemeSupport": [],
+        "unlock": true,
+        "vehicleFinder": false,
+        "vehicleStateSource": "LAST_STATE_CALL"
+      },
+      "state": {
+        "chargingProfile": {
+          "chargingControlType": "WEEKLY_PLANNER",
+          "chargingMode": "DELAYED_CHARGING",
+          "chargingPreference": "CHARGING_WINDOW",
+          "chargingSettings": {
+            "hospitality": "NO_ACTION",
+            "idcc": "NO_ACTION",
+            "targetSoc": 100
+          },
+          "climatisationOn": false,
+          "departureTimes": [
+            {
+              "action": "DEACTIVATE",
+              "id": 1,
+              "timeStamp": { "hour": 7, "minute": 35 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY"
+              ]
+            },
+            {
+              "action": "DEACTIVATE",
+              "id": 2,
+              "timeStamp": { "hour": 18, "minute": 0 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY",
+                "SATURDAY",
+                "SUNDAY"
+              ]
+            },
+            {
+              "action": "DEACTIVATE",
+              "id": 3,
+              "timeStamp": { "hour": 7, "minute": 0 },
+              "timerWeekDays": []
+            },
+            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
+          ],
+          "reductionOfChargeCurrent": {
+            "end": { "hour": 1, "minute": 30 },
+            "start": { "hour": 18, "minute": 1 }
+          }
+        },
+        "checkControlMessages": [],
+        "climateTimers": [
+          {
+            "departureTime": { "hour": 6, "minute": 40 },
+            "isWeeklyTimer": true,
+            "timerAction": "ACTIVATE",
+            "timerWeekDays": ["THURSDAY", "SUNDAY"]
+          },
+          {
+            "departureTime": { "hour": 12, "minute": 50 },
+            "isWeeklyTimer": false,
+            "timerAction": "ACTIVATE",
+            "timerWeekDays": ["MONDAY"]
+          },
+          {
+            "departureTime": { "hour": 18, "minute": 59 },
+            "isWeeklyTimer": true,
+            "timerAction": "DEACTIVATE",
+            "timerWeekDays": ["WEDNESDAY"]
+          }
+        ],
+        "combustionFuelLevel": {
+          "range": 105,
+          "remainingFuelLiters": 6,
+          "remainingFuelPercent": 65
+        },
+        "currentMileage": 137009,
+        "doorsState": {
+          "combinedSecurityState": "UNLOCKED",
+          "combinedState": "CLOSED",
+          "hood": "CLOSED",
+          "leftFront": "CLOSED",
+          "leftRear": "CLOSED",
+          "rightFront": "CLOSED",
+          "rightRear": "CLOSED",
+          "trunk": "CLOSED"
+        },
+        "driverPreferences": { "lscPrivacyMode": "OFF" },
+        "electricChargingState": {
+          "chargingConnectionType": "CONDUCTIVE",
+          "chargingLevelPercent": 82,
+          "chargingStatus": "WAITING_FOR_CHARGING",
+          "chargingTarget": 100,
+          "isChargerConnected": true,
+          "range": 174
+        },
+        "isLeftSteering": true,
+        "isLscSupported": true,
+        "lastFetched": "2022-06-22T14:24:23.982Z",
+        "lastUpdatedAt": "2022-06-22T13:58:52Z",
+        "range": 174,
+        "requiredServices": [
+          {
+            "dateTime": "2022-10-01T00:00:00.000Z",
+            "description": "Next service due by the specified date.",
+            "status": "OK",
+            "type": "BRAKE_FLUID"
+          },
+          {
+            "dateTime": "2023-05-01T00:00:00.000Z",
+            "description": "Next vehicle check due after the specified distance or date.",
+            "status": "OK",
+            "type": "VEHICLE_CHECK"
+          },
+          {
+            "dateTime": "2023-05-01T00:00:00.000Z",
+            "description": "Next state inspection due by the specified date.",
+            "status": "OK",
+            "type": "VEHICLE_TUV"
+          }
+        ],
+        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
+        "windowsState": {
+          "combinedState": "CLOSED",
+          "leftFront": "CLOSED",
+          "rightFront": "CLOSED"
+        }
+      },
+      "is_metric": true,
+      "fetched_at": "2022-07-10T11:00:00+00:00"
+    },
+    "fuel_and_battery": {
+      "remaining_range_fuel": [105, "km"],
+      "remaining_range_electric": [174, "km"],
+      "remaining_range_total": [279, "km"],
+      "remaining_fuel": [6, "L"],
+      "remaining_fuel_percent": 65,
+      "remaining_battery_percent": 82,
+      "charging_status": "WAITING_FOR_CHARGING",
+      "charging_start_time_no_tz": "2022-07-10T18:01:00",
+      "charging_end_time": null,
+      "is_charger_connected": true,
+      "account_timezone": {
+        "_std_offset": "0:00:00",
+        "_dst_offset": "0:00:00",
+        "_dst_saved": "0:00:00",
+        "_hasdst": false,
+        "_tznames": ["UTC", "UTC"]
+      },
+      "charging_start_time": "2022-07-10T18:01:00+00:00"
+    },
+    "vehicle_location": {
+      "location": { "latitude": null, "longitude": null },
+      "heading": null,
+      "vehicle_update_timestamp": "2022-07-10T09:25:53+00:00",
+      "account_region": "row",
+      "remote_service_position": null
+    },
+    "doors_and_windows": {
+      "door_lock_state": "UNLOCKED",
+      "lids": [
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+      ],
+      "windows": [
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true },
+        { "name": "**REDACTED**", "state": "CLOSED", "is_closed": true }
+      ],
+      "all_lids_closed": true,
+      "all_windows_closed": true,
+      "open_lids": [],
+      "open_windows": []
+    },
+    "condition_based_services": {
+      "messages": [
+        {
+          "service_type": "BRAKE_FLUID",
+          "state": "OK",
+          "due_date": "2022-10-01T00:00:00+00:00",
+          "due_distance": [null, null]
+        },
+        {
+          "service_type": "VEHICLE_CHECK",
+          "state": "OK",
+          "due_date": "2023-05-01T00:00:00+00:00",
+          "due_distance": [null, null]
+        },
+        {
+          "service_type": "VEHICLE_TUV",
+          "state": "OK",
+          "due_date": "2023-05-01T00:00:00+00:00",
+          "due_distance": [null, null]
+        }
+      ],
+      "is_service_required": false
+    },
+    "check_control_messages": {
+      "messages": [],
+      "has_check_control_messages": false
+    },
+    "charging_profile": {
+      "is_pre_entry_climatization_enabled": false,
+      "timer_type": "WEEKLY_PLANNER",
+      "departure_times": [
+        {
+          "_timer_dict": {
+            "action": "DEACTIVATE",
+            "id": 1,
+            "timeStamp": { "hour": 7, "minute": 35 },
+            "timerWeekDays": [
+              "MONDAY",
+              "TUESDAY",
+              "WEDNESDAY",
+              "THURSDAY",
+              "FRIDAY"
+            ]
+          },
+          "action": "DEACTIVATE",
+          "start_time": "07:35:00",
+          "timer_id": 1,
+          "weekdays": ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+        },
+        {
+          "_timer_dict": {
+            "action": "DEACTIVATE",
+            "id": 2,
+            "timeStamp": { "hour": 18, "minute": 0 },
+            "timerWeekDays": [
+              "MONDAY",
+              "TUESDAY",
+              "WEDNESDAY",
+              "THURSDAY",
+              "FRIDAY",
+              "SATURDAY",
+              "SUNDAY"
+            ]
+          },
+          "action": "DEACTIVATE",
+          "start_time": "18:00:00",
+          "timer_id": 2,
+          "weekdays": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        {
+          "_timer_dict": {
+            "action": "DEACTIVATE",
+            "id": 3,
+            "timeStamp": { "hour": 7, "minute": 0 },
+            "timerWeekDays": []
+          },
+          "action": "DEACTIVATE",
+          "start_time": "07:00:00",
+          "timer_id": 3,
+          "weekdays": []
+        },
+        {
+          "_timer_dict": {
+            "action": "DEACTIVATE",
+            "id": 4,
+            "timerWeekDays": []
+          },
+          "action": "DEACTIVATE",
+          "start_time": null,
+          "timer_id": 4,
+          "weekdays": []
+        }
+      ],
+      "preferred_charging_window": {
+        "_window_dict": {
+          "end": { "hour": 1, "minute": 30 },
+          "start": { "hour": 18, "minute": 1 }
+        },
+        "end_time": "01:30:00",
+        "start_time": "18:01:00"
+      },
+      "charging_preferences": "CHARGING_WINDOW",
+      "charging_mode": "DELAYED_CHARGING"
+    },
+    "available_attributes": [
+      "gps_position",
+      "vin",
+      "remaining_range_total",
+      "mileage",
+      "charging_time_remaining",
+      "charging_end_time",
+      "charging_time_label",
+      "charging_status",
+      "connection_status",
+      "remaining_battery_percent",
+      "remaining_range_electric",
+      "last_charging_end_result",
+      "remaining_fuel",
+      "remaining_range_fuel",
+      "remaining_fuel_percent",
+      "condition_based_services",
+      "check_control_messages",
+      "door_lock_state",
+      "timestamp",
+      "lids",
+      "windows"
+    ],
+    "brand": "bmw",
+    "drive_train": "ELECTRIC_WITH_RANGE_EXTENDER",
+    "drive_train_attributes": [
+      "remaining_range_total",
+      "mileage",
+      "charging_time_remaining",
+      "charging_end_time",
+      "charging_time_label",
+      "charging_status",
+      "connection_status",
+      "remaining_battery_percent",
+      "remaining_range_electric",
+      "last_charging_end_result",
+      "remaining_fuel",
+      "remaining_range_fuel",
+      "remaining_fuel_percent"
+    ],
+    "has_combustion_drivetrain": true,
+    "has_electric_drivetrain": true,
+    "is_charging_plan_supported": true,
+    "is_lsc_enabled": true,
+    "is_vehicle_active": false,
+    "is_vehicle_tracking_enabled": false,
+    "lsc_type": "ACTIVATED",
+    "mileage": [137009, "km"],
+    "name": "**REDACTED**",
+    "timestamp": "2022-07-10T09:25:53+00:00",
+    "vin": "**REDACTED**"
+  },
+  "fingerprint": {
+    "vehicles_v2_mini_0.json": [],
+    "state_WBY00000000REXI01_0.json": {
+      "capabilities": {
+        "climateFunction": "AIR_CONDITIONING",
+        "climateNow": true,
+        "climateTimerTrigger": "DEPARTURE_TIMER",
+        "horn": true,
+        "isBmwChargingSupported": true,
+        "isCarSharingSupported": false,
+        "isChargeNowForBusinessSupported": false,
+        "isChargingHistorySupported": true,
+        "isChargingHospitalityEnabled": false,
+        "isChargingLoudnessEnabled": false,
+        "isChargingPlanSupported": true,
+        "isChargingPowerLimitEnabled": false,
+        "isChargingSettingsEnabled": false,
+        "isChargingTargetSocEnabled": false,
+        "isClimateTimerSupported": true,
+        "isCustomerEsimSupported": false,
+        "isDCSContractManagementSupported": true,
+        "isDataPrivacyEnabled": false,
+        "isEasyChargeEnabled": false,
+        "isEvGoChargingSupported": false,
+        "isMiniChargingSupported": false,
+        "isNonLscFeatureEnabled": false,
+        "isRemoteEngineStartSupported": false,
+        "isRemoteHistoryDeletionSupported": false,
+        "isRemoteHistorySupported": true,
+        "isRemoteParkingSupported": false,
+        "isRemoteServicesActivationRequired": false,
+        "isRemoteServicesBookingRequired": false,
+        "isScanAndChargeSupported": false,
+        "isSustainabilitySupported": false,
+        "isWifiHotspotServiceSupported": false,
+        "lastStateCallState": "ACTIVATED",
+        "lights": true,
+        "lock": true,
+        "remoteChargingCommands": {},
+        "sendPoi": true,
+        "specialThemeSupport": [],
+        "unlock": true,
+        "vehicleFinder": false,
+        "vehicleStateSource": "LAST_STATE_CALL"
+      },
+      "state": {
+        "chargingProfile": {
+          "chargingControlType": "WEEKLY_PLANNER",
+          "chargingMode": "DELAYED_CHARGING",
+          "chargingPreference": "CHARGING_WINDOW",
+          "chargingSettings": {
+            "hospitality": "NO_ACTION",
+            "idcc": "NO_ACTION",
+            "targetSoc": 100
+          },
+          "climatisationOn": false,
+          "departureTimes": [
+            {
+              "action": "DEACTIVATE",
+              "id": 1,
+              "timeStamp": { "hour": 7, "minute": 35 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY"
+              ]
+            },
+            {
+              "action": "DEACTIVATE",
+              "id": 2,
+              "timeStamp": { "hour": 18, "minute": 0 },
+              "timerWeekDays": [
+                "MONDAY",
+                "TUESDAY",
+                "WEDNESDAY",
+                "THURSDAY",
+                "FRIDAY",
+                "SATURDAY",
+                "SUNDAY"
+              ]
+            },
+            {
+              "action": "DEACTIVATE",
+              "id": 3,
+              "timeStamp": { "hour": 7, "minute": 0 },
+              "timerWeekDays": []
+            },
+            { "action": "DEACTIVATE", "id": 4, "timerWeekDays": [] }
+          ],
+          "reductionOfChargeCurrent": {
+            "end": { "hour": 1, "minute": 30 },
+            "start": { "hour": 18, "minute": 1 }
+          }
+        },
+        "checkControlMessages": [],
+        "climateTimers": [
+          {
+            "departureTime": { "hour": 6, "minute": 40 },
+            "isWeeklyTimer": true,
+            "timerAction": "ACTIVATE",
+            "timerWeekDays": ["THURSDAY", "SUNDAY"]
+          },
+          {
+            "departureTime": { "hour": 12, "minute": 50 },
+            "isWeeklyTimer": false,
+            "timerAction": "ACTIVATE",
+            "timerWeekDays": ["MONDAY"]
+          },
+          {
+            "departureTime": { "hour": 18, "minute": 59 },
+            "isWeeklyTimer": true,
+            "timerAction": "DEACTIVATE",
+            "timerWeekDays": ["WEDNESDAY"]
+          }
+        ],
+        "combustionFuelLevel": {
+          "range": 105,
+          "remainingFuelLiters": 6,
+          "remainingFuelPercent": 65
+        },
+        "currentMileage": 137009,
+        "doorsState": {
+          "combinedSecurityState": "UNLOCKED",
+          "combinedState": "CLOSED",
+          "hood": "CLOSED",
+          "leftFront": "CLOSED",
+          "leftRear": "CLOSED",
+          "rightFront": "CLOSED",
+          "rightRear": "CLOSED",
+          "trunk": "CLOSED"
+        },
+        "driverPreferences": { "lscPrivacyMode": "OFF" },
+        "electricChargingState": {
+          "chargingConnectionType": "CONDUCTIVE",
+          "chargingLevelPercent": 82,
+          "chargingStatus": "WAITING_FOR_CHARGING",
+          "chargingTarget": 100,
+          "isChargerConnected": true,
+          "range": 174
+        },
+        "isLeftSteering": true,
+        "isLscSupported": true,
+        "lastFetched": "2022-06-22T14:24:23.982Z",
+        "lastUpdatedAt": "2022-06-22T13:58:52Z",
+        "range": 174,
+        "requiredServices": [
+          {
+            "dateTime": "2022-10-01T00:00:00.000Z",
+            "description": "Next service due by the specified date.",
+            "status": "OK",
+            "type": "BRAKE_FLUID"
+          },
+          {
+            "dateTime": "2023-05-01T00:00:00.000Z",
+            "description": "Next vehicle check due after the specified distance or date.",
+            "status": "OK",
+            "type": "VEHICLE_CHECK"
+          },
+          {
+            "dateTime": "2023-05-01T00:00:00.000Z",
+            "description": "Next state inspection due by the specified date.",
+            "status": "OK",
+            "type": "VEHICLE_TUV"
+          }
+        ],
+        "roofState": { "roofState": "CLOSED", "roofStateType": "SUN_ROOF" },
+        "windowsState": {
+          "combinedState": "CLOSED",
+          "leftFront": "CLOSED",
+          "rightFront": "CLOSED"
+        }
+      }
+    },
+    "vehicles_v2_bmw_0.json": [
+      {
+        "appVehicleType": "CONNECTED",
+        "attributes": {
+          "a4aType": "USB_ONLY",
+          "bodyType": "I01",
+          "brand": "BMW_I",
+          "color": 4284110934,
+          "countryOfOrigin": "CZ",
+          "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
+          "driverGuideInfo": {
+            "androidAppScheme": "com.bmwgroup.driversguide.row",
+            "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
+            "iosAppScheme": "bmwdriversguide:///open",
+            "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
+          },
+          "headUnitType": "NBT",
+          "hmiVersion": "ID4",
+          "lastFetched": "2022-07-10T09:25:53.104Z",
+          "model": "i3 (+ REX)",
+          "softwareVersionCurrent": {
+            "iStep": 510,
+            "puStep": { "month": 11, "year": 21 },
+            "seriesCluster": "I001"
+          },
+          "softwareVersionExFactory": {
+            "iStep": 502,
+            "puStep": { "month": 3, "year": 15 },
+            "seriesCluster": "I001"
+          },
+          "year": 2015
+        },
+        "mappingInfo": {
+          "isAssociated": false,
+          "isLmmEnabled": false,
+          "isPrimaryUser": true,
+          "mappingStatus": "CONFIRMED"
+        },
+        "vin": "**REDACTED**"
+      }
+    ]
+  }
+}

--- a/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
+++ b/tests/components/bmw_connected_drive/fixtures/diagnostics/diagnostics_device.json
@@ -50,6 +50,8 @@
         "mappingStatus": "CONFIRMED"
       },
       "vin": "**REDACTED**",
+      "is_metric": true,
+      "fetched_at": "2022-07-10T11:00:00+00:00",
       "capabilities": {
         "climateFunction": "AIR_CONDITIONING",
         "climateNow": true,
@@ -253,9 +255,7 @@
           "leftFront": "CLOSED",
           "rightFront": "CLOSED"
         }
-      },
-      "is_metric": true,
-      "fetched_at": "2022-07-10T11:00:00+00:00"
+      }
     },
     "fuel_and_battery": {
       "remaining_range_fuel": [105, "km"],
@@ -288,49 +288,49 @@
       "door_lock_state": "UNLOCKED",
       "lids": [
         {
-          "name": "**REDACTED**",
+          "name": "hood",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "leftFront",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "leftRear",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "rightFront",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "rightRear",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "trunk",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "sunRoof",
           "state": "CLOSED",
           "is_closed": true
         }
       ],
       "windows": [
         {
-          "name": "**REDACTED**",
+          "name": "leftFront",
           "state": "CLOSED",
           "is_closed": true
         },
         {
-          "name": "**REDACTED**",
+          "name": "rightFront",
           "state": "CLOSED",
           "is_closed": true
         }
@@ -515,9 +515,273 @@
     "is_vehicle_tracking_enabled": false,
     "lsc_type": "ACTIVATED",
     "mileage": [137009, "km"],
-    "name": "**REDACTED**",
+    "name": "i3 (+ REX)",
     "timestamp": "2022-07-10T09:25:53+00:00",
     "vin": "**REDACTED**"
   },
-  "fingerprint": []
+  "fingerprint": [
+    {
+      "filename": "bmw-vehicles_.json",
+      "content": [
+        {
+          "appVehicleType": "CONNECTED",
+          "attributes": {
+            "a4aType": "USB_ONLY",
+            "bodyType": "I01",
+            "brand": "BMW_I",
+            "color": 4284110934,
+            "countryOfOrigin": "CZ",
+            "driveTrain": "ELECTRIC_WITH_RANGE_EXTENDER",
+            "driverGuideInfo": {
+              "androidAppScheme": "com.bmwgroup.driversguide.row",
+              "androidStoreUrl": "https://play.google.com/store/apps/details?id=com.bmwgroup.driversguide.row",
+              "iosAppScheme": "bmwdriversguide:///open",
+              "iosStoreUrl": "https://apps.apple.com/de/app/id714042749?mt=8"
+            },
+            "headUnitType": "NBT",
+            "hmiVersion": "ID4",
+            "lastFetched": "2022-07-10T09:25:53.104Z",
+            "model": "i3 (+ REX)",
+            "softwareVersionCurrent": {
+              "iStep": 510,
+              "puStep": {
+                "month": 11,
+                "year": 21
+              },
+              "seriesCluster": "I001"
+            },
+            "softwareVersionExFactory": {
+              "iStep": 502,
+              "puStep": {
+                "month": 3,
+                "year": 15
+              },
+              "seriesCluster": "I001"
+            },
+            "year": 2015
+          },
+          "mappingInfo": {
+            "isAssociated": false,
+            "isLmmEnabled": false,
+            "isPrimaryUser": true,
+            "mappingStatus": "CONFIRMED"
+          },
+          "vin": "**REDACTED**"
+        }
+      ]
+    },
+    {
+      "filename": "mini-vehicles_.json",
+      "content": []
+    },
+    {
+      "filename": "bmw-vehicles_WBY0FINGERPRINT01_state_.json",
+      "content": {
+        "capabilities": {
+          "climateFunction": "AIR_CONDITIONING",
+          "climateNow": true,
+          "climateTimerTrigger": "DEPARTURE_TIMER",
+          "horn": true,
+          "isBmwChargingSupported": true,
+          "isCarSharingSupported": false,
+          "isChargeNowForBusinessSupported": false,
+          "isChargingHistorySupported": true,
+          "isChargingHospitalityEnabled": false,
+          "isChargingLoudnessEnabled": false,
+          "isChargingPlanSupported": true,
+          "isChargingPowerLimitEnabled": false,
+          "isChargingSettingsEnabled": false,
+          "isChargingTargetSocEnabled": false,
+          "isClimateTimerSupported": true,
+          "isCustomerEsimSupported": false,
+          "isDCSContractManagementSupported": true,
+          "isDataPrivacyEnabled": false,
+          "isEasyChargeEnabled": false,
+          "isEvGoChargingSupported": false,
+          "isMiniChargingSupported": false,
+          "isNonLscFeatureEnabled": false,
+          "isRemoteEngineStartSupported": false,
+          "isRemoteHistoryDeletionSupported": false,
+          "isRemoteHistorySupported": true,
+          "isRemoteParkingSupported": false,
+          "isRemoteServicesActivationRequired": false,
+          "isRemoteServicesBookingRequired": false,
+          "isScanAndChargeSupported": false,
+          "isSustainabilitySupported": false,
+          "isWifiHotspotServiceSupported": false,
+          "lastStateCallState": "ACTIVATED",
+          "lights": true,
+          "lock": true,
+          "remoteChargingCommands": {},
+          "sendPoi": true,
+          "specialThemeSupport": [],
+          "unlock": true,
+          "vehicleFinder": false,
+          "vehicleStateSource": "LAST_STATE_CALL"
+        },
+        "state": {
+          "chargingProfile": {
+            "chargingControlType": "WEEKLY_PLANNER",
+            "chargingMode": "DELAYED_CHARGING",
+            "chargingPreference": "CHARGING_WINDOW",
+            "chargingSettings": {
+              "hospitality": "NO_ACTION",
+              "idcc": "NO_ACTION",
+              "targetSoc": 100
+            },
+            "climatisationOn": false,
+            "departureTimes": [
+              {
+                "action": "DEACTIVATE",
+                "id": 1,
+                "timeStamp": {
+                  "hour": 7,
+                  "minute": 35
+                },
+                "timerWeekDays": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY"
+                ]
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 2,
+                "timeStamp": {
+                  "hour": 18,
+                  "minute": 0
+                },
+                "timerWeekDays": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY",
+                  "SATURDAY",
+                  "SUNDAY"
+                ]
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 3,
+                "timeStamp": {
+                  "hour": 7,
+                  "minute": 0
+                },
+                "timerWeekDays": []
+              },
+              {
+                "action": "DEACTIVATE",
+                "id": 4,
+                "timerWeekDays": []
+              }
+            ],
+            "reductionOfChargeCurrent": {
+              "end": {
+                "hour": 1,
+                "minute": 30
+              },
+              "start": {
+                "hour": 18,
+                "minute": 1
+              }
+            }
+          },
+          "checkControlMessages": [],
+          "climateTimers": [
+            {
+              "departureTime": {
+                "hour": 6,
+                "minute": 40
+              },
+              "isWeeklyTimer": true,
+              "timerAction": "ACTIVATE",
+              "timerWeekDays": ["THURSDAY", "SUNDAY"]
+            },
+            {
+              "departureTime": {
+                "hour": 12,
+                "minute": 50
+              },
+              "isWeeklyTimer": false,
+              "timerAction": "ACTIVATE",
+              "timerWeekDays": ["MONDAY"]
+            },
+            {
+              "departureTime": {
+                "hour": 18,
+                "minute": 59
+              },
+              "isWeeklyTimer": true,
+              "timerAction": "DEACTIVATE",
+              "timerWeekDays": ["WEDNESDAY"]
+            }
+          ],
+          "combustionFuelLevel": {
+            "range": 105,
+            "remainingFuelLiters": 6,
+            "remainingFuelPercent": 65
+          },
+          "currentMileage": 137009,
+          "doorsState": {
+            "combinedSecurityState": "UNLOCKED",
+            "combinedState": "CLOSED",
+            "hood": "CLOSED",
+            "leftFront": "CLOSED",
+            "leftRear": "CLOSED",
+            "rightFront": "CLOSED",
+            "rightRear": "CLOSED",
+            "trunk": "CLOSED"
+          },
+          "driverPreferences": {
+            "lscPrivacyMode": "OFF"
+          },
+          "electricChargingState": {
+            "chargingConnectionType": "CONDUCTIVE",
+            "chargingLevelPercent": 82,
+            "chargingStatus": "WAITING_FOR_CHARGING",
+            "chargingTarget": 100,
+            "isChargerConnected": true,
+            "range": 174
+          },
+          "isLeftSteering": true,
+          "isLscSupported": true,
+          "lastFetched": "2022-06-22T14:24:23.982Z",
+          "lastUpdatedAt": "2022-06-22T13:58:52Z",
+          "range": 174,
+          "requiredServices": [
+            {
+              "dateTime": "2022-10-01T00:00:00.000Z",
+              "description": "Next service due by the specified date.",
+              "status": "OK",
+              "type": "BRAKE_FLUID"
+            },
+            {
+              "dateTime": "2023-05-01T00:00:00.000Z",
+              "description": "Next vehicle check due after the specified distance or date.",
+              "status": "OK",
+              "type": "VEHICLE_CHECK"
+            },
+            {
+              "dateTime": "2023-05-01T00:00:00.000Z",
+              "description": "Next state inspection due by the specified date.",
+              "status": "OK",
+              "type": "VEHICLE_TUV"
+            }
+          ],
+          "roofState": {
+            "roofState": "CLOSED",
+            "roofStateType": "SUN_ROOF"
+          },
+          "windowsState": {
+            "combinedState": "CLOSED",
+            "leftFront": "CLOSED",
+            "rightFront": "CLOSED"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -6,7 +6,6 @@ import os
 import time
 
 from freezegun import freeze_time
-import pytest
 
 from homeassistant.components.bmw_connected_drive.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -92,7 +91,14 @@ async def test_device_diagnostics_vehicle_not_found(
         reg_device.id, new_identifiers={(DOMAIN, "WBY00000000REXI99")}
     )
 
-    with pytest.raises(AssertionError):
-        await get_diagnostics_for_device(
-            hass, hass_client, mock_config_entry, reg_device
-        )
+    diagnostics = await get_diagnostics_for_device(
+        hass, hass_client, mock_config_entry, reg_device
+    )
+
+    diagnostics_fixture = json.loads(
+        load_fixture("diagnostics/diagnostics_device.json", DOMAIN)
+    )
+    # Mock empty data if car is not found in account anymore
+    diagnostics_fixture["data"] = None
+
+    assert diagnostics == diagnostics_fixture

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -31,8 +31,6 @@ async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client, bmw_fi
 
     mock_config_entry = await setup_mocked_integration(hass)
 
-    assert hass.data[DOMAIN]
-
     diagnostics = await get_diagnostics_for_config_entry(
         hass, hass_client, mock_config_entry
     )
@@ -53,8 +51,6 @@ async def test_device_diagnostics(hass: HomeAssistant, hass_client, bmw_fixture)
     time.tzset()
 
     mock_config_entry = await setup_mocked_integration(hass)
-
-    assert hass.data[DOMAIN]
 
     device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
@@ -84,8 +80,6 @@ async def test_device_diagnostics_vehicle_not_found(
     time.tzset()
 
     mock_config_entry = await setup_mocked_integration(hass)
-
-    assert hass.data[DOMAIN]
 
     device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -1,0 +1,104 @@
+"""Test BMW diagnostics."""
+
+import datetime
+import json
+import os
+import time
+
+from freezegun import freeze_time
+import pytest
+
+from homeassistant.components.bmw_connected_drive.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_mocked_integration
+
+from tests.common import load_fixture
+from tests.components.diagnostics import (
+    get_diagnostics_for_config_entry,
+    get_diagnostics_for_device,
+)
+
+
+@freeze_time(datetime.datetime(2022, 7, 10, 11))
+async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client, bmw_fixture):
+    """Test config entry diagnostics."""
+
+    # Make sure that local timezone for test is UTC
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+
+    mock_config_entry = await setup_mocked_integration(hass)
+
+    assert hass.data[DOMAIN]
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    diagnostics_fixture = json.loads(
+        load_fixture("diagnostics/diagnostics_config_entry.json", DOMAIN)
+    )
+
+    assert diagnostics == diagnostics_fixture
+
+
+@freeze_time(datetime.datetime(2022, 7, 10, 11))
+async def test_device_diagnostics(hass: HomeAssistant, hass_client, bmw_fixture):
+    """Test device diagnostics."""
+
+    # Make sure that local timezone for test is UTC
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+
+    mock_config_entry = await setup_mocked_integration(hass)
+
+    assert hass.data[DOMAIN]
+
+    device_registry = dr.async_get(hass)
+    reg_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "WBY00000000REXI01")},
+    )
+    assert reg_device is not None
+
+    diagnostics = await get_diagnostics_for_device(
+        hass, hass_client, mock_config_entry, reg_device
+    )
+
+    diagnostics_fixture = json.loads(
+        load_fixture("diagnostics/diagnostics_device.json", DOMAIN)
+    )
+
+    assert diagnostics == diagnostics_fixture
+
+
+@freeze_time(datetime.datetime(2022, 7, 10, 11))
+async def test_device_diagnostics_vehicle_not_found(
+    hass: HomeAssistant, hass_client, bmw_fixture
+):
+    """Test device diagnostics when the vehicle cannot be found."""
+
+    # Make sure that local timezone for test is UTC
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+
+    mock_config_entry = await setup_mocked_integration(hass)
+
+    assert hass.data[DOMAIN]
+
+    device_registry = dr.async_get(hass)
+    reg_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "WBY00000000REXI01")},
+    )
+    assert reg_device is not None
+
+    # Change vehicle identifier so that vehicle will not be found
+    device_registry.async_update_device(
+        reg_device.id, new_identifiers={(DOMAIN, "WBY00000000REXI99")}
+    )
+
+    with pytest.raises(AssertionError):
+        await get_diagnostics_for_device(
+            hass, hass_client, mock_config_entry, reg_device
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds entity and device diagnostics to bmw_connected_drive.

To understand what the BMW APIs are providing, we are leveraging the `fingerprint` functionality of our library. If given a path, it will log all response content related to the vehicle (but not related to authentication) to a directory.
This enables us to improve the library around the quirks of some vehicles without the users having to use the console `bimmerconnected fingerprint` command.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: almost all issues related to vehicle data not being as expected
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
