### PR TITLE
Improve device_automation trigger validation

### DIFF
--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from . import DeviceAutomationType, async_get_device_automation_platform
@@ -51,14 +52,15 @@ async def async_validate_action_config(
 ) -> ConfigType:
     """Validate config."""
     try:
+        config = cv.DEVICE_ACTION_SCHEMA(config)
         platform = await async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], DeviceAutomationType.ACTION
         )
         if hasattr(platform, "async_validate_action_config"):
             return await platform.async_validate_action_config(hass, config)
         return cast(ConfigType, platform.ACTION_SCHEMA(config))
-    except InvalidDeviceAutomationConfig as err:
-        raise vol.Invalid(str(err) or "Invalid action configuration") from err
+    except (vol.Invalid, InvalidDeviceAutomationConfig) as err:
+        raise vol.Invalid("invalid action configuration: " + str(err)) from err
 
 
 async def async_call_action_from_config(

--- a/homeassistant/components/device_automation/condition.py
+++ b/homeassistant/components/device_automation/condition.py
@@ -58,8 +58,8 @@ async def async_validate_condition_config(
         if hasattr(platform, "async_validate_condition_config"):
             return await platform.async_validate_condition_config(hass, config)
         return cast(ConfigType, platform.CONDITION_SCHEMA(config))
-    except InvalidDeviceAutomationConfig as err:
-        raise vol.Invalid(str(err) or "Invalid condition configuration") from err
+    except (vol.Invalid, InvalidDeviceAutomationConfig) as err:
+        raise vol.Invalid("invalid condition configuration: " + str(err)) from err
 
 
 async def async_condition_from_config(

--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -61,14 +61,15 @@ async def async_validate_trigger_config(
 ) -> ConfigType:
     """Validate config."""
     try:
+        config = TRIGGER_SCHEMA(config)
         platform = await async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], DeviceAutomationType.TRIGGER
         )
         if not hasattr(platform, "async_validate_trigger_config"):
             return cast(ConfigType, platform.TRIGGER_SCHEMA(config))
         return await platform.async_validate_trigger_config(hass, config)
-    except InvalidDeviceAutomationConfig as err:
-        raise vol.Invalid(str(err) or "Invalid trigger configuration") from err
+    except (vol.Invalid, InvalidDeviceAutomationConfig) as err:
+        raise InvalidDeviceAutomationConfig("invalid trigger configuration") from err
 
 
 async def async_attach_trigger(

--- a/homeassistant/components/humidifier/device_trigger.py
+++ b/homeassistant/components/humidifier/device_trigger.py
@@ -46,12 +46,9 @@ HUMIDIFIER_TRIGGER_SCHEMA = vol.All(
     cv.has_at_least_one_key(CONF_BELOW, CONF_ABOVE),
 )
 
-TRIGGER_SCHEMA = vol.All(
-    vol.Any(
-        HUMIDIFIER_TRIGGER_SCHEMA,
-        toggle_entity.TRIGGER_SCHEMA,
-    ),
-    vol.Schema({vol.Required(CONF_DOMAIN): DOMAIN}, extra=vol.ALLOW_EXTRA),
+TRIGGER_SCHEMA = vol.Any(
+    HUMIDIFIER_TRIGGER_SCHEMA,
+    toggle_entity.TRIGGER_SCHEMA,
 )
 
 

--- a/homeassistant/components/humidifier/device_trigger.py
+++ b/homeassistant/components/humidifier/device_trigger.py
@@ -46,9 +46,12 @@ HUMIDIFIER_TRIGGER_SCHEMA = vol.All(
     cv.has_at_least_one_key(CONF_BELOW, CONF_ABOVE),
 )
 
-TRIGGER_SCHEMA = vol.Any(
-    HUMIDIFIER_TRIGGER_SCHEMA,
-    toggle_entity.TRIGGER_SCHEMA,
+TRIGGER_SCHEMA = vol.All(
+    vol.Any(
+        HUMIDIFIER_TRIGGER_SCHEMA,
+        toggle_entity.TRIGGER_SCHEMA,
+    ),
+    vol.Schema({vol.Required(CONF_DOMAIN): DOMAIN}, extra=vol.ALLOW_EXTRA),
 )
 
 

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -76,7 +76,6 @@ async def async_validate_action_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType:
     """Validate config."""
-    config = ACTION_SCHEMA(config)
     commands, _ = _get_commands(hass, config[CONF_DEVICE_ID], config[CONF_TYPE])
     sub_type = config[CONF_SUBTYPE]
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -720,7 +720,28 @@ async def test_automation_with_bad_condition_action(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_condition(hass, caplog):
+async def test_automation_with_bad_condition_missing_domain(hass, caplog):
+    """Test automation with bad device condition."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event1"},
+                "condition": {"condition": "device", "device_id": "hello.device"},
+                "action": {"service": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+
+    assert (
+        "Invalid config for [automation]: required key not provided @ data['condition'][0]['domain']"
+        in caplog.text
+    )
+
+
+async def test_automation_with_bad_condition_missing_device_id(hass, caplog):
     """Test automation with bad device condition."""
     assert await async_setup_component(
         hass,
@@ -735,7 +756,10 @@ async def test_automation_with_bad_condition(hass, caplog):
         },
     )
 
-    assert "required key not provided" in caplog.text
+    assert (
+        "Invalid config for [automation]: required key not provided @ data['condition'][0]['device_id']"
+        in caplog.text
+    )
 
 
 @pytest.fixture
@@ -876,8 +900,25 @@ async def test_automation_with_bad_sub_condition(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_trigger(hass, caplog):
-    """Test automation with bad device trigger."""
+async def test_automation_with_bad_trigger_missing_domain(hass, caplog):
+    """Test automation with device trigger this is missing domain."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "device", "device_id": "hello.device"},
+                "action": {"service": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+
+    assert "required key not provided @ data['domain']" in caplog.text
+
+
+async def test_automation_with_bad_trigger_missing_device_id(hass, caplog):
+    """Test automation with device trigger that is missing device_id."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -890,7 +931,7 @@ async def test_automation_with_bad_trigger(hass, caplog):
         },
     )
 
-    assert "required key not provided" in caplog.text
+    assert "required key not provided @ data['device_id']" in caplog.text
 
 
 async def test_websocket_device_not_found(hass, hass_ws_client):

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -128,8 +128,7 @@ async def test_get_triggers_for_invalid_device_id(hass, caplog):
     await hass.async_block_till_done()
 
     assert (
-        "Invalid config for [automation]: Device invalid_device_id is not a valid webostv device"
-        in caplog.text
+        "Invalid config for [automation]: invalid trigger configuration" in caplog.text
     )
 
 


### PR DESCRIPTION
## Proposed change

Validates the trigger configuration against the device_trigger schema before trying to access any of the properties in order to provide better error messages.
Updates the error message to include an explicit indication that the error is coming from a trigger configuration.

Similar updates could probably be applied to the action and condition schemas if they don't already do it.

Fixes #74380

FYI: @emontnemery - I noticed the condition and action schemas are in the config_validation helpers file, but not the trigger schema.  You were the last person to make a major change to this (https://github.com/home-assistant/core/pull/51727) so before I go ahead and make the change to move the schema, do you have any suggestions/thoughts why I shouldn't?


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74380

## Without validation improvements

**Blueprint with missing `domain`**
```
2022-07-12 06:02:18.351 ERROR (MainThread) [homeassistant.setup] Error during setup of component automation
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/setup.py", line 235, in _async_setup_component
    result = await task
  File "/workspaces/core/homeassistant/components/automation/__init__.py", line 241, in async_setup
    if not await _async_process_config(hass, config, component):
  File "/workspaces/core/homeassistant/components/automation/__init__.py", line 648, in _async_process_config
    await async_validate_config_item(hass, raw_config),
  File "/workspaces/core/homeassistant/components/automation/config.py", line 74, in async_validate_config_item
    config[CONF_TRIGGER] = await async_validate_trigger_config(
  File "/workspaces/core/homeassistant/helpers/trigger.py", line 59, in async_validate_trigger_config
    conf = await platform.async_validate_trigger_config(hass, conf)
  File "/workspaces/core/homeassistant/components/device_automation/trigger.py", line 67, in async_validate_trigger_config
    hass, config[CONF_DOMAIN], DeviceAutomationType.TRIGGER
KeyError: 'domain'
```

**Blueprint with missing `property` (specific to zwave_js event schema)**
```
2022-07-12 06:09:54.206 ERROR (MainThread) [homeassistant.components.automation] Blueprint Missing Property generated invalid automation with inputs OrderedDict([('control_switch', '498be56d796836a67406e9ad373d23db')]): required key not provided @ data['property']. Got None
```

## With validation improvements

**Blueprint with missing `domain`**
```
2022-07-12 06:12:16.080 ERROR (MainThread) [homeassistant.components.automation] Blueprint Missing Domain generated invalid automation with inputs OrderedDict([('control_switch', '498be56d796836a67406e9ad373d23db')]): invalid trigger configuration: required key not provided @ data['domain']. Got <homeassistant.components.blueprint.models.BlueprintInputs object at 0x7f581e097820>
```

**Blueprint with missing `property` (specific to zwave_js event schema)**
```
2022-07-12 06:12:16.680 ERROR (MainThread) [homeassistant.components.automation] Blueprint Missing Property generated invalid automation with inputs OrderedDict([('control_switch', '498be56d796836a67406e9ad373d23db')]): invalid trigger configuration: required key not provided @ data['property']. Got <homeassistant.components.blueprint.models.BlueprintInputs object at 0x7f581c0dc9d0>
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure