### PR TITLE
Migrate DSMR to new entity naming style

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -78,7 +78,7 @@ class DSMRSensorEntityDescription(
 SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="current_electricity_usage",
-        name="Power Consumption",
+        name="Power consumption",
         obis_reference=obis_references.CURRENT_ELECTRICITY_USAGE,
         device_class=SensorDeviceClass.POWER,
         force_update=True,
@@ -86,7 +86,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivery",
-        name="Power Production",
+        name="Power production",
         obis_reference=obis_references.CURRENT_ELECTRICITY_DELIVERY,
         device_class=SensorDeviceClass.POWER,
         force_update=True,
@@ -94,14 +94,14 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_active_tariff",
-        name="Power Tariff",
+        name="Active tariff",
         obis_reference=obis_references.ELECTRICITY_ACTIVE_TARIFF,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         icon="mdi:flash",
     ),
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_1",
-        name="Energy Consumption (tarif 1)",
+        name="Energy consumption (tarif 1)",
         obis_reference=obis_references.ELECTRICITY_USED_TARIFF_1,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENERGY,
@@ -110,7 +110,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_2",
-        name="Energy Consumption (tarif 2)",
+        name="Energy consumption (tarif 2)",
         obis_reference=obis_references.ELECTRICITY_USED_TARIFF_2,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
@@ -119,7 +119,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_1",
-        name="Energy Production (tarif 1)",
+        name="Energy production (tarif 1)",
         obis_reference=obis_references.ELECTRICITY_DELIVERED_TARIFF_1,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
@@ -128,7 +128,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_2",
-        name="Energy Production (tarif 2)",
+        name="Energy production (tarif 2)",
         obis_reference=obis_references.ELECTRICITY_DELIVERED_TARIFF_2,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
@@ -137,7 +137,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_positive",
-        name="Power Consumption Phase L1",
+        name="Power consumption phase L1",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -145,7 +145,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_positive",
-        name="Power Consumption Phase L2",
+        name="Power consumption phase L2",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -153,7 +153,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_positive",
-        name="Power Consumption Phase L3",
+        name="Power consumption phase L3",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -161,7 +161,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_negative",
-        name="Power Production Phase L1",
+        name="Power production phase L1",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -169,7 +169,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_negative",
-        name="Power Production Phase L2",
+        name="Power production phase L2",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -177,7 +177,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_negative",
-        name="Power Production Phase L3",
+        name="Power production phase L3",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -185,7 +185,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="short_power_failure_count",
-        name="Short Power Failure Count",
+        name="Short power failure count",
         obis_reference=obis_references.SHORT_POWER_FAILURE_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -194,7 +194,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="long_power_failure_count",
-        name="Long Power Failure Count",
+        name="Long power failure count",
         obis_reference=obis_references.LONG_POWER_FAILURE_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -203,7 +203,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_sag_l1_count",
-        name="Voltage Sags Phase L1",
+        name="Voltage sags phase L1",
         obis_reference=obis_references.VOLTAGE_SAG_L1_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -211,7 +211,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_sag_l2_count",
-        name="Voltage Sags Phase L2",
+        name="Voltage sags phase L2",
         obis_reference=obis_references.VOLTAGE_SAG_L2_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -219,7 +219,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_sag_l3_count",
-        name="Voltage Sags Phase L3",
+        name="Voltage sags phase L3",
         obis_reference=obis_references.VOLTAGE_SAG_L3_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -227,7 +227,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_swell_l1_count",
-        name="Voltage Swells Phase L1",
+        name="Voltage swells phase L1",
         obis_reference=obis_references.VOLTAGE_SWELL_L1_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -236,7 +236,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_swell_l2_count",
-        name="Voltage Swells Phase L2",
+        name="Voltage swells phase L2",
         obis_reference=obis_references.VOLTAGE_SWELL_L2_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -245,7 +245,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_swell_l3_count",
-        name="Voltage Swells Phase L3",
+        name="Voltage swells phase L3",
         obis_reference=obis_references.VOLTAGE_SWELL_L3_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -254,7 +254,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l1",
-        name="Voltage Phase L1",
+        name="Voltage phase L1",
         obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L1,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
@@ -263,7 +263,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l2",
-        name="Voltage Phase L2",
+        name="Voltage phase L2",
         obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L2,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
@@ -272,7 +272,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l3",
-        name="Voltage Phase L3",
+        name="Voltage phase L3",
         obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L3,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
