### PR TITLE
Fix ZHA light turn on issues

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -226,9 +226,12 @@ class BaseLight(LogMixin, light.LightEntity):
         # the light needs to be turned on first at a low brightness level where the light is immediately transitioned
         # to the correct color. Afterwards, the transition is only from the low brightness to the new brightness.
         # Otherwise, the transition is from the color the light had before being turned on to the new color.
-        # This can look especially bad with transitions longer than a second.
+        # This can look especially bad with transitions longer than a second. We do not want to do this for
+        # devices that need to be forced to use the on command because we would end up with 4 commands sent:
+        # move to level, on, color, move to level...
         color_provided_while_off = (
             not isinstance(self, LightGroup)
+            and not self._FORCE_ON
             and not self._state
             and brightness_supported(self._attr_supported_color_modes)
             and (light.ATTR_COLOR_TEMP in kwargs or light.ATTR_HS_COLOR in kwargs)
@@ -610,7 +613,7 @@ class HueLight(Light):
 @STRICT_MATCH(
     channel_names=CHANNEL_ON_OFF,
     aux_channels={CHANNEL_COLOR, CHANNEL_LEVEL},
-    manufacturers={"Jasco", "Quotra-Vision"},
+    manufacturers={"Jasco", "Quotra-Vision", "eWeLight", "eWeLink"},
 )
 class ForceOnLight(Light):
     """Representation of a light which does not respect move_to_level_with_on_off."""

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -476,6 +476,7 @@ class Light(BaseLight, ZhaEntity):
         """Set the state."""
         self._state = bool(value)
         if value:
+            self._off_with_transition = False
             self._off_brightness = None
         self.async_write_ha_state()
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -330,8 +330,8 @@ class BaseLight(LogMixin, light.LightEntity):
         if hs_color is not None:
             xy_color = color_util.color_hs_to_xy(*hs_color)
             result = await self._color_channel.move_to_color(
-                int(xy_color[0] * 65535),
-                int(xy_color[1] * 65535),
+                int(xy_color[0] * 65536),
+                int(xy_color[1] * 65536),
                 self._DEFAULT_MIN_TRANSITION_TIME
                 if new_color_provided_while_off
                 else duration,
@@ -455,7 +455,7 @@ class Light(BaseLight, ZhaEntity):
                 curr_y = self._color_channel.current_y
                 if curr_x is not None and curr_y is not None:
                     self._hs_color = color_util.color_xy_to_hs(
-                        float(curr_x / 65535), float(curr_y / 65535)
+                        float(curr_x / 65536), float(curr_y / 65536)
                     )
                 else:
                     self._hs_color = (0, 0)
@@ -588,7 +588,7 @@ class Light(BaseLight, ZhaEntity):
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
                         self._hs_color = color_util.color_xy_to_hs(
-                            float(color_x / 65535), float(color_y / 65535)
+                            float(color_x / 65536), float(color_y / 65536)
                         )
                         self._color_temp = None
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -255,14 +255,6 @@ class BaseLight(LogMixin, light.LightEntity):
             and brightness_supported(self._attr_supported_color_modes)
         )
 
-        self.warning(
-            "WTF COLORS SHIT: %s temp: %s, my temp: %s, mode: %s",
-            new_color_provided_while_off,
-            temperature,
-            self._color_temp,
-            self._attr_color_mode,
-        )
-
         if (
             brightness is None
             and (self._off_with_transition or new_color_provided_while_off)

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -139,7 +139,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
-        self._default_transition = None
+        self._default_transition = self._DEFAULT_MIN_TRANSITION_TIME
         self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
@@ -214,12 +214,8 @@ class BaseLight(LogMixin, light.LightEntity):
         """Turn the entity on."""
         transition = kwargs.get(light.ATTR_TRANSITION)
         duration = (
-            transition * 10
-            if transition is not None
-            else self._default_transition * 10
-            if self._default_transition is not None
-            else self._DEFAULT_MIN_TRANSITION_TIME
-        )
+            transition * 10 if transition is not None else self._default_transition * 10
+        ) or self._DEFAULT_MIN_TRANSITION_TIME  # if 0 is passed in some devices still need the minimum default
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)
         flash = kwargs.get(light.ATTR_FLASH)

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -336,7 +336,6 @@ class BaseLight(LogMixin, light.LightEntity):
             self._hs_color = None
 
         if hs_color is not None:
