### PR TITLE
Verisure config flow cleanups

### DIFF
--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -1,0 +1,50 @@
+"""Fixtures for Verisure integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.verisure.const import CONF_GIID, DOMAIN
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="12345",
+        data={
+            CONF_EMAIL: "verisure_my_pages@example.com",
+            CONF_GIID: "12345",
+            CONF_PASSWORD: "SuperS3cr3t!",
+        },
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.verisure.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup
+
+
+@pytest.fixture
+def mock_verisure_config_flow() -> Generator[None, MagicMock, None]:
+    """Return a mocked Tailscale client."""
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure", autospec=True
+    ) as verisure_mock:
+        verisure = verisure_mock.return_value
+        verisure.login.return_value = True
+        verisure.installations = [
+            {"giid": "12345", "alias": "ascending", "street": "12345th street"},
+            {"giid": "54321", "alias": "descending", "street": "54321th street"},
+        ]
+        yield verisure

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Verisure config flow."""
 from __future__ import annotations
 
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from verisure import Error as VerisureError, LoginError as VerisureLoginError
@@ -21,151 +21,151 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-TEST_INSTALLATIONS = [
-    {"giid": "12345", "alias": "ascending", "street": "12345th street"},
-    {"giid": "54321", "alias": "descending", "street": "54321th street"},
-]
-TEST_INSTALLATION = [TEST_INSTALLATIONS[0]]
 
-
-async def test_full_user_flow_single_installation(hass: HomeAssistant) -> None:
+async def test_full_user_flow_single_installation(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_verisure_config_flow: MagicMock,
+) -> None:
     """Test a full user initiated configuration flow with a single installation."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["step_id"] == "user"
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
+    assert result.get("step_id") == "user"
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {}
+    assert "flow_id" in result
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure",
-    ) as mock_verisure, patch(
-        "homeassistant.components.verisure.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        type(mock_verisure.return_value).installations = PropertyMock(
-            return_value=TEST_INSTALLATION
-        )
-        mock_verisure.login.return_value = True
+    mock_verisure_config_flow.installations = [
+        mock_verisure_config_flow.installations[0]
+    ]
 
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "SuperS3cr3t!",
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "SuperS3cr3t!",
+        },
+    )
+    await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "ascending (12345th street)"
-    assert result2["data"] == {
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2.get("title") == "ascending (12345th street)"
+    assert result2.get("data") == {
         CONF_GIID: "12345",
         CONF_EMAIL: "verisure_my_pages@example.com",
         CONF_PASSWORD: "SuperS3cr3t!",
     }
 
-    assert len(mock_verisure.mock_calls) == 2
+    assert len(mock_verisure_config_flow.login.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_full_user_flow_multiple_installations(hass: HomeAssistant) -> None:
+async def test_full_user_flow_multiple_installations(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_verisure_config_flow: MagicMock,
+) -> None:
     """Test a full user initiated configuration flow with multiple installations."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["step_id"] == "user"
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
+    assert result.get("step_id") == "user"
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {}
+    assert "flow_id" in result
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure",
-    ) as mock_verisure:
-        type(mock_verisure.return_value).installations = PropertyMock(
-            return_value=TEST_INSTALLATIONS
-        )
-        mock_verisure.login.return_value = True
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "SuperS3cr3t!",
+        },
+    )
+    await hass.async_block_till_done()
 
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "SuperS3cr3t!",
-            },
-        )
-        await hass.async_block_till_done()
+    assert result2.get("step_id") == "installation"
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors") is None
+    assert "flow_id" in result2
 
