### PR TITLE
Fix Insteon thermostat issues

### DIFF
--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -86,7 +86,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        if self._insteon_device.properties[CELSIUS].value:
+        if self._insteon_device.configuration[CELSIUS].value:
             return TEMP_CELSIUS
         return TEMP_FAHRENHEIT
 

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -4,8 +4,8 @@
   "documentation": "https://www.home-assistant.io/integrations/insteon",
   "dependencies": ["http", "websocket_api"],
   "requirements": [
-    "pyinsteon==1.1.1",
-    "insteon-frontend-home-assistant==0.1.1"
+    "pyinsteon==1.1.3",
+    "insteon-frontend-home-assistant==0.2.0"
   ],
   "codeowners": ["@teharris1"],
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -894,7 +894,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.insteon
-insteon-frontend-home-assistant==0.1.1
+insteon-frontend-home-assistant==0.2.0
 
 # homeassistant.components.intellifire
 intellifire4py==2.0.1
@@ -1562,7 +1562,7 @@ pyialarm==2.2.0
 pyicloud==1.0.0
 
 # homeassistant.components.insteon
-pyinsteon==1.1.1
+pyinsteon==1.1.3
 
 # homeassistant.components.intesishome
 pyintesishome==1.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -640,7 +640,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.insteon
-insteon-frontend-home-assistant==0.1.1
+insteon-frontend-home-assistant==0.2.0
 
 # homeassistant.components.intellifire
 intellifire4py==2.0.1
@@ -1059,7 +1059,7 @@ pyialarm==2.2.0
 pyicloud==1.0.0
 
 # homeassistant.components.insteon
-pyinsteon==1.1.1
+pyinsteon==1.1.3
 
 # homeassistant.components.ipma
 pyipma==2.0.5


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes issues with the Insteon thermostat not updating the device state when changes are made from the UI such as changing the set point, fan mode, or system mode.


Release notes: https://github.com/pyinsteon/pyinsteon/releases/tag/1.1.3
Changelog: https://github.com/pyinsteon/pyinsteon/compare/1.1.1...1.1.3

Release notes: https://github.com/pyinsteon/insteon-panel/releases/tag/0.2.0
Changelog: https://github.com/pyinsteon/insteon-panel/compare/0.1.1..0.2.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72723
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
