### PR TITLE
Add install UniFi device update feature

### DIFF
--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -72,13 +72,14 @@ class UniFiDeviceUpdateEntity(UniFiBase, UpdateEntity):
     DOMAIN = DOMAIN
     TYPE = DEVICE_UPDATE
     _attr_device_class = UpdateDeviceClass.FIRMWARE
-    _attr_supported_features = UpdateEntityFeature.PROGRESS
 
     def __init__(self, device, controller):
         """Set up device update entity."""
         super().__init__(device, controller)
 
         self.device = self._item
+
+        self._attr_supported_features = UpdateEntityFeature.PROGRESS
 
         if self.controller.site_role == "admin":
             self._attr_supported_features |= UpdateEntityFeature.INSTALL

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -72,12 +72,16 @@ class UniFiDeviceUpdateEntity(UniFiBase, UpdateEntity):
     DOMAIN = DOMAIN
     TYPE = DEVICE_UPDATE
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature.PROGRESS
 
     def __init__(self, device, controller):
         """Set up device update entity."""
         super().__init__(device, controller)
 
         self.device = self._item
+
+        if self.controller.site_role == "admin":
+            self._attr_supported_features |= UpdateEntityFeature.INSTALL
 
     @property
     def name(self) -> str:
@@ -108,16 +112,6 @@ class UniFiDeviceUpdateEntity(UniFiBase, UpdateEntity):
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         return self.device.upgrade_to_firmware or self.device.version
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        features: int = UpdateEntityFeature.PROGRESS
-
-        if self.controller.site_role == "admin":
-            features |= UpdateEntityFeature.INSTALL
-
-        return features
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -112,7 +112,7 @@ class UniFiDeviceUpdateEntity(UniFiBase, UpdateEntity):
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
-        features = UpdateEntityFeature.PROGRESS
+        features: int = UpdateEntityFeature.PROGRESS
 
         if self.controller.site_role == "admin":
             features |= UpdateEntityFeature.INSTALL

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -1,23 +1,59 @@
 """The tests for the UniFi Network update platform."""
+from copy import deepcopy
 
 from aiounifi.controller import MESSAGE_DEVICE
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
+from yarl import URL
 
+from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
     ATTR_LATEST_VERSION,
     DOMAIN as UPDATE_DOMAIN,
+    SERVICE_INSTALL,
     UpdateDeviceClass,
+    UpdateEntityFeature,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
 
-from .test_controller import setup_unifi_integration
+from .test_controller import DESCRIPTION, setup_unifi_integration
+
+DEVICE_1 = {
+    "board_rev": 3,
+    "device_id": "mock-id",
+    "ip": "10.0.1.1",
+    "last_seen": 1562600145,
+    "mac": "00:00:00:00:01:01",
+    "model": "US16P150",
+    "name": "Device 1",
+    "next_interval": 20,
+    "state": 1,
+    "type": "usw",
+    "upgradable": True,
+    "version": "4.0.42.10433",
+    "upgrade_to_firmware": "4.3.17.11279",
+}
+
+DEVICE_2 = {
+    "board_rev": 3,
+    "device_id": "mock-id",
+    "ip": "10.0.1.2",
+    "mac": "00:00:00:00:01:02",
+    "model": "US16P150",
+    "name": "Device 2",
+    "next_interval": 20,
+    "state": 0,
+    "type": "usw",
+    "version": "4.0.42.10433",
+}
 
 
 async def test_no_entities(hass, aioclient_mock):
@@ -31,41 +67,11 @@ async def test_device_updates(
     hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
 ):
     """Test the update_items function with some devices."""
