### PR TITLE
Do not spam log when Life360 member location is missing

### DIFF
--- a/homeassistant/components/life360/__init__.py
+++ b/homeassistant/components/life360/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     SHOW_DRIVING,
     SHOW_MOVING,
 )
-from .coordinator import Life360DataUpdateCoordinator
+from .coordinator import Life360DataUpdateCoordinator, MissingLocReason
 
 PLATFORMS = [Platform.DEVICE_TRACKER]
 
@@ -126,6 +126,10 @@ class IntegData:
     cfg_options: dict[str, Any] | None = None
     # ConfigEntry.entry_id: Life360DataUpdateCoordinator
     coordinators: dict[str, Life360DataUpdateCoordinator] = field(
+        init=False, default_factory=dict
+    )
+    # member_id: missing location reason
+    missing_loc_reason: dict[str, MissingLocReason] = field(
         init=False, default_factory=dict
     )
     # member_id: ConfigEntry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a Life360 member's device has not been seen by the Life360 server for a long time,
e.g., the device has been off or has lost service, the data returned for the member
will not contain any location information. Currently this causes an ERROR in the log
every time the coordinator updates (by default every 10 seconds.)

This change will only report that error once. If the server starts providing location
information for the member again, the corresponding entity will begin to update
again (as before.) If, after that, location data goes missing again the error will be
reported again (but only once per occurrence.)

Actually, there might be up to two error messages. The server sometimes provides
a reason, but sometimes it doesn't. Also, if the member is in multiple circles, a reason
might be reported for one circle, but not the other. The change will log an explicit
reason, even if a vague reason was given already.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Example of log spam where two members have lost connection to the Life360 server:
```text
2022-07-11 13:24:32 ERROR (MainThread) [homeassistant.components.life360] xxx: Lost Connection: This user has lost connection to Life360. Visit our troubleshooting guide to help them reconnect.
2022-07-11 13:24:32 ERROR (MainThread) [homeassistant.components.life360] yyy: Lost Connection: This user has lost connection to Life360. Visit our troubleshooting guide to help them reconnect.
2022-07-11 13:24:42 ERROR (MainThread) [homeassistant.components.life360] yyy: Lost Connection: This user has lost connection to Life360. Visit our troubleshooting guide to help them reconnect.
2022-07-11 13:24:42 ERROR (MainThread) [homeassistant.components.life360] xxx: Lost Connection: This user has lost connection to Life360. Visit our troubleshooting guide to help them reconnect.
```

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