@@ -281,7 +281,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l1",
-        name="Current Phase L1",
+        name="Current phase L1",
         obis_reference=obis_references.INSTANTANEOUS_CURRENT_L1,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -290,7 +290,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l2",
-        name="Current Phase L2",
+        name="Current phase L2",
         obis_reference=obis_references.INSTANTANEOUS_CURRENT_L2,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -299,7 +299,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l3",
-        name="Current Phase L3",
+        name="Current phase L3",
         obis_reference=obis_references.INSTANTANEOUS_CURRENT_L3,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -328,7 +328,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_imported_total",
-        name="Energy Consumption (total)",
+        name="Energy consumption (total)",
         obis_reference=obis_references.ELECTRICITY_IMPORTED_TOTAL,
         dsmr_versions={"5L", "5S", "Q3D"},
         force_update=True,
@@ -337,7 +337,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_exported_total",
-        name="Energy Production (total)",
+        name="Energy production (total)",
         obis_reference=obis_references.ELECTRICITY_EXPORTED_TOTAL,
         dsmr_versions={"5L", "5S", "Q3D"},
         force_update=True,
@@ -346,7 +346,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="hourly_gas_meter_reading",
-        name="Gas Consumption",
+        name="Gas consumption",
         obis_reference=obis_references.HOURLY_GAS_METER_READING,
         dsmr_versions={"4", "5", "5L"},
         is_gas=True,
@@ -356,7 +356,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_5min_gas_meter_reading",
-        name="Gas Consumption",
+        name="Gas consumption",
         obis_reference=obis_references.BELGIUM_5MIN_GAS_METER_READING,
         dsmr_versions={"5B"},
         is_gas=True,
@@ -366,7 +366,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="gas_meter_reading",
-        name="Gas Consumption",
+        name="Gas consumption",
         obis_reference=obis_references.GAS_METER_READING,
         dsmr_versions={"2.2"},
         is_gas=True,
@@ -513,6 +513,7 @@ class DSMREntity(SensorEntity):
     """Entity reading values from DSMR telegram."""
 
     entity_description: DSMRSensorEntityDescription
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -77,18 +77,18 @@ async def test_default_setup(hass, dsmr_connection_fixture):
 
     registry = er.async_get(hass)
 
-    entry = registry.async_get("sensor.power_consumption")
+    entry = registry.async_get("sensor.electricity_meter_power_consumption")
     assert entry
     assert entry.unique_id == "1234_current_electricity_usage"
 
-    entry = registry.async_get("sensor.gas_consumption")
+    entry = registry.async_get("sensor.gas_meter_gas_consumption")
     assert entry
     assert entry.unique_id == "5678_gas_meter_reading"
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
     # make sure entities have been created and return 'unknown' state
