### PR TITLE
Fix MQTT race awaiting an ACK when disconnecting

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -434,7 +434,7 @@ class MQTT:
         # wait for ACK-s to be processed
         async with self._paho_lock:
             tasks = [
-                self.hass.async_create_task(self._wait_for_mid(mid, True))
+                self.hass.async_create_task(self._wait_for_mid(mid))
                 for mid in self._pending_acks
             ]
         await asyncio.gather(*tasks)
@@ -666,7 +666,7 @@ class MQTT:
             result_code,
         )
 
-    async def _wait_for_mid(self, mid: int, shutdown: bool = False) -> None:
+    async def _wait_for_mid(self, mid: int) -> None:
         """Wait for ACK from broker."""
         # Create the mid event if not created, either _mqtt_handle_mid or _wait_for_mid
         # may be executed first.

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -387,8 +387,6 @@ class MQTT:
         self, topic: str, payload: PublishPayloadType, qos: int, retain: bool
     ) -> None:
         """Publish a MQTT message."""
-        # We don't import on the top because some integrations
-        # should be able to optionally rely on MQTT.
         async with self._paho_lock:
             msg_info = await self.hass.async_add_executor_job(
                 self._mqttc.publish, topic, payload, qos, retain

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -696,7 +696,6 @@ class MQTT:
 
         if mid not in self._pending_operations:
             self._pending_operations[mid] = asyncio.Event()
-
         try:
             await asyncio.wait_for(self._pending_operations[mid].wait(), TIMEOUT_ACK)
         except asyncio.TimeoutError:
@@ -704,7 +703,6 @@ class MQTT:
                 "No ACK from MQTT server in %s seconds (mid: %s)", TIMEOUT_ACK, mid
             )
         finally:
-            # Cleanup
             del self._pending_operations[mid]
 
     async def _discovery_cooldown(self):

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -613,7 +613,7 @@ class MQTT:
         self.hass.add_job(self._mqtt_handle_message, msg)
 
     @lru_cache(2048)
-    def _matching_subscriptions(self, topic: str):
+    def _matching_subscriptions(self, topic):
         subscriptions = []
         for subscription in self.subscriptions:
             if subscription.matcher(topic):
@@ -709,7 +709,7 @@ class MQTT:
             async with self._paho_lock:
                 self._pending_acks.remove(mid)
 
-    async def _discovery_cooldown(self) -> None:
+    async def _discovery_cooldown(self):
         now = time.time()
         # Reset discovery and subscribe cooldowns
         self.hass.data[LAST_DISCOVERY] = now

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -683,7 +683,9 @@ class MQTT:
             async with self._pending_operations_condition:
                 # Cleanup ACK sync buffer
                 del self._pending_operations[mid]
-                self._pending_acks.remove(mid)
+                if mid in self._pending_acks:
+                    # self._pending_acks only has unsubscribe mids
+                    self._pending_acks.remove(mid)
                 self._pending_operations_condition.notify_all()
 
     async def _discovery_cooldown(self):

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -431,7 +431,7 @@ class MQTT:
             # Do not disconnect, we want the broker to always publish will
             self._mqttc.loop_stop()
 
-        # wait for ACK-s to be processed
+        # wait for ACK-s to be processed (unsubscribe only)
         async with self._paho_lock:
             tasks = [
                 self.hass.async_create_task(self._wait_for_mid(mid))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure all ACK's on subscribes, unsubscribes or published have been processed (not only unsubscribe).
When awaiting the ACK at disconnect we should only wait once.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

During tests I found out that when disconnecting it in some test cases a key error occured on removing the `_pending_operation`. This was caused on disconnecting while the client had not yet it's call back and the ack was not yet added to pending operations to be awaited.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
