### PR TITLE
Add ZHA config option for "enhanced light transition from an off-state"

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -144,7 +144,7 @@ CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY = 60 * 60 * 6  # 6 hours
 CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
-        vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=True): cv.boolean,
+        vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=False): cv.boolean,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
         vol.Optional(
             CONF_CONSIDER_UNAVAILABLE_MAINS,

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -128,6 +128,7 @@ CONF_CUSTOM_QUIRKS_PATH = "custom_quirks_path"
 CONF_DATABASE = "database_path"
 CONF_DEFAULT_LIGHT_TRANSITION = "default_light_transition"
 CONF_DEVICE_CONFIG = "device_config"
+CONF_ENABLE_ENHANCED_LIGHT_TRANSITION = "enhanced_light_transition"
 CONF_ENABLE_IDENTIFY_ON_JOIN = "enable_identify_on_join"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_FLOWCONTROL = "flow_control"
@@ -143,6 +144,7 @@ CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY = 60 * 60 * 6  # 6 hours
 CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
+        vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=True): cv.boolean,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
         vol.Optional(
             CONF_CONSIDER_UNAVAILABLE_MAINS,

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -702,12 +702,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
-        self._enhanced_light_transition = async_get_zha_config_value(
-            zha_device.gateway.config_entry,
-            ZHA_OPTIONS,
-            CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
-            False,
-        )
+        self._enhanced_light_transition = False
         self._attr_color_mode = None
 
     # remove this when all ZHA platforms and base entities are updated

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -122,7 +122,6 @@ class BaseLight(LogMixin, light.LightEntity):
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
-        self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
         self._zha_config_enhanced_light_transition: bool = False
 
     @property

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -178,8 +178,7 @@ class BaseLight(LogMixin, light.LightEntity):
         # move to level, on, color, move to level... We also will not set this if the bulb is already in the
         # desired color mode with the desired color or color temperature.
         new_color_provided_while_off = (
-            not isinstance(self, LightGroup)
-            and self._zha_config_enhanced_light_transition
+            self._zha_config_enhanced_light_transition
             and not self._FORCE_ON
             and not self._attr_state
             and (

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -118,11 +118,11 @@ class BaseLight(LogMixin, light.LightEntity):
         self._off_with_transition: bool = False
         self._off_brightness: int | None = None
         self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
+        self._zha_config_enhanced_light_transition: bool = False
         self._on_off_channel = None
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
-        self._zha_config_enhanced_light_transition: bool = False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -41,6 +41,7 @@ from .core.const import (
     CHANNEL_LEVEL,
     CHANNEL_ON_OFF,
     CONF_DEFAULT_LIGHT_TRANSITION,
+    CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
     DATA_ZHA,
     EFFECT_BLINK,
     EFFECT_BREATHE,
@@ -121,6 +122,9 @@ class BaseLight(LogMixin, light.LightEntity):
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
+        self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
+        self._enhanced_light_transition: bool = False
+        self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -175,6 +179,7 @@ class BaseLight(LogMixin, light.LightEntity):
         # desired color mode with the desired color or color temperature.
         new_color_provided_while_off = (
             not isinstance(self, LightGroup)
+            and self._enhanced_light_transition
             and not self._FORCE_ON
             and not self._attr_state
             and (
@@ -482,6 +487,12 @@ class Light(BaseLight, ZhaEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
+        self._enhanced_light_transition = async_get_zha_config_value(
+            zha_device.gateway.config_entry,
+            ZHA_OPTIONS,
+            CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
+            True,
+        )
 
     @callback
     def async_set_state(self, attr_id, attr_name, value):
@@ -690,6 +701,12 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             ZHA_OPTIONS,
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
+        )
+        self._enhanced_light_transition = async_get_zha_config_value(
+            zha_device.gateway.config_entry,
+            ZHA_OPTIONS,
+            CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
+            True,
         )
         self._attr_color_mode = None
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -123,7 +123,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._color_channel = None
         self._identify_channel = None
         self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
-        self._enhanced_light_transition: bool = False
+        self._zha_config_enhanced_light_transition: bool = False
         self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
@@ -179,7 +179,7 @@ class BaseLight(LogMixin, light.LightEntity):
         # desired color mode with the desired color or color temperature.
         new_color_provided_while_off = (
             not isinstance(self, LightGroup)
-            and self._enhanced_light_transition
+            and self._zha_config_enhanced_light_transition
             and not self._FORCE_ON
             and not self._attr_state
             and (
@@ -487,7 +487,7 @@ class Light(BaseLight, ZhaEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
-        self._enhanced_light_transition = async_get_zha_config_value(
+        self._zha_config_enhanced_light_transition = async_get_zha_config_value(
             zha_device.gateway.config_entry,
             ZHA_OPTIONS,
             CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
@@ -702,7 +702,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
-        self._enhanced_light_transition = False
+        self._zha_config_enhanced_light_transition = False
         self._attr_color_mode = None
 
     # remove this when all ZHA platforms and base entities are updated

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -124,7 +124,6 @@ class BaseLight(LogMixin, light.LightEntity):
         self._identify_channel = None
         self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
         self._zha_config_enhanced_light_transition: bool = False
-        self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -491,7 +491,7 @@ class Light(BaseLight, ZhaEntity):
             zha_device.gateway.config_entry,
             ZHA_OPTIONS,
             CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
-            True,
+            False,
         )
 
     @callback
@@ -706,7 +706,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             zha_device.gateway.config_entry,
             ZHA_OPTIONS,
             CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
-            True,
+            False,
         )
         self._attr_color_mode = None
 

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -37,6 +37,7 @@
   "config_panel": {
     "zha_options": {
       "title": "Global Options",
+      "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
       "enable_identify_on_join": "Enable identify effect when devices join the network",
       "default_light_transition": "Default light transition time (seconds)",
       "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -50,6 +50,7 @@
             "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",
             "default_light_transition": "Default light transition time (seconds)",
             "enable_identify_on_join": "Enable identify effect when devices join the network",
+            "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
             "title": "Global Options"
         }
     },

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -70,11 +70,14 @@ async def config_entry_fixture(hass):
         },
         options={
             zha_const.CUSTOM_CONFIGURATION: {
+                zha_const.ZHA_OPTIONS: {
+                    zha_const.CONF_ENABLE_ENHANCED_LIGHT_TRANSITION: True,
+                },
                 zha_const.ZHA_ALARM_OPTIONS: {
                     zha_const.CONF_ALARM_ARM_REQUIRES_CODE: False,
                     zha_const.CONF_ALARM_MASTER_CODE: "4321",
                     zha_const.CONF_ALARM_FAILED_TRIES: 2,
-                }
+                },
             }
         },
     )

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -560,7 +560,7 @@ async def test_transitions(
 
     dev1_cluster_level.request.reset_mock()
 
-    # test non 0 length transition and color temp while turning light on (color_provided_while_off)
+    # test non 0 length transition and color temp while turning light on (new_color_provided_while_off)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
@@ -596,7 +596,7 @@ async def test_transitions(
         10,
         dev1_cluster_color.commands_by_name["move_to_color_temp"].schema,
         235,  # color temp mireds
-        0,  # transition time (ZCL time in 10ths of a second) - no transition when color_provided_while_off
+        0,  # transition time (ZCL time in 10ths of a second) - no transition when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
         tries=1,
@@ -645,7 +645,7 @@ async def test_transitions(
     dev1_cluster_color.request.reset_mock()
     dev1_cluster_level.request.reset_mock()
 
-    # test no transition provided and color temp while turning light on (color_provided_while_off)
+    # test no transition provided and color temp while turning light on (new_color_provided_while_off)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
@@ -680,7 +680,7 @@ async def test_transitions(
         10,
         dev1_cluster_color.commands_by_name["move_to_color_temp"].schema,
         236,  # color temp mireds
-        0,  # transition time (ZCL time in 10ths of a second) - no transition when color_provided_while_off
+        0,  # transition time (ZCL time in 10ths of a second) - no transition when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
         tries=1,
@@ -761,7 +761,7 @@ async def test_transitions(
         10,
         dev1_cluster_color.commands_by_name["move_to_color_temp"].schema,
         236,  # color temp mireds
-        0,  # transition time (ZCL time in 10ths of a second) - no transition when color_provided_while_off
+        0,  # transition time (ZCL time in 10ths of a second) - no transition when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
         tries=1,
@@ -854,7 +854,7 @@ async def test_transitions(
 
     dev2_cluster_on_off.request.reset_mock()
 
-    # test non 0 length transition and color temp while turning light on and sengled (color_provided_while_off)
+    # test non 0 length transition and color temp while turning light on and sengled (new_color_provided_while_off)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
@@ -890,7 +890,7 @@ async def test_transitions(
         10,
         dev2_cluster_color.commands_by_name["move_to_color_temp"].schema,
         235,  # color temp mireds
-        1,  # transition time (ZCL time in 10ths of a second) - sengled transition == 1 when color_provided_while_off
+        1,  # transition time (ZCL time in 10ths of a second) - sengled transition == 1 when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
         tries=1,
@@ -937,7 +937,7 @@ async def test_transitions(
 
     dev2_cluster_on_off.request.reset_mock()
 
-    # test non 0 length transition and color temp while turning group light on (color_provided_while_off)
+    # test non 0 length transition and color temp while turning group light on (new_color_provided_while_off)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
@@ -960,13 +960,13 @@ async def test_transitions(
     assert group_level_channel.request.call_count == 1
     assert group_level_channel.request.await_count == 1
 
-    # groups are omitted from the 3 call dance for color_provided_while_off
+    # groups are omitted from the 3 call dance for new_color_provided_while_off
     assert group_color_channel.request.call_args == call(
         False,
         10,
         dev2_cluster_color.commands_by_name["move_to_color_temp"].schema,
         235,  # color temp mireds
-        10.0,  # transition time (ZCL time in 10ths of a second) - sengled transition == 1 when color_provided_while_off
+        10.0,  # transition time (ZCL time in 10ths of a second) - sengled transition == 1 when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
         tries=1,
@@ -1074,7 +1074,7 @@ async def test_transitions(
 
     dev2_cluster_level.request.reset_mock()
 
-    # test eWeLink color temp while turning light on from off (color_provided_while_off)
+    # test eWeLink color temp while turning light on from off (new_color_provided_while_off)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a config option to toggle the enhanced color/temperature light transition from an off-state and always disable "enhanced light transitions" for ZHA groups.

https://github.com/home-assistant/core/pull/74024 worked around the issue of Zigbee lights not being able to change their color/temperature when off (video in that PR).
This works by quickly turning on the light at 1% brightness, switching the color/temperature without a transition and then slowly fading up to the appropriate brightness (if the light is off and a color/temperature is provided in the service call). (This is also what the Hue integration in combination with the Hue Bridge in HA does.)

However, some Zigbee networks (and/or known-buggy bulbs) seem to have issues with this. While the core issue isn't caused by the mentioned change, it does seem to amplify an underlying issue on some networks. (Reference: https://github.com/home-assistant/core/issues/74861)

This change allows users who do not want or need the "enhanced light transition for color/temperature" to simply turn it off (and revert back to pre-2022.7.0 behavior).
![image](https://user-images.githubusercontent.com/6409465/178875154-10474564-ef52-4a0d-9fb4-d5c6f54f4546.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/74861
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
