### PR TITLE
Add power saving zone ID sensor to Tractive integration

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     ATTR_LED,
     ATTR_LIVE_TRACKING,
     ATTR_MINUTES_ACTIVE,
+    ATTR_POWER_SAVING_ZONE,
     ATTR_TRACKER_STATE,
     CLIENT,
     CLIENT_ID,
@@ -233,6 +234,7 @@ class TractiveClient:
             ATTR_LIVE_TRACKING: event.get("live_tracking", {}).get("active"),
             ATTR_BUZZER: event.get("buzzer_control", {}).get("active"),
             ATTR_LED: event.get("led_control", {}).get("active"),
+            ATTR_POWER_SAVING_ZONE: event["hardware"]["power_saving_zone_id"],
         }
         self._dispatch_tracker_event(
             TRACKER_HARDWARE_STATUS_UPDATED, event["tracker_id"], payload

--- a/homeassistant/components/tractive/const.py
+++ b/homeassistant/components/tractive/const.py
@@ -12,6 +12,7 @@ ATTR_LED = "led"
 ATTR_LIVE_TRACKING = "live_tracking"
 ATTR_MINUTES_ACTIVE = "minutes_active"
 ATTR_TRACKER_STATE = "tracker_state"
+ATTR_POWER_SAVING_ZONE = "power_saving"
 
 # This client ID was issued by Tractive specifically for Home Assistant.
 # Please do not use it anywhere else.

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -20,6 +20,7 @@ from . import Trackables
 from .const import (
     ATTR_DAILY_GOAL,
     ATTR_MINUTES_ACTIVE,
+    ATTR_POWER_SAVING_ZONE,
     ATTR_TRACKER_STATE,
     CLIENT,
     DOMAIN,
@@ -160,6 +161,13 @@ SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
         icon="mdi:flag-checkered",
         native_unit_of_measurement=TIME_MINUTES,
         entity_class=TractiveActivitySensor,
+    ),
+    TractiveSensorEntityDescription(
+        key=ATTR_POWER_SAVING_ZONE,
+        name="Power Saving Zone Id",
+        icon="mdid:battery-plus-variant",
+        entity_class=TractiveHardwareSensor,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The latest trackers from tractive contain Wi-Fi to enable power saving zones. These zones are setup within the app and you select Wi-Fi networks that the device will treat as power saving zones. When in this mode, the device enters a reduced power state, disabling mobile data and GPS. This PR adds a diagnostic sensor to expose the current power saving zone that the tracker is in, allowing users to do automations based on pets entering and leaving the range of their Wi-Fi network.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works. There were no tests for the existing functionality

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