-            hs_color = kwargs[light.ATTR_HS_COLOR]
             xy_color = color_util.color_hs_to_xy(*hs_color)
             result = await self._color_channel.move_to_color(
                 int(xy_color[0] * 65535),

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -296,7 +296,10 @@ class BaseLight(LogMixin, light.LightEntity):
         if light.ATTR_COLOR_TEMP in kwargs:
             temperature = kwargs[light.ATTR_COLOR_TEMP]
             result = await self._color_channel.move_to_color_temp(
-                temperature, 0 if color_provided_while_off else duration
+                temperature,
+                0 or self._DEFAULT_TRANSITION_TIME
+                if color_provided_while_off
+                else duration,
             )
             t_log["move_to_color_temp"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -312,7 +315,9 @@ class BaseLight(LogMixin, light.LightEntity):
             result = await self._color_channel.move_to_color(
                 int(xy_color[0] * 65535),
                 int(xy_color[1] * 65535),
-                0 if color_provided_while_off else duration,
+                0 or self._DEFAULT_TRANSITION_TIME
+                if color_provided_while_off
+                else duration,
             )
             t_log["move_to_color"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -297,9 +297,7 @@ class BaseLight(LogMixin, light.LightEntity):
             temperature = kwargs[light.ATTR_COLOR_TEMP]
             result = await self._color_channel.move_to_color_temp(
                 temperature,
-                0 or self._DEFAULT_TRANSITION_TIME
-                if color_provided_while_off
-                else duration,
+                self._DEFAULT_TRANSITION_TIME if color_provided_while_off else duration,
             )
             t_log["move_to_color_temp"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -315,9 +313,7 @@ class BaseLight(LogMixin, light.LightEntity):
             result = await self._color_channel.move_to_color(
                 int(xy_color[0] * 65535),
                 int(xy_color[1] * 65535),
-                0 or self._DEFAULT_TRANSITION_TIME
-                if color_provided_while_off
-                else duration,
+                self._DEFAULT_TRANSITION_TIME if color_provided_while_off else duration,
             )
             t_log["move_to_color"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -218,7 +218,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if transition is not None
             else self._default_transition * 10
             if self._default_transition is not None
-            else 0 or self._DEFAULT_TRANSITION_TIME
+            else self._DEFAULT_TRANSITION_TIME
         )
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -249,7 +249,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         t_log = {}
 
-        if color_provided_while_off:
+        if color_provided_while_off and not isinstance(self, LightGroup):
             # If the light is currently off, we first need to turn it on at a low brightness level with no transition.
             # After that, we set it to the desired color/temperature with no transition.
             result = await self._level_channel.move_to_level_with_on_off(
@@ -264,7 +264,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             (brightness is not None or transition)
-            and not color_provided_while_off
+            and (not color_provided_while_off or isinstance(self, LightGroup))
             and brightness_supported(self._attr_supported_color_modes)
         ):
             result = await self._level_channel.move_to_level_with_on_off(
@@ -321,7 +321,7 @@ class BaseLight(LogMixin, light.LightEntity):
             self._hs_color = hs_color
             self._color_temp = None
 
-        if color_provided_while_off:
+        if color_provided_while_off and not isinstance(self, LightGroup):
             # The light is has the correct color, so we can now transition it to the correct brightness level.
             result = await self._level_channel.move_to_level(level, duration)
             t_log["move_to_level_if_color"] = result

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -118,7 +118,7 @@ class BaseLight(LogMixin, light.LightEntity):
     """Operations common to all light entities."""
 
     _FORCE_ON = False
-    _DEFAULT_TRANSITION_TIME = 0
+    _DEFAULT_MIN_TRANSITION_TIME = 0
 
     def __init__(self, *args, **kwargs):
         """Initialize the light."""
@@ -218,7 +218,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if transition is not None
             else self._default_transition * 10
             if self._default_transition is not None
-            else self._DEFAULT_TRANSITION_TIME
+            else self._DEFAULT_MIN_TRANSITION_TIME
         )
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)
@@ -254,7 +254,7 @@ class BaseLight(LogMixin, light.LightEntity):
             # If the light is currently off, we first need to turn it on at a low brightness level with no transition.
             # After that, we set it to the desired color/temperature with no transition.
             result = await self._level_channel.move_to_level_with_on_off(
-                DEFAULT_MIN_BRIGHTNESS, self._DEFAULT_TRANSITION_TIME
+                DEFAULT_MIN_BRIGHTNESS, self._DEFAULT_MIN_TRANSITION_TIME
             )
             t_log["move_to_level_with_on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -297,7 +297,9 @@ class BaseLight(LogMixin, light.LightEntity):
             temperature = kwargs[light.ATTR_COLOR_TEMP]
             result = await self._color_channel.move_to_color_temp(
                 temperature,
-                self._DEFAULT_TRANSITION_TIME if color_provided_while_off else duration,
+                self._DEFAULT_MIN_TRANSITION_TIME
+                if color_provided_while_off
+                else duration,
             )
             t_log["move_to_color_temp"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -313,7 +315,9 @@ class BaseLight(LogMixin, light.LightEntity):
             result = await self._color_channel.move_to_color(
                 int(xy_color[0] * 65535),
                 int(xy_color[1] * 65535),
-                self._DEFAULT_TRANSITION_TIME if color_provided_while_off else duration,
+                self._DEFAULT_MIN_TRANSITION_TIME
+                if color_provided_while_off
+                else duration,
             )
             t_log["move_to_color"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -623,7 +627,7 @@ class ForceOnLight(Light):
 class SengledLight(Light):
     """Representation of a Sengled light which does not react to move_to_color_temp with 0 as a transition."""
 
-    _DEFAULT_TRANSITION_TIME = 1
+    _DEFAULT_MIN_TRANSITION_TIME = 1
 
 
 @GROUP_MATCH()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -374,7 +374,8 @@ class BaseLight(LogMixin, light.LightEntity):
         transition = kwargs.get(light.ATTR_TRANSITION)
         supports_level = brightness_supported(self._attr_supported_color_modes)
 
-        if transition and supports_level:
+        # is not none looks odd here but it will override built in bulb transition times if we pass 0 in here
+        if transition is not None and supports_level:
             result = await self._level_channel.move_to_level_with_on_off(
                 0, transition * 10
             )

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -254,7 +254,7 @@ class BaseLight(LogMixin, light.LightEntity):
             # If the light is currently off, we first need to turn it on at a low brightness level with no transition.
             # After that, we set it to the desired color/temperature with no transition.
             result = await self._level_channel.move_to_level_with_on_off(
-                DEFAULT_MIN_BRIGHTNESS, 0 or self._DEFAULT_TRANSITION_TIME
+                DEFAULT_MIN_BRIGHTNESS, self._DEFAULT_TRANSITION_TIME
             )
             t_log["move_to_level_with_on_off"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -139,7 +139,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
-        self._default_transition = self._DEFAULT_MIN_TRANSITION_TIME
+        self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
         self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
 
     @property
@@ -214,7 +214,9 @@ class BaseLight(LogMixin, light.LightEntity):
         """Turn the entity on."""
         transition = kwargs.get(light.ATTR_TRANSITION)
         duration = (
-            transition * 10 if transition is not None else self._default_transition * 10
+            transition * 10
+            if transition is not None
+            else self._zha_config_transition * 10
         ) or self._DEFAULT_MIN_TRANSITION_TIME  # if 0 is passed in some devices still need the minimum default
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)
@@ -462,7 +464,7 @@ class Light(BaseLight, ZhaEntity):
         if effect_list:
             self._effect_list = effect_list
 
-        self._default_transition = async_get_zha_config_value(
+        self._zha_config_transition = async_get_zha_config_value(
             zha_device.gateway.config_entry,
             ZHA_OPTIONS,
             CONF_DEFAULT_LIGHT_TRANSITION,
@@ -641,7 +643,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
         self._color_channel = group.endpoint[Color.cluster_id]
         self._identify_channel = group.endpoint[Identify.cluster_id]
         self._debounced_member_refresh = None
-        self._default_transition = async_get_zha_config_value(
+        self._zha_config_transition = async_get_zha_config_value(
             zha_device.gateway.config_entry,
             ZHA_OPTIONS,
             CONF_DEFAULT_LIGHT_TRANSITION,

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -230,19 +230,19 @@ class BaseLight(LogMixin, light.LightEntity):
         # to the correct color. Afterwards, the transition is only from the low brightness to the new brightness.
         # Otherwise, the transition is from the color the light had before being turned on to the new color.
         # This can look especially bad with transitions longer than a second.
-        color_provided_from_off = (
+        color_provided_while_off = (
             not self._state
             and brightness_supported(self._attr_supported_color_modes)
             and (light.ATTR_COLOR_TEMP in kwargs or light.ATTR_HS_COLOR in kwargs)
         )
         final_duration = duration
-        if color_provided_from_off:
+        if color_provided_while_off:
             # Set the duration for the color changing commands to 0.
             duration = 0
 
         if (
             brightness is None
-            and (self._off_with_transition or color_provided_from_off)
+            and (self._off_with_transition or color_provided_while_off)
             and self._off_brightness is not None
         ):
             brightness = self._off_brightness
@@ -254,7 +254,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         t_log = {}
 
-        if color_provided_from_off:
+        if color_provided_while_off:
             # If the light is currently off, we first need to turn it on at a low brightness level with no transition.
             # After that, we set it to the desired color/temperature with no transition.
             result = await self._level_channel.move_to_level_with_on_off(
@@ -269,7 +269,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             (brightness is not None or transition)
-            and not color_provided_from_off
+            and not color_provided_while_off
             and brightness_supported(self._attr_supported_color_modes)
         ):
             result = await self._level_channel.move_to_level_with_on_off(
@@ -285,7 +285,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             brightness is None
-            and not color_provided_from_off
+            and not color_provided_while_off
             or (self._FORCE_ON and brightness)
         ):
             # since some lights don't always turn on with move_to_level_with_on_off,
@@ -322,7 +322,7 @@ class BaseLight(LogMixin, light.LightEntity):
             self._hs_color = hs_color
             self._color_temp = None
 
-        if color_provided_from_off:
+        if color_provided_while_off:
             # The light is has the correct color, so we can now transition it to the correct brightness level.
             result = await self._level_channel.move_to_level(level, final_duration)
             t_log["move_to_level_if_color"] = result

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -330,8 +330,8 @@ class BaseLight(LogMixin, light.LightEntity):
         if hs_color is not None:
             xy_color = color_util.color_hs_to_xy(*hs_color)
             result = await self._color_channel.move_to_color(
-                int(xy_color[0] * 65536),
-                int(xy_color[1] * 65536),
+                int(xy_color[0] * 65535),
+                int(xy_color[1] * 65535),
                 self._DEFAULT_MIN_TRANSITION_TIME
                 if new_color_provided_while_off
                 else duration,
@@ -455,7 +455,7 @@ class Light(BaseLight, ZhaEntity):
                 curr_y = self._color_channel.current_y
                 if curr_x is not None and curr_y is not None:
                     self._hs_color = color_util.color_xy_to_hs(
-                        float(curr_x / 65536), float(curr_y / 65536)
+                        float(curr_x / 65535), float(curr_y / 65535)
                     )
                 else:
                     self._hs_color = (0, 0)
@@ -588,7 +588,7 @@ class Light(BaseLight, ZhaEntity):
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
                         self._hs_color = color_util.color_xy_to_hs(
-                            float(color_x / 65536), float(color_y / 65536)
+                            float(color_x / 65535), float(color_y / 65535)
                         )
                         self._color_temp = None
 

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1037,7 +1037,7 @@ async def test_transitions(
         10,
         dev1_cluster_color.commands_by_name["move_to_color_temp"].schema,
         235,  # color temp mireds
-        0,  # transition time (ZCL time in 10ths of a second) - no transition when color_provided_while_off
+        0,  # transition time (ZCL time in 10ths of a second)
         expect_reply=True,
         manufacturer=None,
         tries=1,

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -925,7 +925,7 @@ async def test_transitions(hass, device_light_1, device_light_2, coordinator):
         4,
         dev2_cluster_level.commands_by_name["move_to_level_with_on_off"].schema,
         0,  # brightness (level in ZCL)
-        20,  # transition time - sengled light uses default minimum
+        20,  # transition time
         expect_reply=True,
         manufacturer=None,
         tries=1,

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -937,7 +937,7 @@ async def test_transitions(hass, device_light_1, device_light_2, coordinator):
 
     dev2_cluster_level.request.reset_mock()
 
-    # turn the light back on with no args should use a transition
+    # turn the light back on with no args should use a transition and last known brightness
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -463,7 +463,7 @@ async def async_test_level_on_off_from_hass(
         4,
         level_cluster.commands_by_name["move_to_level_with_on_off"].schema,
         10,
-        1,
+        0,
         expect_reply=True,
         manufacturer=None,
         tries=1,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a couple of issues in ZHA lights:

 - a default transition accidentally broken for sengled 
 - the new color correction code is not playing well with groups so this adds guards to the commands to omit groups
 - renamed variables for clarity
 - handle 0 as a transition value correctly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75244
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
