### PR TITLE
Replace SimpliSafe `clear_notifications` service with a button

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1090,6 +1090,7 @@ omit =
     homeassistant/components/simplisafe/__init__.py
     homeassistant/components/simplisafe/alarm_control_panel.py
     homeassistant/components/simplisafe/binary_sensor.py
+    homeassistant/components/simplisafe/button.py
     homeassistant/components/simplisafe/lock.py
     homeassistant/components/simplisafe/sensor.py
     homeassistant/components/simulated/sensor.py

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -393,7 +393,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "button.press",
             "button.alarm_control_panel_clear_notifications",
-            "2022.11.0",
+            "2022.12.0",
         )
         await system.async_clear_notifications()
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -126,6 +126,7 @@ EVENT_SIMPLISAFE_NOTIFICATION = "SIMPLISAFE_NOTIFICATION"
 PLATFORMS = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.LOCK,
     Platform.SENSOR,
 ]
@@ -258,6 +259,25 @@ def _async_get_system_for_service_call(
 
 
 @callback
+def _async_log_deprecated_service_call(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    alternate_service: str,
+    alternate_target: str,
+) -> None:
+    """Log a warning about a deprecated service call."""
+    LOGGER.warning(
+        (
+            'The "%s" service is deprecated and will be removed in a future version; '
+            'use the "%s" service and pass it a target entity ID of "%s"'
+        ),
+        f"{call.domain}.{call.service}",
+        alternate_service,
+        alternate_target,
+    )
+
+
+@callback
 def _async_register_base_station(
     hass: HomeAssistant, entry: ConfigEntry, system: SystemType
 ) -> None:
@@ -347,6 +367,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     @extract_system
     async def async_clear_notifications(call: ServiceCall, system: SystemType) -> None:
         """Clear all active notifications."""
+        _async_log_deprecated_service_call(
+            hass,
+            call,
+            "button.press",
+            f"button.guardian_valve_controller_{1+1}_reboot",
+        )
         await system.async_clear_notifications()
 
     @_verify_domain_control
@@ -839,9 +865,7 @@ class SimpliSafeEntity(CoordinatorEntity):
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity when new data comes from the REST API."""
-        raise NotImplementedError()
 
     @callback
     def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
         """Update the entity when new data comes from the websocket."""
-        raise NotImplementedError()

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -45,7 +45,6 @@ from simplipy.websocket import (
 )
 import voluptuous as vol
 
-from homeassistant.components.repairs import IssueSeverity, async_create_issue
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_CODE,
@@ -72,6 +71,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.service import (
     async_register_admin_service,
     verify_domain_control,

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -371,7 +371,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             call,
             "button.press",
-            f"button.guardian_valve_controller_{1+1}_reboot",
+            "button.alarm_control_panel_clear_notifications",
         )
         await system.async_clear_notifications()
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -275,7 +275,7 @@ def _async_log_deprecated_service_call(
         DOMAIN,
         f"deprecated_service_{deprecated_service}",
         breaks_in_ha_version=breaks_in_ha_version,
-        is_fixable=False,
+        is_fixable=True,
         is_persistent=True,
         severity=IssueSeverity.WARNING,
         translation_key="deprecated_service",

--- a/homeassistant/components/simplisafe/button.py
+++ b/homeassistant/components/simplisafe/button.py
@@ -1,0 +1,93 @@
+"""Buttons for the SimpliSafe integration."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from simplipy.errors import SimplipyError
+from simplipy.system import System
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SimpliSafe, SimpliSafeEntity
+from .const import DOMAIN
+from .typing import SystemType
+
+
+@dataclass
+class SimpliSafeButtonDescriptionMixin:
+    """Define an entity description mixin for SimpliSafe buttons."""
+
+    push_action: Callable[[System], Awaitable]
+
+
+@dataclass
+class SimpliSafeButtonDescription(
+    ButtonEntityDescription, SimpliSafeButtonDescriptionMixin
+):
+    """Describe a SimpliSafe button description."""
+
+
+BUTTON_KIND_CLEAR_NOTIFICATIONS = "clear_notifications"
+
+
+async def _async_clear_notifications(system: System) -> None:
+    """Reboot the SimpliSafe."""
+    await system.async_clear_notifications()
+
+
+BUTTON_DESCRIPTIONS = (
+    SimpliSafeButtonDescription(
+        key=BUTTON_KIND_CLEAR_NOTIFICATIONS,
+        name="Clear notifications",
+        push_action=_async_clear_notifications,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up SimpliSafe buttons based on a config entry."""
+    simplisafe = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        [
+            SimpliSafeButton(simplisafe, system, description)
+            for system in simplisafe.systems.values()
+            for description in BUTTON_DESCRIPTIONS
+        ]
+    )
+
+
+class SimpliSafeButton(SimpliSafeEntity, ButtonEntity):
+    """Define a SimpliSafe button."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    entity_description: SimpliSafeButtonDescription
+
+    def __init__(
+        self,
+        simplisafe: SimpliSafe,
+        system: SystemType,
+        description: SimpliSafeButtonDescription,
+    ) -> None:
+        """Initialize the SimpliSafe alarm."""
+        super().__init__(simplisafe, system)
+
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        """Send out a restart command."""
+        try:
+            await self.entity_description.push_action(self._system)
+        except SimplipyError as err:
+            raise HomeAssistantError(
+                f'Error while pressing button "{self.entity_id}": {err}'
+            ) from err

--- a/homeassistant/components/simplisafe/button.py
+++ b/homeassistant/components/simplisafe/button.py
@@ -30,7 +30,7 @@ class SimpliSafeButtonDescriptionMixin:
 class SimpliSafeButtonDescription(
     ButtonEntityDescription, SimpliSafeButtonDescriptionMixin
 ):
-    """Describe a SimpliSafe button description."""
+    """Describe a SimpliSafe button entity."""
 
 
 BUTTON_KIND_CLEAR_NOTIFICATIONS = "clear_notifications"

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,6 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
+  "dependencies": ["repairs"],
   "requirements": ["simplisafe-python==2022.07.1"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,6 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "dependencies": ["repairs"],
   "requirements": ["simplisafe-python==2022.07.1"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -1,16 +1,4 @@
 # Describes the format for available SimpliSafe services
-clear_notifications:
-  name: Clear notifications
-  description: Clear any active SimpliSafe notifications
-  fields:
-    device_id:
-      name: System
-      description: The system to remove the PIN from
-      required: true
-      selector:
-        device:
-          integration: simplisafe
-          model: alarm_control_panel
 remove_pin:
   name: Remove PIN
   description: Remove a PIN by its label or value.

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -32,8 +32,8 @@
   },
   "issues": {
     "deprecated_service": {
-      "title": "The {deprecated_service} service is deprecated",
-      "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead."
+      "title": "The {deprecated_service} service is being removed",
+      "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved."
     }
   }
 }

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -29,5 +29,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_service": {
+      "title": "The {deprecated_service} service is deprecated",
+      "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead."
+    }
   }
 }

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -22,8 +22,8 @@
     },
     "issues": {
         "deprecated_service": {
-            "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead.",
-            "title": "The {deprecated_service} service is deprecated"
+            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved.",
+            "title": "The {deprecated_service} service is being removed"
         }
     },
     "options": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "This SimpliSafe account is already in use.",
