### PR TITLE
Fix playback of hls cameras in stream

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -57,9 +57,15 @@ from .const import (
     SOURCE_TIMEOUT,
     STREAM_RESTART_INCREMENT,
     STREAM_RESTART_RESET_TIME,
-    TARGET_SEGMENT_DURATION_NON_LL_HLS,
 )
-from .core import PROVIDERS, IdleTimer, KeyFrameConverter, StreamOutput, StreamSettings
+from .core import (
+    PROVIDERS,
+    STREAM_SETTINGS_NON_LL_HLS,
+    IdleTimer,
+    KeyFrameConverter,
+    StreamOutput,
+    StreamSettings,
+)
 from .diagnostics import Diagnostics
 from .hls import HlsStreamOutput, async_setup_hls
 
@@ -224,14 +230,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hls_part_timeout=2 * conf[CONF_PART_DURATION],
         )
     else:
-        hass.data[DOMAIN][ATTR_SETTINGS] = StreamSettings(
-            ll_hls=False,
-            min_segment_duration=TARGET_SEGMENT_DURATION_NON_LL_HLS
-            - SEGMENT_DURATION_ADJUSTER,
-            part_target_duration=TARGET_SEGMENT_DURATION_NON_LL_HLS,
-            hls_advance_part_limit=3,
-            hls_part_timeout=TARGET_SEGMENT_DURATION_NON_LL_HLS,
-        )
+        hass.data[DOMAIN][ATTR_SETTINGS] = STREAM_SETTINGS_NON_LL_HLS
 
     # Setup HLS
     hls_endpoint = async_setup_hls(hass)

--- a/homeassistant/components/stream/fmp4utils.py
+++ b/homeassistant/components/stream/fmp4utils.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from io import BytesIO
 
 
 def find_box(
@@ -135,3 +139,11 @@ def get_codec_string(mp4_bytes: bytes) -> str:
         codecs.append(codec)
 
     return ",".join(codecs)
+
+
+def read_init(bytes_io: BytesIO) -> bytes:
+    """Read the init from a mp4 file."""
+    bytes_io.seek(24)
+    moov_len = int.from_bytes(bytes_io.read(4), byteorder="big")
+    bytes_io.seek(0)
+    return bytes_io.read(24 + moov_len)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -5,7 +5,7 @@ from collections import defaultdict, deque
 from collections.abc import Callable, Generator, Iterator, Mapping
 import contextlib
 import datetime
-from io import BytesIO
+from io import SEEK_END, BytesIO
 import logging
 from threading import Event
 from typing import Any, cast
@@ -34,6 +34,7 @@ from .core import (
     StreamSettings,
 )
 from .diagnostics import Diagnostics
+from .fmp4utils import read_init
 from .hls import HlsStreamOutput
 
 _LOGGER = logging.getLogger(__name__)
@@ -116,7 +117,7 @@ class StreamMuxer:
         hass: HomeAssistant,
         video_stream: av.video.VideoStream,
         audio_stream: av.audio.stream.AudioStream | None,
-        audio_bsf: av.BitStreamFilterContext | None,
+        audio_bsf: av.BitStreamFilter | None,
         stream_state: StreamState,
         stream_settings: StreamSettings,
     ) -> None:
@@ -128,6 +129,7 @@ class StreamMuxer:
         self._input_video_stream: av.video.VideoStream = video_stream
         self._input_audio_stream: av.audio.stream.AudioStream | None = audio_stream
         self._audio_bsf = audio_bsf
+        self._audio_bsf_context: av.BitStreamFilterContext = None
         self._output_video_stream: av.video.VideoStream = None
         self._output_audio_stream: av.audio.stream.AudioStream | None = None
         self._segment: Segment | None = None
