### PR TITLE
Prevent config fields being assigned to None in Generic Camera options

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -387,12 +387,6 @@ class GenericOptionsFlowHandler(OptionsFlow):
                             CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False
                         ),
                     )
-                if CONF_LIMIT_REFETCH_TO_URL_CHANGE not in user_input:
-                    data[CONF_LIMIT_REFETCH_TO_URL_CHANGE] = (
-                        self.config_entry.options.get(
-                            CONF_LIMIT_REFETCH_TO_URL_CHANGE, False
-                        ),
-                    )
                 return self.async_create_entry(
                     title=title,
                     data=data,

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -264,7 +264,7 @@ async def async_test_stream(
 class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for generic IP camera."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize Generic ConfigFlow."""
@@ -377,26 +377,22 @@ class GenericOptionsFlowHandler(OptionsFlow):
                     # The automatically generated still image that stream generates
                     # is always jpeg
                     still_format = "image/jpeg"
-                data = {
-                    CONF_AUTHENTICATION: user_input.get(CONF_AUTHENTICATION),
-                    CONF_STREAM_SOURCE: user_input.get(CONF_STREAM_SOURCE),
-                    CONF_PASSWORD: user_input.get(CONF_PASSWORD),
-                    CONF_STILL_IMAGE_URL: user_input.get(CONF_STILL_IMAGE_URL),
-                    CONF_CONTENT_TYPE: still_format
-                    or self.config_entry.options.get(CONF_CONTENT_TYPE),
-                    CONF_USERNAME: user_input.get(CONF_USERNAME),
-                    CONF_LIMIT_REFETCH_TO_URL_CHANGE: user_input[
-                        CONF_LIMIT_REFETCH_TO_URL_CHANGE
-                    ],
-                    CONF_FRAMERATE: user_input[CONF_FRAMERATE],
-                    CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
-                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS: user_input.get(
-                        CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+                data = user_input
+                data[CONF_CONTENT_TYPE] = still_format or self.config_entry.options.get(
+                    CONF_CONTENT_TYPE
+                )
+                if CONF_USE_WALLCLOCK_AS_TIMESTAMPS not in user_input:
+                    data[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = (
                         self.config_entry.options.get(
                             CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False
                         ),
-                    ),
-                }
+                    )
+                if CONF_LIMIT_REFETCH_TO_URL_CHANGE not in user_input:
+                    data[CONF_LIMIT_REFETCH_TO_URL_CHANGE] = (
+                        self.config_entry.options.get(
+                            CONF_LIMIT_REFETCH_TO_URL_CHANGE, False
+                        ),
+                    )
                 return self.async_create_entry(
                     title=title,
                     data=data,

--- a/homeassistant/components/generic/diagnostics.py
+++ b/homeassistant/components/generic/diagnostics.py
@@ -44,6 +44,7 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "title": entry.title,
+        "version": entry.version,
         "data": async_redact_data(entry.data, TO_REDACT),
         "options": options,
     }

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -81,7 +81,7 @@ async def test_form(hass, fakeimg_png, user_flow, mock_create_stream):
         CONF_FRAMERATE: 5,
         CONF_VERIFY_SSL: False,
     }
-
+    assert result2["version"] == 2
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -594,6 +594,7 @@ async def test_options_only_stream(hass, fakeimgbytes_png, mock_create_stream):
         )
     assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["data"][CONF_CONTENT_TYPE] == "image/jpeg"
+    assert CONF_STILL_IMAGE_URL not in result3["data"]
 
 
 # These below can be deleted after deprecation period is finished.

--- a/tests/components/generic/test_diagnostics.py
+++ b/tests/components/generic/test_diagnostics.py
@@ -9,6 +9,7 @@ async def test_entry_diagnostics(hass, hass_client, setup_entry):
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, setup_entry) == {
         "title": "Test Camera",
+        "version": 2,
         "data": {},
         "options": {
             "still_image_url": "http://****:****@example.com/****?****=****",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#75265 Adjusting the config for generic camera using the options flow resulted in some config fields being assigned to `None` in the stored config.  These values are used as defaults when the user tries to configure a second time, but are rejected by the config validator.  This PR prevents the problem and cleans up existing configs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
During the options flow, a merge operation happens between the existing config and what the user has entered.  The issue is that this merge uses the `get()` operation.  If a field doesn't exist (ok for optional fields), the `get()` operation returns `None`.  This then creates a field assigned to `None`, e.g.
```
data = {
    ...
    CONF_STILL_IMAGE_URL: user_input.get(CONF_STILL_IMAGE_URL),
    ...
}
```
Actually this causes no problem initially because the `None` data is ignored by the integration base code.  The problem is that this `None` sits in the stored config and is put back to the UI on the second attempt.  For the fields defined as optional with a data type of `str`, this is invalid (the field can be omitted or `str`, but not `None`).  So the user sees an error message.  And there's not a lot they can do about it.

This PR fixes the problem in two steps:

1. Fixes the merging operation so that `None` fields aren't assigned anymore.
2. Adds a config migrator to get rid of `None` values on startup.
Tests are added to ensure that the new code works.

- This PR fixes or closes issue: fixes #75265
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
