### PR TITLE
Migrate Environment Canada to new entity naming style

### DIFF
--- a/homeassistant/components/environment_canada/__init__.py
+++ b/homeassistant/components/environment_canada/__init__.py
@@ -93,7 +93,7 @@ def device_info(config_entry: ConfigEntry) -> DeviceInfo:
     """Build and return the device info for EC."""
     return DeviceInfo(
         entry_type=DeviceEntryType.SERVICE,
-        identifiers={(DOMAIN, config_entry.title)},
+        identifiers={(DOMAIN, config_entry.entry_id)},
         manufacturer="Environment Canada / Environnement Canada",
         name=config_entry.title,
         configuration_url="https://weather.gc.ca/",

--- a/homeassistant/components/environment_canada/__init__.py
+++ b/homeassistant/components/environment_canada/__init__.py
@@ -9,6 +9,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_LANGUAGE, CONF_STATION, DOMAIN
@@ -85,6 +87,17 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     hass.data[DOMAIN].pop(config_entry.entry_id)
 
     return unload_ok
+
+
+def device_info(config_entry: ConfigEntry) -> DeviceInfo:
+    """Build and return the device info for EC."""
+    return DeviceInfo(
+        entry_type=DeviceEntryType.SERVICE,
+        identifiers={(DOMAIN, config_entry.title)},
+        manufacturer="Environment Canada / Environnement Canada",
+        name=config_entry.title,
+        configuration_url="https://weather.gc.ca/",
+    )
 
 
 class ECDataUpdateCoordinator(DataUpdateCoordinator):

--- a/homeassistant/components/environment_canada/__init__.py
+++ b/homeassistant/components/environment_canada/__init__.py
@@ -94,7 +94,7 @@ def device_info(config_entry: ConfigEntry) -> DeviceInfo:
     return DeviceInfo(
         entry_type=DeviceEntryType.SERVICE,
         identifiers={(DOMAIN, config_entry.entry_id)},
-        manufacturer="Environment Canada / Environnement Canada",
+        manufacturer="Environment Canada",
         name=config_entry.title,
         configuration_url="https://weather.gc.ca/",
     )

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -49,7 +49,7 @@ class ECCamera(CoordinatorEntity, Camera):
         Camera.__init__(self)
 
         self.radar_object = coordinator.ec_data
-        self._attr_name = f"{coordinator.config_entry.title} Radar"
+        self._attr_name = "Radar"
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-radar"
         self._attr_attribution = self.radar_object.metadata["attribution"]
         self._attr_entity_registry_enabled_default = False

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -40,6 +40,8 @@ async def async_setup_entry(
 class ECCamera(CoordinatorEntity, Camera):
     """Implementation of an Environment Canada radar camera."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator):
         """Initialize the camera."""
         super().__init__(coordinator)

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -42,6 +42,7 @@ class ECCamera(CoordinatorEntity, Camera):
     """Implementation of an Environment Canada radar camera."""
 
     _attr_has_entity_name = True
+    _attr_name = "Radar"
 
     def __init__(self, coordinator):
         """Initialize the camera."""
@@ -49,7 +50,6 @@ class ECCamera(CoordinatorEntity, Camera):
         Camera.__init__(self)
 
         self.radar_object = coordinator.ec_data
-        self._attr_name = "Radar"
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-radar"
         self._attr_attribution = self.radar_object.metadata["attribution"]
         self._attr_entity_registry_enabled_default = False

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import device_info
 from .const import ATTR_OBSERVATION_TIME, DOMAIN
 
 SERVICE_SET_RADAR_TYPE = "set_radar_type"
@@ -52,6 +53,7 @@ class ECCamera(CoordinatorEntity, Camera):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-radar"
         self._attr_attribution = self.radar_object.metadata["attribution"]
         self._attr_entity_registry_enabled_default = False
+        self._attr_device_info = device_info(coordinator.config_entry)
 
         self.content_type = "image/gif"
 

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -51,12 +51,12 @@ class ECSensorEntityDescription(
 SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="condition",
-        name="Current Condition",
+        name="Current condition",
         value_fn=lambda data: data.conditions.get("condition", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="dewpoint",
-        name="Dew Point",
+        name="Dew point",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
@@ -64,7 +64,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ),
     ECSensorEntityDescription(
         key="high_temp",
-        name="High Temperature",
+        name="High temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
@@ -88,12 +88,12 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ),
     ECSensorEntityDescription(
         key="icon_code",
-        name="Icon Code",
+        name="Icon code",
         value_fn=lambda data: data.conditions.get("icon_code", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="low_temp",
-        name="Low Temperature",
+        name="Low temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
@@ -101,34 +101,34 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ),
     ECSensorEntityDescription(
         key="normal_high",
-        name="Normal High Temperature",
+        name="Normal high temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         value_fn=lambda data: data.conditions.get("normal_high", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="normal_low",
-        name="Normal Low Temperature",
+        name="Normal low temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         value_fn=lambda data: data.conditions.get("normal_low", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="pop",
-        name="Chance of Precipitation",
+        name="Chance of precipitation",
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda data: data.conditions.get("pop", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="precip_yesterday",
-        name="Precipitation Yesterday",
+        name="Precipitation yesterday",
         native_unit_of_measurement=LENGTH_MILLIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.conditions.get("precip_yesterday", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="pressure",
-        name="Barometric Pressure",
+        name="Barometric pressure",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=PRESSURE_KPA,
         state_class=SensorStateClass.MEASUREMENT,
@@ -156,13 +156,13 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ),
     ECSensorEntityDescription(
         key="timestamp",
-        name="Observation Time",
+        name="Observation time",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.metadata.get("timestamp"),
     ),
     ECSensorEntityDescription(
         key="uv_index",
-        name="UV Index",
+        name="UV index",
         native_unit_of_measurement=UV_INDEX,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.conditions.get("uv_index", {}).get("value"),
@@ -176,13 +176,13 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ),
     ECSensorEntityDescription(
         key="wind_bearing",
-        name="Wind Bearing",
+        name="Wind bearing",
         native_unit_of_measurement=DEGREE,
         value_fn=lambda data: data.conditions.get("wind_bearing", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="wind_chill",
-        name="Wind Chill",
+        name="Wind chill",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
@@ -190,19 +190,19 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ),
     ECSensorEntityDescription(
         key="wind_dir",
-        name="Wind Direction",
+        name="Wind direction",
         value_fn=lambda data: data.conditions.get("wind_dir", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="wind_gust",
-        name="Wind Gust",
+        name="Wind gust",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.conditions.get("wind_gust", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="wind_speed",
-        name="Wind Speed",
+        name="Wind speed",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.conditions.get("wind_speed", {}).get("value"),
@@ -285,6 +285,7 @@ class ECBaseSensor(CoordinatorEntity, SensorEntity):
     """Environment Canada sensor base."""
 
     entity_description: ECSensorEntityDescription
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, description):
         """Initialize the base sensor."""

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -294,7 +294,6 @@ class ECBaseSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
         self._ec_data = coordinator.ec_data
         self._attr_attribution = self._ec_data.metadata["attribution"]
-        self._attr_name = description.name
         self._attr_unique_id = f"{coordinator.config_entry.title}-{description.key}"
         self._attr_device_info = device_info(coordinator.config_entry)
 

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import device_info
 from .const import ATTR_STATION, DOMAIN
 
 ATTR_TIME = "alert time"
@@ -295,6 +296,7 @@ class ECBaseSensor(CoordinatorEntity, SensorEntity):
         self._attr_attribution = self._ec_data.metadata["attribution"]
         self._attr_name = f"{coordinator.config_entry.title} {description.name}"
         self._attr_unique_id = f"{coordinator.config_entry.title}-{description.key}"
+        self._attr_device_info = device_info(coordinator.config_entry)
 
     @property
     def native_value(self):

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -294,7 +294,7 @@ class ECBaseSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
         self._ec_data = coordinator.ec_data
         self._attr_attribution = self._ec_data.metadata["attribution"]
-        self._attr_name = f"{coordinator.config_entry.title} {description.name}"
+        self._attr_name = description.name
         self._attr_unique_id = f"{coordinator.config_entry.title}-{description.key}"
         self._attr_device_info = device_info(coordinator.config_entry)
 

--- a/homeassistant/components/environment_canada/weather.py
+++ b/homeassistant/components/environment_canada/weather.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
 
+from . import device_info
 from .const import DOMAIN
 
 # Icon codes from http://dd.weatheroffice.ec.gc.ca/citypage_weather/
@@ -87,6 +88,7 @@ class ECWeather(CoordinatorEntity, WeatherEntity):
         )
         self._attr_entity_registry_enabled_default = not hourly
         self._hourly = hourly
+        self._attr_device_info = device_info(coordinator.config_entry)
 
     @property
     def native_temperature(self):

--- a/homeassistant/components/environment_canada/weather.py
+++ b/homeassistant/components/environment_canada/weather.py
@@ -80,9 +80,7 @@ class ECWeather(CoordinatorEntity, WeatherEntity):
         super().__init__(coordinator)
         self.ec_data = coordinator.ec_data
         self._attr_attribution = self.ec_data.metadata["attribution"]
-        self._attr_name = (
-            f"{coordinator.config_entry.title}{' Hourly' if hourly else ''}"
-        )
+        self._attr_name = "Hourly forecast" if hourly else "Forecast"
         self._attr_unique_id = (
             f"{coordinator.config_entry.unique_id}{'-hourly' if hourly else '-daily'}"
         )

--- a/homeassistant/components/environment_canada/weather.py
+++ b/homeassistant/components/environment_canada/weather.py
@@ -68,6 +68,7 @@ async def async_setup_entry(
 class ECWeather(CoordinatorEntity, WeatherEntity):
     """Representation of a weather condition."""
 
+    _attr_has_entity_name = True
     _attr_native_pressure_unit = PRESSURE_KPA
     _attr_native_temperature_unit = TEMP_CELSIUS
     _attr_native_visibility_unit = LENGTH_KILOMETERS


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate Environment Canada to new entity naming style. 

This may not be correct as the names all have the weather station as part of the name. For example "Ottawa Radar". Is the right thing to add `device_info` (for a service) that has a name of the weather station and then remove the station from all of the entities? An example of the code here: https://github.com/home-assistant/core/blob/dev/homeassistant/components/environment_canada/sensor.py#L295

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
