### PR TITLE
Fix flapping system log test

### DIFF
--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -1,6 +1,7 @@
 """Support for system log."""
 from collections import OrderedDict, deque
 import logging
+from logging.handlers import QueueListener
 import queue
 import re
 import traceback
@@ -195,6 +196,10 @@ class LogErrorHandler(logging.Handler):
             self.hass.bus.fire(EVENT_SYSTEM_LOG, entry.to_dict())
 
 
+class HASSQueueListener(QueueListener):
+    """Queue listener for Home Assistant events."""
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the logger component."""
     if (conf := config.get(DOMAIN)) is None:
@@ -209,9 +214,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.data[DOMAIN] = handler
 
-    listener = logging.handlers.QueueListener(
-        simple_queue, handler, respect_handler_level=True
-    )
+    listener = HASSQueueListener(simple_queue, handler, respect_handler_level=True)
 
     listener.start()
 

--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -181,7 +181,7 @@ class LogErrorHandler(logging.Handler):
         )
         self.records.add_entry(entry)
         if self.fire_event:
-            self.hass.bus.async_fire(EVENT_SYSTEM_LOG, entry.to_dict())
+            self.hass.bus.fire(EVENT_SYSTEM_LOG, entry.to_dict())
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -3,7 +3,6 @@ from collections import OrderedDict, deque
 import logging
 import re
 import traceback
-from typing import cast
 
 import voluptuous as vol
 
@@ -191,7 +190,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         conf = CONFIG_SCHEMA({DOMAIN: {}})[DOMAIN]
 
     hass_path: str = HOMEASSISTANT_PATH[0]
-    config_dir = cast(str, hass.config.config_dir)
+    config_dir = hass.config.config_dir
+    assert config_dir is not None
     paths_re = re.compile(
         r"(?:{})/(.*)".format("|".join([re.escape(x) for x in (hass_path, config_dir)]))
     )

--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -79,7 +79,7 @@ def _figure_out_source(record, call_stack, paths_re):
     for pathname in reversed(stack):
 
         # Try to match with a file within Home Assistant
-        if match := re.match(paths_re, pathname[0]):
+        if match := paths_re.match(pathname[0]):
             return [match.group(1), pathname[1]]
     # Ok, we don't know what this is
     return (record.pathname, record.lineno)

--- a/tests/components/network/conftest.py
+++ b/tests/components/network/conftest.py
@@ -6,4 +6,8 @@ import pytest
 @pytest.fixture(autouse=True)
 def mock_get_source_ip():
     """Override mock of network util's async_get_source_ip."""
-    return
+
+
+@pytest.fixture(autouse=True)
+def mock_network():
+    """Override mock of network util's async_get_adapters."""

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -340,12 +340,12 @@ async def async_log_error_from_test_path(hass, path, watcher):
 
 async def test_homeassistant_path(hass, hass_ws_client):
     """Test error logged from Home Assistant path."""
-    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
 
     with patch(
         "homeassistant.components.system_log.HOMEASSISTANT_PATH",
         new=["venv_path/homeassistant"],
     ):
+        watcher = await async_setup_system_log(hass, BASIC_CONFIG)
         await async_log_error_from_test_path(
             hass, "venv_path/homeassistant/component/component.py", watcher
         )
@@ -355,9 +355,10 @@ async def test_homeassistant_path(hass, hass_ws_client):
 
 async def test_config_path(hass, hass_ws_client):
     """Test error logged from config path."""
-    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
 
     with patch.object(hass.config, "config_dir", new="config"):
+        watcher = await async_setup_system_log(hass, BASIC_CONFIG)
+
         await async_log_error_from_test_path(
             hass, "config/custom_component/test.py", watcher
         )

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -50,9 +50,10 @@ async def _install_log_catcher(hass, sq):
 
     async def _async_wait_and_remove():
         await hass.async_add_executor_job(_wait_handler_lock)
+        await event.wait()
         await hass.async_block_till_done()
         await hass.async_add_executor_job(_wait_handler_lock)
