### PR TITLE
Use pydeconz interface controls for lights

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any, cast
 import async_timeout
 from pydeconz import DeconzSession, errors
 from pydeconz.interfaces import sensors
-from pydeconz.interfaces.api import APIItems, GroupedAPIItems
-from pydeconz.interfaces.groups import Groups
+from pydeconz.interfaces.api_handlers import APIHandler, GroupedAPIHandler
+from pydeconz.interfaces.groups import GroupHandler
 from pydeconz.models.event import EventType
 
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
@@ -127,7 +127,7 @@ class DeconzGateway:
     def register_platform_add_device_callback(
         self,
         add_device_callback: Callable[[EventType, str], None],
-        deconz_device_interface: APIItems | GroupedAPIItems,
+        deconz_device_interface: APIHandler | GroupedAPIHandler,
         always_ignore_clip_sensors: bool = False,
     ) -> None:
         """Wrap add_device_callback to check allow_new_devices option."""
@@ -148,7 +148,7 @@ class DeconzGateway:
                 self.ignored_devices.add((async_add_device, device_id))
                 return
 
-            if isinstance(deconz_device_interface, Groups):
+            if isinstance(deconz_device_interface, GroupHandler):
                 self.deconz_groups.add((async_add_device, device_id))
                 if not self.option_allow_deconz_groups:
                     return

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -3,16 +3,12 @@ from __future__ import annotations
 
 from typing import Any, Generic, TypedDict, TypeVar
 
+from pydeconz.interfaces.groups import GroupHandler
+from pydeconz.interfaces.lights import LightHandler
 from pydeconz.models import ResourceType
 from pydeconz.models.event import EventType
 from pydeconz.models.group import Group
-from pydeconz.models.light import (
-    ALERT_LONG,
-    ALERT_SHORT,
-    EFFECT_COLOR_LOOP,
-    EFFECT_NONE,
-)
-from pydeconz.models.light.light import Light
+from pydeconz.models.light.light import Light, LightAlert, LightColorMode, LightEffect
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -42,8 +38,14 @@ from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 DECONZ_GROUP = "is_deconz_group"
-EFFECT_TO_DECONZ = {EFFECT_COLORLOOP: EFFECT_COLOR_LOOP, "None": EFFECT_NONE}
-FLASH_TO_DECONZ = {FLASH_SHORT: ALERT_SHORT, FLASH_LONG: ALERT_LONG}
+EFFECT_TO_DECONZ = {EFFECT_COLORLOOP: LightEffect.COLOR_LOOP, "None": LightEffect.NONE}
+FLASH_TO_DECONZ = {FLASH_SHORT: LightAlert.SHORT, FLASH_LONG: LightAlert.LONG}
+
+DECONZ_TO_COLOR_MODE = {
+    LightColorMode.CT: ColorMode.COLOR_TEMP,
+    LightColorMode.HS: ColorMode.HS,
+    LightColorMode.XY: ColorMode.XY,
+}
 
 _L = TypeVar("_L", Group, Light)
 
@@ -51,10 +53,10 @@ _L = TypeVar("_L", Group, Light)
 class SetStateAttributes(TypedDict, total=False):
     """Attributes available with set state call."""
 
-    alert: str
+    alert: LightAlert
     brightness: int
     color_temperature: int
-    effect: str
+    effect: LightEffect
     hue: int
     on: bool
     saturation: int
@@ -130,7 +132,13 @@ class DeconzBaseLight(Generic[_L], DeconzDevice, LightEntity):
         """Set up light."""
         super().__init__(device, gateway)
 
-        self._attr_supported_color_modes: set[str] = set()
+        self.api: GroupHandler | LightHandler
+        if isinstance(self._device, Light):
+            self.api = self.gateway.api.lights.lights
+        elif isinstance(self._device, Group):
+            self.api = self.gateway.api.groups
+
+        self._attr_supported_color_modes: set[ColorMode] = set()
 
         if device.color_temp is not None:
             self._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
@@ -158,12 +166,8 @@ class DeconzBaseLight(Generic[_L], DeconzDevice, LightEntity):
     @property
     def color_mode(self) -> str | None:
         """Return the color mode of the light."""
-        if self._device.color_mode == "ct":
-            color_mode = ColorMode.COLOR_TEMP
-        elif self._device.color_mode == "hs":
-            color_mode = ColorMode.HS
-        elif self._device.color_mode == "xy":
-            color_mode = ColorMode.XY
+        if self._device.color_mode in DECONZ_TO_COLOR_MODE:
+            color_mode = DECONZ_TO_COLOR_MODE[self._device.color_mode]
         elif self._device.brightness is not None:
             color_mode = ColorMode.BRIGHTNESS
         else:
@@ -229,7 +233,7 @@ class DeconzBaseLight(Generic[_L], DeconzDevice, LightEntity):
         if ATTR_EFFECT in kwargs and kwargs[ATTR_EFFECT] in EFFECT_TO_DECONZ:
             data["effect"] = EFFECT_TO_DECONZ[kwargs[ATTR_EFFECT]]
 
-        await self._device.set_state(**data)
+        await self.api.set_state(id=self._device.resource_id, **data)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off light."""
@@ -246,7 +250,7 @@ class DeconzBaseLight(Generic[_L], DeconzDevice, LightEntity):
             data["alert"] = FLASH_TO_DECONZ[kwargs[ATTR_FLASH]]
             del data["on"]
 
-        await self._device.set_state(**data)
+        await self.api.set_state(id=self._device.resource_id, **data)
 
     @property
     def extra_state_attributes(self) -> dict[str, bool]:

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==99"],
+  "requirements": ["pydeconz==100"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/mypy.ini
+++ b/mypy.ini
@@ -2697,4 +2697,3 @@ ignore_errors = true
 
 [mypy-homeassistant.components.sonos.statistics]
 ignore_errors = true
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1447,7 +1447,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==99
+pydeconz==100
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -980,7 +980,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==99
+pydeconz==100
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move controls over to the interface classes in pydeconz
Use enums rather than constants

Similar to 
- https://github.com/home-assistant/core/pull/72317
- https://github.com/home-assistant/core/pull/73670
- https://github.com/home-assistant/core/pull/73748
- https://github.com/home-assistant/core/pull/74535
- https://github.com/home-assistant/core/pull/74654
- https://github.com/home-assistant/core/pull/74666
- https://github.com/home-assistant/core/pull/75156

Library bump https://github.com/Kane610/deconz/compare/v99...v100
Mostly changes related to what was needed for this PR, with the goal of separating controls and data models.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
