### PR TITLE
Add multi-factor authentication support to Verisure

### DIFF
--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -107,10 +107,11 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await self.hass.async_add_executor_job(
-                    self.verisure.mfa_validate, user_input[CONF_CODE], True
-                )
-                await self.hass.async_add_executor_job(self.verisure.login)
+                def work():
+                    self.verisure.mfa_validate(user_input[CONF_CODE], True)
+                    self.verisure.login()
+
+                await self.hass.async_add_executor_job(work)
             except VerisureLoginError as ex:
                 LOGGER.debug("Could not log in to Verisure, %s", ex)
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -57,7 +57,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 username=self.email,
                 password=self.password,
                 cookieFileName=self.hass.config.path(
-                    STORAGE_DIR, f"verisure-{user_input[CONF_EMAIL]}"
+                    STORAGE_DIR, f"verisure_{user_input[CONF_EMAIL]}"
                 ),
             )
 

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -76,7 +76,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                             "Unexpected response from Verisure during MFA set up, %s",
                             mfa_ex,
                         )
-                        errors["base"] = "unknown"
+                        errors["base"] = "unknown_mfa"
                     else:
                         return await self.async_step_mfa()
                 else:
@@ -204,7 +204,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                             "Unexpected response from Verisure during MFA set up, %s",
                             mfa_ex,
                         )
-                        errors["base"] = "unknown"
+                        errors["base"] = "unknown_mfa"
                     else:
                         return await self.async_step_reauth_mfa()
                 else:
@@ -258,11 +258,10 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 LOGGER.debug("Unexpected response from Verisure, %s", ex)
                 errors["base"] = "unknown"
             else:
