### PR TITLE
Appropriately mark Guardian entities as `unavailable` during reboot

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -419,9 +419,7 @@ class GuardianEntity(CoordinatorEntity[GuardianDataUpdateCoordinator]):
     _attr_has_entity_name = True
 
     def __init__(
-        self,
-        coordinator: GuardianDataUpdateCoordinator,
-        description: EntityDescription,
+        self, coordinator: GuardianDataUpdateCoordinator, description: EntityDescription
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -455,20 +455,6 @@ class GuardianEntity(CoordinatorEntity[GuardianDataUpdateCoordinator]):
         self.async_write_ha_state()
 
     @callback
-    def _async_reboot_completed(self) -> None:
-        """Respond to a completed controller reboot."""
-        self._attr_available = True
-        self._rebooting = False
-        self.async_write_ha_state()
-
-    @callback
-    def _async_reboot_requested(self) -> None:
-        """Respond to a requested controller reboot."""
-        self._attr_available = False
-        self._rebooting = True
-        self.async_write_ha_state()
-
-    @callback
     def _async_update_from_latest_data(self) -> None:
         """Update the entity's underlying data.
 
@@ -486,9 +472,22 @@ class GuardianEntity(CoordinatorEntity[GuardianDataUpdateCoordinator]):
         self._async_update_from_latest_data()
         self.async_write_ha_state()
 
+        @callback
+        def async_reboot_completed() -> None:
+            """Respond to a completed controller reboot."""
+            self._attr_available = True
+            self._rebooting = False
+
+        @callback
+        def async_reboot_requested() -> None:
+            """Respond to a requested controller reboot."""
+            self._attr_available = False
+            self._rebooting = True
+            self.async_write_ha_state()
+
         for signal, func in (
-            (self._signal_reboot_completed, self._async_reboot_completed),
-            (self._signal_reboot_requested, self._async_reboot_requested),
+            (self._signal_reboot_completed, async_reboot_completed),
+            (self._signal_reboot_requested, async_reboot_requested),
         ):
             self.async_on_remove(async_dispatcher_connect(self.hass, signal, func))
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -432,8 +432,8 @@ class GuardianEntity(CoordinatorEntity[GuardianDataUpdateCoordinator]):
     def available(self) -> bool:
         """Return True if entity is available.
 
-        We override the inherited instance of this property so that we can force entity
-        available when desired (e.g., a reboot).
+        Since we don't call our parent's __init__(), we remake our own version of this
+        property so that we can force entity available when desired (e.g., a reboot).
         """
         return self._attr_available
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -158,6 +158,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             api
         ] = GuardianDataUpdateCoordinator(
             hass,
+            entry=entry,
             client=client,
             api_name=api,
             api_coro=api_coro,
@@ -359,6 +360,7 @@ class PairedSensorManager:
 
         coordinator = self.coordinators[uid] = GuardianDataUpdateCoordinator(
             self._hass,
+            entry=self._entry,
             client=self._client,
             api_name=f"{API_SENSOR_PAIRED_SENSOR_STATUS}_{uid}",
             api_coro=lambda: cast(

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -420,7 +420,6 @@ class GuardianEntity(CoordinatorEntity[GuardianDataUpdateCoordinator]):
 
     def __init__(
         self,
-        entry: ConfigEntry,
         coordinator: GuardianDataUpdateCoordinator,
         description: EntityDescription,
     ) -> None:
@@ -459,7 +458,7 @@ class PairedSensorEntity(GuardianEntity):
         description: EntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(entry, coordinator, description)
+        super().__init__(coordinator, description)
 
         paired_sensor_uid = coordinator.data["uid"]
         self._attr_device_info = DeviceInfo(
@@ -496,7 +495,7 @@ class ValveControllerEntity(GuardianEntity):
         description: ValveControllerEntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(entry, coordinators[description.api_category], description)
+        super().__init__(coordinators[description.api_category], description)
 
         self._diagnostics_coordinator = coordinators[API_SYSTEM_DIAGNOSTICS]
 

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -137,7 +137,7 @@ class PairedSensorBinarySensor(PairedSensorEntity, BinarySensorEntity):
 
     @callback
     def _async_update_from_latest_data(self) -> None:
-        """Update the entity."""
+        """Update the entity's underlying data."""
         if self.entity_description.key == SENSOR_KIND_LEAK_DETECTED:
             self._attr_is_on = self.coordinator.data["wet"]
         elif self.entity_description.key == SENSOR_KIND_MOVED:

--- a/homeassistant/components/guardian/button.py
+++ b/homeassistant/components/guardian/button.py
@@ -113,4 +113,4 @@ class GuardianButton(ValveControllerEntity, ButtonEntity):
                 f'Error while pressing button "{self.entity_id}": {err}'
             ) from err
 
