### PR TITLE
Alexa: Fix duplicate proactive reports

### DIFF
--- a/homeassistant/components/alexa/config.py
+++ b/homeassistant/components/alexa/config.py
@@ -65,6 +65,7 @@ class AbstractConfig(ABC):
 
     async def async_enable_proactive_mode(self):
         """Enable proactive mode."""
+        _LOGGER.debug("Enable proactive mode")
         if self._unsub_proactive_report is None:
             self._unsub_proactive_report = self.hass.async_create_task(
                 async_enable_proactive_mode(self.hass, self)
@@ -77,6 +78,7 @@ class AbstractConfig(ABC):
 
     async def async_disable_proactive_mode(self):
         """Disable proactive mode."""
+        _LOGGER.debug("Disable proactive mode")
         if unsub_func := await self._unsub_proactive_report:
             unsub_func()
         self._unsub_proactive_report = None
@@ -113,7 +115,6 @@ class AbstractConfig(ABC):
         self._store.set_authorized(authorized)
         if self.should_report_state != self.is_reporting_states:
             if self.should_report_state:
-                _LOGGER.debug("Enable proactive mode")
                 try:
                     await self.async_enable_proactive_mode()
                 except Exception:
@@ -121,7 +122,6 @@ class AbstractConfig(ABC):
                     self._store.set_authorized(False)
                     raise
             else:
-                _LOGGER.debug("Disable proactive mode")
                 await self.async_disable_proactive_mode()
 
 

--- a/homeassistant/components/alexa/smart_home_http.py
+++ b/homeassistant/components/alexa/smart_home_http.py
@@ -12,7 +12,6 @@ from .auth import Auth
 from .config import AbstractConfig
 from .const import CONF_ENDPOINT, CONF_ENTITY_CONFIG, CONF_FILTER, CONF_LOCALE
 from .smart_home import async_handle_message
-from .state_report import async_enable_proactive_mode
 
 _LOGGER = logging.getLogger(__name__)
 SMART_HOME_HTTP_ENDPOINT = "/api/alexa/smart_home"
@@ -104,7 +103,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> None:
     hass.http.register_view(SmartHomeView(smart_home_config))
 
     if smart_home_config.should_report_state:
-        await async_enable_proactive_mode(hass, smart_home_config)
+        await smart_home_config.async_enable_proactive_mode()
 
 
 class SmartHomeView(HomeAssistantView):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix duplicate proactive reports after first incoming request from Alexa.

Previously, the proactive reports handler would be registered on component setup in [`smart_home_http.py#L107`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/alexa/smart_home_http.py#L107). This would call an internal method without properly registering the [`_unsub_proactive_report` handler](https://github.com/home-assistant/core/blob/dev/homeassistant/components/alexa/config.py#L68-L76). As a result, [`is_reporting_state`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/alexa/config.py#L57-L59) would report `False`.

As soon as a request from Alexa comes in (e.g. switching on any light, or triggering a discovery), the [`set_authorized` method](https://github.com/home-assistant/core/blob/dev/homeassistant/components/alexa/config.py#L114-L118) falsely assumes that proactive reports have not yet been activated, and activate them again, this time with a correct `_unsub_proactive_report` handler. As a result, from now on Alexa will receive two proactive reports for every event.

Reproduction:
* Setup:
  * Enable proactive events (see documentation)
  * Create an Alexa routine that listens for a binary sensor change and plays a sound on your Alexa device
* Test 1:
  * Trigger state change, e.g. press binary sensor
  * Expected result: Sound plays once. Actual result: Sound plays once (which is good)
* Now trigger an external request from Alexa: "Alexa, turn on the living room lights" (or similar), or trigger device discovery from the Alexa app
* Test 2:
  * Trigger state change, e.g. press binary sensor
  * Expected result: Sound plays once. Actual result: Sound plays twice

This PR fixes the issue by correctly registering the `_unsub_proactive_report` handler upon component setup.

Unfortunately, I don't know how to write a failing test for this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #67829
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