-    assert result2["step_id"] == "installation"
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] is None
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], {"giid": "54321"}
+    )
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.verisure.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], {"giid": "54321"}
-        )
-        await hass.async_block_till_done()
-
-    assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "descending (54321th street)"
-    assert result3["data"] == {
+    assert result3.get("type") == FlowResultType.CREATE_ENTRY
+    assert result3.get("title") == "descending (54321th street)"
+    assert result3.get("data") == {
         CONF_GIID: "54321",
         CONF_EMAIL: "verisure_my_pages@example.com",
         CONF_PASSWORD: "SuperS3cr3t!",
     }
 
-    assert len(mock_verisure.mock_calls) == 2
+    assert len(mock_verisure_config_flow.login.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_invalid_login(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "side_effect,error",
+    [
+        (VerisureLoginError, "invalid_auth"),
+        (VerisureError, "unknown"),
+    ],
+)
+async def test_verisure_errors(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_verisure_config_flow: MagicMock,
+    side_effect: Exception,
+    error: str,
+) -> None:
     """Test a flow with an invalid Verisure My Pages login."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure.login",
-        side_effect=VerisureLoginError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "SuperS3cr3t!",
-            },
-        )
-        await hass.async_block_till_done()
+    assert "flow_id" in result
 
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_unknown_error(hass: HomeAssistant) -> None:
-    """Test a flow with an invalid Verisure My Pages login."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    mock_verisure_config_flow.login.side_effect = side_effect
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "SuperS3cr3t!",
+        },
     )
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure.login",
-        side_effect=VerisureError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "SuperS3cr3t!",
-            },
-        )
-        await hass.async_block_till_done()
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "user"
+    assert result2.get("errors") == {"base": error}
+    assert "flow_id" in result2
 
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "unknown"}
+    mock_verisure_config_flow.login.side_effect = None
+    mock_verisure_config_flow.installations = [
+        mock_verisure_config_flow.installations[0]
+    ]
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "SuperS3cr3t!",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result3.get("type") == FlowResultType.CREATE_ENTRY
+    assert result3.get("title") == "ascending (12345th street)"
+    assert result3.get("data") == {
+        CONF_GIID: "12345",
+        CONF_EMAIL: "verisure_my_pages@example.com",
+        CONF_PASSWORD: "SuperS3cr3t!",
+    }
+
+    assert len(mock_verisure_config_flow.login.mock_calls) == 2
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_dhcp(hass: HomeAssistant) -> None:
@@ -178,144 +178,121 @@ async def test_dhcp(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_DHCP},
     )
 
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
 
 
-async def test_reauth_flow(hass: HomeAssistant) -> None:
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_verisure_config_flow: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
     """Test a reauthentication flow."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="12345",
-        data={
-            CONF_EMAIL: "verisure_my_pages@example.com",
-            CONF_GIID: "12345",
-            CONF_PASSWORD: "SuperS3cr3t!",
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
             "source": config_entries.SOURCE_REAUTH,
-            "unique_id": entry.unique_id,
-            "entry_id": entry.entry_id,
+            "unique_id": mock_config_entry.unique_id,
+            "entry_id": mock_config_entry.entry_id,
         },
-        data=entry.data,
+        data=mock_config_entry.data,
     )
-    assert result["step_id"] == "reauth_confirm"
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
+    assert result.get("step_id") == "reauth_confirm"
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {}
+    assert "flow_id" in result
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure.login",
-        return_value=True,
-    ) as mock_verisure, patch(
-        "homeassistant.components.verisure.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "correct horse battery staple",
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "correct horse battery staple",
+        },
+    )
+    await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
-    assert entry.data == {
+    assert result2.get("type") == FlowResultType.ABORT
+    assert result2.get("reason") == "reauth_successful"
+    assert mock_config_entry.data == {
         CONF_GIID: "12345",
         CONF_EMAIL: "verisure_my_pages@example.com",
         CONF_PASSWORD: "correct horse battery staple",
     }
 
-    assert len(mock_verisure.mock_calls) == 1
+    assert len(mock_verisure_config_flow.login.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_reauth_flow_invalid_login(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "side_effect,error",
+    [
+        (VerisureLoginError, "invalid_auth"),
+        (VerisureError, "unknown"),
+    ],
+)
+async def test_reauth_flow_errors(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_verisure_config_flow: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    error: str,
+) -> None:
     """Test a reauthentication flow."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="12345",
-        data={
-            CONF_EMAIL: "verisure_my_pages@example.com",
-            CONF_GIID: "12345",
-            CONF_PASSWORD: "SuperS3cr3t!",
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
             "source": config_entries.SOURCE_REAUTH,
-            "unique_id": entry.unique_id,
-            "entry_id": entry.entry_id,
+            "unique_id": mock_config_entry.unique_id,
+            "entry_id": mock_config_entry.entry_id,
         },
-        data=entry.data,
+        data=mock_config_entry.data,
     )
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure.login",
-        side_effect=VerisureLoginError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "WrOngP4ssw0rd!",
-            },
-        )
-        await hass.async_block_till_done()
+    assert "flow_id" in result
 
-    assert result2["step_id"] == "reauth_confirm"
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_reauth_flow_unknown_error(hass: HomeAssistant) -> None:
-    """Test a reauthentication flow, with an unknown error happening."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="12345",
-        data={
-            CONF_EMAIL: "verisure_my_pages@example.com",
-            CONF_GIID: "12345",
-            CONF_PASSWORD: "SuperS3cr3t!",
+    mock_verisure_config_flow.login.side_effect = side_effect
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "WrOngP4ssw0rd!",
         },
     )
-    entry.add_to_hass(hass)
+    await hass.async_block_till_done()
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": entry.unique_id,
-            "entry_id": entry.entry_id,
+    assert result2.get("step_id") == "reauth_confirm"
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors") == {"base": error}
+    assert "flow_id" in result2
+
+    mock_verisure_config_flow.login.side_effect = None
+    mock_verisure_config_flow.installations = [
+        mock_verisure_config_flow.installations[0]
+    ]
+
+    await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {
+            "email": "verisure_my_pages@example.com",
+            "password": "correct horse battery staple",
         },
-        data=entry.data,
     )
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.verisure.config_flow.Verisure.login",
-        side_effect=VerisureError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "email": "verisure_my_pages@example.com",
-                "password": "WrOngP4ssw0rd!",
-            },
-        )
-        await hass.async_block_till_done()
+    assert mock_config_entry.data == {
+        CONF_GIID: "12345",
+        CONF_EMAIL: "verisure_my_pages@example.com",
+        CONF_PASSWORD: "correct horse battery staple",
+    }
 
-    assert result2["step_id"] == "reauth_confirm"
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "unknown"}
+    assert len(mock_verisure_config_flow.login.mock_calls) == 2
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.parametrize(
@@ -362,16 +339,17 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "init"
+    assert "flow_id" in result
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input=input,
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["data"] == output
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("data") == output
 
 
 async def test_options_flow_code_format_mismatch(hass: HomeAssistant) -> None:
@@ -392,9 +370,10 @@ async def test_options_flow_code_format_mismatch(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
-    assert result["errors"] == {}
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "init"
+    assert result.get("errors") == {}
+    assert "flow_id" in result
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -404,6 +383,6 @@ async def test_options_flow_code_format_mismatch(hass: HomeAssistant) -> None:
         },
     )
 
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
-    assert result["errors"] == {"base": "code_format_mismatch"}
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "init"
+    assert result.get("errors") == {"base": "code_format_mismatch"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Small adjustments to the config flow of Verisure. This helps making the follow-up changes for MFA support smaller and cleaner.

- Fixes linter warnings in tests
- Add some fixtures
- Parameterize tests in a couple of places
- Finishes flows on errors
- Move all "installations" handling inside the installations step.

No functional changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