-        async_dispatcher_send(self.hass, self._signal_reboot_requested)
+        async_dispatcher_send(self.hass, self.coordinator.signal_reboot_requested)

--- a/homeassistant/components/guardian/button.py
+++ b/homeassistant/components/guardian/button.py
@@ -15,6 +15,7 @@ from homeassistant.components.button import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -111,3 +112,5 @@ class GuardianButton(ValveControllerEntity, ButtonEntity):
             raise HomeAssistantError(
                 f'Error while pressing button "{self.entity_id}": {err}'
             ) from err
+
+        async_dispatcher_send(self.hass, self._signal_reboot_requested)

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -15,3 +15,5 @@ API_WIFI_STATUS = "wifi_status"
 CONF_UID = "uid"
 
 SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED = "guardian_paired_sensor_coordinator_added_{0}"
+SIGNAL_REBOOT_COMPLETED = "rainmachine_reboot_completed_{0}"
+SIGNAL_REBOOT_REQUESTED = "rainmachine_reboot_requested_{0}"

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -15,5 +15,3 @@ API_WIFI_STATUS = "wifi_status"
 CONF_UID = "uid"
 
 SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED = "guardian_paired_sensor_coordinator_added_{0}"
-SIGNAL_REBOOT_COMPLETED = "rainmachine_reboot_completed_{0}"
-SIGNAL_REBOOT_REQUESTED = "rainmachine_reboot_requested_{0}"

--- a/homeassistant/components/guardian/sensor.py
+++ b/homeassistant/components/guardian/sensor.py
@@ -128,7 +128,7 @@ class PairedSensorSensor(PairedSensorEntity, SensorEntity):
 
     @callback
     def _async_update_from_latest_data(self) -> None:
-        """Update the entity."""
+        """Update the entity's underlying data."""
         if self.entity_description.key == SENSOR_KIND_BATTERY:
             self._attr_native_value = self.coordinator.data["battery"]
         elif self.entity_description.key == SENSOR_KIND_TEMPERATURE:
@@ -142,7 +142,7 @@ class ValveControllerSensor(ValveControllerEntity, SensorEntity):
 
     @callback
     def _async_update_from_latest_data(self) -> None:
-        """Update the entity."""
+        """Update the entity's underlying data."""
         if self.entity_description.key == SENSOR_KIND_TEMPERATURE:
             self._attr_native_value = self.coordinator.data["temperature"]
         elif self.entity_description.key == SENSOR_KIND_UPTIME:

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -10,8 +10,7 @@ from aioguardian import Client
 from aioguardian.errors import GuardianError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -24,6 +23,8 @@ SIGNAL_REBOOT_REQUESTED = "guardian_reboot_requested_{0}"
 
 class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
     """Define an extended DataUpdateCoordinator with some Guardian goodies."""
+
+    config_entry: ConfigEntry
 
     def __init__(
         self,
@@ -79,9 +80,9 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         )
 
         @callback
-        def async_teardown(_: Event) -> None:
+        def async_teardown() -> None:
             """Tear the coordinator down appropriately."""
             for unsub in self._signal_handler_unsubs:
                 unsub()
 
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_teardown)
+        self.config_entry.async_on_unload(async_teardown)

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -9,12 +9,16 @@ from typing import Any, cast
 from aioguardian import Client
 from aioguardian.errors import GuardianError
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import LOGGER
 
 DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
