### PR TITLE
Improve calendar error handling to match best practices

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.components import frontend, http
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
@@ -336,9 +337,14 @@ class CalendarEventView(http.HomeAssistantView):
         if not isinstance(entity, CalendarEntity):
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 
-        calendar_event_list = await entity.async_get_events(
-            request.app["hass"], start_date, end_date
-        )
+        try:
+            calendar_event_list = await entity.async_get_events(
+                request.app["hass"], start_date, end_date
+            )
+        except HomeAssistantError as err:
+            return self.json_message(
+                f"Error reading events: {err}", HTTPStatus.INTERNAL_SERVER_ERROR
+            )
         return self.json(
             [
                 {

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -282,8 +282,7 @@ class GoogleCalendarEntity(CalendarEntity):
             async for result_page in result:
                 result_items.extend(result_page.items)
         except ApiException as err:
-            _LOGGER.error("Unable to connect to Google: %s", err)
-            return []
+            raise HomeAssistantError(str(err)) from err
         return [
             _get_calendar_event(event)
             for event in filter(self._event_filter, result_items)

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -1,8 +1,10 @@
 """The tests for the calendar component."""
 from datetime import timedelta
 from http import HTTPStatus
+from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
 
 
@@ -11,8 +13,6 @@ async def test_events_http_api(hass, hass_client):
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
     client = await hass_client()
-    response = await client.get("/api/calendars/calendar.calendar_2")
-    assert response.status == HTTPStatus.BAD_REQUEST
     start = dt_util.now()
     end = start + timedelta(days=1)
     response = await client.get(
@@ -23,6 +23,36 @@ async def test_events_http_api(hass, hass_client):
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert events[0]["summary"] == "Future Event"
+
+
+async def test_events_http_api_missing_fields(hass, hass_client):
+    """Test the calendar demo view."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+    client = await hass_client()
+    response = await client.get("/api/calendars/calendar.calendar_2")
+    assert response.status == HTTPStatus.BAD_REQUEST
+
+
+async def test_events_http_api_error(hass, hass_client):
+    """Test the calendar demo view."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+    client = await hass_client()
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    with patch(
+        "homeassistant.components.demo.calendar.DemoCalendar.async_get_events",
+        side_effect=HomeAssistantError("Failure"),
+    ):
+        response = await client.get(
+            "/api/calendars/calendar.calendar_1?start={}&end={}".format(
+                start.isoformat(), end.isoformat()
+            )
+        )
+        assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert await response.json() == {"message": "Error reading events: Failure"}
 
 
 async def test_calendars_http_api(hass, hass_client):

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -423,10 +423,7 @@ async def test_http_event_api_failure(
     mock_events_list({}, exc=ClientError())
 
     response = await client.get(upcoming_event_url())
-    assert response.status == HTTPStatus.OK
-    # A failure to talk to the server results in an empty list of events
-    events = await response.json()
-    assert events == []
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @pytest.mark.freeze_time("2022-03-27 12:05:00+00:00")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow calendar implementations to throw `HomeAssistantError` and handle with an error json response, following error handling best practices. This fixes Google Calendar to explicitly throw an error rather than silently fail.

The behavior in the frontend is currently identical to the old behavior, where it silently fails to load any calendar that failed leaving it blank. A future improvement will be to update the calendar frontend to display better error messages.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