@@ -159,7 +161,7 @@ class StreamMuxer:
                 **{
                     # Removed skip_sidx - see https://github.com/home-assistant/core/pull/39970
                     # "cmaf" flag replaces several of the movflags used, but too recent to use for now
-                    "movflags": "frag_custom+empty_moov+default_base_moof+frag_discont+negative_cts_offsets+skip_trailer",
+                    "movflags": "frag_custom+empty_moov+default_base_moof+frag_discont+negative_cts_offsets+skip_trailer+delay_moov",
                     # Sometimes the first segment begins with negative timestamps, and this setting just
                     # adjusts the timestamps in the output from that segment to start from 0. Helps from
                     # having to make some adjustments in test_durations
@@ -172,7 +174,7 @@ class StreamMuxer:
                 # Fragment durations may exceed the 15% allowed variance but it seems ok
                 **(
                     {
-                        "movflags": "empty_moov+default_base_moof+frag_discont+negative_cts_offsets+skip_trailer",
+                        "movflags": "empty_moov+default_base_moof+frag_discont+negative_cts_offsets+skip_trailer+delay_moov",
                         # Create a fragment every TARGET_PART_DURATION. The data from each fragment is stored in
                         # a "Part" that can be combined with the data from all the other "Part"s, plus an init
                         # section, to reconstitute the data in a "Segment".
@@ -202,8 +204,11 @@ class StreamMuxer:
         # Check if audio is requested
         output_astream = None
         if input_astream:
+            if self._audio_bsf:
+                self._audio_bsf_context = self._audio_bsf.create()
+                self._audio_bsf_context.set_input_stream(input_astream)
             output_astream = container.add_stream(
-                template=self._audio_bsf or input_astream
+                template=self._audio_bsf_context or input_astream
             )
         return container, output_vstream, output_astream
 
@@ -246,14 +251,28 @@ class StreamMuxer:
             self._part_has_keyframe |= packet.is_keyframe
 
         elif packet.stream == self._input_audio_stream:
-            if self._audio_bsf:
-                self._audio_bsf.send(packet)
-                while packet := self._audio_bsf.recv():
+            if self._audio_bsf_context:
+                self._audio_bsf_context.send(packet)
+                while packet := self._audio_bsf_context.recv():
                     packet.stream = self._output_audio_stream
                     self._av_output.mux(packet)
                 return
             packet.stream = self._output_audio_stream
             self._av_output.mux(packet)
+
+    def create_segment(self) -> None:
+        """Create a segment when the moov is ready."""
+        self._segment = Segment(
+            sequence=self._stream_state.sequence,
+            stream_id=self._stream_state.stream_id,
+            init=read_init(self._memory_file),
+            # Fetch the latest StreamOutputs, which may have changed since the
+            # worker started.
+            stream_outputs=self._stream_state.outputs,
+            start_time=self._start_time,
+        )
+        self._memory_file_pos = self._memory_file.tell()
+        self._memory_file.seek(0, SEEK_END)
 
     def check_flush_part(self, packet: av.Packet) -> None:
         """Check for and mark a part segment boundary and record its duration."""
@@ -262,16 +281,10 @@ class StreamMuxer:
         if self._segment is None:
             # We have our first non-zero byte position. This means the init has just
             # been written. Create a Segment and put it to the queue of each output.
-            self._segment = Segment(
-                sequence=self._stream_state.sequence,
-                stream_id=self._stream_state.stream_id,
-                init=self._memory_file.getvalue(),
-                # Fetch the latest StreamOutputs, which may have changed since the
-                # worker started.
-                stream_outputs=self._stream_state.outputs,
-                start_time=self._start_time,
-            )
-            self._memory_file_pos = self._memory_file.tell()
+            self.create_segment()
+            # When using delay_moov, the moov is not written until a moof is also ready
+            # Flush the moof
+            self.flush(packet, last_part=False)
         else:  # These are the ends of the part segments
             self.flush(packet, last_part=False)
 
@@ -305,6 +318,10 @@ class StreamMuxer:
             # Closing the av_output will write the remaining buffered data to the
             # memory_file as a new moof/mdat.
             self._av_output.close()
+            # With delay_moov, this may be the first time the file pointer has
+            # moved, so the segment may not yet have been created
+            if not self._segment:
+                self.create_segment()
         elif not self._part_has_keyframe:
             # Parts which are not the last part or an independent part should
             # not have durations below 0.85 of the part target duration.
@@ -456,10 +473,7 @@ def get_audio_bitstream_filter(
                         _LOGGER.debug(
                             "ADTS AAC detected. Adding aac_adtstoaac bitstream filter"
                         )
-                        bsf = av.BitStreamFilter("aac_adtstoasc")
-                        bsf_context = bsf.create()
-                        bsf_context.set_input_stream(audio_stream)
-                        return bsf_context
+                        return av.BitStreamFilter("aac_adtstoasc")
             break
     return None
 

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -755,7 +755,9 @@ async def test_durations(hass, worker_finished_stream):
         },
     )
 
-    source = generate_h264_video(duration=SEGMENT_DURATION + 1)
+    source = generate_h264_video(
+        duration=round(SEGMENT_DURATION + target_part_duration + 1)
+    )
     worker_finished, mock_stream = worker_finished_stream
 
     with patch("homeassistant.components.stream.Stream", wraps=mock_stream):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR includes 3 bugfixes for stream:
1) Stream is able to use an av.CodecContext to decode a still image. However, this CodecContext can occasionally get into a state where it needs to be reset (flushed). This PR closes and reopens the CodecContext when this occurs.
2) #72547 attempted to disable LL-HLS when HLS inputs were detected. However, it did this by resetting the ll_hls attribute of StreamSettings while not setting the other related attributes. This PR resets the other attributes of StreamSettings as well.
3) #74151 uses a bitstream filter to enable ADTS AAC audio in stream. However, due to some parameters not being available until the first packet is processed, the resulting files did not have complete headers. This PR uses the delay_moov option to address this. It also resets the av.BitstreamFilterContext on each output file in order for the parameters to be passed correctly into each output file.
This PR can be split into separate PRs, but keeping them together makes it easier to cherry pick for a patch release. Also, # 2 and # 3 are closely related as they are needed together to resolve issues with HLS cameras.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74747
- This PR is related to issue: #75134
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
