### PR TITLE
Avoid loading platforms in HKC if we are going to raise ConfigEntryNotReady

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -170,14 +170,18 @@ class HKDevice:
         async_dispatcher_send(self.hass, self.signal_state_updated)
 
     async def async_ensure_available(self) -> bool:
-        """Verifyt the accessory is available after processing the entity map."""
+        """Verify the accessory is available after processing the entity map."""
         if self.available:
             return True
         if self.watchable_characteristics and self.pollable_characteristics:
             # We already tried, no need to try again
             return False
         # We there are no watchable and not pollable characteristics,
-        # we need to force a connection to the device.
+        # we need to force a connection to the device to verify its alive.
+        #
+        # This is similar to iOS's behavior for keeping alive connections
+        # to cameras.
+        #
         primary = self.entity_map.aid(1)
         iid = primary.accessory_information[CharacteristicsTypes.SERIAL_NUMBER].iid
         try:

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -184,11 +184,16 @@ class HKDevice:
             return False
         # If everything is up to date, we can create the entities
         # since we know the data is not stale.
-        self.add_entities()
+        await self.async_add_new_entities()
         self._polling_interval_remover = async_track_time_interval(
             self.hass, self.async_update, DEFAULT_SCAN_INTERVAL
         )
         return True
+
+    async def async_add_new_entities(self) -> None:
+        """Add new entities to Home Assistant."""
+        await self.async_load_platforms()
+        self.add_entities()
 
     def device_info_for_accessory(self, accessory: Accessory) -> DeviceInfo:
         """Build a DeviceInfo for a given accessory."""
@@ -369,8 +374,6 @@ class HKDevice:
         # Migrate to new device ids
         self.async_migrate_devices()
 
-        await self.async_load_platforms()
-
         self.async_create_devices()
 
         # Load any triggers for this config entry
@@ -398,7 +401,7 @@ class HKDevice:
         """Refresh the entity map and entities for this pairing."""
         await self.async_refresh_entity_map(config_num)
         await self.async_process_entity_map()
-        self.add_entities()
+        await self.async_add_new_entities()
 
     async def async_refresh_entity_map(self, config_num: int) -> bool:
         """Handle setup of a HomeKit accessory."""

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -182,10 +182,11 @@ class HKDevice:
         # This is similar to iOS's behavior for keeping alive connections
         # to cameras.
         #
-        primary = self.entity_map.aid(1)
+        primary = self.entity_map.accessories[0]
+        aid = primary.aid
         iid = primary.accessory_information[CharacteristicsTypes.SERIAL_NUMBER].iid
         try:
-            await self.pairing.get_characteristics([(1, iid)])
+            await self.pairing.get_characteristics([(aid, iid)])
         except (AccessoryDisconnectedError, EncryptionError, AccessoryNotFoundError):
             return False
         self.async_set_available_state(True)

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from aiohomekit import exceptions
+from aiohomekit import AccessoryDisconnectedError, exceptions
 from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
@@ -110,6 +110,9 @@ async def test_offline_device_raises(hass):
         def is_connected(self):
             nonlocal is_connected
             return is_connected
+
+        def get_characteristics(self, chars, *args, **kwargs):
+            raise AccessoryDisconnectedError("any")
 
     class OfflineFakeDiscovery(FakeDiscovery):
         """Fake discovery that returns an offline pairing."""


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Followup to #75021
- This could lead to a race where we loaded platforms twice, and
  its inefficient to load and unload them so we should wait until
  we are sure we are going to setup


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
