### PR TITLE
Migrate AdGuard Home to new entity naming style

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -132,6 +132,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class AdGuardHomeEntity(Entity):
     """Defines a base AdGuard Home entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         adguard: AdGuardHome,

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -100,7 +100,7 @@ class AdGuardHomeDNSQueriesSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "DNS Queries",
+            "DNS queries",
             "mdi:magnify",
             "dns_queries",
             "queries",
@@ -119,7 +119,7 @@ class AdGuardHomeBlockedFilteringSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "DNS Queries Blocked",
+            "DNS queries blocked",
             "mdi:magnify-close",
             "blocked_filtering",
             "queries",
@@ -139,7 +139,7 @@ class AdGuardHomePercentageBlockedSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "DNS Queries Blocked Ratio",
+            "DNS queries blocked ratio",
             "mdi:magnify-close",
             "blocked_percentage",
             PERCENTAGE,
@@ -159,7 +159,7 @@ class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "Parental Control Blocked",
+            "Parental control blocked",
             "mdi:human-male-girl",
             "blocked_parental",
             "requests",
@@ -178,7 +178,7 @@ class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "Safe Browsing Blocked",
+            "Safe browsing blocked",
             "mdi:shield-half-full",
             "blocked_safebrowsing",
             "requests",
@@ -197,7 +197,7 @@ class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "Safe Searches Enforced",
+            "Safe searches enforced",
             "mdi:shield-search",
             "enforced_safesearch",
             "requests",
@@ -216,7 +216,7 @@ class AdGuardHomeAverageProcessingTimeSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "Average Processing Speed",
+            "Average processing speed",
             "mdi:speedometer",
             "average_speed",
             TIME_MILLISECONDS,
@@ -236,7 +236,7 @@ class AdGuardHomeRulesCountSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "Rules Count",
+            "Rules count",
             "mdi:counter",
             "rules_count",
             "rules",

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -100,7 +100,7 @@ class AdGuardHomeDNSQueriesSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard DNS Queries",
+            "DNS Queries",
             "mdi:magnify",
             "dns_queries",
             "queries",
@@ -119,7 +119,7 @@ class AdGuardHomeBlockedFilteringSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard DNS Queries Blocked",
+            "DNS Queries Blocked",
             "mdi:magnify-close",
             "blocked_filtering",
             "queries",
@@ -139,7 +139,7 @@ class AdGuardHomePercentageBlockedSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard DNS Queries Blocked Ratio",
+            "DNS Queries Blocked Ratio",
             "mdi:magnify-close",
             "blocked_percentage",
             PERCENTAGE,
@@ -159,7 +159,7 @@ class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard Parental Control Blocked",
+            "Parental Control Blocked",
             "mdi:human-male-girl",
             "blocked_parental",
             "requests",
@@ -178,7 +178,7 @@ class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard Safe Browsing Blocked",
+            "Safe Browsing Blocked",
             "mdi:shield-half-full",
             "blocked_safebrowsing",
             "requests",
@@ -197,7 +197,7 @@ class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard Safe Searches Enforced",
+            "Safe Searches Enforced",
             "mdi:shield-search",
             "enforced_safesearch",
             "requests",
@@ -216,7 +216,7 @@ class AdGuardHomeAverageProcessingTimeSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard Average Processing Speed",
+            "Average Processing Speed",
             "mdi:speedometer",
             "average_speed",
             TIME_MILLISECONDS,
@@ -236,7 +236,7 @@ class AdGuardHomeRulesCountSensor(AdGuardHomeSensor):
         super().__init__(
             adguard,
             entry,
-            "AdGuard Rules Count",
+            "Rules Count",
             "mdi:counter",
             "rules_count",
             "rules",

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -107,9 +107,7 @@ class AdGuardHomeProtectionSwitch(AdGuardHomeSwitch):
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
-        super().__init__(
-            adguard, entry, "AdGuard Protection", "mdi:shield-check", "protection"
-        )
+        super().__init__(adguard, entry, "Protection", "mdi:shield-check", "protection")
 
     async def _adguard_turn_off(self) -> None:
         """Turn off the switch."""
@@ -130,7 +128,7 @@ class AdGuardHomeParentalSwitch(AdGuardHomeSwitch):
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
         super().__init__(
-            adguard, entry, "AdGuard Parental Control", "mdi:shield-check", "parental"
+            adguard, entry, "Parental Control", "mdi:shield-check", "parental"
         )
 
     async def _adguard_turn_off(self) -> None:
@@ -152,7 +150,7 @@ class AdGuardHomeSafeSearchSwitch(AdGuardHomeSwitch):
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
         super().__init__(
-            adguard, entry, "AdGuard Safe Search", "mdi:shield-check", "safesearch"
+            adguard, entry, "Safe Search", "mdi:shield-check", "safesearch"
         )
 
     async def _adguard_turn_off(self) -> None:
@@ -174,7 +172,7 @@ class AdGuardHomeSafeBrowsingSwitch(AdGuardHomeSwitch):
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
         super().__init__(
-            adguard, entry, "AdGuard Safe Browsing", "mdi:shield-check", "safebrowsing"
+            adguard, entry, "Safe Browsing", "mdi:shield-check", "safebrowsing"
         )
 
     async def _adguard_turn_off(self) -> None:
@@ -195,9 +193,7 @@ class AdGuardHomeFilteringSwitch(AdGuardHomeSwitch):
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
-        super().__init__(
-            adguard, entry, "AdGuard Filtering", "mdi:shield-check", "filtering"
-        )
+        super().__init__(adguard, entry, "Filtering", "mdi:shield-check", "filtering")
 
     async def _adguard_turn_off(self) -> None:
         """Turn off the switch."""
@@ -220,7 +216,7 @@ class AdGuardHomeQueryLogSwitch(AdGuardHomeSwitch):
         super().__init__(
             adguard,
             entry,
-            "AdGuard Query Log",
+            "Query Log",
             "mdi:shield-check",
             "querylog",
             enabled_default=False,

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -128,7 +128,7 @@ class AdGuardHomeParentalSwitch(AdGuardHomeSwitch):
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
         super().__init__(
-            adguard, entry, "Parental Control", "mdi:shield-check", "parental"
+            adguard, entry, "Parental control", "mdi:shield-check", "parental"
         )
 
     async def _adguard_turn_off(self) -> None:
@@ -150,7 +150,7 @@ class AdGuardHomeSafeSearchSwitch(AdGuardHomeSwitch):
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
         super().__init__(
-            adguard, entry, "Safe Search", "mdi:shield-check", "safesearch"
+            adguard, entry, "Safe search", "mdi:shield-check", "safesearch"
         )
 
     async def _adguard_turn_off(self) -> None:
@@ -172,7 +172,7 @@ class AdGuardHomeSafeBrowsingSwitch(AdGuardHomeSwitch):
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home switch."""
         super().__init__(
-            adguard, entry, "Safe Browsing", "mdi:shield-check", "safebrowsing"
+            adguard, entry, "Safe browsing", "mdi:shield-check", "safebrowsing"
         )
 
     async def _adguard_turn_off(self) -> None:
@@ -216,7 +216,7 @@ class AdGuardHomeQueryLogSwitch(AdGuardHomeSwitch):
         super().__init__(
             adguard,
             entry,
-            "Query Log",
+            "Query log",
             "mdi:shield-check",
             "querylog",
             enabled_default=False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
