### PR TITLE
Add entity descriptions in AdGuard Home sensors

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -138,8 +138,8 @@ class AdGuardHomeEntity(Entity):
         self,
         adguard: AdGuardHome,
         entry: ConfigEntry,
-        name: str,
-        icon: str,
+        name: str | None,
+        icon: str | None,
         enabled_default: bool = True,
     ) -> None:
         """Initialize the AdGuard Home entity."""
@@ -151,12 +151,12 @@ class AdGuardHomeEntity(Entity):
         self.adguard = adguard
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the entity."""
         return self._name
 
     @property
-    def icon(self) -> str:
+    def icon(self) -> str | None:
         """Return the mdi icon of the entity."""
         return self._icon
 

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -1,11 +1,14 @@
 """Support for AdGuard Home sensors."""
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from datetime import timedelta
+from typing import Any
 
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, TIME_MILLISECONDS
 from homeassistant.core import HomeAssistant
@@ -17,6 +20,81 @@ from .const import DATA_ADGUARD_CLIENT, DATA_ADGUARD_VERSION, DOMAIN
 
 SCAN_INTERVAL = timedelta(seconds=300)
 PARALLEL_UPDATES = 4
+
+
+@dataclass
+class AdGuardHomeEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[AdGuardHome], Callable[[], Coroutine[Any, Any, int | float]]]
+
+
+@dataclass
+class AdGuardHomeEntityDescription(
+    SensorEntityDescription, AdGuardHomeEntityDescriptionMixin
+):
+    """Describes AdGuard Home sensor entity."""
+
+
+SENSORS: tuple[AdGuardHomeEntityDescription, ...] = (
+    AdGuardHomeEntityDescription(
+        key="dns_queries",
+        name="DNS queries",
+        icon="mdi:magnify",
+        native_unit_of_measurement="queries",
+        value_fn=lambda adguard: adguard.stats.dns_queries,
+    ),
+    AdGuardHomeEntityDescription(
+        key="blocked_filtering",
+        name="DNS queries blocked",
+        icon="mdi:magnify-close",
+        native_unit_of_measurement="queries",
+        value_fn=lambda adguard: adguard.stats.blocked_filtering,
+    ),
+    AdGuardHomeEntityDescription(
+        key="blocked_percentage",
+        name="DNS queries blocked ratio",
+        icon="mdi:magnify-close",
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda adguard: adguard.stats.blocked_percentage,
+    ),
+    AdGuardHomeEntityDescription(
+        key="blocked_parental",
+        name="Parental control blocked",
+        icon="mdi:human-male-girl",
+        native_unit_of_measurement="requests",
+        value_fn=lambda adguard: adguard.stats.replaced_parental,
+    ),
+    AdGuardHomeEntityDescription(
+        key="blocked_safebrowsing",
+        name="Safe browsing blocked",
+        icon="mdi:shield-half-full",
+        native_unit_of_measurement="requests",
+        value_fn=lambda adguard: adguard.stats.replaced_safebrowsing,
+    ),
+    AdGuardHomeEntityDescription(
+        key="enforced_safesearch",
+        name="Safe searches enforced",
+        icon="mdi:shield-search",
+        native_unit_of_measurement="requests",
+        value_fn=lambda adguard: adguard.stats.replaced_safesearch,
+    ),
+    AdGuardHomeEntityDescription(
+        key="average_speed",
+        name="Average processing speed",
+        icon="mdi:speedometer",
+        native_unit_of_measurement=TIME_MILLISECONDS,
+        value_fn=lambda adguard: adguard.stats.avg_processing_time,
+    ),
+    AdGuardHomeEntityDescription(
+        key="rules_count",
+        name="Rules count",
+        icon="mdi:counter",
+        native_unit_of_measurement="rules",
+        value_fn=lambda adguard: adguard.stats.avg_processing_time,
+        entity_registry_enabled_default=False,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -34,215 +112,47 @@ async def async_setup_entry(
 
     hass.data[DOMAIN][entry.entry_id][DATA_ADGUARD_VERSION] = version
 
-    sensors = [
-        AdGuardHomeDNSQueriesSensor(adguard, entry),
-        AdGuardHomeBlockedFilteringSensor(adguard, entry),
-        AdGuardHomePercentageBlockedSensor(adguard, entry),
-        AdGuardHomeReplacedParentalSensor(adguard, entry),
-        AdGuardHomeReplacedSafeBrowsingSensor(adguard, entry),
-        AdGuardHomeReplacedSafeSearchSensor(adguard, entry),
-        AdGuardHomeAverageProcessingTimeSensor(adguard, entry),
-        AdGuardHomeRulesCountSensor(adguard, entry),
-    ]
-
-    async_add_entities(sensors, True)
+    async_add_entities(
+        [AdGuardHomeSensor(adguard, entry, description) for description in SENSORS],
+        True,
+    )
 
 
 class AdGuardHomeSensor(AdGuardHomeDeviceEntity, SensorEntity):
     """Defines a AdGuard Home sensor."""
 
+    entity_description: AdGuardHomeEntityDescription
+
     def __init__(
         self,
         adguard: AdGuardHome,
         entry: ConfigEntry,
-        name: str,
-        icon: str,
-        measurement: str,
-        unit_of_measurement: str,
-        enabled_default: bool = True,
+        description: AdGuardHomeEntityDescription,
     ) -> None:
         """Initialize AdGuard Home sensor."""
-        self._state: int | str | None = None
-        self._unit_of_measurement = unit_of_measurement
-        self.measurement = measurement
+        self.entity_description = description
 
-        super().__init__(adguard, entry, name, icon, enabled_default)
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for this sensor."""
-        return "_".join(
+        self._attr_unique_id = "_".join(
             [
                 DOMAIN,
-                self.adguard.host,
-                str(self.adguard.port),
+                adguard.host,
+                str(adguard.port),
                 "sensor",
-                self.measurement,
+                description.key,
             ]
         )
 
-    @property
-    def native_value(self) -> int | str | None:
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit this state is expressed in."""
-        return self._unit_of_measurement
-
-
-class AdGuardHomeDNSQueriesSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home DNS Queries sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
         super().__init__(
             adguard,
             entry,
-            "DNS queries",
-            "mdi:magnify",
-            "dns_queries",
-            "queries",
+            description.name,
+            description.icon,
+            description.entity_registry_enabled_default,
         )
 
     async def _adguard_update(self) -> None:
         """Update AdGuard Home entity."""
-        self._state = await self.adguard.stats.dns_queries()
-
-
-class AdGuardHomeBlockedFilteringSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home blocked by filtering sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "DNS queries blocked",
-            "mdi:magnify-close",
-            "blocked_filtering",
-            "queries",
-            enabled_default=False,
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        self._state = await self.adguard.stats.blocked_filtering()
-
-
-class AdGuardHomePercentageBlockedSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home blocked percentage sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "DNS queries blocked ratio",
-            "mdi:magnify-close",
-            "blocked_percentage",
-            PERCENTAGE,
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        percentage = await self.adguard.stats.blocked_percentage()
-        self._state = f"{percentage:.2f}"
-
-
-class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home replaced by parental control sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "Parental control blocked",
-            "mdi:human-male-girl",
-            "blocked_parental",
-            "requests",
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        self._state = await self.adguard.stats.replaced_parental()
-
-
-class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home replaced by safe browsing sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "Safe browsing blocked",
-            "mdi:shield-half-full",
-            "blocked_safebrowsing",
-            "requests",
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        self._state = await self.adguard.stats.replaced_safebrowsing()
-
-
-class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home replaced by safe search sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "Safe searches enforced",
-            "mdi:shield-search",
-            "enforced_safesearch",
-            "requests",
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        self._state = await self.adguard.stats.replaced_safesearch()
-
-
-class AdGuardHomeAverageProcessingTimeSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home average processing time sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "Average processing speed",
-            "mdi:speedometer",
-            "average_speed",
-            TIME_MILLISECONDS,
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        average = await self.adguard.stats.avg_processing_time()
-        self._state = f"{average:.2f}"
-
-
-class AdGuardHomeRulesCountSensor(AdGuardHomeSensor):
-    """Defines a AdGuard Home rules count sensor."""
-
-    def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
-        """Initialize AdGuard Home sensor."""
-        super().__init__(
-            adguard,
-            entry,
-            "Rules count",
-            "mdi:counter",
-            "rules_count",
-            "rules",
-            enabled_default=False,
-        )
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        self._state = await self.adguard.filtering.rules_count(allowlist=False)
+        value = await self.entity_description.value_fn(self.adguard)()
+        self._attr_native_value = value
+        if isinstance(value, float):
+            self._attr_native_value = f"{value:.2f}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

ℹ️ This is a first step in extending, modernizing this integration, trying to get it to a platinum level integration. This means this PR might not fix/optimize it all but is one step closer to that direction. More PRs inbound after this one.

This PR adds a small first step of introducing `EntityDescription`s in the AdGuard Home sensors. Its main focus is getting those in, while getting rid of all those sensor classes.

This PR does not change anything functional or user-facing, not does it refactor anything else besides introducing a tiny bit of `EntityDescription`s carefully.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