+
+SIGNAL_REBOOT_REQUESTED = "rainmachine_reboot_requested_{0}"
 
 
 class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
@@ -41,6 +45,12 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._api_coro = api_coro
         self._api_lock = api_lock
         self._client = client
+        self._signal_handler_unsubs: list[Callable[..., None]] = []
+
+        assert self.config_entry
+        self.signal_reboot_requested = SIGNAL_REBOOT_REQUESTED.format(
+            self.config_entry.entry_id
+        )
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Execute a "locked" API request against the valve controller."""
@@ -51,14 +61,25 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                 raise UpdateFailed(err) from err
         return cast(dict[str, Any], resp["data"])
 
-    @callback
-    def async_respond_to_reboot_completed(self) -> None:
-        """Respond to reboot complete."""
-        self.last_update_success = True
-        self.async_update_listeners()
+    async def async_initialize(self) -> None:
+        """Initialize the coordinator."""
 
-    @callback
-    def async_respond_to_reboot_requested(self) -> None:
-        """Respond to a reboot request."""
-        self.last_update_success = False
-        self.async_update_listeners()
+        @callback
+        def async_reboot_requested() -> None:
+            """Respond to a reboot request."""
+            self.last_update_success = False
+            self.async_update_listeners()
+
+        self._signal_handler_unsubs.append(
+            async_dispatcher_connect(
+                self.hass, self.signal_reboot_requested, async_reboot_requested
+            )
+        )
+
+        @callback
+        def async_teardown(_: Event) -> None:
+            """Tear the coordinator down appropriately."""
+            for unsub in self._signal_handler_unsubs:
+                unsub()
+
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_teardown)

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -47,9 +47,8 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._client = client
         self._signal_handler_unsubs: list[Callable[..., None]] = []
 
-        assert self.config_entry
         self.signal_reboot_requested = SIGNAL_REBOOT_REQUESTED.format(
-            self.config_entry.entry_id
+            self.config_entry.entry_id  # type: ignore[union-attr]
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from aioguardian import Client
 from aioguardian.errors import GuardianError
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -28,6 +29,7 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self,
         hass: HomeAssistant,
         *,
+        entry: ConfigEntry,
         client: Client,
         api_name: str,
         api_coro: Callable[..., Awaitable],
@@ -47,8 +49,9 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._client = client
         self._signal_handler_unsubs: list[Callable[..., None]] = []
 
+        self.config_entry = entry
         self.signal_reboot_requested = SIGNAL_REBOOT_REQUESTED.format(
-            self.config_entry.entry_id  # type: ignore[union-attr]
+            self.config_entry.entry_id
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 from aioguardian import Client
 from aioguardian.errors import GuardianError
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import LOGGER
@@ -50,3 +50,15 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             except GuardianError as err:
                 raise UpdateFailed(err) from err
         return cast(dict[str, Any], resp["data"])
+
+    @callback
+    def async_respond_to_reboot_completed(self) -> None:
+        """Respond to reboot complete."""
+        self.last_update_success = True
+        self.async_update_listeners()
+
+    @callback
+    def async_respond_to_reboot_requested(self) -> None:
+        """Respond to a reboot request."""
+        self.last_update_success = False
+        self.async_update_listeners()

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -18,7 +18,7 @@ from .const import LOGGER
 
 DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
 
-SIGNAL_REBOOT_REQUESTED = "rainmachine_reboot_requested_{0}"
+SIGNAL_REBOOT_REQUESTED = "guardian_reboot_requested_{0}"
 
 
 class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict]):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/75028 added a `reboot` button to Guardian, but it was "fire and forget" – users could still interact with entities when the controller was rebooting (resulting in errors and a poor user experience). This PR modifies that logic a bit to turn all Guardian entities `unavailable` as soon as a reboot occurs and turn them back to `available` once the API is back up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/75028
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
