### PR TITLE
Replace Guardian `disable_ap` and `enable_ap` services with a switch

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -47,6 +47,8 @@ DATA_PAIRED_SENSOR_MANAGER = "paired_sensor_manager"
 SERVICE_NAME_DISABLE_AP = "disable_ap"
 SERVICE_NAME_ENABLE_AP = "enable_ap"
 SERVICE_NAME_PAIR_SENSOR = "pair_sensor"
+SERVICE_NAME_REBOOT = "reboot"
+SERVICE_NAME_RESET_VALVE_DIAGNOSTICS = "reset_valve_diagnostics"
 SERVICE_NAME_UNPAIR_SENSOR = "unpair_sensor"
 SERVICE_NAME_UPGRADE_FIRMWARE = "upgrade_firmware"
 
@@ -54,6 +56,8 @@ SERVICES = (
     SERVICE_NAME_DISABLE_AP,
     SERVICE_NAME_ENABLE_AP,
     SERVICE_NAME_PAIR_SENSOR,
+    SERVICE_NAME_REBOOT,
+    SERVICE_NAME_RESET_VALVE_DIAGNOSTICS,
     SERVICE_NAME_UNPAIR_SENSOR,
     SERVICE_NAME_UPGRADE_FIRMWARE,
 )
@@ -297,6 +301,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             SERVICE_NAME_PAIR_SENSOR,
             SERVICE_PAIR_UNPAIR_SENSOR_SCHEMA,
             async_pair_sensor,
+        ),
+        (SERVICE_NAME_REBOOT, SERVICE_BASE_SCHEMA, async_reboot),
+        (
+            SERVICE_NAME_RESET_VALVE_DIAGNOSTICS,
+            SERVICE_BASE_SCHEMA,
+            async_reset_valve_diagnostics,
         ),
         (
             SERVICE_NAME_UNPAIR_SENSOR,

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -47,8 +47,6 @@ DATA_PAIRED_SENSOR_MANAGER = "paired_sensor_manager"
 SERVICE_NAME_DISABLE_AP = "disable_ap"
 SERVICE_NAME_ENABLE_AP = "enable_ap"
 SERVICE_NAME_PAIR_SENSOR = "pair_sensor"
-SERVICE_NAME_REBOOT = "reboot"
-SERVICE_NAME_RESET_VALVE_DIAGNOSTICS = "reset_valve_diagnostics"
 SERVICE_NAME_UNPAIR_SENSOR = "unpair_sensor"
 SERVICE_NAME_UPGRADE_FIRMWARE = "upgrade_firmware"
 
@@ -56,8 +54,6 @@ SERVICES = (
     SERVICE_NAME_DISABLE_AP,
     SERVICE_NAME_ENABLE_AP,
     SERVICE_NAME_PAIR_SENSOR,
-    SERVICE_NAME_REBOOT,
-    SERVICE_NAME_RESET_VALVE_DIAGNOSTICS,
     SERVICE_NAME_UNPAIR_SENSOR,
     SERVICE_NAME_UPGRADE_FIRMWARE,
 )
@@ -301,12 +297,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             SERVICE_NAME_PAIR_SENSOR,
             SERVICE_PAIR_UNPAIR_SENSOR_SCHEMA,
             async_pair_sensor,
-        ),
-        (SERVICE_NAME_REBOOT, SERVICE_BASE_SCHEMA, async_reboot),
-        (
-            SERVICE_NAME_RESET_VALVE_DIAGNOSTICS,
-            SERVICE_BASE_SCHEMA,
-            async_reset_valve_diagnostics,
         ),
         (
             SERVICE_NAME_UNPAIR_SENSOR,

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -243,6 +243,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "switch.turn_off",
             f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
+            "2022.11.0",
         )
         await data.client.wifi.disable_ap()
 
@@ -254,6 +255,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "switch.turn_on",
             f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
+            "2022.11.0",
         )
         await data.client.wifi.enable_ap()
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -243,7 +243,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "switch.turn_off",
             f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
