### PR TITLE
Replace a custom service with Number platform in Advantage Air

### DIFF
--- a/homeassistant/components/advantage_air/__init__.py
+++ b/homeassistant/components/advantage_air/__init__.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.COVER,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AdvantageAirTimeTo(AdvantageAirEntity, NumberEntity):
     """Representation of Advantage Air TimeTo number."""
 
-    _attr_unit_of_measurement = TIME_MINUTES
+    _attr_native_unit_of_measurement = TIME_MINUTES
     _attr_entity_category = EntityCategory.CONFIG
     _attr_step = 1
     _attr_min_value = 0

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -8,7 +8,7 @@ from .entity import AdvantageAirEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up AdvantageAir toggle platform."""
+    """Set up AdvantageAir number platform."""
 
     instance = hass.data[ADVANTAGE_AIR_DOMAIN][config_entry.entry_id]
 

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -1,0 +1,54 @@
+"""Number platform for Advantage Air integration."""
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.const import ENTITY_CATEGORY_CONFIG, TIME_MINUTES
+
+from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
+from .entity import AdvantageAirEntity
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up AdvantageAir toggle platform."""
+
+    instance = hass.data[ADVANTAGE_AIR_DOMAIN][config_entry.entry_id]
+
+    entities = []
+    for ac_key in instance["coordinator"].data["aircons"]:
+        entities.append(AdvantageAirTimeTo(instance, ac_key, "On"))
+        entities.append(AdvantageAirTimeTo(instance, ac_key, "Off"))
+    async_add_entities(entities)
+
+
+class AdvantageAirTimeTo(AdvantageAirEntity, NumberEntity):
+    """Representation of Advantage Air TimeTo number."""
+
+    _attr_unit_of_measurement = TIME_MINUTES
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_step = 1
+    _attr_min_value = 0
+    _attr_max_value = 720
+
+    def __init__(self, instance: str, ac_key: str, action: str) -> None:
+        """Initialize the Advantage Air timer number."""
+        super().__init__(instance, ac_key)
+        self._time_key = f"countDownTo{action}"
+        self._attr_name = f'{self._ac["name"]} Time To {action}'
+        self._attr_unique_id = (
+            f'{self.coordinator.data["system"]["rid"]}-{self.ac_key}-timeto{action}'
+        )
+
+    @property
+    def value(self):
+        """Return the current value."""
+        return self._ac.get(self._time_key)
+
+    @property
+    def icon(self):
+        """Return a representative icon of the timer."""
+        if self._ac.get(self._time_key) > 0:
+            return "mdi:timer-outline"
+        return "mdi:timer-off-outline"
+
+    async def async_set_value(self, value: float):
+        """Set the timer value."""
+        await self.async_change({self.ac_key: {"info": {self._time_key: int(value)}}})

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -1,14 +1,21 @@
 """Number platform for Advantage Air integration."""
 
 from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TIME_MINUTES
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
 from .entity import AdvantageAirEntity
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up AdvantageAir number platform."""
 
     instance = hass.data[ADVANTAGE_AIR_DOMAIN][config_entry.entry_id]

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -40,7 +40,7 @@ class AdvantageAirTimeTo(AdvantageAirEntity, NumberEntity):
         """Initialize the Advantage Air timer number."""
         super().__init__(instance, ac_key)
         self._time_key = f"countDownTo{action}"
-        self._attr_name = f'{self._ac["name"]} Time To {action}'
+        self._attr_name = f"Time to {action}"
         self._attr_unique_id = (
             f'{self.coordinator.data["system"]["rid"]}-{self.ac_key}-timeto{action}'
         )

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirAcEntity
 
 
 async def async_setup_entry(
@@ -27,7 +27,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AdvantageAirTimeTo(AdvantageAirEntity, NumberEntity):
+class AdvantageAirTimeTo(AdvantageAirAcEntity, NumberEntity):
     """Representation of Advantage Air TimeTo number."""
 
     _attr_native_unit_of_measurement = TIME_MINUTES

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -1,7 +1,8 @@
 """Number platform for Advantage Air integration."""
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.const import ENTITY_CATEGORY_CONFIG, TIME_MINUTES
+from homeassistant.const import TIME_MINUTES
+from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
 from .entity import AdvantageAirEntity
@@ -23,7 +24,7 @@ class AdvantageAirTimeTo(AdvantageAirEntity, NumberEntity):
     """Representation of Advantage Air TimeTo number."""
 
     _attr_unit_of_measurement = TIME_MINUTES
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_step = 1
     _attr_min_value = 0
     _attr_max_value = 720

--- a/homeassistant/components/advantage_air/number.py
+++ b/homeassistant/components/advantage_air/number.py
@@ -1,4 +1,5 @@
 """Number platform for Advantage Air integration."""
+from typing import Any
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
@@ -32,11 +33,11 @@ class AdvantageAirTimeTo(AdvantageAirAcEntity, NumberEntity):
 
     _attr_native_unit_of_measurement = TIME_MINUTES
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_step = 1
-    _attr_min_value = 0
-    _attr_max_value = 720
+    _attr_native_step = 1
+    _attr_native_min_value = 0
+    _attr_native_max_value = 720
 
-    def __init__(self, instance: str, ac_key: str, action: str) -> None:
+    def __init__(self, instance: dict[str, Any], ac_key: str, action: str) -> None:
         """Initialize the Advantage Air timer number."""
         super().__init__(instance, ac_key)
         self._time_key = f"countDownTo{action}"
@@ -46,7 +47,7 @@ class AdvantageAirTimeTo(AdvantageAirAcEntity, NumberEntity):
         )
 
     @property
-    def value(self):
+    def native_value(self):
         """Return the current value."""
         return self._ac.get(self._time_key)
 
@@ -57,6 +58,6 @@ class AdvantageAirTimeTo(AdvantageAirAcEntity, NumberEntity):
             return "mdi:timer-outline"
         return "mdi:timer-off-outline"
 
-    async def async_set_value(self, value: float):
+    async def async_set_native_value(self, value: float) -> None:
         """Set the timer value."""
-        await self.async_change({self.ac_key: {"info": {self._time_key: int(value)}}})
+        await self.aircon({self.ac_key: {"info": {self._time_key: int(value)}}})

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -40,8 +40,6 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
     if aircons := instance["coordinator"].data.get("aircons"):
         for ac_key, ac_device in aircons.items():
-            entities.append(AdvantageAirTimeTo(instance, ac_key, "On"))
-            entities.append(AdvantageAirTimeTo(instance, ac_key, "Off"))
             for zone_key, zone in ac_device["zones"].items():
                 # Only show damper and temp sensors when zone is in temperature control
                 if zone["type"] != 0:
@@ -58,39 +56,6 @@ async def async_setup_entry(
         {vol.Required("minutes"): cv.positive_int},
         "set_time_to",
     )
-
-
-class AdvantageAirTimeTo(AdvantageAirAcEntity, SensorEntity):
-    """Representation of Advantage Air timer control."""
-
-    _attr_native_unit_of_measurement = ADVANTAGE_AIR_SET_COUNTDOWN_UNIT
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_entity_registry_enabled_default = False
-
-    def __init__(self, instance: dict[str, Any], ac_key: str, action: str) -> None:
-        """Initialize the Advantage Air timer control."""
-        super().__init__(instance, ac_key)
-        self.action = action
-        self._time_key = f"countDownTo{action}"
-        self._attr_name = f"Time to {action}"
-        self._attr_unique_id += f"-timeto{action}"
-
-    @property
-    def native_value(self) -> Decimal:
-        """Return the current value."""
-        return self._ac[self._time_key]
-
-    @property
-    def icon(self) -> str:
-        """Return a representative icon of the timer."""
-        if self._ac[self._time_key] > 0:
-            return "mdi:timer-outline"
-        return "mdi:timer-off-outline"
-
-    async def set_time_to(self, **kwargs: Any) -> None:
-        """Set the timer value."""
-        value = min(720, max(0, int(kwargs[ADVANTAGE_AIR_SET_COUNTDOWN_VALUE])))
-        await self.aircon({self.ac_key: {"info": {self._time_key: value}}})
 
 
 class AdvantageAirZoneVent(AdvantageAirZoneEntity, SensorEntity):

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ADVANTAGE_AIR_STATE_OPEN, DOMAIN as ADVANTAGE_AIR_DOMAIN
-from .entity import AdvantageAirAcEntity, AdvantageAirZoneEntity
+from .entity import AdvantageAirZoneEntity
 
 ADVANTAGE_AIR_SET_COUNTDOWN_VALUE = "minutes"
 ADVANTAGE_AIR_SET_COUNTDOWN_UNIT = "min"

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -65,6 +65,7 @@ class AdvantageAirTimeTo(AdvantageAirAcEntity, SensorEntity):
 
     _attr_native_unit_of_measurement = ADVANTAGE_AIR_SET_COUNTDOWN_UNIT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, instance: dict[str, Any], ac_key: str, action: str) -> None:
         """Initialize the Advantage Air timer control."""

--- a/tests/components/advantage_air/test_number.py
+++ b/tests/components/advantage_air/test_number.py
@@ -15,7 +15,7 @@ from tests.components.advantage_air import (
 
 
 async def test_number_platform(hass, aioclient_mock):
-    """Test sensor platform."""
+    """Test number platform."""
 
     aioclient_mock.get(
         TEST_SYSTEM_URL,

--- a/tests/components/advantage_air/test_number.py
+++ b/tests/components/advantage_air/test_number.py
@@ -32,7 +32,7 @@ async def test_number_platform(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
     # Test First TimeToOn Sensor
-    entity_id = "number.ac_one_time_to_on"
+    entity_id = "number.testname_ac_one_time_to_on"
     state = hass.states.get(entity_id)
     assert state
     assert int(state.state) == 0

--- a/tests/components/advantage_air/test_number.py
+++ b/tests/components/advantage_air/test_number.py
@@ -1,0 +1,57 @@
+"""Test the Advantage Air Number Platform."""
+from json import loads
+
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import entity_registry as er
+
+from tests.components.advantage_air import (
+    TEST_SET_RESPONSE,
+    TEST_SET_URL,
+    TEST_SYSTEM_DATA,
+    TEST_SYSTEM_URL,
+    add_mock_config,
+)
+
+
+async def test_number_platform(hass, aioclient_mock):
+    """Test sensor platform."""
+
+    aioclient_mock.get(
+        TEST_SYSTEM_URL,
+        text=TEST_SYSTEM_DATA,
+    )
+    aioclient_mock.get(
+        TEST_SET_URL,
+        text=TEST_SET_RESPONSE,
+    )
+    await add_mock_config(hass)
+
+    registry = er.async_get(hass)
+
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # Test First TimeToOn Sensor
+    entity_id = "number.ac_one_time_to_on"
+    state = hass.states.get(entity_id)
+    assert state
+    assert int(state.state) == 0
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "uniqueid-ac1-timetoOn"
+
+    value = 20
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: [entity_id], "value": value},
+        blocking=True,
+    )
+    assert len(aioclient_mock.mock_calls) == 3
+    assert aioclient_mock.mock_calls[-2][0] == "GET"
+    assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
+    data = loads(aioclient_mock.mock_calls[-2][1].query["json"])
+    assert data["ac1"]["info"]["countDownToOn"] == value
+    assert aioclient_mock.mock_calls[-1][0] == "GET"
+    assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"

--- a/tests/components/advantage_air/test_number.py
+++ b/tests/components/advantage_air/test_number.py
@@ -32,7 +32,7 @@ async def test_number_platform(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
     # Test First TimeToOn Sensor
-    entity_id = "number.testname_ac_one_time_to_on"
+    entity_id = "number.ac_one_time_to_on"
     state = hass.states.get(entity_id)
     assert state
     assert int(state.state) == 0

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -1,15 +1,8 @@
 """Test the Advantage Air Sensor Platform."""
 
 from datetime import timedelta
-from json import loads
 
-from homeassistant.components.advantage_air.const import DOMAIN as ADVANTAGE_AIR_DOMAIN
-from homeassistant.components.advantage_air.sensor import (
-    ADVANTAGE_AIR_SERVICE_SET_TIME_TO,
-    ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
-)
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
-from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
@@ -40,72 +33,6 @@ async def test_sensor_platform(hass, aioclient_mock):
     registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
-
-    # Test First TimeToOn Sensor
-    entity_id = "sensor.testname_ac_one_time_to_on"
-
-    registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 0
-
-    entry = registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-timetoOn"
-
-    value = 20
-    await hass.services.async_call(
-        ADVANTAGE_AIR_DOMAIN,
-        ADVANTAGE_AIR_SERVICE_SET_TIME_TO,
-        {ATTR_ENTITY_ID: [entity_id], ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: value},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[-2][0] == "GET"
-    assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
-    data = loads(aioclient_mock.mock_calls[-2][1].query["json"])
-    assert data["ac1"]["info"]["countDownToOn"] == value
-    assert aioclient_mock.mock_calls[-1][0] == "GET"
-    assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"
-
-    # Test First TimeToOff Sensor
-    entity_id = "sensor.testname_ac_one_time_to_off"
-
-    registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 10
-
-    entry = registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-timetoOff"
-
-    value = 0
-    await hass.services.async_call(
-        ADVANTAGE_AIR_DOMAIN,
-        ADVANTAGE_AIR_SERVICE_SET_TIME_TO,
-        {ATTR_ENTITY_ID: [entity_id], ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: value},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[-2][0] == "GET"
-    assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
-    data = loads(aioclient_mock.mock_calls[-2][1].query["json"])
-    assert data["ac1"]["info"]["countDownToOff"] == value
-    assert aioclient_mock.mock_calls[-1][0] == "GET"
-    assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"
 
     # Test First Zone Vent Sensor
     entity_id = "sensor.ac_one_zone_open_with_sensor_vent"

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -42,7 +42,16 @@ async def test_sensor_platform(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
     # Test First TimeToOn Sensor
-    entity_id = "sensor.ac_one_time_to_on"
+    entity_id = "sensor.testname_ac_one_time_to_on"
+
+    registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+    await hass.async_block_till_done()
+    async_fire_time_changed(
+        hass,
+        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
     state = hass.states.get(entity_id)
     assert state
     assert int(state.state) == 0
@@ -58,7 +67,6 @@ async def test_sensor_platform(hass, aioclient_mock):
         {ATTR_ENTITY_ID: [entity_id], ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: value},
         blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 3
     assert aioclient_mock.mock_calls[-2][0] == "GET"
     assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
     data = loads(aioclient_mock.mock_calls[-2][1].query["json"])
@@ -67,7 +75,16 @@ async def test_sensor_platform(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"
 
     # Test First TimeToOff Sensor
-    entity_id = "sensor.ac_one_time_to_off"
+    entity_id = "sensor.testname_ac_one_time_to_off"
+
+    registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+    await hass.async_block_till_done()
+    async_fire_time_changed(
+        hass,
+        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
     state = hass.states.get(entity_id)
     assert state
     assert int(state.state) == 10
@@ -83,7 +100,6 @@ async def test_sensor_platform(hass, aioclient_mock):
         {ATTR_ENTITY_ID: [entity_id], ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: value},
         blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 5
     assert aioclient_mock.mock_calls[-2][0] == "GET"
     assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
     data = loads(aioclient_mock.mock_calls[-2][1].query["json"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The time to on and time to off sensor and service has been removed, and replaced with a number entity for time to on and time to off.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the number platform to replace the custom service and sensor entities which have been performing these functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23397

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
