### PR TITLE
Various cleanups in AdGuard Home

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,6 +23,7 @@ omit =
     homeassistant/components/adax/climate.py
     homeassistant/components/adguard/__init__.py
     homeassistant/components/adguard/const.py
+    homeassistant/components/adguard/entity.py
     homeassistant/components/adguard/sensor.py
     homeassistant/components/adguard/switch.py
     homeassistant/components/ads/*

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -1,12 +1,10 @@
 """Support for AdGuard Home."""
 from __future__ import annotations
 
-import logging
-
-from adguardhome import AdGuardHome, AdGuardHomeConnectionError, AdGuardHomeError
+from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -22,13 +20,10 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import (
     CONF_FORCE,
     DATA_ADGUARD_CLIENT,
-    DATA_ADGUARD_VERSION,
     DOMAIN,
     SERVICE_ADD_URL,
     SERVICE_DISABLE_URL,
@@ -36,8 +31,6 @@ from .const import (
     SERVICE_REFRESH,
     SERVICE_REMOVE_URL,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 SERVICE_URL_SCHEMA = vol.Schema({vol.Required(CONF_URL): cv.url})
 SERVICE_ADD_URL_SCHEMA = vol.Schema(
@@ -127,93 +120,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         del hass.data[DOMAIN]
 
     return unload_ok
-
-
-class AdGuardHomeEntity(Entity):
-    """Defines a base AdGuard Home entity."""
-
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        adguard: AdGuardHome,
-        entry: ConfigEntry,
-        name: str | None,
-        icon: str | None,
-        enabled_default: bool = True,
-    ) -> None:
-        """Initialize the AdGuard Home entity."""
-        self._available = True
-        self._enabled_default = enabled_default
-        self._icon = icon
-        self._name = name
-        self._entry = entry
-        self.adguard = adguard
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the entity."""
-        return self._name
-
-    @property
-    def icon(self) -> str | None:
-        """Return the mdi icon of the entity."""
-        return self._icon
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return self._enabled_default
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self._available
-
-    async def async_update(self) -> None:
-        """Update AdGuard Home entity."""
-        if not self.enabled:
-            return
-
-        try:
-            await self._adguard_update()
-            self._available = True
-        except AdGuardHomeError:
-            if self._available:
-                _LOGGER.debug(
-                    "An error occurred while updating AdGuard Home sensor",
-                    exc_info=True,
-                )
-            self._available = False
-
-    async def _adguard_update(self) -> None:
-        """Update AdGuard Home entity."""
-        raise NotImplementedError()
-
-
-class AdGuardHomeDeviceEntity(AdGuardHomeEntity):
-    """Defines a AdGuard Home device entity."""
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this AdGuard Home instance."""
-        if self._entry.source == SOURCE_HASSIO:
-            config_url = "homeassistant://hassio/ingress/a0d7b954_adguard"
-        else:
-            if self.adguard.tls:
-                config_url = f"https://{self.adguard.host}:{self.adguard.port}"
-            else:
-                config_url = f"http://{self.adguard.host}:{self.adguard.port}"
-
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={
-                (DOMAIN, self.adguard.host, self.adguard.port, self.adguard.base_path)  # type: ignore[arg-type]
-            },
-            manufacturer="AdGuard Team",
-            name="AdGuard Home",
-            sw_version=self.hass.data[DOMAIN][self._entry.entry_id].get(
-                DATA_ADGUARD_VERSION
-            ),
-            configuration_url=config_url,
-        )

--- a/homeassistant/components/adguard/const.py
+++ b/homeassistant/components/adguard/const.py
@@ -1,6 +1,9 @@
 """Constants for the AdGuard Home integration."""
+import logging
 
 DOMAIN = "adguard"
+
+LOGGER = logging.getLogger(__package__)
 
 DATA_ADGUARD_CLIENT = "adguard_client"
 DATA_ADGUARD_VERSION = "adguard_version"

--- a/homeassistant/components/adguard/entity.py
+++ b/homeassistant/components/adguard/entity.py
@@ -1,0 +1,70 @@
+"""AdGuard Home base entity."""
+from __future__ import annotations
+
+from adguardhome import AdGuardHome, AdGuardHomeError
+
+from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo, Entity
+
+from .const import DATA_ADGUARD_VERSION, DOMAIN, LOGGER
+
+
+class AdGuardHomeEntity(Entity):
+    """Defines a base AdGuard Home entity."""
+
+    _attr_has_entity_name = True
+    _attr_available = True
+
+    def __init__(
+        self,
+        adguard: AdGuardHome,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the AdGuard Home entity."""
+        self._entry = entry
+        self.adguard = adguard
+
+    async def async_update(self) -> None:
+        """Update AdGuard Home entity."""
+        if not self.enabled:
+            return
+
+        try:
+            await self._adguard_update()
+            self._attr_available = True
+        except AdGuardHomeError:
+            if self._attr_available:
+                LOGGER.debug(
+                    "An error occurred while updating AdGuard Home sensor",
+                    exc_info=True,
+                )
+            self._attr_available = False
+
+    async def _adguard_update(self) -> None:
+        """Update AdGuard Home entity."""
+        raise NotImplementedError()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this AdGuard Home instance."""
+        if self._entry.source == SOURCE_HASSIO:
+            config_url = "homeassistant://hassio/ingress/a0d7b954_adguard"
+        else:
+            if self.adguard.tls:
+                config_url = f"https://{self.adguard.host}:{self.adguard.port}"
+            else:
+                config_url = f"http://{self.adguard.host}:{self.adguard.port}"
+
+        return DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={
+                (DOMAIN, self.adguard.host, self.adguard.port, self.adguard.base_path)  # type: ignore[arg-type]
+            },
+            manufacturer="AdGuard Team",
+            name="AdGuard Home",
+            sw_version=self.hass.data[DOMAIN][self._entry.entry_id].get(
+                DATA_ADGUARD_VERSION
+            ),
+            configuration_url=config_url,
+        )

--- a/homeassistant/components/adguard/entity.py
+++ b/homeassistant/components/adguard/entity.py
@@ -50,11 +50,10 @@ class AdGuardHomeEntity(Entity):
         """Return device information about this AdGuard Home instance."""
         if self._entry.source == SOURCE_HASSIO:
             config_url = "homeassistant://hassio/ingress/a0d7b954_adguard"
+        elif self.adguard.tls:
+            config_url = f"https://{self.adguard.host}:{self.adguard.port}"
         else:
-            if self.adguard.tls:
-                config_url = f"https://{self.adguard.host}:{self.adguard.port}"
-            else:
-                config_url = f"http://{self.adguard.host}:{self.adguard.port}"
+            config_url = f"http://{self.adguard.host}:{self.adguard.port}"
 
         return DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -15,8 +15,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import AdGuardHomeDeviceEntity
 from .const import DATA_ADGUARD_CLIENT, DATA_ADGUARD_VERSION, DOMAIN
+from .entity import AdGuardHomeEntity
 
 SCAN_INTERVAL = timedelta(seconds=300)
 PARALLEL_UPDATES = 4
@@ -118,7 +118,7 @@ async def async_setup_entry(
     )
 
 
-class AdGuardHomeSensor(AdGuardHomeDeviceEntity, SensorEntity):
+class AdGuardHomeSensor(AdGuardHomeEntity, SensorEntity):
     """Defines a AdGuard Home sensor."""
 
     entity_description: AdGuardHomeEntityDescription
@@ -130,8 +130,8 @@ class AdGuardHomeSensor(AdGuardHomeDeviceEntity, SensorEntity):
         description: AdGuardHomeEntityDescription,
     ) -> None:
         """Initialize AdGuard Home sensor."""
+        super().__init__(adguard, entry)
         self.entity_description = description
-
         self._attr_unique_id = "_".join(
             [
                 DOMAIN,
@@ -140,14 +140,6 @@ class AdGuardHomeSensor(AdGuardHomeDeviceEntity, SensorEntity):
                 "sensor",
                 description.key,
             ]
-        )
-
-        super().__init__(
-            adguard,
-            entry,
-            description.name,
-            description.icon,
-            description.entity_registry_enabled_default,
         )
 
     async def _adguard_update(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

ℹ️ This is a small step in extending, modernizing this integration, trying to get it to a platinum level integration. This means this PR might not fix/optimize it all but is one step closer to that direction. More PRs inbound after this one.

This PR combines a bunch of smaller cleanups that can be done, since the introduction of `EntityDescription`s in the previous PRs.

- Move logger to const (package level logger)
- Combine the base entity class and base device class, into a single base entity and moved it into `entity.py`
- Use `_attr_available` instead of the property method
- Remove `name`, `icon`, and `entity_registry_enabled_default` property methods from base class, letting entity descriptions handle that.

This PR does not change anything functional or user-facing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
