### PR TITLE
Shorten Entity Name in Aussie Broadband

### DIFF
--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+import re
 from typing import Any, cast
 
 from homeassistant.components.sensor import (
@@ -152,7 +153,7 @@ class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
             identifiers={(DOMAIN, service[SERVICE_ID])},
             manufacturer="Aussie Broadband",
             configuration_url=f"https://my.aussiebroadband.com.au/#/{service['name'].lower()}/{service[SERVICE_ID]}/",
-            name=service["description"],
+            name=re.sub(r" - AVC\d+$", "", service["description"]),
             model=service["name"],
         )
 

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -33,7 +33,7 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
     # Internet Services sensors
     SensorValueEntityDescription(
         key="usedMb",
-        name="Data Used",
+        name="Data used",
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=DATA_MEGABYTES,
         icon="mdi:network",
@@ -55,35 +55,35 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
     # Mobile Phone Services sensors
     SensorValueEntityDescription(
         key="national",
-        name="National Calls",
+        name="National calls",
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:phone",
         value=lambda x: x.get("calls"),
     ),
     SensorValueEntityDescription(
         key="mobile",
-        name="Mobile Calls",
+        name="Mobile calls",
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:phone",
         value=lambda x: x.get("calls"),
     ),
     SensorValueEntityDescription(
         key="international",
-        name="International Calls",
+        name="International calls",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:phone-plus",
     ),
     SensorValueEntityDescription(
         key="sms",
-        name="SMS Sent",
+        name="SMS sent",
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:message-processing",
         value=lambda x: x.get("calls"),
     ),
     SensorValueEntityDescription(
         key="internet",
-        name="Data Used",
+        name="Data used",
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=DATA_KILOBYTES,
         icon="mdi:network",
@@ -91,14 +91,14 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
     ),
     SensorValueEntityDescription(
         key="voicemail",
-        name="Voicemail Calls",
+        name="Voicemail calls",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:phone",
     ),
     SensorValueEntityDescription(
         key="other",
-        name="Other Calls",
+        name="Other calls",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:phone",
@@ -106,13 +106,13 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
     # Generic sensors
     SensorValueEntityDescription(
         key="daysTotal",
-        name="Billing Cycle Length",
+        name="Billing cycle length",
         native_unit_of_measurement=TIME_DAYS,
         icon="mdi:calendar-range",
     ),
     SensorValueEntityDescription(
         key="daysRemaining",
-        name="Billing Cycle Remaining",
+        name="Billing cycle remaining",
         native_unit_of_measurement=TIME_DAYS,
         icon="mdi:calendar-clock",
     ),
@@ -137,6 +137,7 @@ async def async_setup_entry(
 class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
     """Base class for Aussie Broadband metric sensors."""
 
+    _attr_has_entity_name = True
     entity_description: SensorValueEntityDescription
 
     def __init__(
@@ -146,7 +147,7 @@ class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
         super().__init__(service["coordinator"])
         self.entity_description = description
         self._attr_unique_id = f"{service[SERVICE_ID]}:{description.key}"
-        self._attr_name = f"{service['name']} {description.name}"
+        # self._attr_name = f"{service['name']} {description.name}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, service[SERVICE_ID])},

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -147,7 +147,6 @@ class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
         super().__init__(service["coordinator"])
         self.entity_description = description
         self._attr_unique_id = f"{service[SERVICE_ID]}:{description.key}"
-        # self._attr_name = f"{service['name']} {description.name}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, service[SERVICE_ID])},

--- a/tests/components/aussie_broadband/common.py
+++ b/tests/components/aussie_broadband/common.py
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 FAKE_SERVICES = [
     {
         "service_id": "12345678",
-        "description": "Fake ABB NBN Service",
+        "description": "Fake ABB NBN Service - AVC123456789",
         "type": "NBN",
         "name": "NBN",
     },

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -44,11 +44,17 @@ async def test_nbn_sensor_states(hass):
 
     await setup_platform(hass, [SENSOR_DOMAIN], usage=MOCK_NBN_USAGE)
 
-    assert hass.states.get("sensor.nbn_data_used").state == "54321"
-    assert hass.states.get("sensor.nbn_downloaded").state == "50000"
-    assert hass.states.get("sensor.nbn_uploaded").state == "4321"
-    assert hass.states.get("sensor.nbn_billing_cycle_length").state == "28"
-    assert hass.states.get("sensor.nbn_billing_cycle_remaining").state == "25"
+    assert hass.states.get("sensor.fake_abb_nbn_service_data_used").state == "54321"
+    assert hass.states.get("sensor.fake_abb_nbn_service_downloaded").state == "50000"
+    assert hass.states.get("sensor.fake_abb_nbn_service_uploaded").state == "4321"
+    assert (
+        hass.states.get("sensor.fake_abb_nbn_service_billing_cycle_length").state
+        == "28"
+    )
+    assert (
+        hass.states.get("sensor.fake_abb_nbn_service_billing_cycle_remaining").state
+        == "25"
+    )
 
 
 async def test_phone_sensor_states(hass):
@@ -56,12 +62,18 @@ async def test_phone_sensor_states(hass):
 
     await setup_platform(hass, [SENSOR_DOMAIN], usage=MOCK_MOBILE_USAGE)
 
-    assert hass.states.get("sensor.mobile_national_calls").state == "1"
-    assert hass.states.get("sensor.mobile_mobile_calls").state == "2"
-    assert hass.states.get("sensor.mobile_sms_sent").state == "4"
-    assert hass.states.get("sensor.mobile_data_used").state == "512"
-    assert hass.states.get("sensor.mobile_billing_cycle_length").state == "31"
-    assert hass.states.get("sensor.mobile_billing_cycle_remaining").state == "30"
+    assert hass.states.get("sensor.fake_abb_mobile_service_national_calls").state == "1"
+    assert hass.states.get("sensor.fake_abb_mobile_service_mobile_calls").state == "2"
+    assert hass.states.get("sensor.fake_abb_mobile_service_sms_sent").state == "4"
+    assert hass.states.get("sensor.fake_abb_mobile_service_data_used").state == "512"
+    assert (
+        hass.states.get("sensor.fake_abb_mobile_service_billing_cycle_length").state
+        == "31"
+    )
+    assert (
+        hass.states.get("sensor.fake_abb_mobile_service_billing_cycle_remaining").state
+        == "30"
+    )
 
 
 async def test_voip_sensor_states(hass):
@@ -69,6 +81,10 @@ async def test_voip_sensor_states(hass):
 
     await setup_platform(hass, [SENSOR_DOMAIN], usage=MOCK_VOIP_USAGE)
 
-    assert hass.states.get("sensor.mobile_national_calls").state == "1"
-    assert hass.states.get("sensor.mobile_sms_sent").state == STATE_UNKNOWN
-    assert hass.states.get("sensor.mobile_data_used").state == STATE_UNKNOWN
+    assert hass.states.get("sensor.fake_abb_voip_service_national_calls").state == "1"
+    assert (
+        hass.states.get("sensor.fake_abb_voip_service_sms_sent").state == STATE_UNKNOWN
+    )
+    assert (
+        hass.states.get("sensor.fake_abb_voip_service_data_used").state == STATE_UNKNOWN
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The default service names are very long for Aussie Broadband NBN services, so this PR adds a regular expression that strips the numerical service identifer from the name to give shorter service and entity names.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/74937
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
