### PR TITLE
Consolidate executor jobs when loading integration manifests

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -35,7 +35,6 @@ from .setup import (
     async_setup_component,
 )
 from .util import dt as dt_util
-from .util.async_ import gather_with_concurrency
 from .util.logging import async_activate_log_queue_handler
 from .util.package import async_get_user_site, is_virtual_env
 
@@ -479,14 +478,7 @@ async def _async_set_up_integrations(
 
         integrations_to_process = [
             int_or_exc
-            for int_or_exc in await gather_with_concurrency(
-                loader.MAX_LOAD_CONCURRENTLY,
-                *(
-                    loader.async_get_integration(hass, domain)
-                    for domain in old_to_resolve
-                ),
-                return_exceptions=True,
-            )
+            for int_or_exc in await loader.async_get_integrations(hass, old_to_resolve)
             if isinstance(int_or_exc, loader.Integration)
         ]
         resolve_dependencies_tasks = [

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -478,7 +478,9 @@ async def _async_set_up_integrations(
 
         integrations_to_process = [
             int_or_exc
-            for int_or_exc in await loader.async_get_integrations(hass, old_to_resolve)
+            for int_or_exc in (
+                await loader.async_get_integrations(hass, old_to_resolve)
+            ).values()
             if isinstance(int_or_exc, loader.Integration)
         ]
         resolve_dependencies_tasks = [

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.system_info import async_get_system_info
-from homeassistant.loader import IntegrationNotFound, async_get_integration
+from homeassistant.loader import IntegrationNotFound, async_get_integrations
 from homeassistant.setup import async_get_loaded_integrations
 
 from .const import (
@@ -182,15 +182,9 @@ class Analytics:
         if self.preferences.get(ATTR_USAGE, False) or self.preferences.get(
             ATTR_STATISTICS, False
         ):
-            configured_integrations = await asyncio.gather(
-                *(
-                    async_get_integration(self.hass, domain)
-                    for domain in async_get_loaded_integrations(self.hass)
-                ),
-                return_exceptions=True,
-            )
-
-            for integration in configured_integrations:
+            domains = async_get_loaded_integrations(self.hass)
+            configured_integrations = await async_get_integrations(self.hass, domains)
+            for integration in configured_integrations.values():
                 if isinstance(integration, IntegrationNotFound):
                     continue
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -31,13 +31,7 @@ from homeassistant.exceptions import (
     Unauthorized,
     UnknownUser,
 )
-from homeassistant.loader import (
-    MAX_LOAD_CONCURRENTLY,
-    Integration,
-    async_get_integration,
-    bind_hass,
-)
-from homeassistant.util.async_ import gather_with_concurrency
+from homeassistant.loader import Integration, async_get_integrations, bind_hass
 from homeassistant.util.yaml import load_yaml
 from homeassistant.util.yaml.loader import JSON_TYPE
 
@@ -467,10 +461,12 @@ async def async_get_all_descriptions(
     loaded = {}
 
     if missing:
-        integrations = await gather_with_concurrency(
-            MAX_LOAD_CONCURRENTLY,
-            *(async_get_integration(hass, domain) for domain in missing),
-        )
+        ints_or_excs = await async_get_integrations(hass, missing)
+        integrations = [
+            int_or_exc
+            for int_or_exc in ints_or_excs.values()
+            if isinstance(int_or_exc, Integration)
+        ]
 
         contents = await hass.async_add_executor_job(
             _load_services_files, hass, integrations

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -9,13 +9,11 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import (
-    MAX_LOAD_CONCURRENTLY,
     Integration,
     async_get_config_flows,
-    async_get_integration,
+    async_get_integrations,
     bind_hass,
 )
-from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.json import load_json
 
 _LOGGER = logging.getLogger(__name__)
@@ -151,16 +149,13 @@ async def async_get_component_strings(
 ) -> dict[str, Any]:
     """Load translations."""
     domains = list({loaded.split(".")[-1] for loaded in components})
-    integrations = dict(
-        zip(
-            domains,
-            await gather_with_concurrency(
-                MAX_LOAD_CONCURRENTLY,
-                *(async_get_integration(hass, domain) for domain in domains),
-            ),
-        )
-    )
 
+    integrations: dict[str, Integration] = {}
+    ints_or_excs = await async_get_integrations(hass, domains)
+    for domain, int_or_exc in ints_or_excs.items():
+        if isinstance(int_or_exc, Exception):
+            raise int_or_exc
+        integrations[domain] = int_or_exc
     translations: dict[str, Any] = {}
 
     # Determine paths of missing components/platforms

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -7,7 +7,7 @@ documentation as possible to keep it understandable.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import suppress
 import functools as ft
 import importlib
@@ -702,7 +702,7 @@ async def async_get_integration(hass: HomeAssistant, domain: str) -> Integration
 
 
 async def async_get_integrations(
-    hass: HomeAssistant, domains: list[str]
+    hass: HomeAssistant, domains: Iterable[str]
 ) -> dict[str, Integration | Exception]:
     """Get integrations."""
     if (cache := hass.data.get(DATA_INTEGRATIONS)) is None:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -750,7 +750,7 @@ async def async_get_integrations(
             if domain in needed:
                 del needed[domain]
 
-    # No the rest use resolve_from_root
+    # Now the rest use resolve_from_root
     if needed:
         from . import components  # pylint: disable=import-outside-toplevel
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -166,7 +166,10 @@ async def _async_get_custom_components(
     )
 
     integrations = await hass.async_add_executor_job(
-        resolve_integrations_from_root, hass, custom_components, dirs
+        _resolve_integrations_from_root,
+        hass,
+        custom_components,
+        [comp.name for comp in dirs],
     )
     return {
         integration.domain: integration
@@ -673,7 +676,7 @@ class Integration:
         return f"<Integration {self.domain}: {self.pkg_path}>"
 
 
-def resolve_integrations_from_root(
+def _resolve_integrations_from_root(
     hass: HomeAssistant, root_module: ModuleType, domains: list[str]
 ) -> dict[str, Integration]:
     """Resolve multiple integrations from root."""
@@ -751,7 +754,7 @@ async def async_get_integrations(
         from . import components  # pylint: disable=import-outside-toplevel
 
         integrations = await hass.async_add_executor_job(
-            resolve_integrations_from_root, hass, components, list(needed)
+            _resolve_integrations_from_root, hass, components, list(needed)
         )
         for domain, event in needed.items():
             if domain in integrations:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -757,18 +757,17 @@ async def async_get_integrations(
             _resolve_integrations_from_root, hass, components, list(needed)
         )
         for domain, event in needed.items():
-            if domain in integrations:
-                int_or_exc = integrations[domain]
-                if isinstance(int_or_exc, Exception):
-                    cache.pop(domain)
-                    exc = IntegrationNotFound(domain)
-                    exc.__cause__ = int_or_exc
-                    results[domain] = exc
-                else:
-                    results[domain] = cache[domain] = int_or_exc
-            else:
+            int_or_exc = integrations.get(domain)
+            if not int_or_exc:
                 cache.pop(domain)
                 results[domain] = IntegrationNotFound(domain)
+            elif isinstance(int_or_exc, Exception):
+                cache.pop(domain)
+                exc = IntegrationNotFound(domain)
+                exc.__cause__ = int_or_exc
+                results[domain] = exc
+            else:
+                results[domain] = cache[domain] = int_or_exc
             event.set()
 
     return results

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -127,6 +127,7 @@ class Manifest(TypedDict, total=False):
     version: str
     codeowners: list[str]
     loggers: list[str]
+    supported_brands: dict[str, str]
 
 
 def manifest_from_legacy_module(domain: str, module: ModuleType) -> Manifest:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -168,9 +168,6 @@ async def _async_get_custom_components(
     integrations = await hass.async_add_executor_job(
         resolve_integrations_from_root, hass, custom_components, dirs
     )
-    import pprint
-
-    pprint.pprint(["integrations", integrations])
     return {
         integration.domain: integration
         for integration in integrations.values()
@@ -695,10 +692,6 @@ def resolve_integrations_from_root(
 async def async_get_integration(hass: HomeAssistant, domain: str) -> Integration:
     """Get integration."""
     integrations_or_excs = await async_get_integrations(hass, [domain])
-
-    import pprint
-
-    pprint.pprint(integrations_or_excs)
     int_or_exc = integrations_or_excs[domain]
     if isinstance(int_or_exc, Integration):
         return int_or_exc

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -269,8 +269,8 @@ async def test_send_statistics_one_integration_fails(hass, caplog, aioclient_moc
     hass.config.components = ["default_config"]
 
     with patch(
-        "homeassistant.components.analytics.analytics.async_get_integration",
-        side_effect=IntegrationNotFound("any"),
+        "homeassistant.components.analytics.analytics.async_get_integrations",
+        return_value={"any": IntegrationNotFound("any")},
     ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
 
@@ -291,8 +291,8 @@ async def test_send_statistics_async_get_integration_unknown_exception(
     hass.config.components = ["default_config"]
 
     with pytest.raises(ValueError), patch(
-        "homeassistant.components.analytics.analytics.async_get_integration",
-        side_effect=ValueError,
+        "homeassistant.components.analytics.analytics.async_get_integrations",
+        return_value={"any": ValueError()},
     ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -135,8 +135,8 @@ async def test_get_translations_loads_config_flows(hass, mock_config_flows):
         "homeassistant.helpers.translation.load_translations_files",
         return_value={"component1": {"title": "world"}},
     ), patch(
-        "homeassistant.helpers.translation.async_get_integration",
-        return_value=integration,
+        "homeassistant.helpers.translation.async_get_integrations",
+        return_value={"component1": integration},
     ):
         translations = await translation.async_get_translations(
             hass, "en", "title", config_flow=True
@@ -164,8 +164,8 @@ async def test_get_translations_loads_config_flows(hass, mock_config_flows):
         "homeassistant.helpers.translation.load_translations_files",
         return_value={"component2": {"title": "world"}},
     ), patch(
-        "homeassistant.helpers.translation.async_get_integration",
-        return_value=integration,
+        "homeassistant.helpers.translation.async_get_integrations",
+        return_value={"component2": integration},
     ):
         translations = await translation.async_get_translations(
             hass, "en", "title", config_flow=True
@@ -212,8 +212,8 @@ async def test_get_translations_while_loading_components(hass):
         "homeassistant.helpers.translation.load_translations_files",
         mock_load_translation_files,
     ), patch(
-        "homeassistant.helpers.translation.async_get_integration",
-        return_value=integration,
+        "homeassistant.helpers.translation.async_get_integrations",
+        return_value={"component1": integration},
     ):
         tasks = [
             translation.async_get_translations(hass, "en", "title") for _ in range(5)


### PR DESCRIPTION
This is part of a series of cleanups to fix the event loop getting too far behind and causing unreliability at startup when the frontend is open.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The current `gather_with_concurrency` solution helps reduce the I/O on the system but as we have added more and more integrations, loading the integrations screen has to get more translations for the config flows.  This generates a large number of tasks for integrations that are not yet loaded which swamps some of our less performant platforms like RPI3bs.  The goal here is to minimize the amount of tasks and executor jobs.

Now a single executor job to get the non-loaded integrations at startup when frontend open

```
2022-07-14 11:37:06.622 INFO (SyncWorker_13) [homeassistant.loader] Loaded airtouch4 from homeassistant.components.airtouch4
2022-07-14 11:37:06.622 INFO (SyncWorker_13) [homeassistant.loader] Loaded guardian from homeassistant.components.guardian
2022-07-14 11:37:06.622 INFO (SyncWorker_13) [homeassistant.loader] Loaded flunearyou from homeassistant.components.flunearyou
2022-07-14 11:37:06.623 INFO (SyncWorker_13) [homeassistant.loader] Loaded intellifire from homeassistant.components.intellifire
2022-07-14 11:37:06.623 INFO (SyncWorker_13) [homeassistant.loader] Loaded dexcom from homeassistant.components.dexcom
2022-07-14 11:37:06.623 INFO (SyncWorker_13) [homeassistant.loader] Loaded netatmo from homeassistant.components.netatmo
2022-07-14 11:37:06.623 INFO (SyncWorker_13) [homeassistant.loader] Loaded tomorrowio from homeassistant.components.tomorrowio
2022-07-14 11:37:06.624 INFO (SyncWorker_13) [homeassistant.loader] Loaded waze_travel_time from homeassistant.components.waze_travel_time
2022-07-14 11:37:06.624 INFO (SyncWorker_13) [homeassistant.loader] Loaded opentherm_gw from homeassistant.components.opentherm_gw
2022-07-14 11:37:06.624 INFO (SyncWorker_13) [homeassistant.loader] Loaded venstar from homeassistant.components.venstar
2022-07-14 11:37:06.624 INFO (SyncWorker_13) [homeassistant.loader] Loaded elgato from homeassistant.components.elgato
2022-07-14 11:37:06.624 INFO (SyncWorker_13) [homeassistant.loader] Loaded simplepush from homeassistant.components.simplepush
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded omnilogic from homeassistant.components.omnilogic
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded mqtt from homeassistant.components.mqtt
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded habitica from homeassistant.components.habitica
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded tuya from homeassistant.components.tuya
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded derivative from homeassistant.components.derivative
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded panasonic_viera from homeassistant.components.panasonic_viera
2022-07-14 11:37:06.625 INFO (SyncWorker_13) [homeassistant.loader] Loaded devolo_home_control from homeassistant.components.devolo_home_control
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded tibber from homeassistant.components.tibber
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded locative from homeassistant.components.locative
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded aseko_pool_live from homeassistant.components.aseko_pool_live
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded solarlog from homeassistant.components.solarlog
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded azure_devops from homeassistant.components.azure_devops
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded tankerkoenig from homeassistant.components.tankerkoenig
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded aussie_broadband from homeassistant.components.aussie_broadband
2022-07-14 11:37:06.626 INFO (SyncWorker_13) [homeassistant.loader] Loaded nmap_tracker from homeassistant.components.nmap_tracker
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded freebox from homeassistant.components.freebox
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded traccar from homeassistant.components.traccar
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded moehlenhoff_alpha2 from homeassistant.components.moehlenhoff_alpha2
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded subaru from homeassistant.components.subaru
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded p1_monitor from homeassistant.components.p1_monitor
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded home_plus_control from homeassistant.components.home_plus_control
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded geonetnz_volcano from homeassistant.components.geonetnz_volcano
2022-07-14 11:37:06.627 INFO (SyncWorker_13) [homeassistant.loader] Loaded wolflink from homeassistant.components.wolflink
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded netgear from homeassistant.components.netgear
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded bond from homeassistant.components.bond
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded blebox from homeassistant.components.blebox
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded arcam_fmj from homeassistant.components.arcam_fmj
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded soundtouch from homeassistant.components.soundtouch
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded vicare from homeassistant.components.vicare
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded dynalite from homeassistant.components.dynalite
2022-07-14 11:37:06.628 INFO (SyncWorker_13) [homeassistant.loader] Loaded owntracks from homeassistant.components.owntracks
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded ambient_station from homeassistant.components.ambient_station
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded tellduslive from homeassistant.components.tellduslive
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded pvpc_hourly_pricing from homeassistant.components.pvpc_hourly_pricing
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded transmission from homeassistant.components.transmission
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded met_eireann from homeassistant.components.met_eireann
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded coronavirus from homeassistant.components.coronavirus
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded eight_sleep from homeassistant.components.eight_sleep
2022-07-14 11:37:06.629 INFO (SyncWorker_13) [homeassistant.loader] Loaded point from homeassistant.components.point
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded min_max from homeassistant.components.min_max
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded advantage_air from homeassistant.components.advantage_air
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded vlc_telnet from homeassistant.components.vlc_telnet
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded fireservicerota from homeassistant.components.fireservicerota
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded ialarm from homeassistant.components.ialarm
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded tado from homeassistant.components.tado
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded forked_daapd from homeassistant.components.forked_daapd
2022-07-14 11:37:06.630 INFO (SyncWorker_13) [homeassistant.loader] Loaded nina from homeassistant.components.nina
2022-07-14 11:37:06.631 INFO (SyncWorker_13) [homeassistant.loader] Loaded axis from homeassistant.components.axis
2022-07-14 11:37:06.631 INFO (SyncWorker_13) [homeassistant.loader] Loaded ring from homeassistant.components.ring
2022-07-14 11:37:06.631 INFO (SyncWorker_13) [homeassistant.loader] Loaded huisbaasje from homeassistant.components.huisbaasje
2022-07-14 11:37:06.631 INFO (SyncWorker_13) [homeassistant.loader] Loaded hvv_departures from homeassistant.components.hvv_departures
2022-07-14 11:37:06.631 INFO (SyncWorker_13) [homeassistant.loader] Loaded tailscale from homeassistant.components.tailscale
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded open_meteo from homeassistant.components.open_meteo
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded nws from homeassistant.components.nws
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded speedtestdotnet from homeassistant.components.speedtestdotnet
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded modem_callerid from homeassistant.components.modem_callerid
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded kostal_plenticore from homeassistant.components.kostal_plenticore
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded adax from homeassistant.components.adax
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded almond from homeassistant.components.almond
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded google from homeassistant.components.google
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded picnic from homeassistant.components.picnic
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded islamic_prayer_times from homeassistant.components.islamic_prayer_times
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded jellyfin from homeassistant.components.jellyfin
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded faa_delays from homeassistant.components.faa_delays
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded homewizard from homeassistant.components.homewizard
2022-07-14 11:37:06.632 INFO (SyncWorker_13) [homeassistant.loader] Loaded cloudflare from homeassistant.components.cloudflare
2022-07-14 11:37:06.633 INFO (SyncWorker_13) [homeassistant.loader] Loaded tod from homeassistant.components.tod
2022-07-14 11:37:06.633 INFO (SyncWorker_13) [homeassistant.loader] Loaded wiffi from homeassistant.components.wiffi
2022-07-14 11:37:06.633 INFO (SyncWorker_13) [homeassistant.loader] Loaded airnow from homeassistant.components.airnow
2022-07-14 11:37:06.633 INFO (SyncWorker_13) [homeassistant.loader] Loaded threshold from homeassistant.components.threshold
2022-07-14 11:37:06.633 INFO (SyncWorker_13) [homeassistant.loader] Loaded alarmdecoder from homeassistant.components.alarmdecoder
2022-07-14 11:37:06.633 INFO (SyncWorker_13) [homeassistant.loader] Loaded vulcan from homeassistant.components.vulcan
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded logi_circle from homeassistant.components.logi_circle
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded syncthru from homeassistant.components.syncthru
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded slimproto from homeassistant.components.slimproto
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded kodi from homeassistant.components.kodi
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded airthings from homeassistant.components.airthings
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded azure_event_hub from homeassistant.components.azure_event_hub
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded vizio from homeassistant.components.vizio
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded iss from homeassistant.components.iss
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded metoffice from homeassistant.components.metoffice
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded directv from homeassistant.components.directv
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded mullvad from homeassistant.components.mullvad
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded tile from homeassistant.components.tile
2022-07-14 11:37:06.634 INFO (SyncWorker_13) [homeassistant.loader] Loaded peco from homeassistant.components.peco
2022-07-14 11:37:06.635 INFO (SyncWorker_13) [homeassistant.loader] Loaded tesla_wall_connector from homeassistant.components.tesla_wall_connector
2022-07-14 11:37:06.635 INFO (SyncWorker_13) [homeassistant.loader] Loaded canary from homeassistant.components.canary
2022-07-14 11:37:06.635 INFO (SyncWorker_13) [homeassistant.loader] Loaded airvisual from homeassistant.components.airvisual
2022-07-14 11:37:06.635 INFO (SyncWorker_13) [homeassistant.loader] Loaded evil_genius_labs from homeassistant.components.evil_genius_labs
2022-07-14 11:37:06.635 INFO (SyncWorker_13) [homeassistant.loader] Loaded nfandroidtv from homeassistant.components.nfandroidtv
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded agent_dvr from homeassistant.components.agent_dvr
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded cpuspeed from homeassistant.components.cpuspeed
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded launch_library from homeassistant.components.launch_library
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded iaqualink from homeassistant.components.iaqualink
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded pi_hole from homeassistant.components.pi_hole
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded philips_js from homeassistant.components.philips_js
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded twentemilieu from homeassistant.components.twentemilieu
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded glances from homeassistant.components.glances
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded upcloud from homeassistant.components.upcloud
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded aemet from homeassistant.components.aemet
2022-07-14 11:37:06.636 INFO (SyncWorker_13) [homeassistant.loader] Loaded spider from homeassistant.components.spider
2022-07-14 11:37:06.637 INFO (SyncWorker_13) [homeassistant.loader] Loaded efergy from homeassistant.components.efergy
2022-07-14 11:37:06.637 INFO (SyncWorker_13) [homeassistant.loader] Loaded blink from homeassistant.components.blink
2022-07-14 11:37:06.637 INFO (SyncWorker_13) [homeassistant.loader] Loaded recollect_waste from homeassistant.components.recollect_waste
2022-07-14 11:37:06.637 INFO (SyncWorker_13) [homeassistant.loader] Loaded plugwise from homeassistant.components.plugwise
2022-07-14 11:37:06.638 INFO (SyncWorker_13) [homeassistant.loader] Loaded smart_meter_texas from homeassistant.components.smart_meter_texas
2022-07-14 11:37:06.638 INFO (SyncWorker_13) [homeassistant.loader] Loaded vesync from homeassistant.components.vesync
2022-07-14 11:37:06.638 INFO (SyncWorker_13) [homeassistant.loader] Loaded amberelectric from homeassistant.components.amberelectric
2022-07-14 11:37:06.638 INFO (SyncWorker_13) [homeassistant.loader] Loaded fritzbox_callmonitor from homeassistant.components.fritzbox_callmonitor
2022-07-14 11:37:06.638 INFO (SyncWorker_13) [homeassistant.loader] Loaded fivem from homeassistant.components.fivem
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded xbox from homeassistant.components.xbox
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded openuv from homeassistant.components.openuv
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded environment_canada from homeassistant.components.environment_canada
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded ambiclimate from homeassistant.components.ambiclimate
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded ondilo_ico from homeassistant.components.ondilo_ico
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded zwave_me from homeassistant.components.zwave_me
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded ifttt from homeassistant.components.ifttt
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded icloud from homeassistant.components.icloud
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded tolo from homeassistant.components.tolo
2022-07-14 11:37:06.639 INFO (SyncWorker_13) [homeassistant.loader] Loaded crownstone from homeassistant.components.crownstone
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded geonetnz_quakes from homeassistant.components.geonetnz_quakes
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded elmax from homeassistant.components.elmax
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded huawei_lte from homeassistant.components.huawei_lte
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded iotawatt from homeassistant.components.iotawatt
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded pvoutput from homeassistant.components.pvoutput
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded flo from homeassistant.components.flo
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded laundrify from homeassistant.components.laundrify
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded vilfo from homeassistant.components.vilfo
2022-07-14 11:37:06.640 INFO (SyncWorker_13) [homeassistant.loader] Loaded life360 from homeassistant.components.life360
2022-07-14 11:37:06.641 INFO (SyncWorker_13) [homeassistant.loader] Loaded brunt from homeassistant.components.brunt
2022-07-14 11:37:06.641 INFO (SyncWorker_13) [homeassistant.loader] Loaded dialogflow from homeassistant.components.dialogflow
2022-07-14 11:37:06.641 INFO (SyncWorker_13) [homeassistant.loader] Loaded ezviz from homeassistant.components.ezviz
2022-07-14 11:37:06.641 INFO (SyncWorker_13) [homeassistant.loader] Loaded eafm from homeassistant.components.eafm
2022-07-14 11:37:06.641 INFO (SyncWorker_13) [homeassistant.loader] Loaded iqvia from homeassistant.components.iqvia
2022-07-14 11:37:06.641 INFO (SyncWorker_13) [homeassistant.loader] Loaded whirlpool from homeassistant.components.whirlpool
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded gios from homeassistant.components.gios
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded soma from homeassistant.components.soma
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded stookalert from homeassistant.components.stookalert
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded version from homeassistant.components.version
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded zerproc from homeassistant.components.zerproc
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded fritzbox from homeassistant.components.fritzbox
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded octoprint from homeassistant.components.octoprint
2022-07-14 11:37:06.642 INFO (SyncWorker_13) [homeassistant.loader] Loaded growatt_server from homeassistant.components.growatt_server
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded gpslogger from homeassistant.components.gpslogger
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded wallbox from homeassistant.components.wallbox
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded goodwe from homeassistant.components.goodwe
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded smappee from homeassistant.components.smappee
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded steamist from homeassistant.components.steamist
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded radiotherm from homeassistant.components.radiotherm
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded mill from homeassistant.components.mill
2022-07-14 11:37:06.643 INFO (SyncWorker_13) [homeassistant.loader] Loaded plaato from homeassistant.components.plaato
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded upb from homeassistant.components.upb
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded hangouts from homeassistant.components.hangouts
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded ambee from homeassistant.components.ambee
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded mysensors from homeassistant.components.mysensors
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded tractive from homeassistant.components.tractive
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded withings from homeassistant.components.withings
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded xiaomi_aqara from homeassistant.components.xiaomi_aqara
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded anthemav from homeassistant.components.anthemav
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded foscam from homeassistant.components.foscam
2022-07-14 11:37:06.644 INFO (SyncWorker_13) [homeassistant.loader] Loaded braviatv from homeassistant.components.braviatv
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded cert_expiry from homeassistant.components.cert_expiry
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded rtsp_to_webrtc from homeassistant.components.rtsp_to_webrtc
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded adguard from homeassistant.components.adguard
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded luftdaten from homeassistant.components.luftdaten
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded home_connect from homeassistant.components.home_connect
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded progettihwsw from homeassistant.components.progettihwsw
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded sonarr from homeassistant.components.sonarr
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded ecobee from homeassistant.components.ecobee
2022-07-14 11:37:06.645 INFO (SyncWorker_13) [homeassistant.loader] Loaded freedompro from homeassistant.components.freedompro
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded songpal from homeassistant.components.songpal
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded control4 from homeassistant.components.control4
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded integration from homeassistant.components.integration
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded sms from homeassistant.components.sms
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded wemo from homeassistant.components.wemo
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded hlk_sw16 from homeassistant.components.hlk_sw16
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded local_ip from homeassistant.components.local_ip
2022-07-14 11:37:06.646 INFO (SyncWorker_13) [homeassistant.loader] Loaded motion_blinds from homeassistant.components.motion_blinds
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded github from homeassistant.components.github
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded nuheat from homeassistant.components.nuheat
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded airly from homeassistant.components.airly
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded ruckus_unleashed from homeassistant.components.ruckus_unleashed
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded senz from homeassistant.components.senz
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded moon from homeassistant.components.moon
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded honeywell from homeassistant.components.honeywell
2022-07-14 11:37:06.647 INFO (SyncWorker_13) [homeassistant.loader] Loaded rpi_power from homeassistant.components.rpi_power
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded slack from homeassistant.components.slack
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded bosch_shc from homeassistant.components.bosch_shc
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded velbus from homeassistant.components.velbus
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded trafikverket_weatherstation from homeassistant.components.trafikverket_weatherstation
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded ridwell from homeassistant.components.ridwell
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded melcloud from homeassistant.components.melcloud
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded lyric from homeassistant.components.lyric
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded bsblan from homeassistant.components.bsblan
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded tasmota from homeassistant.components.tasmota
2022-07-14 11:37:06.648 INFO (SyncWorker_13) [homeassistant.loader] Loaded meater from homeassistant.components.meater
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded plum_lightpad from homeassistant.components.plum_lightpad
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded discord from homeassistant.components.discord
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded surepetcare from homeassistant.components.surepetcare
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded zha from homeassistant.components.zha
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded dunehd from homeassistant.components.dunehd
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded nightscout from homeassistant.components.nightscout
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded uptime from homeassistant.components.uptime
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded mjpeg from homeassistant.components.mjpeg
2022-07-14 11:37:06.649 INFO (SyncWorker_13) [homeassistant.loader] Loaded twilio from homeassistant.components.twilio
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded srp_energy from homeassistant.components.srp_energy
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded trafikverket_ferry from homeassistant.components.trafikverket_ferry
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded garages_amsterdam from homeassistant.components.garages_amsterdam
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded vera from homeassistant.components.vera
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded bmw_connected_drive from homeassistant.components.bmw_connected_drive
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded buienradar from homeassistant.components.buienradar
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded vallox from homeassistant.components.vallox
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded forecast_solar from homeassistant.components.forecast_solar
2022-07-14 11:37:06.650 INFO (SyncWorker_13) [homeassistant.loader] Loaded litterrobot from homeassistant.components.litterrobot
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded mutesync from homeassistant.components.mutesync
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded sia from homeassistant.components.sia
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded denonavr from homeassistant.components.denonavr
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded emulated_roku from homeassistant.components.emulated_roku
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded rfxtrx from homeassistant.components.rfxtrx
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded epson from homeassistant.components.epson
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded broadlink from homeassistant.components.broadlink
2022-07-14 11:37:06.651 INFO (SyncWorker_13) [homeassistant.loader] Loaded xiaomi_miio from homeassistant.components.xiaomi_miio
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded fjaraskupan from homeassistant.components.fjaraskupan
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded smarttub from homeassistant.components.smarttub
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded renault from homeassistant.components.renault
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded google_travel_time from homeassistant.components.google_travel_time
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded utility_meter from homeassistant.components.utility_meter
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded nextdns from homeassistant.components.nextdns
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded flume from homeassistant.components.flume
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded flipr from homeassistant.components.flipr
2022-07-14 11:37:06.652 INFO (SyncWorker_13) [homeassistant.loader] Loaded skybell from homeassistant.components.skybell
2022-07-14 11:37:06.653 INFO (SyncWorker_13) [homeassistant.loader] Loaded kaleidescape from homeassistant.components.kaleidescape
2022-07-14 11:37:06.653 INFO (SyncWorker_13) [homeassistant.loader] Loaded hive from homeassistant.components.hive
2022-07-14 11:37:06.653 INFO (SyncWorker_13) [homeassistant.loader] Loaded accuweather from homeassistant.components.accuweather
2022-07-14 11:37:06.653 INFO (SyncWorker_13) [homeassistant.loader] Loaded rainmachine from homeassistant.components.rainmachine
2022-07-14 11:37:06.653 INFO (SyncWorker_13) [homeassistant.loader] Loaded fronius from homeassistant.components.fronius
2022-07-14 11:37:06.653 INFO (SyncWorker_13) [homeassistant.loader] Loaded aurora_abb_powerone from homeassistant.components.aurora_abb_powerone
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded notion from homeassistant.components.notion
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded nuki from homeassistant.components.nuki
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded openweathermap from homeassistant.components.openweathermap
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded androidtv from homeassistant.components.androidtv
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded coolmaster from homeassistant.components.coolmaster
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded daikin from homeassistant.components.daikin
2022-07-14 11:37:06.654 INFO (SyncWorker_13) [homeassistant.loader] Loaded meteo_france from homeassistant.components.meteo_france
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded keenetic_ndms2 from homeassistant.components.keenetic_ndms2
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded syncthing from homeassistant.components.syncthing
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded goalzero from homeassistant.components.goalzero
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded tautulli from homeassistant.components.tautulli
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded rhasspy from homeassistant.components.rhasspy
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded nzbget from homeassistant.components.nzbget
2022-07-14 11:37:06.655 INFO (SyncWorker_13) [homeassistant.loader] Loaded solax from homeassistant.components.solax
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded onewire from homeassistant.components.onewire
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded webostv from homeassistant.components.webostv
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded wilight from homeassistant.components.wilight
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded nam from homeassistant.components.nam
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded enocean from homeassistant.components.enocean
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded knx from homeassistant.components.knx
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded monoprice from homeassistant.components.monoprice
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded watttime from homeassistant.components.watttime
2022-07-14 11:37:06.656 INFO (SyncWorker_13) [homeassistant.loader] Loaded gree from homeassistant.components.gree
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded squeezebox from homeassistant.components.squeezebox
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded system_bridge from homeassistant.components.system_bridge
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded brother from homeassistant.components.brother
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded devolo_home_network from homeassistant.components.devolo_home_network
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded airzone from homeassistant.components.airzone
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded sleepiq from homeassistant.components.sleepiq
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded litejet from homeassistant.components.litejet
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded geocaching from homeassistant.components.geocaching
2022-07-14 11:37:06.657 INFO (SyncWorker_13) [homeassistant.loader] Loaded emonitor from homeassistant.components.emonitor
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded opengarage from homeassistant.components.opengarage
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded roon from homeassistant.components.roon
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded trafikverket_train from homeassistant.components.trafikverket_train
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded dsmr from homeassistant.components.dsmr
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded fritz from homeassistant.components.fritz
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded smhi from homeassistant.components.smhi
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded flick_electric from homeassistant.components.flick_electric
2022-07-14 11:37:06.658 INFO (SyncWorker_13) [homeassistant.loader] Loaded modern_forms from homeassistant.components.modern_forms
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded rituals_perfume_genie from homeassistant.components.rituals_perfume_genie
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded motioneye from homeassistant.components.motioneye
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded zwave_js from homeassistant.components.zwave_js
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded sma from homeassistant.components.sma
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded poolsense from homeassistant.components.poolsense
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded ipma from homeassistant.components.ipma
2022-07-14 11:37:06.659 INFO (SyncWorker_13) [homeassistant.loader] Loaded konnected from homeassistant.components.konnected
2022-07-14 11:37:06.660 INFO (SyncWorker_13) [homeassistant.loader] Loaded shopping_list from homeassistant.components.shopping_list
2022-07-14 11:37:06.660 INFO (SyncWorker_13) [homeassistant.loader] Loaded ukraine_alarm from homeassistant.components.ukraine_alarm
2022-07-14 11:37:06.660 INFO (SyncWorker_13) [homeassistant.loader] Loaded here_travel_time from homeassistant.components.here_travel_time
2022-07-14 11:37:06.660 INFO (SyncWorker_13) [homeassistant.loader] Loaded juicenet from homeassistant.components.juicenet
2022-07-14 11:37:06.660 INFO (SyncWorker_13) [homeassistant.loader] Loaded uptimerobot from homeassistant.components.uptimerobot
2022-07-14 11:37:06.660 INFO (SyncWorker_13) [homeassistant.loader] Loaded starline from homeassistant.components.starline
2022-07-14 11:37:06.661 INFO (SyncWorker_13) [homeassistant.loader] Loaded aurora from homeassistant.components.aurora
2022-07-14 11:37:06.661 INFO (SyncWorker_13) [homeassistant.loader] Loaded coinbase from homeassistant.components.coinbase
2022-07-14 11:37:06.661 INFO (SyncWorker_13) [homeassistant.loader] Loaded awair from homeassistant.components.awair
2022-07-14 11:37:06.661 INFO (SyncWorker_13) [homeassistant.loader] Loaded insteon from homeassistant.components.insteon
2022-07-14 11:37:06.661 INFO (SyncWorker_13) [homeassistant.loader] Loaded hyperion from homeassistant.components.hyperion
2022-07-14 11:37:06.661 INFO (SyncWorker_13) [homeassistant.loader] Loaded yale_smart_alarm from homeassistant.components.yale_smart_alarm
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded cast from homeassistant.components.cast
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded yamaha_musiccast from homeassistant.components.yamaha_musiccast
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded mikrotik from homeassistant.components.mikrotik
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded simplisafe from homeassistant.components.simplisafe
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded verisure from homeassistant.components.verisure
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded rainforest_eagle from homeassistant.components.rainforest_eagle
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded tradfri from homeassistant.components.tradfri
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded deconz from homeassistant.components.deconz
2022-07-14 11:37:06.662 INFO (SyncWorker_13) [homeassistant.loader] Loaded mazda from homeassistant.components.mazda
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded fibaro from homeassistant.components.fibaro
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded yolink from homeassistant.components.yolink
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded sentry from homeassistant.components.sentry
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded geofency from homeassistant.components.geofency
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded atag from homeassistant.components.atag
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded overkiz from homeassistant.components.overkiz
2022-07-14 11:37:06.663 INFO (SyncWorker_13) [homeassistant.loader] Loaded deluge from homeassistant.components.deluge
2022-07-14 11:37:06.664 INFO (SyncWorker_13) [homeassistant.loader] Loaded sabnzbd from homeassistant.components.sabnzbd
2022-07-14 11:37:06.664 INFO (SyncWorker_13) [homeassistant.loader] Loaded somfy_mylink from homeassistant.components.somfy_mylink
2022-07-14 11:37:06.664 INFO (SyncWorker_13) [homeassistant.loader] Loaded qnap_qsw from homeassistant.components.qnap_qsw
2022-07-14 11:37:06.664 INFO (SyncWorker_13) [homeassistant.loader] Loaded minecraft_server from homeassistant.components.minecraft_server
2022-07-14 11:37:06.664 INFO (SyncWorker_13) [homeassistant.loader] Loaded switcher_kis from homeassistant.components.switcher_kis
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded prosegur from homeassistant.components.prosegur
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded mailgun from homeassistant.components.mailgun
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded toon from homeassistant.components.toon
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded kulersky from homeassistant.components.kulersky
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded volumio from homeassistant.components.volumio
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded ios from homeassistant.components.ios
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded ws66i from homeassistant.components.ws66i
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded aladdin_connect from homeassistant.components.aladdin_connect
2022-07-14 11:37:06.665 INFO (SyncWorker_13) [homeassistant.loader] Loaded nut from homeassistant.components.nut
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded lg_soundbar from homeassistant.components.lg_soundbar
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded meteoclimatic from homeassistant.components.meteoclimatic
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded heos from homeassistant.components.heos
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded steam_online from homeassistant.components.steam_online
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded ps4 from homeassistant.components.ps4
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded homematicip_cloud from homeassistant.components.homematicip_cloud
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded econet from homeassistant.components.econet
2022-07-14 11:37:06.666 INFO (SyncWorker_13) [homeassistant.loader] Loaded neato from homeassistant.components.neato
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded pure_energie from homeassistant.components.pure_energie
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded acmeda from homeassistant.components.acmeda
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded co2signal from homeassistant.components.co2signal
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded sharkiq from homeassistant.components.sharkiq
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded asuswrt from homeassistant.components.asuswrt
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded ovo_energy from homeassistant.components.ovo_energy
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded risco from homeassistant.components.risco
2022-07-14 11:37:06.667 INFO (SyncWorker_13) [homeassistant.loader] Loaded abode from homeassistant.components.abode
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded hisense_aehw4a1 from homeassistant.components.hisense_aehw4a1
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded kmtronic from homeassistant.components.kmtronic
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded izone from homeassistant.components.izone
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded kraken from homeassistant.components.kraken
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded balboa from homeassistant.components.balboa
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded smartthings from homeassistant.components.smartthings
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded totalconnect from homeassistant.components.totalconnect
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded season from homeassistant.components.season
2022-07-14 11:37:06.668 INFO (SyncWorker_13) [homeassistant.loader] Loaded rdw from homeassistant.components.rdw
2022-07-14 11:37:06.669 INFO (SyncWorker_13) [homeassistant.loader] Loaded youless from homeassistant.components.youless
```

- [x] TODO: `analytics` does something similar

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
