### PR TITLE
Plugwise prefer use of Adam instead of Anna

### DIFF
--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -119,6 +119,32 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         _version = _properties.get("version", "n/a")
         _name = f"{ZEROCONF_MAP.get(_product, _product)} v{_version}"
 
+        # This is an Anna, but we already have config entries.
+        # Assuming that the user has already configured Adam, aborting discovery.
+        if self._async_current_entries() and _product == "smile_thermo":
+            return self.async_abort(reason="anna_with_adam")
+
+        # If we have discovered a Adam or Anna, both might be on the network.
+        # In that case, we need to cancel the Anna flow, as the Adam should
+        # be added.
+        for flow in self._async_in_progress():
+            # This is an Anna, and there is already an Adam flow in progress
+            if (
+                _product == "smile_thermo"
+                and "context" in flow
+                and flow["context"].get("product") == "smile_open_therm"
+            ):
+                return self.async_abort(reason="anna_with_adam")
+
+            # This is an Adam, and there is already an Anna flow in progress
+            if (
+                _product == "smile_open_therm"
+                and "context" in flow
+                and flow["context"].get("product") == "smile_thermo"
+                and "flow_id" in flow
+            ):
+                self.hass.config_entries.flow.async_abort(flow["flow_id"])
+
         self.context.update(
             {
                 "title_placeholders": {
@@ -128,6 +154,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: self._username,
                 },
                 "configuration_url": f"http://{discovery_info.host}:{discovery_info.port}",
+                "product": _product,
             }
         )
         return await self.async_step_user()

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -124,7 +124,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._async_current_entries() and _product == "smile_thermo":
             return self.async_abort(reason="anna_with_adam")
 
-        # If we have discovered a Adam or Anna, both might be on the network.
+        # If we have discovered an Adam or Anna, both might be on the network.
         # In that case, we need to cancel the Anna flow, as the Adam should
         # be added.
         for flow in self._async_in_progress():

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -19,7 +19,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "anna_with_adam": "Both Anna and Adam detected. Add your Adam instead of your Anna"
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a Plugwise Adam & Anna are on the network, the Adam should be used. The Anna is connected to Adam and adding it again will get you into trouble.

Yet, we currently discover both.

![image](https://user-images.githubusercontent.com/195327/178940226-e5eaac22-fa3f-4384-933d-c8565ca28e03.png)

> ☝️ Eenie meenie miney mo... Don't pick the wrong one though!

This PR makes discovery for Plugwise a little bit more conservative by only showing the Adam when both the Anna & Adam are discovered. Additionally, we no longer discover the Anna once a config entry has been found.

There is an edge case in case someone might have two boilers, with 2 Anna's or an Adam & Anna that are not interconnected; however, that occurrence may be considered extremely low. In such case, one can still add those manually.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
