### PR TITLE
Use pydeconz interface controls for fans

### DIFF
--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -1,17 +1,10 @@
 """Support for deCONZ fans."""
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 from pydeconz.models.event import EventType
-from pydeconz.models.light.fan import (
-    FAN_SPEED_25_PERCENT,
-    FAN_SPEED_50_PERCENT,
-    FAN_SPEED_75_PERCENT,
-    FAN_SPEED_100_PERCENT,
-    FAN_SPEED_OFF,
-    Fan,
-)
+from pydeconz.models.light.light import Light, LightFanSpeed
 
 from homeassistant.components.fan import DOMAIN, FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -25,11 +18,11 @@ from homeassistant.util.percentage import (
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
-ORDERED_NAMED_FAN_SPEEDS: list[Literal[0, 1, 2, 3, 4, 5, 6]] = [
-    FAN_SPEED_25_PERCENT,
-    FAN_SPEED_50_PERCENT,
-    FAN_SPEED_75_PERCENT,
-    FAN_SPEED_100_PERCENT,
+ORDERED_NAMED_FAN_SPEEDS: list[LightFanSpeed] = [
+    LightFanSpeed.PERCENT_25,
+    LightFanSpeed.PERCENT_50,
+    LightFanSpeed.PERCENT_75,
+    LightFanSpeed.PERCENT_100,
 ]
 
 
@@ -45,12 +38,14 @@ async def async_setup_entry(
     @callback
     def async_add_fan(_: EventType, fan_id: str) -> None:
         """Add fan from deCONZ."""
-        fan = gateway.api.lights.fans[fan_id]
+        fan = gateway.api.lights.lights[fan_id]
+        if not fan.supports_fan_speed:
+            return
         async_add_entities([DeconzFan(fan, gateway)])
 
     gateway.register_platform_add_device_callback(
         async_add_fan,
-        gateway.api.lights.fans,
+        gateway.api.lights.lights,
     )
 
 
@@ -58,33 +53,32 @@ class DeconzFan(DeconzDevice, FanEntity):
     """Representation of a deCONZ fan."""
 
     TYPE = DOMAIN
-    _device: Fan
-    _default_on_speed: Literal[0, 1, 2, 3, 4, 5, 6]
+    _device: Light
+    _default_on_speed = LightFanSpeed.PERCENT_50
 
     _attr_supported_features = FanEntityFeature.SET_SPEED
 
-    def __init__(self, device: Fan, gateway: DeconzGateway) -> None:
+    def __init__(self, device: Light, gateway: DeconzGateway) -> None:
         """Set up fan."""
         super().__init__(device, gateway)
 
-        self._default_on_speed = FAN_SPEED_50_PERCENT
-        if self._device.speed in ORDERED_NAMED_FAN_SPEEDS:
-            self._default_on_speed = self._device.speed
+        if device.fan_speed in ORDERED_NAMED_FAN_SPEEDS:
+            self._default_on_speed = device.fan_speed
 
     @property
     def is_on(self) -> bool:
         """Return true if fan is on."""
-        return self._device.speed != FAN_SPEED_OFF
+        return self._device.fan_speed != LightFanSpeed.OFF
 
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
-        if self._device.speed == FAN_SPEED_OFF:
+        if self._device.fan_speed == LightFanSpeed.OFF:
             return 0
-        if self._device.speed not in ORDERED_NAMED_FAN_SPEEDS:
+        if self._device.fan_speed not in ORDERED_NAMED_FAN_SPEEDS:
             return None
         return ordered_list_item_to_percentage(
-            ORDERED_NAMED_FAN_SPEEDS, self._device.speed
+            ORDERED_NAMED_FAN_SPEEDS, self._device.fan_speed
         )
 
     @property
@@ -95,16 +89,19 @@ class DeconzFan(DeconzDevice, FanEntity):
     @callback
     def async_update_callback(self) -> None:
         """Store latest configured speed from the device."""
-        if self._device.speed in ORDERED_NAMED_FAN_SPEEDS:
-            self._default_on_speed = self._device.speed
+        if self._device.fan_speed in ORDERED_NAMED_FAN_SPEEDS:
+            self._default_on_speed = self._device.fan_speed
         super().async_update_callback()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         if percentage == 0:
             return await self.async_turn_off()
-        await self._device.set_speed(
-            percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
+        await self.gateway.api.lights.lights.set_state(
+            id=self._device.resource_id,
+            fan_speed=percentage_to_ordered_list_item(
+                ORDERED_NAMED_FAN_SPEEDS, percentage
+            ),
         )
 
     async def async_turn_on(
@@ -117,8 +114,14 @@ class DeconzFan(DeconzDevice, FanEntity):
         if percentage is not None:
             await self.async_set_percentage(percentage)
             return
-        await self._device.set_speed(self._default_on_speed)
+        await self.gateway.api.lights.lights.set_state(
+            id=self._device.resource_id,
+            fan_speed=self._default_on_speed,
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off fan."""
-        await self._device.set_speed(FAN_SPEED_OFF)
+        await self.gateway.api.lights.lights.set_state(
+            id=self._device.resource_id,
+            fan_speed=LightFanSpeed.OFF,
+        )

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -85,8 +85,7 @@ async def async_setup_entry(
     @callback
     def async_add_light(_: EventType, light_id: str) -> None:
         """Add light from deCONZ."""
-        light = gateway.api.lights[light_id]
-        assert isinstance(light, Light)
+        light = gateway.api.lights.lights[light_id]
         if light.type in POWER_PLUGS:
             return
 
@@ -95,11 +94,6 @@ async def async_setup_entry(
     gateway.register_platform_add_device_callback(
         async_add_light,
         gateway.api.lights.lights,
-    )
-
-    gateway.register_platform_add_device_callback(
-        async_add_light,
-        gateway.api.lights.fans,
     )
 
     @callback

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==98"],
+  "requirements": ["pydeconz==99"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1447,7 +1447,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==98
+pydeconz==99
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -980,7 +980,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==98
+pydeconz==99
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move controls over to the interface class in pydeconz
Use enums rather than constants

Similar to 
- https://github.com/home-assistant/core/pull/72317
- https://github.com/home-assistant/core/pull/73670
- https://github.com/home-assistant/core/pull/73748
- https://github.com/home-assistant/core/pull/74535
- https://github.com/home-assistant/core/pull/74654
- https://github.com/home-assistant/core/pull/74666

Library bump https://github.com/Kane610/deconz/compare/v98...v99
- Moves fan controls into lights as there are some devices which don't identify as fans
- Otherwise mostly cosmetic things moved around or removed (based on removals in referenced HA PRs above)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
