### PR TITLE
Migrate BraviaTV to new entity naming style

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -136,6 +136,7 @@ omit =
     homeassistant/components/bosch_shc/switch.py
     homeassistant/components/braviatv/__init__.py
     homeassistant/components/braviatv/const.py
+    homeassistant/components/braviatv/entity.py
     homeassistant/components/braviatv/media_player.py
     homeassistant/components/braviatv/remote.py
     homeassistant/components/broadlink/__init__.py

--- a/homeassistant/components/braviatv/const.py
+++ b/homeassistant/components/braviatv/const.py
@@ -12,6 +12,5 @@ CONF_IGNORED_SOURCES: Final = "ignored_sources"
 
 BRAVIA_CONFIG_FILE: Final = "bravia.conf"
 CLIENTID_PREFIX: Final = "HomeAssistant"
-DEFAULT_NAME: Final = f"{ATTR_MANUFACTURER} Bravia TV"
 DOMAIN: Final = "braviatv"
 NICKNAME: Final = "Home Assistant"

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -7,7 +7,7 @@ from .const import ATTR_MANUFACTURER, DOMAIN
 
 
 class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
-    """Tractive entity class."""
+    """BraviaTV entity class."""
 
     def __init__(
         self,

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -1,4 +1,6 @@
 """A entity class for BraviaTV integration."""
+from typing import Any
+
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -9,6 +11,8 @@ from .const import ATTR_MANUFACTURER, DOMAIN
 class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
     """BraviaTV entity class."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: BraviaTVCoordinator,
@@ -18,9 +22,18 @@ class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
 
+        self._attr_unique_id = unique_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},
             manufacturer=ATTR_MANUFACTURER,
             model=model,
             name=f"{ATTR_MANUFACTURER} {model}",
         )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        await self.coordinator.async_turn_on()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        await self.coordinator.async_turn_off()

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -1,0 +1,26 @@
+"""A entity class for BraviaTV integration."""
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import BraviaTVCoordinator
+from .const import ATTR_MANUFACTURER, DOMAIN
+
+
+class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
+    """Tractive entity class."""
+
+    def __init__(
+        self,
+        coordinator: BraviaTVCoordinator,
+        unique_id: str,
+        model: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            manufacturer=ATTR_MANUFACTURER,
+            model=model,
+            name=f"{ATTR_MANUFACTURER} {model}",
+        )

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -1,6 +1,4 @@
 """A entity class for BraviaTV integration."""
-from typing import Any
-
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -29,11 +27,3 @@ class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
             model=model,
             name=f"{ATTR_MANUFACTURER} {model}",
         )
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the device on."""
-        await self.coordinator.async_turn_on()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the device off."""
-        await self.coordinator.async_turn_off()

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -91,6 +91,14 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
         """Duration of current playing media in seconds."""
         return self.coordinator.duration
 
+    async def async_turn_on(self) -> None:
+        """Turn the device on."""
+        await self.coordinator.async_turn_on()
+
+    async def async_turn_off(self) -> None:
+        """Turn the device off."""
+        await self.coordinator.async_turn_off()
+
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self.coordinator.async_set_volume_level(volume)

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -9,12 +9,11 @@ from homeassistant.components.media_player import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BraviaTVCoordinator
-from .const import ATTR_MANUFACTURER, DEFAULT_NAME, DOMAIN
+from .const import DOMAIN
+from .entity import BraviaTVEntity
 
 
 async def async_setup_entry(
@@ -27,17 +26,13 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     unique_id = config_entry.unique_id
     assert unique_id is not None
-    device_info = DeviceInfo(
-        identifiers={(DOMAIN, unique_id)},
-        manufacturer=ATTR_MANUFACTURER,
-        model=config_entry.title,
-        name=DEFAULT_NAME,
+
+    async_add_entities(
+        [BraviaTVMediaPlayer(coordinator, unique_id, config_entry.title)]
     )
 
-    async_add_entities([BraviaTVMediaPlayer(coordinator, unique_id, device_info)])
 
-
-class BraviaTVMediaPlayer(CoordinatorEntity[BraviaTVCoordinator], MediaPlayerEntity):
+class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     """Representation of a Bravia TV Media Player."""
 
     _attr_device_class = MediaPlayerDeviceClass.TV
@@ -60,14 +55,12 @@ class BraviaTVMediaPlayer(CoordinatorEntity[BraviaTVCoordinator], MediaPlayerEnt
         self,
         coordinator: BraviaTVCoordinator,
         unique_id: str,
-        device_info: DeviceInfo,
+        model: str,
     ) -> None:
         """Initialize the entity."""
-
-        self._attr_device_info = device_info
         self._attr_unique_id = unique_id
 
-        super().__init__(coordinator)
+        super().__init__(coordinator, unique_id, model)
 
     @property
     def state(self) -> str | None:

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -11,7 +11,6 @@ from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BraviaTVCoordinator
 from .const import DOMAIN
 from .entity import BraviaTVEntity
 
@@ -36,7 +35,6 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     """Representation of a Bravia TV Media Player."""
 
     _attr_device_class = MediaPlayerDeviceClass.TV
-    _attr_has_entity_name = True
     _attr_supported_features = (
         MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.VOLUME_STEP
@@ -50,17 +48,6 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.PLAY
         | MediaPlayerEntityFeature.STOP
     )
-
-    def __init__(
-        self,
-        coordinator: BraviaTVCoordinator,
-        unique_id: str,
-        model: str,
-    ) -> None:
-        """Initialize the entity."""
-        self._attr_unique_id = unique_id
-
-        super().__init__(coordinator, unique_id, model)
 
     @property
     def state(self) -> str | None:
@@ -103,14 +90,6 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     def media_duration(self) -> int | None:
         """Duration of current playing media in seconds."""
         return self.coordinator.duration
-
-    async def async_turn_on(self) -> None:
-        """Turn the device on."""
-        await self.coordinator.async_turn_on()
-
-    async def async_turn_off(self) -> None:
-        """Turn the device off."""
-        await self.coordinator.async_turn_off()
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -34,15 +34,14 @@ async def async_setup_entry(
         name=DEFAULT_NAME,
     )
 
-    async_add_entities(
-        [BraviaTVMediaPlayer(coordinator, DEFAULT_NAME, unique_id, device_info)]
-    )
+    async_add_entities([BraviaTVMediaPlayer(coordinator, unique_id, device_info)])
 
 
 class BraviaTVMediaPlayer(CoordinatorEntity[BraviaTVCoordinator], MediaPlayerEntity):
     """Representation of a Bravia TV Media Player."""
 
     _attr_device_class = MediaPlayerDeviceClass.TV
+    _attr_has_entity_name = True
     _attr_supported_features = (
         MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.VOLUME_STEP
@@ -60,14 +59,12 @@ class BraviaTVMediaPlayer(CoordinatorEntity[BraviaTVCoordinator], MediaPlayerEnt
     def __init__(
         self,
         coordinator: BraviaTVCoordinator,
-        name: str,
         unique_id: str,
         device_info: DeviceInfo,
     ) -> None:
         """Initialize the entity."""
 
         self._attr_device_info = device_info
-        self._attr_name = name
         self._attr_unique_id = unique_id
 
         super().__init__(coordinator)

--- a/homeassistant/components/braviatv/remote.py
+++ b/homeassistant/components/braviatv/remote.py
@@ -9,7 +9,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BraviaTVCoordinator
 from .const import DOMAIN
 from .entity import BraviaTVEntity
 
@@ -31,31 +30,10 @@ async def async_setup_entry(
 class BraviaTVRemote(BraviaTVEntity, RemoteEntity):
     """Representation of a Bravia TV Remote."""
 
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        coordinator: BraviaTVCoordinator,
-        unique_id: str,
-        model: str,
-    ) -> None:
-        """Initialize the entity."""
-        self._attr_unique_id = unique_id
-
-        super().__init__(coordinator, unique_id, model)
-
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.coordinator.is_on
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the device on."""
-        await self.coordinator.async_turn_on()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the device off."""
-        await self.coordinator.async_turn_off()
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to device."""

--- a/homeassistant/components/braviatv/remote.py
+++ b/homeassistant/components/braviatv/remote.py
@@ -32,25 +32,23 @@ async def async_setup_entry(
         name=DEFAULT_NAME,
     )
 
-    async_add_entities(
-        [BraviaTVRemote(coordinator, DEFAULT_NAME, unique_id, device_info)]
-    )
+    async_add_entities([BraviaTVRemote(coordinator, unique_id, device_info)])
 
 
 class BraviaTVRemote(CoordinatorEntity[BraviaTVCoordinator], RemoteEntity):
     """Representation of a Bravia TV Remote."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: BraviaTVCoordinator,
-        name: str,
         unique_id: str,
         device_info: DeviceInfo,
     ) -> None:
         """Initialize the entity."""
 
         self._attr_device_info = device_info
-        self._attr_name = name
         self._attr_unique_id = unique_id
 
         super().__init__(coordinator)

--- a/homeassistant/components/braviatv/remote.py
+++ b/homeassistant/components/braviatv/remote.py
@@ -35,6 +35,14 @@ class BraviaTVRemote(BraviaTVEntity, RemoteEntity):
         """Return true if device is on."""
         return self.coordinator.is_on
 
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        await self.coordinator.async_turn_on()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        await self.coordinator.async_turn_off()
+
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to device."""
         repeats = kwargs[ATTR_NUM_REPEATS]

--- a/homeassistant/components/braviatv/remote.py
+++ b/homeassistant/components/braviatv/remote.py
@@ -7,12 +7,11 @@ from typing import Any
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BraviaTVCoordinator
-from .const import ATTR_MANUFACTURER, DEFAULT_NAME, DOMAIN
+from .const import DOMAIN
+from .entity import BraviaTVEntity
 
 
 async def async_setup_entry(
@@ -25,17 +24,11 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     unique_id = config_entry.unique_id
     assert unique_id is not None
-    device_info = DeviceInfo(
-        identifiers={(DOMAIN, unique_id)},
-        manufacturer=ATTR_MANUFACTURER,
-        model=config_entry.title,
-        name=DEFAULT_NAME,
-    )
 
-    async_add_entities([BraviaTVRemote(coordinator, unique_id, device_info)])
+    async_add_entities([BraviaTVRemote(coordinator, unique_id, config_entry.title)])
 
 
-class BraviaTVRemote(CoordinatorEntity[BraviaTVCoordinator], RemoteEntity):
+class BraviaTVRemote(BraviaTVEntity, RemoteEntity):
     """Representation of a Bravia TV Remote."""
 
     _attr_has_entity_name = True
@@ -44,14 +37,12 @@ class BraviaTVRemote(CoordinatorEntity[BraviaTVCoordinator], RemoteEntity):
         self,
         coordinator: BraviaTVCoordinator,
         unique_id: str,
-        device_info: DeviceInfo,
+        model: str,
     ) -> None:
         """Initialize the entity."""
-
-        self._attr_device_info = device_info
         self._attr_unique_id = unique_id
 
-        super().__init__(coordinator)
+        super().__init__(coordinator, unique_id, model)
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR migrates BraviaTV to the new style entity naming. Besides, I removed the duplicate code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
