### PR TITLE
Migrate Tractive to new entity naming style

### DIFF
--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -77,7 +77,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
 
 SENSOR_TYPE = BinarySensorEntityDescription(
     key=ATTR_BATTERY_CHARGING,
-    name="Battery charging",
+    name="Tracker battery charging",
     device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
     entity_category=EntityCategory.DIAGNOSTIC,
 )

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -77,7 +77,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
 
 SENSOR_TYPE = BinarySensorEntityDescription(
     key=ATTR_BATTERY_CHARGING,
-    name="Battery Charging",
+    name="Battery charging",
     device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
     entity_category=EntityCategory.DIAGNOSTIC,
 )

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -31,13 +31,14 @@ TRACKERS_WITH_BUILTIN_BATTERY = ("TRNJA4", "TRAXL1")
 class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
     """Tractive sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self, user_id: str, item: Trackables, description: BinarySensorEntityDescription
     ) -> None:
         """Initialize sensor entity."""
         super().__init__(user_id, item.trackable, item.tracker_details)
 
-        self._attr_name = f"{item.trackable['details']['name']} {description.name}"
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self.entity_description = description
 

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -42,6 +42,7 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
 
     _attr_has_entity_name = True
     _attr_icon = "mdi:paw"
+    _attr_name = "Tracker"
 
     def __init__(self, user_id: str, item: Trackables) -> None:
         """Initialize tracker entity."""
@@ -52,8 +53,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self._longitude: float = item.pos_report["latlong"][1]
         self._accuracy: int = item.pos_report["pos_uncertainty"]
         self._source_type: str = item.pos_report["sensor_used"]
-
-        self._attr_name = "Tracker"
         self._attr_unique_id = item.trackable["_id"]
 
     @property

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -40,6 +40,7 @@ async def async_setup_entry(
 class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
     """Tractive device tracker."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:paw"
 
     def __init__(self, user_id: str, item: Trackables) -> None:
@@ -51,8 +52,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self._longitude: float = item.pos_report["latlong"][1]
         self._accuracy: int = item.pos_report["pos_uncertainty"]
         self._source_type: str = item.pos_report["sensor_used"]
-
-        self._attr_name = f"{self._tracker_id} {item.trackable['details']['name']}"
         self._attr_unique_id = item.trackable["_id"]
 
     @property

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -52,6 +52,7 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self._longitude: float = item.pos_report["latlong"][1]
         self._accuracy: int = item.pos_report["pos_uncertainty"]
         self._source_type: str = item.pos_report["sensor_used"]
+
         self._attr_name = "Tracker"
         self._attr_unique_id = item.trackable["_id"]
 

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -52,6 +52,7 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self._longitude: float = item.pos_report["latlong"][1]
         self._accuracy: int = item.pos_report["pos_uncertainty"]
         self._source_type: str = item.pos_report["sensor_used"]
+        self._attr_name = "Tracker"
         self._attr_unique_id = item.trackable["_id"]
 
     @property

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -18,7 +18,7 @@ class TractiveEntity(Entity):
         self._attr_device_info = DeviceInfo(
             configuration_url="https://my.tractive.com/",
             identifiers={(DOMAIN, tracker_details["_id"])},
-            name=f"Tractive ({tracker_details['_id']})",
+            name=f"{trackable['details']['name']} ({tracker_details['_id']})",
             manufacturer="Tractive GmbH",
             sw_version=tracker_details["fw_version"],
             model=tracker_details["model_number"],

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -18,7 +18,7 @@ class TractiveEntity(Entity):
         self._attr_device_info = DeviceInfo(
             configuration_url="https://my.tractive.com/",
             identifiers={(DOMAIN, tracker_details["_id"])},
-            name=f"{trackable['details']['name']} ({tracker_details['_id']})",
+            name=trackable["details"]["name"],
             manufacturer="Tractive GmbH",
             sw_version=tracker_details["fw_version"],
             model=tracker_details["model_number"],

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -134,7 +134,7 @@ class TractiveActivitySensor(TractiveSensor):
 SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
     TractiveSensorEntityDescription(
         key=ATTR_BATTERY_LEVEL,
-        name="Battery Level",
+        name="Battery level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         entity_class=TractiveHardwareSensor,
@@ -150,14 +150,14 @@ SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
     ),
     TractiveSensorEntityDescription(
         key=ATTR_MINUTES_ACTIVE,
-        name="Minutes Active",
+        name="Minutes active",
         icon="mdi:clock-time-eight-outline",
         native_unit_of_measurement=TIME_MINUTES,
         entity_class=TractiveActivitySensor,
     ),
     TractiveSensorEntityDescription(
         key=ATTR_DAILY_GOAL,
-        name="Daily Goal",
+        name="Daily goal",
         icon="mdi:flag-checkered",
         native_unit_of_measurement=TIME_MINUTES,
         entity_class=TractiveActivitySensor,

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -134,7 +134,7 @@ class TractiveActivitySensor(TractiveSensor):
 SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
     TractiveSensorEntityDescription(
         key=ATTR_BATTERY_LEVEL,
-        name="Battery level",
+        name="Tracker battery level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         entity_class=TractiveHardwareSensor,

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -48,6 +48,8 @@ class TractiveSensorEntityDescription(
 class TractiveSensor(TractiveEntity, SensorEntity):
     """Tractive sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         user_id: str,
@@ -57,7 +59,6 @@ class TractiveSensor(TractiveEntity, SensorEntity):
         """Initialize sensor entity."""
         super().__init__(user_id, item.trackable, item.tracker_details)
 
-        self._attr_name = f"{item.trackable['details']['name']} {description.name}"
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self.entity_description = description
 

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -47,7 +47,7 @@ class TractiveSwitchEntityDescription(
 SWITCH_TYPES: tuple[TractiveSwitchEntityDescription, ...] = (
     TractiveSwitchEntityDescription(
         key=ATTR_BUZZER,
-        name="Tracker Buzzer",
+        name="Tracker buzzer",
         icon="mdi:volume-high",
         method="async_set_buzzer",
         entity_category=EntityCategory.CONFIG,
@@ -61,7 +61,7 @@ SWITCH_TYPES: tuple[TractiveSwitchEntityDescription, ...] = (
     ),
     TractiveSwitchEntityDescription(
         key=ATTR_LIVE_TRACKING,
-        name="Live Tracking",
+        name="Live tracking",
         icon="mdi:map-marker-path",
         method="async_set_live_tracking",
         entity_category=EntityCategory.CONFIG,
@@ -88,6 +88,7 @@ async def async_setup_entry(
 class TractiveSwitch(TractiveEntity, SwitchEntity):
     """Tractive switch."""
 
+    _attr_has_entity_name = True
     entity_description: TractiveSwitchEntityDescription
 
     def __init__(
@@ -99,7 +100,6 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         """Initialize switch entity."""
         super().__init__(user_id, item.trackable, item.tracker_details)
 
-        self._attr_name = f"{item.trackable['details']['name']} {description.name}"
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
         self._tracker = item.tracker


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR migrates Tractive to the new style entity naming.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
