### PR TITLE
Use json_loads by default for the aiohttp helper

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -36,7 +36,7 @@ SERVER_SOFTWARE = "HomeAssistant/{0} aiohttp/{1} Python/{2[0]}.{2[1]}".format(
 WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"
 
 
-class HassClientRequest(aiohttp.ClientRequest):
+class HassClientResponse(aiohttp.ClientResponse):
     """aiohttp.ClientRequest with a json method that uses json_loads by default."""
 
     async def json(
@@ -46,7 +46,7 @@ class HassClientRequest(aiohttp.ClientRequest):
         **kwargs: Any,
     ) -> Any:
         """Send a json request and parse the json response."""
-        return await self.json(*args, loads=loads, **kwargs)
+        return await super().json(*args, loads=loads, **kwargs)
 
 
 @callback
@@ -113,7 +113,7 @@ def _async_create_clientsession(
     clientsession = aiohttp.ClientSession(
         connector=_async_get_connector(hass, verify_ssl),
         json_serialize=json_dumps,
-        request_class=HassClientRequest,
+        response_class=HassClientResponse,
         **kwargs,
     )
     # Prevent packages accidentally overriding our default headers

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -7,12 +7,11 @@ from contextlib import suppress
 from ssl import SSLContext
 import sys
 from types import MappingProxyType
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
-from aiohttp.typedefs import JSONDecoder
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
 
@@ -24,6 +23,10 @@ from homeassistant.util import ssl as ssl_util
 
 from .frame import warn_use
 from .json import json_dumps, json_loads
+
+if TYPE_CHECKING:
+    from aiohttp.typedefs import JSONDecoder
+
 
 DATA_CONNECTOR = "aiohttp_connector"
 DATA_CONNECTOR_NOTVERIFY = "aiohttp_connector_notverify"

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -37,7 +37,7 @@ WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"
 
 
 class HassClientRequest(aiohttp.ClientRequest):
-    """aiohttp.ClientRequest with a json method that uses json_loads."""
+    """aiohttp.ClientRequest with a json method that uses json_loads by default."""
 
     async def json(
         self,

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -37,7 +37,7 @@ WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"
 
 
 class HassClientResponse(aiohttp.ClientResponse):
-    """aiohttp.ClientRequest with a json method that uses json_loads by default."""
+    """aiohttp.ClientResponse with a json method that uses json_loads by default."""
 
     async def json(
         self,

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 import aiohttp
 from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
+from aiohttp.typedefs import JSONDecoder
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
 
@@ -22,7 +23,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.util import ssl as ssl_util
 
 from .frame import warn_use
-from .json import json_dumps
+from .json import json_dumps, json_loads
 
 DATA_CONNECTOR = "aiohttp_connector"
 DATA_CONNECTOR_NOTVERIFY = "aiohttp_connector_notverify"
@@ -33,6 +34,19 @@ SERVER_SOFTWARE = "HomeAssistant/{0} aiohttp/{1} Python/{2[0]}.{2[1]}".format(
 )
 
 WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"
+
+
+class HassClientRequest(aiohttp.ClientRequest):
+    """aiohttp.ClientRequest with a json method that uses json_loads."""
+
+    async def json(
+        self,
+        *args: Any,
+        loads: JSONDecoder = json_loads,
+        **kwargs: Any,
+    ) -> Any:
+        """Send a json request and parse the json response."""
+        return await self.json(*args, loads=loads, **kwargs)
 
 
 @callback
@@ -99,6 +113,7 @@ def _async_create_clientsession(
     clientsession = aiohttp.ClientSession(
         connector=_async_get_connector(hass, verify_ssl),
         json_serialize=json_dumps,
+        request_class=HassClientRequest,
         **kwargs,
     )
     # Prevent packages accidentally overriding our default headers


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use json_loads by default for the aiohttp helper.

I didn't do this on round1 as I wanted to wait until we had ironed out any issues from the initial merge

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