-    device_1 = {
-        "board_rev": 3,
-        "device_id": "mock-id",
-        "has_fan": True,
-        "fan_level": 0,
-        "ip": "10.0.1.1",
-        "last_seen": 1562600145,
-        "mac": "00:00:00:00:01:01",
-        "model": "US16P150",
-        "name": "Device 1",
-        "next_interval": 20,
-        "overheating": True,
-        "state": 1,
-        "type": "usw",
-        "upgradable": True,
-        "version": "4.0.42.10433",
-        "upgrade_to_firmware": "4.3.17.11279",
-    }
-    device_2 = {
-        "board_rev": 3,
-        "device_id": "mock-id",
-        "has_fan": True,
-        "ip": "10.0.1.2",
-        "mac": "00:00:00:00:01:02",
-        "model": "US16P150",
-        "name": "Device 2",
-        "next_interval": 20,
-        "state": 0,
-        "type": "usw",
-        "version": "4.0.42.10433",
-    }
+    device_1 = deepcopy(DEVICE_1)
     await setup_unifi_integration(
         hass,
         aioclient_mock,
-        devices_response=[device_1, device_2],
+        devices_response=[device_1, DEVICE_2],
     )
 
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 2
@@ -76,6 +82,10 @@ async def test_device_updates(
     assert device_1_state.attributes[ATTR_LATEST_VERSION] == "4.3.17.11279"
     assert device_1_state.attributes[ATTR_IN_PROGRESS] is False
     assert device_1_state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert (
+        device_1_state.attributes[ATTR_SUPPORTED_FEATURES]
+        == UpdateEntityFeature.PROGRESS | UpdateEntityFeature.INSTALL
+    )
 
     device_2_state = hass.states.get("update.device_2")
     assert device_2_state.state == STATE_OFF
@@ -83,6 +93,10 @@ async def test_device_updates(
     assert device_2_state.attributes[ATTR_LATEST_VERSION] == "4.0.42.10433"
     assert device_2_state.attributes[ATTR_IN_PROGRESS] is False
     assert device_2_state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert (
+        device_2_state.attributes[ATTR_SUPPORTED_FEATURES]
+        == UpdateEntityFeature.PROGRESS | UpdateEntityFeature.INSTALL
+    )
 
     # Simulate start of update
 
@@ -122,46 +136,79 @@ async def test_device_updates(
     assert device_1_state.attributes[ATTR_IN_PROGRESS] is False
 
 
-async def test_controller_state_change(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
-    """Verify entities state reflect on controller becoming unavailable."""
-    device = {
-        "board_rev": 3,
-        "device_id": "mock-id",
-        "has_fan": True,
-        "fan_level": 0,
-        "ip": "10.0.1.1",
-        "last_seen": 1562600145,
-        "mac": "00:00:00:00:01:01",
-        "model": "US16P150",
-        "name": "Device",
-        "next_interval": 20,
-        "overheating": True,
-        "state": 1,
-        "type": "usw",
-        "upgradable": True,
-        "version": "4.0.42.10433",
-        "upgrade_to_firmware": "4.3.17.11279",
-    }
+async def test_not_admin(hass, aioclient_mock):
+    """Test that the INSTALL feature is not available on a non-admin account."""
+    description = deepcopy(DESCRIPTION)
+    description[0]["site_role"] = "not admin"
 
     await setup_unifi_integration(
         hass,
         aioclient_mock,
-        devices_response=[device],
+        site_description=description,
+        devices_response=[DEVICE_1],
     )
 
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
-    assert hass.states.get("update.device").state == STATE_ON
+    device_state = hass.states.get("update.device_1")
+    assert device_state.state == STATE_ON
+    assert (
+        device_state.attributes[ATTR_SUPPORTED_FEATURES] == UpdateEntityFeature.PROGRESS
+    )
+
+
+async def test_install(hass, aioclient_mock):
+    """Test the device update install call."""
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, devices_response=[DEVICE_1]
+    )
+
+    assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
+    device_state = hass.states.get("update.device_1")
+    assert device_state.state == STATE_ON
+
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    url = f"https://{controller.host}:1234/api/s/{controller.site}/cmd/devmgr"
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(url)
+
+    await hass.services.async_call(
+        UPDATE_DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: "update.device_1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.mock_calls[0] == (
+        "post",
+        URL(url),
+        {"cmd": "upgrade", "mac": "00:00:00:00:01:01"},
+        {},
+    )
+
+
+async def test_controller_state_change(
+    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
+):
+    """Verify entities state reflect on controller becoming unavailable."""
+    await setup_unifi_integration(
+        hass,
+        aioclient_mock,
+        devices_response=[DEVICE_1],
+    )
+
+    assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
+    assert hass.states.get("update.device_1").state == STATE_ON
 
     # Controller unavailable
     mock_unifi_websocket(state=STATE_DISCONNECTED)
     await hass.async_block_till_done()
 
-    assert hass.states.get("update.device").state == STATE_UNAVAILABLE
+    assert hass.states.get("update.device_1").state == STATE_UNAVAILABLE
 
     # Controller available
     mock_unifi_websocket(state=STATE_RUNNING)
     await hass.async_block_till_done()
 
-    assert hass.states.get("update.device").state == STATE_ON
+    assert hass.states.get("update.device_1").state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows updating the firmware of Ubiquiti network devices directly from Home Assistant.

This adds the Install button to the upgrade entities added in #71700.

![Screenshot_20220716_113620](https://user-images.githubusercontent.com/983821/179349382-bd308441-e2c1-4461-bfcc-7eb914f2627c.png)

This feature requires that the configured user in the Unifi Network Application has admin privileges. For read-only users the Install button won't be shown.

These changes are tested locally with UniFi Network Application version 7.1.66.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#23412

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
