### PR TITLE
Fix Epson wrong volume value

### DIFF
--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -3,7 +3,7 @@
   "name": "Epson",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
-  "requirements": ["epson-projector==0.4.2"],
+  "requirements": ["epson-projector==0.4.4"],
   "codeowners": ["@pszafer"],
   "iot_class": "local_polling",
   "loggers": ["epson_projector"]

--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -3,7 +3,7 @@
   "name": "Epson",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
-  "requirements": ["epson-projector==0.4.4"],
+  "requirements": ["epson-projector==0.4.6"],
   "codeowners": ["@pszafer"],
   "iot_class": "local_polling",
   "loggers": ["epson_projector"]

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -179,11 +179,13 @@ class EpsonProjectorMediaPlayer(MediaPlayerEntity):
         """Turn on epson."""
         if self._state == STATE_OFF:
             await self._projector.send_command(TURN_ON)
+            self._state = STATE_ON
 
     async def async_turn_off(self):
         """Turn off epson."""
         if self._state == STATE_ON:
             await self._projector.send_command(TURN_OFF)
+            self._state = STATE_OFF
 
     @property
     def source_list(self):

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -133,7 +133,10 @@ class EpsonProjectorMediaPlayer(MediaPlayerEntity):
             self._source = SOURCE_LIST.get(source, self._source)
             volume = await self._projector.get_property(VOLUME)
             if volume:
-                self._volume = volume
+                try:
+                    self._volume = float(volume)
+                except ValueError:
+                    pass
         elif power_state == BUSY:
             self._state = STATE_ON
         else:

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -136,7 +136,7 @@ class EpsonProjectorMediaPlayer(MediaPlayerEntity):
                 try:
                     self._volume = float(volume)
                 except ValueError:
-                    pass
+                    self._volume = None
         elif power_state == BUSY:
             self._state = STATE_ON
         else:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -613,7 +613,7 @@ envoy_reader==0.20.1
 ephem==4.1.2
 
 # homeassistant.components.epson
-epson-projector==0.4.2
+epson-projector==0.4.4
 
 # homeassistant.components.epsonworkforce
 epsonprinter==0.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -613,7 +613,7 @@ envoy_reader==0.20.1
 ephem==4.1.2
 
 # homeassistant.components.epson
-epson-projector==0.4.4
+epson-projector==0.4.6
 
 # homeassistant.components.epsonworkforce
 epsonprinter==0.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -453,7 +453,7 @@ envoy_reader==0.20.1
 ephem==4.1.2
 
 # homeassistant.components.epson
-epson-projector==0.4.4
+epson-projector==0.4.6
 
 # homeassistant.components.faa_delays
 faadelays==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -453,7 +453,7 @@ envoy_reader==0.20.1
 ephem==4.1.2
 
 # homeassistant.components.epson
-epson-projector==0.4.2
+epson-projector==0.4.4
 
 # homeassistant.components.faa_delays
 faadelays==0.0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some Epson projectors with wrong hdmi connection (?) returns ERR as volume level. It shouldn't return anything.
Also I upgraded upstream library so it won't pass loop to create_connection (remove in python 3.10).

I'm unable to test those changes locally as my projector returns value for volume always.
Would be nice if @Anto79-ops tested it.
I also added optimistic state update for turn_on and turn_off operation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74342 , #75604
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. -> https://github.com/pszafer/epson_projector/compare/cdc4b45...f64b0d2
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