-            "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
             "reauth_successful": "Re-authentication was successful",
             "wrong_account": "The user credentials provided do not match this SimpliSafe account."
         },
@@ -12,31 +11,19 @@
             "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
             "unknown": "Unexpected error"
         },
-        "progress": {
-            "email_2fa": "Check your email for a verification link from Simplisafe."
-        },
         "step": {
-            "reauth_confirm": {
-                "data": {
-                    "password": "Password"
-                },
-                "description": "Please re-enter the password for {username}.",
-                "title": "Reauthenticate Integration"
-            },
-            "sms_2fa": {
-                "data": {
-                    "code": "Code"
-                },
-                "description": "Input the two-factor authentication code sent to you via SMS."
-            },
             "user": {
                 "data": {
-                    "auth_code": "Authorization Code",
-                    "password": "Password",
-                    "username": "Username"
+                    "auth_code": "Authorization Code"
                 },
                 "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. If you've already logged into SimpliSafe in your browser, you may want to open a new tab, then copy/paste the above URL into that tab.\n\nWhen the process is complete, return here and input the authorization code from the `com.simplisafe.mobile` URL."
             }
+        }
+    },
+    "issues": {
+        "deprecated_service": {
+            "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead.",
+            "title": "The {deprecated_service} service is deprecated"
         }
     },
     "options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR replaces the `clear_notifications` SimpliSafe service with a button.

![CleanShot 2022-07-15 at 12 10 08](https://user-images.githubusercontent.com/47216/179286190-5ca5a581-b315-43d3-afff-d6dba5a0901d.png)

Users will be warned about the service deprecation in the logs:

```
2022-07-15 14:37:44.067 WARNING (MainThread) [homeassistant.components.guardian] The "guardian.reboot" service is deprecated and will be removed in a future version; use the "button.press" service and pass it a target entity ID of "button.alarm_control_panel_clear_notifications"
```

I'll plan on making the breaking change after two versions from when this is merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23670

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
