### PR TITLE
Bump python-eq3bt requirement

### DIFF
--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 
-from bluepy.btle import BTLEException  # pylint: disable=import-error
 import eq3bt as eq3  # pylint: disable=import-error
 import voluptuous as vol
 
@@ -218,5 +217,5 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
         try:
             self._thermostat.update()
-        except BTLEException as ex:
+        except eq3.BackendException as ex:
             _LOGGER.warning("Updating the state failed: %s", ex)

--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "eq3btsmart",
-  "name": "EQ3 Bluetooth Smart Thermostats",
+  "name": "eQ-3 Bluetooth Smart Thermostats",
   "documentation": "https://www.home-assistant.io/integrations/eq3btsmart",
   "requirements": ["construct==2.10.56", "python-eq3bt==0.2"],
+  "dependencies": ["bluetooth"],
   "codeowners": ["@rytilahti"],
   "iot_class": "local_polling",
   "loggers": ["bleak", "eq3bt"]

--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -2,8 +2,8 @@
   "domain": "eq3btsmart",
   "name": "EQ3 Bluetooth Smart Thermostats",
   "documentation": "https://www.home-assistant.io/integrations/eq3btsmart",
-  "requirements": ["construct==2.10.56", "python-eq3bt==0.1.11"],
+  "requirements": ["construct==2.10.56", "python-eq3bt==0.2"],
   "codeowners": ["@rytilahti"],
   "iot_class": "local_polling",
-  "loggers": ["bluepy", "eq3bt"]
+  "loggers": ["bleak", "eq3bt"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1893,7 +1893,7 @@ python-digitalocean==1.13.2
 python-ecobee-api==0.2.14
 
 # homeassistant.components.eq3btsmart
-# python-eq3bt==0.1.11
+# python-eq3bt==0.2
 
 # homeassistant.components.etherscan
 python-etherscan-api==0.0.3


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR upgrades python-eq3bt requirement used by eq3btsmart integration.
The biggest change in the new python-eq3bt is that it uses bleak instead of bluepy for communications.

Changelog: https://github.com/rytilahti/python-eq3bt/releases/tag/0.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74959
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