-        await event.wait()
+        await hass.async_block_till_done()
         logging.root.removeHandler(handler)
 
     return _async_wait_and_remove()

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -197,7 +197,7 @@ async def test_error_posted_as_event(hass, simple_queue):
 
     _LOGGER.error("error message")
     await wait_empty
-
+    await hass.async_block_till_done()
     assert len(events) == 1
     assert_log(events[0].data, "", "error message", "ERROR")
 

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -104,7 +104,7 @@ def get_frame(name):
     return (name, 5, None, None)
 
 
-async def setup_system_log(hass, config) -> WatchHASSQueueListener:
+async def async_setup_system_log(hass, config) -> WatchHASSQueueListener:
     """Set up the system_log component."""
     WatchHASSQueueListener.instances = []
     with patch(
@@ -119,7 +119,7 @@ async def setup_system_log(hass, config) -> WatchHASSQueueListener:
 
 async def test_normal_logs(hass, simple_queue, hass_ws_client):
     """Test that debug and info are not logged."""
-    await setup_system_log(hass, BASIC_CONFIG)
+    await async_setup_system_log(hass, BASIC_CONFIG)
 
     _LOGGER.debug("debug")
     _LOGGER.info("info")
@@ -131,7 +131,7 @@ async def test_normal_logs(hass, simple_queue, hass_ws_client):
 
 async def test_exception(hass, simple_queue, hass_ws_client):
     """Test that exceptions are logged and retrieved correctly."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
     wait_empty = watcher.add_watcher("log message")
 
     _generate_and_log_exception("exception message", "log message")
@@ -143,7 +143,7 @@ async def test_exception(hass, simple_queue, hass_ws_client):
 
 async def test_warning(hass, simple_queue, hass_ws_client):
     """Test that warning are logged and retrieved correctly."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
 
     wait_empty = watcher.add_watcher("warning message")
     _LOGGER.warning("warning message")
@@ -155,7 +155,7 @@ async def test_warning(hass, simple_queue, hass_ws_client):
 
 async def test_error(hass, simple_queue, hass_ws_client):
     """Test that errors are logged and retrieved correctly."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
 
     wait_empty = watcher.add_watcher("error message")
 
@@ -168,7 +168,7 @@ async def test_error(hass, simple_queue, hass_ws_client):
 
 async def test_config_not_fire_event(hass, simple_queue):
     """Test that errors are not posted as events with default config."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
     wait_empty = watcher.add_watcher("error message")
 
     events = []
@@ -188,7 +188,7 @@ async def test_config_not_fire_event(hass, simple_queue):
 
 async def test_error_posted_as_event(hass, simple_queue):
     """Test that error are posted as events."""
-    watcher = await setup_system_log(
+    watcher = await async_setup_system_log(
         hass, {"system_log": {"max_entries": 2, "fire_event": True}}
     )
     wait_empty = watcher.add_watcher("error message")
@@ -204,7 +204,7 @@ async def test_error_posted_as_event(hass, simple_queue):
 
 async def test_critical(hass, simple_queue, hass_ws_client):
     """Test that critical are logged and retrieved correctly."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
     wait_empty = watcher.add_watcher("critical message")
 
     _LOGGER.critical("critical message")
@@ -216,7 +216,7 @@ async def test_critical(hass, simple_queue, hass_ws_client):
 
 async def test_remove_older_logs(hass, simple_queue, hass_ws_client):
     """Test that older logs are rotated out."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
     wait_empty = watcher.add_watcher("error message 1")
     _LOGGER.error("error message 1")
     await wait_empty
@@ -241,7 +241,7 @@ def log_msg(nr=2):
 
 async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     """Test that duplicate log entries are dedupe."""
-    watcher = await setup_system_log(hass, {})
+    watcher = await async_setup_system_log(hass, {})
     wait_empty = watcher.add_watcher("error message 1")
     _LOGGER.error("error message 1")
     await wait_empty
@@ -305,7 +305,7 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
 
 async def test_clear_logs(hass, simple_queue, hass_ws_client):
     """Test that the log can be cleared via a service call."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
     wait_empty = watcher.add_watcher("error message")
     _LOGGER.error("error message")
     await wait_empty
@@ -364,7 +364,7 @@ async def test_write_choose_level(hass):
 
 async def test_unknown_path(hass, simple_queue, hass_ws_client):
     """Test error logged from unknown path."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
     wait_empty = watcher.add_watcher("error message")
     _LOGGER.findCaller = MagicMock(return_value=("unknown_path", 0, None, None))
     _LOGGER.error("error message")
@@ -396,7 +396,7 @@ async def async_log_error_from_test_path(hass, path, watcher):
 
 async def test_homeassistant_path(hass, simple_queue, hass_ws_client):
     """Test error logged from Home Assistant path."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
 
     with patch(
         "homeassistant.components.system_log.HOMEASSISTANT_PATH",
@@ -411,7 +411,7 @@ async def test_homeassistant_path(hass, simple_queue, hass_ws_client):
 
 async def test_config_path(hass, simple_queue, hass_ws_client):
     """Test error logged from config path."""
-    watcher = await setup_system_log(hass, BASIC_CONFIG)
+    watcher = await async_setup_system_log(hass, BASIC_CONFIG)
 
     with patch.object(hass.config, "config_dir", new="config"):
         await async_log_error_from_test_path(

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -217,9 +217,14 @@ async def test_remove_older_logs(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
     wait_empty = await _install_log_catcher(hass)
-
     _LOGGER.error("error message 1")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     _LOGGER.error("error message 2")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     _LOGGER.error("error message 3")
     await wait_empty
 
@@ -238,10 +243,18 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, {})
     await hass.async_block_till_done()
     wait_empty = await _install_log_catcher(hass)
-
     _LOGGER.error("error message 1")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     log_msg()
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     log_msg("2-2")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     _LOGGER.error("error message 3")
     await wait_empty
 
@@ -260,10 +273,18 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     assert log[0]["timestamp"] > log[0]["first_occurred"]
 
     wait_empty = await _install_log_catcher(hass)
-
     log_msg("2-3")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     log_msg("2-4")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     log_msg("2-5")
+    await wait_empty
+
+    wait_empty = await _install_log_catcher(hass)
     log_msg("2-6")
     await wait_empty
 
@@ -287,12 +308,10 @@ async def test_clear_logs(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
     wait_empty = await _install_log_catcher(hass)
-
     _LOGGER.error("error message")
     await wait_empty
 
     wait_empty = await _install_log_catcher(hass)
-
     await hass.services.async_call(system_log.DOMAIN, system_log.SERVICE_CLEAR, {})
     await wait_empty
 
@@ -351,7 +370,6 @@ async def test_unknown_path(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
     wait_empty = await _install_log_catcher(hass)
-
     _LOGGER.findCaller = MagicMock(return_value=("unknown_path", 0, None, None))
     _LOGGER.error("error message")
     await wait_empty
@@ -376,7 +394,6 @@ async def async_log_error_from_test_path(hass, path, sq):
         ),
     ):
         wait_empty = await _install_log_catcher(hass)
-
         _LOGGER.error("error message")
         await wait_empty
 

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -155,10 +155,10 @@ async def test_warning(hass, simple_queue, hass_ws_client):
 
 async def test_error(hass, simple_queue, hass_ws_client):
     """Test that errors are logged and retrieved correctly."""
-    await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+    watcher = await setup_system_log(hass, BASIC_CONFIG)
     await hass.async_block_till_done()
 
-    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
+    wait_empty = watcher.add_watcher("error message")
 
     _LOGGER.error("error message")
 

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -47,8 +47,8 @@ async def _install_log_catcher(hass):
         handler.release()
 
     async def _async_wait_and_remove():
-        await event.wait()
         await hass.async_add_executor_job(_wait_handler_lock)
+        await event.wait()
         logging.root.removeHandler(handler)
 
     return _async_wait_and_remove()

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -29,7 +29,6 @@ def simple_queue():
 
 async def _install_log_catcher(hass):
     event = asyncio.Event()
-    await hass.async_block_till_done()
 
     class EmitEventHandler(logging.Handler):
         """Set an event when called."""
@@ -47,6 +46,8 @@ async def _install_log_catcher(hass):
         handler.release()
 
     async def _async_wait_and_remove():
+        await hass.async_add_executor_job(_wait_handler_lock)
+        await hass.async_block_till_done()
         await hass.async_add_executor_job(_wait_handler_lock)
         await event.wait()
         logging.root.removeHandler(handler)

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -161,6 +161,7 @@ async def test_config_not_fire_event(hass):
     hass.bus.async_listen(system_log.EVENT_SYSTEM_LOG, event_listener)
 
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 0
 
@@ -177,6 +178,8 @@ async def test_error_posted_as_event(hass):
     _LOGGER.error("error message")
     await wait_empty
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
     assert len(events) == 1
     assert_log(events[0].data, "", "error message", "ERROR")
 

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -5,7 +5,6 @@ import asyncio
 from collections.abc import Awaitable
 import logging
 import queue
-import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -28,7 +28,7 @@ def simple_queue():
         yield simple_queue_fixed
 
 
-async def _install_log_catcher(hass, sq):
+async def _install_log_catcher(hass, sq, msg):
     event = asyncio.Event()
 
     class EmitEventHandler(logging.Handler):
@@ -36,7 +36,8 @@ async def _install_log_catcher(hass, sq):
 
         def emit(self, record):
             """Emit a log record."""
-            event.set()
+            if msg in record.message:
+                event.set()
 
     handler = EmitEventHandler()
     logging.root.addHandler(handler)
@@ -112,11 +113,11 @@ async def test_normal_logs(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "debug")
     _LOGGER.debug("debug")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "info")
     _LOGGER.info("info")
     await wait_empty
 
@@ -129,7 +130,7 @@ async def test_exception(hass, simple_queue, hass_ws_client):
     """Test that exceptions are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "log message")
 
     _generate_and_log_exception("exception message", "log message")
     await wait_empty
@@ -143,7 +144,7 @@ async def test_warning(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "warning message")
 
     _LOGGER.warning("warning message")
     await wait_empty
@@ -157,7 +158,7 @@ async def test_error(hass, simple_queue, hass_ws_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
 
     _LOGGER.error("error message")
 
@@ -170,7 +171,7 @@ async def test_config_not_fire_event(hass, simple_queue):
     """Test that errors are not posted as events with default config."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
 
     events = []
 
@@ -193,7 +194,7 @@ async def test_error_posted_as_event(hass, simple_queue):
         hass, system_log.DOMAIN, {"system_log": {"max_entries": 2, "fire_event": True}}
     )
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
 
     events = async_capture_events(hass, system_log.EVENT_SYSTEM_LOG)
 
@@ -208,7 +209,7 @@ async def test_critical(hass, simple_queue, hass_ws_client):
     """Test that critical are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "critical message")
 
     _LOGGER.critical("critical message")
     await wait_empty
@@ -221,15 +222,15 @@ async def test_remove_older_logs(hass, simple_queue, hass_ws_client):
     """Test that older logs are rotated out."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message 1")
     _LOGGER.error("error message 1")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message 2")
     _LOGGER.error("error message 2")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message 3")
     _LOGGER.error("error message 3")
     await wait_empty
 
@@ -247,19 +248,19 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     """Test that duplicate log entries are dedupe."""
     await async_setup_component(hass, system_log.DOMAIN, {})
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message 1")
     _LOGGER.error("error message 1")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     log_msg()
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     log_msg("2-2")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     _LOGGER.error("error message 3")
     await wait_empty
 
@@ -268,7 +269,7 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     assert log[1]["count"] == 2
     assert_log(log[1], "", ["error message 2", "error message 2-2"], "ERROR")
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
 
     log_msg()
     await wait_empty
@@ -277,19 +278,19 @@ async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     assert_log(log[0], "", ["error message 2", "error message 2-2"], "ERROR")
     assert log[0]["timestamp"] > log[0]["first_occurred"]
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     log_msg("2-3")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     log_msg("2-4")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     log_msg("2-5")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     log_msg("2-6")
     await wait_empty
 
@@ -312,14 +313,12 @@ async def test_clear_logs(hass, simple_queue, hass_ws_client):
     """Test that the log can be cleared via a service call."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     _LOGGER.error("error message")
     await wait_empty
 
-    wait_empty = await _install_log_catcher(hass, simple_queue)
     await hass.services.async_call(system_log.DOMAIN, system_log.SERVICE_CLEAR, {})
-    await wait_empty
-
+    await hass.async_block_till_done()
     # Assert done by get_error_log
     await get_error_log(hass_ws_client)
 
@@ -374,7 +373,7 @@ async def test_unknown_path(hass, simple_queue, hass_ws_client):
     """Test error logged from unknown path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
-    wait_empty = await _install_log_catcher(hass, simple_queue)
+    wait_empty = await _install_log_catcher(hass, simple_queue, "error message")
     _LOGGER.findCaller = MagicMock(return_value=("unknown_path", 0, None, None))
     _LOGGER.error("error message")
     await wait_empty
@@ -398,7 +397,7 @@ async def async_log_error_from_test_path(hass, path, sq):
             ]
         ),
     ):
-        wait_empty = await _install_log_catcher(hass, sq)
+        wait_empty = await _install_log_catcher(hass, sq, "error message")
         _LOGGER.error("error message")
         await wait_empty
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from homeassistant.auth.const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY
 from homeassistant.auth.models import Credentials
 from homeassistant.auth.providers import homeassistant, legacy_api_password
 from homeassistant.components import mqtt, recorder
+from homeassistant.components.network.models import Adapter, IPv4ConfiguredAddress
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_OK,
@@ -642,6 +643,25 @@ async def mqtt_mock_entry_with_yaml_config(hass, mqtt_client_mock, mqtt_config):
 
     async with _mqtt_mock_entry(hass, mqtt_client_mock, mqtt_config) as mqtt_mock_entry:
         yield _setup_mqtt_entry
+
+
+@pytest.fixture(autouse=True)
+def mock_network():
+    """Mock network."""
+    mock_adapter = Adapter(
+        name="eth0",
+        index=0,
+        enabled=True,
+        auto=True,
+        default=True,
+        ipv4=[IPv4ConfiguredAddress(address="10.10.10.10", network_prefix=24)],
+        ipv6=[],
+    )
+    with patch(
+        "homeassistant.components.network.network.async_load_adapters",
+        return_value=[mock_adapter],
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Change the test to patch the handler so we know when its done.

- Remove the queue handler since its no longer needed as there is never any I/O here.

Fixes
`FAILED tests/components/system_log/test_init.py::test_warning[pyloop] - Asser...`

`DEBUG:homeassistant.components.websocket_api.http.connection:[140515409963344] Sending {"id":5,"type":"result","success":true,"result":[{"name":"asyncio","message":["Executing <Task pending name=Task-13742 coro=<test_warning() running at /home/runner/work/core/core/tests/components/system_log/test_init.py:121> cb=[_run_until_complete_cb() at /opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/asyncio/base_events.py:184] created at /opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/asyncio/tasks.py:636> took 0.126 seconds"],"level":"WARNING","source":["/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/asyncio/base_events.py",1891],"timestamp":1657654067.4792478,"exception":"","count":1,"first_occurred":1657654067.4792478},{"name":"test_logger","message":["warning message"],"level":"WARNING","source":["/home/runner/work/core/core/tests/components/system_log/test_init.py",120],"timestamp":1657654067.3419046,"exception":"","count":1,"first_occurred":1657654067.3419046}]}`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