-                data = self.entry.data.copy()
                 self.hass.config_entries.async_update_entry(
                     self.entry,
                     data={
-                        **data,
+                        **self.entry.data,
                         CONF_EMAIL: self.email,
                         CONF_PASSWORD: self.password,
                     },
@@ -277,7 +276,8 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_CODE): vol.All(
-                        vol.Length(min=6, max=6), vol.Coerce(str)
+                        vol.Coerce(str),
+                        vol.Length(min=6, max=6),
                     )
                 }
             ),

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -126,7 +126,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_CODE): vol.All(
-                        vol.Length(min=6, max=6), vol.Coerce(str)
+                        vol.Coerce(str), vol.Length(min=6, max=6)
                     )
                 }
             ),

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -107,11 +107,10 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                def work():
-                    self.verisure.mfa_validate(user_input[CONF_CODE], True)
-                    self.verisure.login()
-
-                await self.hass.async_add_executor_job(work)
+                await self.hass.async_add_executor_job(
+                    self.verisure.mfa_validate, user_input[CONF_CODE], True
+                )
+                await self.hass.async_add_executor_job(self.verisure.login)
             except VerisureLoginError as ex:
                 LOGGER.debug("Could not log in to Verisure, %s", ex)
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -13,9 +13,10 @@ from verisure import (
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.const import CONF_CODE, CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.storage import STORAGE_DIR
 
 from .const import (
     CONF_GIID,
@@ -53,13 +54,34 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.email = user_input[CONF_EMAIL]
             self.password = user_input[CONF_PASSWORD]
             self.verisure = Verisure(
-                username=user_input[CONF_EMAIL], password=user_input[CONF_PASSWORD]
+                username=self.email,
+                password=self.password,
+                cookieFileName=self.hass.config.path(
+                    STORAGE_DIR, f"verisure-{user_input[CONF_EMAIL]}"
+                ),
             )
+
             try:
                 await self.hass.async_add_executor_job(self.verisure.login)
             except VerisureLoginError as ex:
-                LOGGER.debug("Could not log in to Verisure, %s", ex)
-                errors["base"] = "invalid_auth"
+                if "Multifactor authentication enabled" in str(ex):
+                    try:
+                        await self.hass.async_add_executor_job(self.verisure.login_mfa)
+                    except (
+                        VerisureLoginError,
+                        VerisureError,
+                        VerisureResponseError,
+                    ) as mfa_ex:
+                        LOGGER.debug(
+                            "Unexpected response from Verisure during MFA set up, %s",
+                            mfa_ex,
+                        )
+                        errors["base"] = "unknown"
+                    else:
+                        return await self.async_step_mfa()
+                else:
+                    LOGGER.debug("Could not log in to Verisure, %s", ex)
+                    errors["base"] = "invalid_auth"
             except (VerisureError, VerisureResponseError) as ex:
                 LOGGER.debug("Unexpected response from Verisure, %s", ex)
                 errors["base"] = "unknown"
@@ -75,6 +97,36 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+    async def async_step_mfa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle multifactor authentication step."""
+        if user_input is not None:
+            try:
+                await self.hass.async_add_executor_job(
+                    self.verisure.mfa_validate, user_input[CONF_CODE], True
+                )
+                await self.hass.async_add_executor_job(self.verisure.login)
+            except VerisureLoginError as ex:
+                LOGGER.debug("Could not log in to Verisure, %s", ex)
+                return self.async_abort(reason="invalid_auth")
+            except (VerisureError, VerisureResponseError) as ex:
+                LOGGER.debug("Unexpected response from Verisure, %s", ex)
+                return self.async_abort(reason="unknown")
+            else:
+                return await self.async_step_installation()
+
+        return self.async_show_form(
+            step_id="mfa",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_CODE): vol.All(
+                        vol.Length(min=6, max=6), vol.Coerce(str)
+                    )
+                }
+            ),
         )
 
     async def async_step_installation(
@@ -123,14 +175,38 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            verisure = Verisure(
-                username=user_input[CONF_EMAIL], password=user_input[CONF_PASSWORD]
+            self.email = user_input[CONF_EMAIL]
+            self.password = user_input[CONF_PASSWORD]
+
+            self.verisure = Verisure(
+                username=self.email,
+                password=self.password,
+                cookieFileName=self.hass.config.path(
+                    STORAGE_DIR, f"verisure-{user_input[CONF_EMAIL]}"
+                ),
             )
+
             try:
-                await self.hass.async_add_executor_job(verisure.login)
+                await self.hass.async_add_executor_job(self.verisure.login)
             except VerisureLoginError as ex:
-                LOGGER.debug("Could not log in to Verisure, %s", ex)
-                errors["base"] = "invalid_auth"
+                if "Multifactor authentication enabled" in str(ex):
+                    try:
+                        await self.hass.async_add_executor_job(self.verisure.login_mfa)
+                    except (
+                        VerisureLoginError,
+                        VerisureError,
+                        VerisureResponseError,
+                    ) as mfa_ex:
+                        LOGGER.debug(
+                            "Unexpected response from Verisure during MFA set up, %s",
+                            mfa_ex,
+                        )
+                        errors["base"] = "unknown"
+                    else:
+                        return await self.async_step_reauth_mfa()
+                else:
+                    LOGGER.debug("Could not log in to Verisure, %s", ex)
+                    errors["base"] = "invalid_auth"
             except (VerisureError, VerisureResponseError) as ex:
                 LOGGER.debug("Unexpected response from Verisure, %s", ex)
                 errors["base"] = "unknown"
@@ -158,6 +234,48 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+    async def async_step_reauth_mfa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle multifactor authentication step during re-authentication."""
+        if user_input is not None:
+            try:
+                await self.hass.async_add_executor_job(
+                    self.verisure.mfa_validate, user_input[CONF_CODE], True
+                )
+                await self.hass.async_add_executor_job(self.verisure.login)
+            except VerisureLoginError as ex:
+                LOGGER.debug("Could not log in to Verisure, %s", ex)
+                return self.async_abort(reason="invalid_auth")
+            except (VerisureError, VerisureResponseError) as ex:
+                LOGGER.debug("Unexpected response from Verisure, %s", ex)
+                return self.async_abort(reason="unknown")
+            else:
+                data = self.entry.data.copy()
+                self.hass.config_entries.async_update_entry(
+                    self.entry,
+                    data={
+                        **data,
+                        CONF_EMAIL: user_input[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.entry.entry_id)
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_mfa",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_CODE): vol.All(
+                        vol.Length(min=6, max=6), vol.Coerce(str)
+                    )
+                }
+            ),
         )
 
 

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -31,7 +31,9 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         self.verisure = Verisure(
             username=entry.data[CONF_EMAIL],
             password=entry.data[CONF_PASSWORD],
-            cookieFileName=hass.config.path(STORAGE_DIR, f"verisure_{entry.entry_id}"),
+            cookieFileName=hass.config.path(
+                STORAGE_DIR, f"verisure_{entry.data[CONF_EMAIL]}"
+            ),
         )
 
         super().__init__(

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -2,7 +2,7 @@
   "domain": "verisure",
   "name": "Verisure",
   "documentation": "https://www.home-assistant.io/integrations/verisure",
-  "requirements": ["vsure==1.7.3"],
+  "requirements": ["vsure==1.8.1"],
   "codeowners": ["@frenck"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -36,7 +36,8 @@
     },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown_mfa": "Unknown error occurred during MFA set up"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -8,6 +8,12 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
+      "mfa": {
+        "data": {
+          "description": "Your account has 2-step verification enabled. Please enter the verification code Verisure sends to you.",
+          "code": "Verification Code"
+        }
+      },
       "installation": {
         "description": "Home Assistant found multiple Verisure installations in your My Pages account. Please, select the installation to add to Home Assistant.",
         "data": {
@@ -19,6 +25,12 @@
           "description": "Re-authenticate with your Verisure My Pages account.",
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "reauth_mfa": {
+        "data": {
+          "description": "Your account has 2-step verification enabled. Please enter the verification code Verisure sends to you.",
+          "code": "Verification Code"
         }
       }
     },

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -6,7 +6,8 @@
         },
         "error": {
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "unknown_mfa": "Unknown error occurred during MFA set up"
         },
         "step": {
             "installation": {

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -15,11 +15,23 @@
                 },
                 "description": "Home Assistant found multiple Verisure installations in your My Pages account. Please, select the installation to add to Home Assistant."
             },
+            "mfa": {
+                "data": {
+                    "code": "Verification Code",
+                    "description": "Your account has 2-step verification enabled. Please enter the verification code Verisure sends to you."
+                }
+            },
             "reauth_confirm": {
                 "data": {
                     "description": "Re-authenticate with your Verisure My Pages account.",
                     "email": "Email",
                     "password": "Password"
+                }
+            },
+            "reauth_mfa": {
+                "data": {
+                    "code": "Verification Code",
+                    "description": "Your account has 2-step verification enabled. Please enter the verification code Verisure sends to you."
                 }
             },
             "user": {

--- a/mypy.ini
+++ b/mypy.ini
@@ -2697,4 +2697,3 @@ ignore_errors = true
 
 [mypy-homeassistant.components.sonos.statistics]
 ignore_errors = true
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2402,7 +2402,7 @@ volkszaehler==0.3.2
 volvooncall==0.10.0
 
 # homeassistant.components.verisure
-vsure==1.7.3
+vsure==1.8.1
 
 # homeassistant.components.vasttrafik
 vtjp==0.1.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1602,7 +1602,7 @@ venstarcolortouch==0.17
 vilfo-api-client==0.3.2
 
 # homeassistant.components.verisure
-vsure==1.7.3
+vsure==1.8.1
 
 # homeassistant.components.vulcan
 vulcan-api==2.1.1

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -283,7 +283,7 @@ async def test_verisure_errors(
 
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("step_id") == "user"
-    assert result3.get("errors") == {"base": "unknown"}
+    assert result3.get("errors") == {"base": "unknown_mfa"}
     assert "flow_id" in result3
 
     result4 = await hass.config_entries.flow.async_configure(
@@ -524,7 +524,7 @@ async def test_reauth_flow_errors(
 
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("step_id") == "reauth_confirm"
-    assert result3.get("errors") == {"base": "unknown"}
+    assert result3.get("errors") == {"base": "unknown_mfa"}
     assert "flow_id" in result3
 
     mock_verisure_config_flow.login_mfa.side_effect = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `vsure` to 1.8.1, changelog: <https://github.com/persandstrom/python-verisure#version-history>

Add support for multi-factor authentication (2-step verification as they call it), to the Verisure integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74457
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23394

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