-    power_consumption = hass.states.get("sensor.power_consumption")
+    power_consumption = hass.states.get("sensor.electricity_meter_power_consumption")
     assert power_consumption.state == STATE_UNKNOWN
     assert (
         power_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
@@ -107,22 +107,22 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     await asyncio.sleep(0)
 
     # ensure entities have new state value after incoming telegram
-    power_consumption = hass.states.get("sensor.power_consumption")
+    power_consumption = hass.states.get("sensor.electricity_meter_power_consumption")
     assert power_consumption.state == "0.0"
     assert (
         power_consumption.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
     )
 
     # tariff should be translated in human readable and have no unit
-    power_tariff = hass.states.get("sensor.power_tariff")
-    assert power_tariff.state == "low"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
+    assert active_tariff.state == "low"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
+    assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
 
     # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_consumption")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -155,11 +155,11 @@ async def test_setup_only_energy(hass, dsmr_connection_fixture):
 
     registry = er.async_get(hass)
 
-    entry = registry.async_get("sensor.power_consumption")
+    entry = registry.async_get("sensor.electricity_meter_power_consumption")
     assert entry
     assert entry.unique_id == "1234_current_electricity_usage"
 
-    entry = registry.async_get("sensor.gas_consumption")
+    entry = registry.async_get("sensor.gas_meter_gas_consumption")
     assert not entry
 
 
@@ -213,15 +213,15 @@ async def test_v4_meter(hass, dsmr_connection_fixture):
     await asyncio.sleep(0)
 
     # tariff should be translated in human readable and have no unit
-    power_tariff = hass.states.get("sensor.power_tariff")
-    assert power_tariff.state == "low"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
+    assert active_tariff.state == "low"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
+    assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
 
     # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_consumption")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
@@ -284,15 +284,15 @@ async def test_v5_meter(hass, dsmr_connection_fixture):
     await asyncio.sleep(0)
 
     # tariff should be translated in human readable and have no unit
-    power_tariff = hass.states.get("sensor.power_tariff")
-    assert power_tariff.state == "low"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
+    assert active_tariff.state == "low"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
+    assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
 
     # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_consumption")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -359,24 +359,24 @@ async def test_luxembourg_meter(hass, dsmr_connection_fixture):
     # after receiving telegram entities need to have the chance to update
     await asyncio.sleep(0)
 
-    power_tariff = hass.states.get("sensor.energy_consumption_total")
-    assert power_tariff.state == "123.456"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert power_tariff.attributes.get(ATTR_ICON) is None
+    active_tariff = hass.states.get("sensor.electricity_meter_energy_consumption_total")
+    assert active_tariff.state == "123.456"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert active_tariff.attributes.get(ATTR_ICON) is None
     assert (
-        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        active_tariff.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.TOTAL_INCREASING
     )
     assert (
-        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+        active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
 
-    power_tariff = hass.states.get("sensor.energy_production_total")
-    assert power_tariff.state == "654.321"
-    assert power_tariff.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
+    active_tariff = hass.states.get("sensor.electricity_meter_energy_production_total")
+    assert active_tariff.state == "654.321"
+    assert active_tariff.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
 
     # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_consumption")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -438,15 +438,15 @@ async def test_belgian_meter(hass, dsmr_connection_fixture):
     await asyncio.sleep(0)
 
     # tariff should be translated in human readable and have no unit
-    power_tariff = hass.states.get("sensor.power_tariff")
-    assert power_tariff.state == "normal"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
+    assert active_tariff.state == "normal"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
+    assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
 
     # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_consumption")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -497,12 +497,12 @@ async def test_belgian_meter_low(hass, dsmr_connection_fixture):
     await asyncio.sleep(0)
 
     # tariff should be translated in human readable and have no unit
-    power_tariff = hass.states.get("sensor.power_tariff")
-    assert power_tariff.state == "low"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) is None
-    assert power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
+    active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
+    assert active_tariff.state == "low"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
+    assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
+    assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
 
 
 async def test_swedish_meter(hass, dsmr_connection_fixture):
@@ -553,26 +553,26 @@ async def test_swedish_meter(hass, dsmr_connection_fixture):
     # after receiving telegram entities need to have the chance to update
     await asyncio.sleep(0)
 
-    power_tariff = hass.states.get("sensor.energy_consumption_total")
-    assert power_tariff.state == "123.456"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert power_tariff.attributes.get(ATTR_ICON) is None
+    active_tariff = hass.states.get("sensor.electricity_meter_energy_consumption_total")
+    assert active_tariff.state == "123.456"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert active_tariff.attributes.get(ATTR_ICON) is None
     assert (
-        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        active_tariff.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.TOTAL_INCREASING
     )
     assert (
-        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+        active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
 
-    power_tariff = hass.states.get("sensor.energy_production_total")
-    assert power_tariff.state == "654.321"
+    active_tariff = hass.states.get("sensor.electricity_meter_energy_production_total")
+    assert active_tariff.state == "654.321"
     assert (
-        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        active_tariff.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.TOTAL_INCREASING
     )
     assert (
-        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+        active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
 
 
@@ -627,26 +627,26 @@ async def test_easymeter(hass, dsmr_connection_fixture):
     # after receiving telegram entities need to have the chance to update
     await asyncio.sleep(0)
 
-    power_tariff = hass.states.get("sensor.energy_consumption_total")
-    assert power_tariff.state == "54184.6316"
-    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert power_tariff.attributes.get(ATTR_ICON) is None
+    active_tariff = hass.states.get("sensor.electricity_meter_energy_consumption_total")
+    assert active_tariff.state == "54184.6316"
+    assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert active_tariff.attributes.get(ATTR_ICON) is None
     assert (
-        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        active_tariff.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.TOTAL_INCREASING
     )
     assert (
-        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+        active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
 
-    power_tariff = hass.states.get("sensor.energy_production_total")
-    assert power_tariff.state == "19981.1069"
+    active_tariff = hass.states.get("sensor.electricity_meter_energy_production_total")
+    assert active_tariff.state == "19981.1069"
     assert (
-        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        active_tariff.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.TOTAL_INCREASING
     )
     assert (
-        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+        active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA.

Additionally (since we can now since the last PR), renames "Power tariff" to "Active Tariff". As it's not about power, but about the energy consumed. Anyways, I found the active tariff the most fitting (and matches DSMR specifications).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