-            "2022.11.0",
+            "2022.12.0",
         )
         await data.client.wifi.disable_ap()
 
@@ -255,7 +255,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "switch.turn_on",
             f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
-            "2022.11.0",
+            "2022.12.0",
         )
         await data.client.wifi.enable_ap()
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -238,11 +238,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     @call_with_data
     async def async_disable_ap(call: ServiceCall, data: GuardianData) -> None:
         """Disable the onboard AP."""
+        async_log_deprecated_service_call(
+            hass,
+            call,
+            "switch.turn_off",
+            f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
+        )
         await data.client.wifi.disable_ap()
 
     @call_with_data
     async def async_enable_ap(call: ServiceCall, data: GuardianData) -> None:
         """Enable the onboard AP."""
+        async_log_deprecated_service_call(
+            hass,
+            call,
+            "switch.turn_on",
+            f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
+        )
         await data.client.wifi.enable_ap()
 
     @call_with_data

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Bsensors for the Elexa Guardian integration."""
+"""Binary sensors for the Elexa Guardian integration."""
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -23,6 +23,7 @@ from . import (
 )
 from .const import (
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
+    API_WIFI_STATUS,
     CONF_UID,
     DOMAIN,
     SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED,
@@ -33,6 +34,9 @@ from .util import (
     async_finish_entity_domain_replacements,
 )
 
+ATTR_CONNECTED_CLIENTS = "connected_clients"
+
+SENSOR_KIND_AP_INFO = "ap_enabled"
 SENSOR_KIND_LEAK_DETECTED = "leak_detected"
 SENSOR_KIND_MOVED = "moved"
 
@@ -65,6 +69,13 @@ VALVE_CONTROLLER_DESCRIPTIONS = (
         device_class=BinarySensorDeviceClass.MOISTURE,
         api_category=API_SYSTEM_ONBOARD_SENSOR_STATUS,
     ),
+    ValveControllerBinarySensorDescription(
+        key=SENSOR_KIND_AP_INFO,
+        name="Onboard AP enabled",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        api_category=API_WIFI_STATUS,
+    ),
 )
 
 
@@ -83,6 +94,7 @@ async def async_setup_entry(
                 old_domain=BINARY_SENSOR_DOMAIN,
                 old_unique_id=f"{uid}_ap_enabled",
                 replacement_entity_id=f"switch.guardian_valve_controller_{uid}_onboard_ap",
+                remove_old_entity=False,
             ),
         ),
     )
@@ -170,5 +182,10 @@ class ValveControllerBinarySensor(ValveControllerEntity, BinarySensorEntity):
     @callback
     def _async_update_from_latest_data(self) -> None:
         """Update the entity."""
-        if self.entity_description.key == SENSOR_KIND_LEAK_DETECTED:
+        if self.entity_description.key == SENSOR_KIND_AP_INFO:
+            self._attr_is_on = self.coordinator.data["station_connected"]
+            self._attr_extra_state_attributes[
+                ATTR_CONNECTED_CLIENTS
+            ] = self.coordinator.data.get("ap_clients")
+        elif self.entity_description.key == SENSOR_KIND_LEAK_DETECTED:
             self._attr_is_on = self.coordinator.data["wet"]

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -91,9 +91,10 @@ async def async_setup_entry(
         entry,
         (
             EntityDomainReplacementStrategy(
-                old_domain=BINARY_SENSOR_DOMAIN,
-                old_unique_id=f"{uid}_ap_enabled",
-                replacement_entity_id=f"switch.guardian_valve_controller_{uid}_onboard_ap",
+                BINARY_SENSOR_DOMAIN,
+                f"{uid}_ap_enabled",
+                f"switch.guardian_valve_controller_{uid}_onboard_ap",
+                "2022.12.0",
                 remove_old_entity=False,
             ),
         ),

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -15,3 +15,4 @@ API_WIFI_STATUS = "wifi_status"
 CONF_UID = "uid"
 
 SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED = "guardian_paired_sensor_coordinator_added_{0}"
+SIGNAL_REBOOT = "guardian_reboot"

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -15,4 +15,3 @@ API_WIFI_STATUS = "wifi_status"
 CONF_UID = "uid"
 
 SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED = "guardian_paired_sensor_coordinator_added_{0}"
-SIGNAL_REBOOT = "guardian_reboot"

--- a/homeassistant/components/guardian/services.yaml
+++ b/homeassistant/components/guardian/services.yaml
@@ -1,26 +1,4 @@
 # Describes the format for available Elexa Guardians services
-disable_ap:
-  name: Disable AP
-  description: Disable the device's onboard access point.
-  fields:
-    device_id:
-      name: Valve Controller
-      description: The valve controller whose AP should be disabled
-      required: true
-      selector:
-        device:
-          integration: guardian
-enable_ap:
-  name: Enable AP
-  description: Enable the device's onboard access point.
-  fields:
-    device_id:
-      name: Valve Controller
-      description: The valve controller whose AP should be enabled
-      required: true
-      selector:
-        device:
-          integration: guardian
 pair_sensor:
   name: Pair Sensor
   description: Add a new paired sensor to the valve controller.

--- a/homeassistant/components/guardian/services.yaml
+++ b/homeassistant/components/guardian/services.yaml
@@ -39,6 +39,28 @@ pair_sensor:
       example: 5410EC688BCF
       selector:
         text:
+reboot:
+  name: Reboot
+  description: Reboot the device.
+  fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller to reboot
+      required: true
+      selector:
+        device:
+          integration: guardian
+reset_valve_diagnostics:
+  name: Reset Valve Diagnostics
+  description: Fully (and irrecoverably) reset all valve diagnostics.
+  fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller whose diagnostics should be reset
+      required: true
+      selector:
+        device:
+          integration: guardian
 unpair_sensor:
   name: Unpair Sensor
   description: Remove a paired sensor from the valve controller.

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -25,18 +25,18 @@
         "step": {
           "confirm": {
             "title": "The {deprecated_service} service is being removed",
-            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved."
+            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`."
           }
         }
       }
     },
-    "removed_old_entity": {
-      "title": "The {removed_entity_id} entity is being removed",
+    "replaced_old_entity": {
+      "title": "The {removed_entity_id} entity has been removed",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "The {removed_entity_id} entity is being removed",
-            "description": "This entity is no longer provided by the Guardian integration and has been removed from Home Assistant. Click SUBMIT below to mark this issue as resolved."
+            "title": "The {removed_entity_id} entity has been removed",
+            "description": "This entity has been replaced by `{replacement_entity_id}`."
           }
         }
       }

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -29,6 +29,17 @@
           }
         }
       }
+    },
+    "removed_old_entity": {
+      "title": "The {removed_entity_id} entity is being removed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The {removed_entity_id} entity is being removed",
+            "description": "This entity is no longer provided by the Guardian integration and has been removed from Home Assistant. Click SUBMIT below to mark this issue as resolved."
+          }
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -31,11 +31,11 @@
       }
     },
     "replaced_old_entity": {
-      "title": "The {removed_entity_id} entity has been removed",
+      "title": "The {removed_entity_id} entity will be removed",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "The {removed_entity_id} entity has been removed",
+            "title": "The {removed_entity_id} entity will be removed",
             "description": "This entity has been replaced by `{replacement_entity_id}`."
           }
         }

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -31,11 +31,11 @@
       }
     },
     "replaced_old_entity": {
-      "title": "The {removed_entity_id} entity will be removed",
+      "title": "The {old_entity_id} entity will be removed",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "The {removed_entity_id} entity will be removed",
+            "title": "The {old_entity_id} entity will be removed",
             "description": "This entity has been replaced by `{replacement_entity_id}`."
           }
         }

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -10,16 +10,20 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import GuardianData, ValveControllerEntity, ValveControllerEntityDescription
-from .const import API_VALVE_STATUS, DOMAIN
+from .const import API_VALVE_STATUS, API_WIFI_STATUS, DOMAIN
 
 ATTR_AVG_CURRENT = "average_current"
+ATTR_CONNECTED_CLIENTS = "connected_clients"
 ATTR_INST_CURRENT = "instantaneous_current"
 ATTR_INST_CURRENT_DDT = "instantaneous_current_ddt"
+ATTR_STATION_CONNECTED = "station_connected"
 ATTR_TRAVEL_COUNT = "travel_count"
 
+SWITCH_KIND_ONBOARD_AP = "onboard_ap"
 SWITCH_KIND_VALVE = "valve"
 
 
@@ -31,6 +35,13 @@ class ValveControllerSwitchDescription(
 
 
 VALVE_CONTROLLER_DESCRIPTIONS = (
+    ValveControllerSwitchDescription(
+        key=SWITCH_KIND_ONBOARD_AP,
+        name="Onboard AP",
+        icon="mdi:wifi",
+        entity_category=EntityCategory.CONFIG,
+        api_category=API_WIFI_STATUS,
+    ),
     ValveControllerSwitchDescription(
         key=SWITCH_KIND_VALVE,
         name="Valve controller",
@@ -53,9 +64,7 @@ async def async_setup_entry(
 
 
 class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
-    """Define a switch to open/close the Guardian valve."""
-
-    entity_description: ValveControllerSwitchDescription
+    """Define a base Guardian switch."""
 
     ON_STATES = {
         "start_opening",
@@ -63,6 +72,8 @@ class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
         "finish_opening",
         "opened",
     }
+
+    entity_description: ValveControllerSwitchDescription
 
     def __init__(
         self,
@@ -73,42 +84,64 @@ class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
         """Initialize."""
         super().__init__(entry, data.valve_controller_coordinators, description)
 
-        self._attr_is_on = True
         self._client = data.client
 
     @callback
     def _async_update_from_latest_data(self) -> None:
         """Update the entity."""
-        self._attr_is_on = self.coordinator.data["state"] in self.ON_STATES
-        self._attr_extra_state_attributes.update(
-            {
-                ATTR_AVG_CURRENT: self.coordinator.data["average_current"],
-                ATTR_INST_CURRENT: self.coordinator.data["instantaneous_current"],
-                ATTR_INST_CURRENT_DDT: self.coordinator.data[
-                    "instantaneous_current_ddt"
-                ],
-                ATTR_TRAVEL_COUNT: self.coordinator.data["travel_count"],
-            }
-        )
+        if self.entity_description.key == SWITCH_KIND_ONBOARD_AP:
+            self._attr_extra_state_attributes.update(
+                {
+                    ATTR_CONNECTED_CLIENTS: self.coordinator.data.get("ap_clients"),
+                    ATTR_STATION_CONNECTED: self.coordinator.data["station_connected"],
+                }
+            )
+            self._attr_is_on = self.coordinator.data["ap_enabled"]
+        elif self.entity_description.key == SWITCH_KIND_VALVE:
+            self._attr_is_on = self.coordinator.data["state"] in self.ON_STATES
+            self._attr_extra_state_attributes.update(
+                {
+                    ATTR_AVG_CURRENT: self.coordinator.data["average_current"],
+                    ATTR_INST_CURRENT: self.coordinator.data["instantaneous_current"],
+                    ATTR_INST_CURRENT_DDT: self.coordinator.data[
+                        "instantaneous_current_ddt"
+                    ],
+                    ATTR_TRAVEL_COUNT: self.coordinator.data["travel_count"],
+                }
+            )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the valve off (closed)."""
+        """Turn the switch off."""
+        if self.entity_description.key == SWITCH_KIND_ONBOARD_AP:
+            coro_func = self._client.wifi.disable_ap
+        else:
+            coro_func = self._client.valve.close
+
         try:
             async with self._client:
-                await self._client.valve.close()
+                await coro_func()
         except GuardianError as err:
-            raise HomeAssistantError(f"Error while closing the valve: {err}") from err
+            raise HomeAssistantError(
+                f'Error while turning "{self.entity_id}" off: {err}'
+            ) from err
 
         self._attr_is_on = False
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the valve on (open)."""
+        """Turn the switch on."""
+        if self.entity_description.key == SWITCH_KIND_ONBOARD_AP:
+            coro_func = self._client.wifi.enable_ap
+        else:
+            coro_func = self._client.valve.open
+
         try:
             async with self._client:
-                await self._client.valve.open()
+                await coro_func()
         except GuardianError as err:
-            raise HomeAssistantError(f"Error while opening the valve: {err}") from err
+            raise HomeAssistantError(
+                f'Error while turning "{self.entity_id}" on: {err}'
+            ) from err
 
         self._attr_is_on = True
         self.async_write_ha_state()

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from aioguardian import Client
 from aioguardian.errors import GuardianError
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 from aioguardian.errors import GuardianError
 
@@ -43,6 +43,26 @@ class ValveControllerSwitchDescription(
     """Describe a Guardian valve controller switch."""
 
 
+async def _async_disable_ap(client: Client) -> None:
+    """Disable the onboard AP."""
+    await client.wifi.disable_ap()
+
+
+async def _async_enable_ap(client: Client) -> None:
+    """Enable the onboard AP."""
+    await client.wifi.enable_ap()
+
+
+async def _async_close_valve(client: Client) -> None:
+    """Close the valve."""
+    await client.valve.close()
+
+
+async def _async_open_valve(client: Client) -> None:
+    """Open the valve."""
+    await client.valve.open()
+
+
 VALVE_CONTROLLER_DESCRIPTIONS = (
     ValveControllerSwitchDescription(
         key=SWITCH_KIND_ONBOARD_AP,
@@ -50,20 +70,16 @@ VALVE_CONTROLLER_DESCRIPTIONS = (
         icon="mdi:wifi",
         entity_category=EntityCategory.CONFIG,
         api_category=API_WIFI_STATUS,
-        off_action=lambda client: cast(
-            Awaitable[dict[str, Any]], client.wifi.disable_ap()
-        ),
-        on_action=lambda client: cast(
-            Awaitable[dict[str, Any]], client.wifi.enable_ap()
-        ),
+        off_action=_async_disable_ap,
+        on_action=_async_enable_ap,
     ),
     ValveControllerSwitchDescription(
         key=SWITCH_KIND_VALVE,
         name="Valve controller",
         icon="mdi:water",
         api_category=API_VALVE_STATUS,
-        off_action=lambda client: cast(Awaitable[dict[str, Any]], client.valve.close()),
-        on_action=lambda client: cast(Awaitable[dict[str, Any]], client.valve.open()),
+        off_action=_async_close_valve,
+        on_action=_async_open_valve,
     ),
 )
 

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -97,7 +97,7 @@ async def async_setup_entry(
 
 
 class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
-    """Define a base Guardian switch."""
+    """Define a switch related to a Guardian valve controller."""
 
     ON_STATES = {
         "start_opening",

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -23,23 +23,23 @@
             "fix_flow": {
                 "step": {
                     "confirm": {
-                        "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved.",
+                        "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`.",
                         "title": "The {deprecated_service} service is being removed"
                     }
                 }
             },
             "title": "The {deprecated_service} service is being removed"
         },
-        "removed_old_entity": {
+        "replaced_old_entity": {
             "fix_flow": {
                 "step": {
                     "confirm": {
-                        "description": "This entity is no longer provided by the Guardian integration and has been removed from Home Assistant. Click SUBMIT below to mark this issue as resolved.",
-                        "title": "The {removed_entity_id} entity is being removed"
+                        "description": "This entity has been replaced by `{replacement_entity_id}`.",
+                        "title": "The {removed_entity_id} entity has been removed"
                     }
                 }
             },
-            "title": "The {removed_entity_id} entity is being removed"
+            "title": "The {removed_entity_id} entity has been removed"
         }
     }
 }

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -29,6 +29,17 @@
                 }
             },
             "title": "The {deprecated_service} service is being removed"
+        },
+        "removed_old_entity": {
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "This entity is no longer provided by the Guardian integration and has been removed from Home Assistant. Click SUBMIT below to mark this issue as resolved.",
+                        "title": "The {removed_entity_id} entity is being removed"
+                    }
+                }
+            },
+            "title": "The {removed_entity_id} entity is being removed"
         }
     }
 }

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -35,11 +35,11 @@
                 "step": {
                     "confirm": {
                         "description": "This entity has been replaced by `{replacement_entity_id}`.",
-                        "title": "The {removed_entity_id} entity has been removed"
+                        "title": "The {old_entity_id} entity will be removed"
                     }
                 }
             },
-            "title": "The {removed_entity_id} entity has been removed"
+            "title": "The {old_entity_id} entity will be removed"
         }
     }
 }

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -9,16 +9,51 @@ from typing import Any, cast
 from aioguardian import Client
 from aioguardian.errors import GuardianError
 
+from homeassistant.components.repairs import IssueSeverity, async_create_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import LOGGER
+from .const import DOMAIN, LOGGER
 
 DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
 
 SIGNAL_REBOOT_REQUESTED = "guardian_reboot_requested_{0}"
+
+
+@callback
+def async_clean_up_old_entities(
+    hass: HomeAssistant, entry: ConfigEntry, unique_id_suffixes_to_remove: tuple[str]
+) -> None:
+    """Clean up old, no-longer-used entities."""
+    ent_reg = entity_registry.async_get(hass)
+    for entity_registry_item in [
+        e
+        for e in ent_reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and any(
+            suffix
+            for suffix in unique_id_suffixes_to_remove
+            if e.unique_id.endswith(suffix)
+        )
+    ]:
+        removed_entity_id = entity_registry_item.entity_id
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"removed_old_entity_{removed_entity_id}",
+            is_fixable=True,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="removed_old_entity",
+            translation_placeholders={
+                "removed_entity_id": removed_entity_id,
+            },
+        )
+        LOGGER.debug('Removing old entity: "%s"', removed_entity_id)
+        ent_reg.async_remove(removed_entity_id)
 
 
 class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -10,11 +10,11 @@ from typing import Any, cast
 from aioguardian import Client
 from aioguardian.errors import GuardianError
 
-from homeassistant.components.repairs import IssueSeverity, async_create_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, cast
 
@@ -23,36 +24,53 @@ DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
 SIGNAL_REBOOT_REQUESTED = "guardian_reboot_requested_{0}"
 
 
+@dataclass
+class EntityDomainReplacementStrategy:
+    """Define an entity replacement."""
+
+    old_domain: str
+    old_unique_id: str
+    replacement_entity_id: str
+
+
 @callback
-def async_clean_up_old_entities(
-    hass: HomeAssistant, entry: ConfigEntry, unique_id_suffixes_to_remove: tuple[str]
+def async_finish_entity_domain_replacements(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    entity_replacement_strategies: Iterable[EntityDomainReplacementStrategy],
 ) -> None:
-    """Clean up old, no-longer-used entities."""
+    """Remove old entities and create a repairs issue with info on their replacement."""
     ent_reg = entity_registry.async_get(hass)
-    for entity_registry_item in [
-        e
-        for e in ent_reg.entities.values()
-        if e.config_entry_id == entry.entry_id
-        and any(
-            suffix
-            for suffix in unique_id_suffixes_to_remove
-            if e.unique_id.endswith(suffix)
-        )
-    ]:
-        removed_entity_id = entity_registry_item.entity_id
+    for strategy in entity_replacement_strategies:
+        try:
+            [registry_entry] = [
+                registry_entry
+                for registry_entry in ent_reg.entities.values()
+                if registry_entry.config_entry_id == entry.entry_id
+                and registry_entry.domain == strategy.old_domain
+                and registry_entry.unique_id == strategy.old_unique_id
+            ]
+        except ValueError:
+            continue
+
+        removed_entity_id = registry_entry.entity_id
+        translation_key = "replaced_old_entity"
+
         async_create_issue(
             hass,
             DOMAIN,
-            f"removed_old_entity_{removed_entity_id}",
+            f"{translation_key}_{removed_entity_id}",
             is_fixable=True,
             is_persistent=True,
             severity=IssueSeverity.WARNING,
-            translation_key="removed_old_entity",
+            translation_key=translation_key,
             translation_placeholders={
                 "removed_entity_id": removed_entity_id,
+                "replacement_entity_id": strategy.replacement_entity_id,
             },
         )
-        LOGGER.debug('Removing old entity: "%s"', removed_entity_id)
+
+        LOGGER.info('Removing old entity: "%s"', removed_entity_id)
         ent_reg.async_remove(removed_entity_id)
 
 

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -31,6 +31,7 @@ class EntityDomainReplacementStrategy:
     old_domain: str
     old_unique_id: str
     replacement_entity_id: str
+    remove_old_entity: bool = True
 
 
 @callback
@@ -70,8 +71,9 @@ def async_finish_entity_domain_replacements(
             },
         )
 
-        LOGGER.info('Removing old entity: "%s"', removed_entity_id)
-        ent_reg.async_remove(removed_entity_id)
+        if strategy.remove_old_entity:
+            LOGGER.info('Removing old entity: "%s"', removed_entity_id)
+            ent_reg.async_remove(removed_entity_id)
 
 
 class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -55,27 +55,27 @@ def async_finish_entity_domain_replacements(
         except ValueError:
             continue
 
-        removed_entity_id = registry_entry.entity_id
+        old_entity_id = registry_entry.entity_id
         translation_key = "replaced_old_entity"
 
         async_create_issue(
             hass,
             DOMAIN,
-            f"{translation_key}_{removed_entity_id}",
+            f"{translation_key}_{old_entity_id}",
             breaks_in_ha_version=strategy.breaks_in_ha_version,
             is_fixable=True,
             is_persistent=True,
             severity=IssueSeverity.WARNING,
             translation_key=translation_key,
             translation_placeholders={
-                "removed_entity_id": removed_entity_id,
+                "old_entity_id": old_entity_id,
                 "replacement_entity_id": strategy.replacement_entity_id,
             },
         )
 
         if strategy.remove_old_entity:
-            LOGGER.info('Removing old entity: "%s"', removed_entity_id)
-            ent_reg.async_remove(removed_entity_id)
+            LOGGER.info('Removing old entity: "%s"', old_entity_id)
+            ent_reg.async_remove(old_entity_id)
 
 
 class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -31,6 +31,7 @@ class EntityDomainReplacementStrategy:
     old_domain: str
     old_unique_id: str
     replacement_entity_id: str
+    breaks_in_ha_version: str
     remove_old_entity: bool = True
 
 
@@ -61,6 +62,7 @@ def async_finish_entity_domain_replacements(
             hass,
             DOMAIN,
             f"{translation_key}_{removed_entity_id}",
+            breaks_in_ha_version=strategy.breaks_in_ha_version,
             is_fixable=True,
             is_persistent=True,
             severity=IssueSeverity.WARNING,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR follows up on https://github.com/home-assistant/core/pull/75028 and replaces two more Guardian services – `guardian.disable_ap` and `guardian.enable_ap` – with a switch.

![CleanShot 2022-07-11 at 16 56 15](https://user-images.githubusercontent.com/47216/178372434-ea1d2d4b-63b0-4dd3-a4a0-8db8614128ef.png)

Users will be notified of both the service deprecation and the to-be-removed-in-the-future binary sensor by log entries and repairs issues.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23374

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
