### PR TITLE
Make orjson an optional dependency

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -1,13 +1,25 @@
 """Helpers to help with encoding Home Assistant objects in JSON."""
 
+__all__ = [
+    "ExtendedJSONEncoder",
+    "JSONEncoder",
+    "JSON_DUMP",
+    "JSON_ENCODE_EXCEPTIONS",
+    "JSON_DECODE_EXCEPTIONS",
+    "json_bytes",
+    "json_dumps",
+    "json_dumps_indent",
+    "json_dumps_indent_no_encoder",
+    "json_dumps_sorted",
+    "json_loads",
+]
+
 from typing import Final
 
 from .json_stdlib import JSONEncoder, ExtendedJSONEncoder
 
 try:
-    import orjson
-except ImportError:
-    from .json_stdlib import (
+    from .json_orjson import (
         JSON_ENCODE_EXCEPTIONS,
         JSON_DECODE_EXCEPTIONS,
         json_bytes,
@@ -17,8 +29,8 @@ except ImportError:
         json_dumps_sorted,
         json_loads,
     )
-else:
-    from .json_orjson import (
+except ImportError:
+    from .json_stdlib import (
         JSON_ENCODE_EXCEPTIONS,
         JSON_DECODE_EXCEPTIONS,
         json_bytes,

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -12,6 +12,8 @@ except ImportError:
         JSON_DECODE_EXCEPTIONS,
         json_bytes,
         json_dumps,
+        json_dumps_indent,
+        json_dumps_indent_no_encoder,
         json_dumps_sorted,
         json_loads,
     )
@@ -21,6 +23,8 @@ else:
         JSON_DECODE_EXCEPTIONS,
         json_bytes,
         json_dumps,
+        json_dumps_indent,
+        json_dumps_indent_no_encoder,
         json_dumps_sorted,
         json_loads,
     )

--- a/homeassistant/helpers/json_orjson.py
+++ b/homeassistant/helpers/json_orjson.py
@@ -50,6 +50,24 @@ def json_dumps(data: Any) -> str:
     ).decode("utf-8")
 
 
+def json_dumps_indent(data: Any) -> str:
+    """Dump json string with array and object members indented."""
+    return orjson.dumps(
+        data,
+        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
+        default=json_encoder_default,
+    ).decode("utf-8")
+
+
+def json_dumps_indent_no_encoder(data: Any) -> str:
+    """Dump json string with array and object members indented.
+    Do not apply the HASS default encoder."""
+    return orjson.dumps(
+        data,
+        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
+    ).decode("utf-8")
+
+
 def json_dumps_sorted(data: Any) -> str:
     """Dump json string with keys sorted."""
     return orjson.dumps(

--- a/homeassistant/helpers/json_orjson.py
+++ b/homeassistant/helpers/json_orjson.py
@@ -1,31 +1,12 @@
 """Helpers to help with encoding Home Assistant objects in JSON."""
-import datetime
-import json
+
 from pathlib import Path
-from typing import Any, Final
+from typing import Any
 
 import orjson
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
-
-
-class JSONEncoder(json.JSONEncoder):
-    """JSONEncoder that supports Home Assistant objects."""
-
-    def default(self, o: Any) -> Any:
-        """Convert Home Assistant objects.
-
-        Hand other objects to the original method.
-        """
-        if isinstance(o, datetime.datetime):
-            return o.isoformat()
-        if isinstance(o, set):
-            return list(o)
-        if hasattr(o, "as_dict"):
-            return o.as_dict()
-
-        return json.JSONEncoder.default(self, o)
 
 
 def json_encoder_default(obj: Any) -> Any:
@@ -42,26 +23,6 @@ def json_encoder_default(obj: Any) -> Any:
     if isinstance(obj, Path):
         return obj.as_posix()
     raise TypeError
-
-
-class ExtendedJSONEncoder(JSONEncoder):
-    """JSONEncoder that supports Home Assistant objects and falls back to repr(o)."""
-
-    def default(self, o: Any) -> Any:
-        """Convert certain objects.
-
-        Fall back to repr(o).
-        """
-        if isinstance(o, datetime.timedelta):
-            return {"__type": str(type(o)), "total_seconds": o.total_seconds()}
-        if isinstance(o, datetime.datetime):
-            return o.isoformat()
-        if isinstance(o, (datetime.date, datetime.time)):
-            return {"__type": str(type(o)), "isoformat": o.isoformat()}
-        try:
-            return super().default(o)
-        except TypeError:
-            return {"__type": str(type(o)), "repr": repr(o)}
 
 
 def json_bytes(data: Any) -> bytes:
@@ -99,6 +60,3 @@ def json_dumps_sorted(data: Any) -> str:
 
 
 json_loads = orjson.loads
-
-
-JSON_DUMP: Final = json_dumps

--- a/homeassistant/helpers/json_stdlib.py
+++ b/homeassistant/helpers/json_stdlib.py
@@ -54,6 +54,17 @@ def json_bytes(data: Any) -> bytes:
     return json.dumps(data, cls=JSONEncoder).encode("utf-8")
 
 
+def json_dumps_indent(data: Any) -> str:
+    """Dump json string with array and object members indented."""
+    return json.dumps(data, cls=JSONEncoder, indent=2)
+
+
+def json_dumps_indent_no_encoder(data: Any) -> str:
+    """Dump json string with array and object members indented.
+    Do not apply the HASS default encoder."""
+    return json.dumps(data, indent=2)
+
+
 def json_dumps_sorted(data: Any) -> str:
     """Dump json string with keys sorted."""
     return json.dumps(data, cls=JSONEncoder, sort_keys=True)

--- a/homeassistant/helpers/json_stdlib.py
+++ b/homeassistant/helpers/json_stdlib.py
@@ -1,13 +1,14 @@
 """Helpers to help with encoding Home Assistant objects in JSON."""
+
 import datetime
 import json
-from pathlib import Path
-from typing import Any, Final
-
-import orjson
+from typing import Any
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
-JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
+JSON_DECODE_EXCEPTIONS = (json.JSONDecodeError,)
+
+json_dumps = json.dumps
+json_loads = json.loads
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -26,22 +27,6 @@ class JSONEncoder(json.JSONEncoder):
             return o.as_dict()
 
         return json.JSONEncoder.default(self, o)
-
-
-def json_encoder_default(obj: Any) -> Any:
-    """Convert Home Assistant objects.
-
-    Hand other objects to the original method.
-    """
-    if isinstance(obj, (set, tuple)):
-        return list(obj)
-    if isinstance(obj, float):
-        return float(obj)
-    if hasattr(obj, "as_dict"):
-        return obj.as_dict()
-    if isinstance(obj, Path):
-        return obj.as_posix()
-    raise TypeError
 
 
 class ExtendedJSONEncoder(JSONEncoder):
@@ -66,39 +51,9 @@ class ExtendedJSONEncoder(JSONEncoder):
 
 def json_bytes(data: Any) -> bytes:
     """Dump json bytes."""
-    return orjson.dumps(
-        data, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
-    )
-
-
-def json_dumps(data: Any) -> str:
-    """Dump json string.
-
-    orjson supports serializing dataclasses natively which
-    eliminates the need to implement as_dict in many places
-    when the data is already in a dataclass. This works
-    well as long as all the data in the dataclass can also
-    be serialized.
-
-    If it turns out to be a problem we can disable this
-    with option |= orjson.OPT_PASSTHROUGH_DATACLASS and it
-    will fallback to as_dict
-    """
-    return orjson.dumps(
-        data, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
-    ).decode("utf-8")
+    return json.dumps(data, cls=JSONEncoder).encode("utf-8")
 
 
 def json_dumps_sorted(data: Any) -> str:
     """Dump json string with keys sorted."""
-    return orjson.dumps(
-        data,
-        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
-        default=json_encoder_default,
-    ).decode("utf-8")
-
-
-json_loads = orjson.loads
-
-
-JSON_DUMP: Final = json_dumps
+    return json.dumps(data, cls=JSONEncoder, sort_keys=True)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,6 @@ httpx==0.23.0
 ifaddr==0.1.7
 jinja2==3.1.2
 lru-dict==1.1.8
-orjson==3.7.7
 paho-mqtt==1.6.1
 pillow==9.2.0
 pip>=21.0,<22.2

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable
+import functools
 import json
 import logging
 from typing import Any
-
-import orjson
 
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.json import (
     JSONEncoder as DefaultHASSJSONEncoder,
-    json_encoder_default as default_hass_orjson_encoder,
+    json_dumps_indent,
+    json_dumps_indent_no_encoder,
+    json_loads,
 )
 
 from .file import write_utf8_file, write_utf8_file_atomic
@@ -36,7 +37,7 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
     """
     try:
         with open(filename, encoding="utf-8") as fdesc:
-            return orjson.loads(fdesc.read())  # type: ignore[no-any-return]
+            return json_loads(fdesc.read())  # type: ignore[no-any-return]
     except FileNotFoundError:
         # This is not a fatal error
         _LOGGER.debug("JSON file not found: %s", filename)
@@ -47,22 +48,6 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
         _LOGGER.exception("JSON file reading failed: %s", filename)
         raise HomeAssistantError(error) from error
     return {} if default is None else default
-
-
-def _orjson_encoder(data: Any) -> str:
-    """JSON encoder that uses orjson."""
-    return orjson.dumps(
-        data, option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS
-    ).decode("utf-8")
-
-
-def _orjson_default_encoder(data: Any) -> str:
-    """JSON encoder that uses orjson with hass defaults."""
-    return orjson.dumps(
-        data,
-        option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS,
-        default=default_hass_orjson_encoder,
-    ).decode("utf-8")
 
 
 def save_json(
@@ -78,22 +63,20 @@ def save_json(
     Returns True on success.
     """
     dump: Callable[[Any], Any]
+    if not encoder:
+        dump = json_dumps_indent_no_encoder
+    elif encoder is DefaultHASSJSONEncoder:
+        # For backwards compatibility, if they pass in the
+        # default json encoder we use json_dumps_indent
+        # which is the orjson equivalent to the default encoder.
+        dump = json_dumps_indent
+    else:
+        # If they pass a custom encoder that is not the
+        # DefaultHASSJSONEncoder, we use the slow path of json.dumps
+        dump = functools.partial(json.dumps, indent=2, cls=encoder)
+
     try:
-        if encoder:
-            # For backwards compatibility, if they pass in the
-            # default json encoder we use _orjson_default_encoder
-            # which is the orjson equivalent to the default encoder.
-            if encoder is DefaultHASSJSONEncoder:
-                dump = _orjson_default_encoder
-                json_data = _orjson_default_encoder(data)
-            # If they pass a custom encoder that is not the
-            # DefaultHASSJSONEncoder, we use the slow path of json.dumps
-            else:
-                dump = json.dumps
-                json_data = json.dumps(data, indent=2, cls=encoder)
-        else:
-            dump = _orjson_encoder
-            json_data = _orjson_encoder(data)
+        json_data = dump(data)
     except TypeError as error:
         msg = f"Failed to serialize to JSON: {filename}. Bad data at {format_unserializable_data(find_paths_unserializable_data(data, dump=dump))}"
         _LOGGER.error(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies    = [
     "PyJWT==2.4.0",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==36.0.2",
-    "orjson==3.7.7",
     "pip>=21.0,<22.2",
     "python-slugify==4.0.1",
     "pyyaml==6.0",
@@ -51,6 +50,9 @@ dependencies    = [
     "voluptuous==0.13.1",
     "voluptuous-serialize==2.5.0",
     "yarl==1.7.2",
+]
+optional-dependencies.orjson = [
+    "orjson==3.7.7",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ jinja2==3.1.2
 lru-dict==1.1.8
 PyJWT==2.4.0
 cryptography==36.0.2
-orjson==3.7.7
 pip>=21.0,<22.2
 python-slugify==4.0.1
 pyyaml==6.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,6 +12,7 @@ coverage==6.4.2
 freezegun==1.2.1
 mock-open==1.4.0
 mypy==0.961
+orjson==3.7.7
 pre-commit==2.20.0
 pylint==2.14.4
 pipdeptree==2.2.1

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -132,7 +132,7 @@ def test_default_encoder_is_passed():
     """Test we use orjson if they pass in the default encoder."""
     fname = _path_for("test6")
     with patch(
-        "homeassistant.util.json.orjson.dumps", return_value=b"{}"
+        "homeassistant.helpers.json_orjson.orjson.dumps", return_value=b"{}"
     ) as mock_orjson_dumps:
         save_json(fname, {"any": 1}, encoder=DefaultHASSJSONEncoder)
     assert len(mock_orjson_dumps.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
## Breaking change
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Orjson is fast, clean, correct and safe.
However [orjson leverages maturin as its build system](https://github.com/ijl/orjson/blob/master/pyproject.toml), which pulls in a deep tree of compile-time dependencies:

<details>
<summary>$ cargo tree</summary>

```
maturin v0.13.0 (/home/arnie97/Documents/maturin)
├── anyhow v1.0.58
├── base64 v0.13.0
├── bytesize v1.1.0
├── cargo-options v0.3.0
│   └── clap v3.2.8
│       ├── atty v0.2.14
│       │   └── libc v0.2.126
│       ├── bitflags v1.3.2
│       ├── clap_derive v3.2.7 (proc-macro)
│       │   ├── heck v0.4.0
│       │   ├── proc-macro-error v1.0.4
│       │   │   ├── proc-macro-error-attr v1.0.4 (proc-macro)
│       │   │   │   ├── proc-macro2 v1.0.40
│       │   │   │   │   └── unicode-ident v1.0.1
│       │   │   │   └── quote v1.0.20
│       │   │   │       └── proc-macro2 v1.0.40 (*)
│       │   │   │   [build-dependencies]
│       │   │   │   └── version_check v0.9.4
│       │   │   ├── proc-macro2 v1.0.40 (*)
│       │   │   ├── quote v1.0.20 (*)
│       │   │   └── syn v1.0.98
│       │   │       ├── proc-macro2 v1.0.40 (*)
│       │   │       ├── quote v1.0.20 (*)
│       │   │       └── unicode-ident v1.0.1
│       │   │   [build-dependencies]
│       │   │   └── version_check v0.9.4
│       │   ├── proc-macro2 v1.0.40 (*)
│       │   ├── quote v1.0.20 (*)
│       │   └── syn v1.0.98 (*)
│       ├── clap_lex v0.2.4
│       │   └── os_str_bytes v6.1.0
│       ├── indexmap v1.9.1
│       │   └── hashbrown v0.12.2
│       │   [build-dependencies]
│       │   └── autocfg v1.1.0
│       ├── once_cell v1.13.0
│       ├── strsim v0.10.0
│       ├── termcolor v1.1.3
│       ├── terminal_size v0.1.17
│       │   └── libc v0.2.126
│       └── textwrap v0.15.0
│           ├── smawk v0.3.1
│           ├── terminal_size v0.1.17 (*)
│           ├── unicode-linebreak v0.1.2
│           │   [build-dependencies]
│           │   └── regex v1.6.0
│           │       ├── aho-corasick v0.7.18
│           │       │   └── memchr v2.5.0
│           │       ├── memchr v2.5.0
│           │       └── regex-syntax v0.6.27
│           └── unicode-width v0.1.9
├── cargo-xwin v0.10.0
│   ├── anyhow v1.0.58
│   ├── cargo-options v0.3.0 (*)
│   ├── clap v3.2.8 (*)
│   ├── dirs v4.0.0
│   │   └── dirs-sys v0.3.7
│   │       └── libc v0.2.126
│   ├── fs-err v2.7.0
│   ├── indicatif v0.17.0-rc.6
│   │   ├── console v0.15.0
│   │   │   ├── libc v0.2.126
│   │   │   ├── once_cell v1.13.0
│   │   │   ├── regex v1.6.0 (*)
│   │   │   ├── terminal_size v0.1.17 (*)
│   │   │   └── unicode-width v0.1.9
│   │   ├── number_prefix v0.4.0
│   │   └── unicode-width v0.1.9
│   ├── path-slash v0.1.5
│   ├── which v4.2.5
│   │   ├── either v1.7.0
│   │   └── libc v0.2.126
│   └── xwin v0.2.5
│       ├── anyhow v1.0.58
│       ├── bytes v1.1.0
│       ├── cab v0.4.1
│       │   ├── byteorder v1.4.3
│       │   ├── flate2 v1.0.24
│       │   │   ├── crc32fast v1.3.2
│       │   │   │   └── cfg-if v1.0.0
│       │   │   └── miniz_oxide v0.5.3
│       │   │       └── adler v1.0.2
│       │   ├── lzxd v0.1.4
│       │   └── time v0.3.11
│       │       ├── itoa v1.0.2
│       │       ├── libc v0.2.126
│       │       ├── num_threads v0.1.6
│       │       │   └── libc v0.2.126
│       │       └── time-macros v0.2.4 (proc-macro)
│       ├── camino v1.0.9
│       │   └── serde v1.0.138
│       │       └── serde_derive v1.0.138 (proc-macro)
│       │           ├── proc-macro2 v1.0.40 (*)
│       │           ├── quote v1.0.20 (*)
│       │           └── syn v1.0.98 (*)
│       ├── clap v3.2.8 (*)
│       ├── cli-table v0.4.7
│       │   ├── termcolor v1.1.3
│       │   └── unicode-width v0.1.9
│       ├── flate2 v1.0.24 (*)
│       ├── indicatif v0.17.0-rc.6 (*)
│       ├── msi v0.5.0
│       │   ├── byteorder v1.4.3
│       │   ├── cfb v0.7.3
│       │   │   ├── byteorder v1.4.3
│       │   │   ├── fnv v1.0.7
│       │   │   └── uuid v1.1.2
│       │   ├── encoding v0.2.33
│       │   │   ├── encoding-index-japanese v1.20141219.5
│       │   │   │   └── encoding_index_tests v0.1.4
│       │   │   ├── encoding-index-korean v1.20141219.5
│       │   │   │   └── encoding_index_tests v0.1.4
│       │   │   ├── encoding-index-simpchinese v1.20141219.5
│       │   │   │   └── encoding_index_tests v0.1.4
│       │   │   ├── encoding-index-singlebyte v1.20141219.5
│       │   │   │   └── encoding_index_tests v0.1.4
│       │   │   └── encoding-index-tradchinese v1.20141219.5
│       │   │       └── encoding_index_tests v0.1.4
│       │   └── uuid v1.1.2
│       ├── parking_lot v0.12.1
│       │   ├── lock_api v0.4.7
│       │   │   └── scopeguard v1.1.0
│       │   │   [build-dependencies]
│       │   │   └── autocfg v1.1.0
│       │   └── parking_lot_core v0.9.3
│       │       ├── cfg-if v1.0.0
│       │       ├── libc v0.2.126
│       │       └── smallvec v1.9.0
│       ├── rayon v1.5.3
│       │   ├── crossbeam-deque v0.8.1
│       │   │   ├── cfg-if v1.0.0
│       │   │   ├── crossbeam-epoch v0.9.9
│       │   │   │   ├── cfg-if v1.0.0
│       │   │   │   ├── crossbeam-utils v0.8.10
│       │   │   │   │   ├── cfg-if v1.0.0
│       │   │   │   │   └── once_cell v1.13.0
│       │   │   │   ├── memoffset v0.6.5
│       │   │   │   │   [build-dependencies]
│       │   │   │   │   └── autocfg v1.1.0
│       │   │   │   ├── once_cell v1.13.0
│       │   │   │   └── scopeguard v1.1.0
│       │   │   │   [build-dependencies]
│       │   │   │   └── autocfg v1.1.0
│       │   │   └── crossbeam-utils v0.8.10 (*)
│       │   ├── either v1.7.0
│       │   └── rayon-core v1.9.3
│       │       ├── crossbeam-channel v0.5.5
│       │       │   ├── cfg-if v1.0.0
│       │       │   └── crossbeam-utils v0.8.10 (*)
│       │       ├── crossbeam-deque v0.8.1 (*)
│       │       ├── crossbeam-utils v0.8.10 (*)
│       │       └── num_cpus v1.13.1
│       │           └── libc v0.2.126
│       │   [build-dependencies]
│       │   └── autocfg v1.1.0
│       ├── regex v1.6.0 (*)
│       ├── serde v1.0.138 (*)
│       ├── serde_json v1.0.82
│       │   ├── itoa v1.0.2
│       │   ├── ryu v1.0.10
│       │   └── serde v1.0.138 (*)
│       ├── sha2 v0.10.2
│       │   ├── cfg-if v1.0.0
│       │   ├── cpufeatures v0.2.2
│       │   └── digest v0.10.3
│       │       ├── block-buffer v0.10.2
│       │       │   └── generic-array v0.14.5
│       │       │       └── typenum v1.15.0
│       │       │       [build-dependencies]
│       │       │       └── version_check v0.9.4
│       │       └── crypto-common v0.1.4
│       │           ├── generic-array v0.14.5 (*)
│       │           └── typenum v1.15.0
│       ├── tempfile v3.3.0
│       │   ├── cfg-if v1.0.0
│       │   ├── fastrand v1.7.0
│       │   ├── libc v0.2.126
│       │   └── remove_dir_all v0.5.3
│       ├── tracing v0.1.35
│       │   ├── cfg-if v1.0.0
│       │   ├── pin-project-lite v0.2.9
│       │   ├── tracing-attributes v0.1.22 (proc-macro)
│       │   │   ├── proc-macro2 v1.0.40 (*)
│       │   │   ├── quote v1.0.20 (*)
│       │   │   └── syn v1.0.98 (*)
│       │   └── tracing-core v0.1.28
│       │       └── once_cell v1.13.0
│       ├── tracing-subscriber v0.3.14
│       │   ├── matchers v0.1.0
│       │   │   └── regex-automata v0.1.10
│       │   │       └── regex-syntax v0.6.27
│       │   ├── once_cell v1.13.0
│       │   ├── regex v1.6.0 (*)
│       │   ├── serde v1.0.138 (*)
│       │   ├── serde_json v1.0.82 (*)
│       │   ├── sharded-slab v0.1.4
│       │   │   └── lazy_static v1.4.0
│       │   ├── thread_local v1.1.4
│       │   │   └── once_cell v1.13.0
│       │   ├── tracing v0.1.35 (*)
│       │   ├── tracing-core v0.1.28 (*)
│       │   └── tracing-serde v0.1.3
│       │       ├── serde v1.0.138 (*)
│       │       └── tracing-core v0.1.28 (*)
│       ├── twox-hash v1.6.3
│       │   ├── cfg-if v1.0.0
│       │   ├── rand v0.8.5
│       │   │   ├── libc v0.2.126
│       │   │   ├── rand_chacha v0.3.1
│       │   │   │   ├── ppv-lite86 v0.2.16
│       │   │   │   └── rand_core v0.6.3
│       │   │   │       └── getrandom v0.2.7
│       │   │   │           ├── cfg-if v1.0.0
│       │   │   │           └── libc v0.2.126
│       │   │   └── rand_core v0.6.3 (*)
│       │   └── static_assertions v1.1.0
│       ├── ureq v2.4.0
│       │   ├── base64 v0.13.0
│       │   ├── chunked_transfer v1.4.0
│       │   ├── flate2 v1.0.24 (*)
│       │   ├── log v0.4.17
│       │   │   └── cfg-if v1.0.0
│       │   ├── once_cell v1.13.0
│       │   ├── rustls v0.20.6
│       │   │   ├── log v0.4.17 (*)
│       │   │   ├── ring v0.16.20
│       │   │   │   ├── spin v0.5.2
│       │   │   │   └── untrusted v0.7.1
│       │   │   │   [build-dependencies]
│       │   │   │   └── cc v1.0.73
│       │   │   ├── sct v0.7.0
│       │   │   │   ├── ring v0.16.20 (*)
│       │   │   │   └── untrusted v0.7.1
│       │   │   └── webpki v0.22.0
│       │   │       ├── ring v0.16.20 (*)
│       │   │       └── untrusted v0.7.1
│       │   ├── socks v0.3.4
│       │   │   ├── byteorder v1.4.3
│       │   │   └── libc v0.2.126
│       │   ├── url v2.2.2
│       │   │   ├── form_urlencoded v1.0.1
│       │   │   │   ├── matches v0.1.9
│       │   │   │   └── percent-encoding v2.1.0
│       │   │   ├── idna v0.2.3
│       │   │   │   ├── matches v0.1.9
│       │   │   │   ├── unicode-bidi v0.3.8
│       │   │   │   └── unicode-normalization v0.1.21
│       │   │   │       └── tinyvec v1.6.0
│       │   │   │           └── tinyvec_macros v0.1.0
│       │   │   ├── matches v0.1.9
│       │   │   └── percent-encoding v2.1.0
│       │   ├── webpki v0.22.0 (*)
│       │   └── webpki-roots v0.22.4
│       │       └── webpki v0.22.0 (*)
│       └── zip v0.6.2
│           ├── byteorder v1.4.3
│           ├── bzip2 v0.4.3
│           │   ├── bzip2-sys v0.1.11+1.0.8
│           │   │   └── libc v0.2.126
│           │   │   [build-dependencies]
│           │   │   ├── cc v1.0.73
│           │   │   └── pkg-config v0.3.25
│           │   └── libc v0.2.126
│           ├── crc32fast v1.3.2 (*)
│           ├── flate2 v1.0.24 (*)
│           └── time v0.3.11 (*)
├── cargo-zigbuild v0.11.1
│   ├── anyhow v1.0.58
│   ├── cargo-options v0.3.0 (*)
│   ├── cargo_metadata v0.15.0
│   │   ├── camino v1.0.9 (*)
│   │   ├── cargo-platform v0.1.2
│   │   │   └── serde v1.0.138 (*)
│   │   ├── semver v1.0.12
│   │   │   └── serde v1.0.138 (*)
│   │   ├── serde v1.0.138 (*)
│   │   └── serde_json v1.0.82 (*)
│   ├── clap v3.2.8 (*)
│   ├── dirs v4.0.0 (*)
│   ├── fs-err v2.7.0
│   ├── path-slash v0.1.5
│   ├── rustc_version v0.4.0
│   │   └── semver v1.0.12 (*)
│   ├── semver v1.0.12 (*)
│   ├── serde v1.0.138 (*)
│   ├── serde_json v1.0.82 (*)
│   └── target-lexicon v0.12.4
├── cargo_metadata v0.15.0 (*)
├── cbindgen v0.24.3
│   ├── heck v0.4.0
│   ├── indexmap v1.9.1 (*)
│   ├── log v0.4.17 (*)
│   ├── proc-macro2 v1.0.40 (*)
│   ├── quote v1.0.20 (*)
│   ├── serde v1.0.138 (*)
│   ├── serde_json v1.0.82 (*)
│   ├── syn v1.0.98 (*)
│   ├── tempfile v3.3.0 (*)
│   └── toml v0.5.9
│       └── serde v1.0.138 (*)
├── cc v1.0.73
├── clap v3.2.8 (*)
├── clap_complete v3.2.3
│   └── clap v3.2.8 (*)
├── clap_complete_fig v3.2.4
│   ├── clap v3.2.8 (*)
│   └── clap_complete v3.2.3 (*)
├── configparser v3.0.0
├── console v0.15.0 (*)
├── dialoguer v0.10.1
│   └── console v0.15.0 (*)
├── dirs v4.0.0 (*)
├── dunce v1.0.2
├── fat-macho v0.4.5
│   └── goblin v0.5.2
│       ├── log v0.4.17 (*)
│       ├── plain v0.2.3
│       └── scroll v0.11.0
│           └── scroll_derive v0.11.0 (proc-macro)
│               ├── proc-macro2 v1.0.40 (*)
│               ├── quote v1.0.20 (*)
│               └── syn v1.0.98 (*)
├── flate2 v1.0.24 (*)
├── fs-err v2.7.0
├── glob v0.3.0
├── goblin v0.5.2 (*)
├── human-panic v1.0.3
│   ├── backtrace v0.3.66
│   │   ├── addr2line v0.17.0
│   │   │   └── gimli v0.26.1
│   │   ├── cfg-if v1.0.0
│   │   ├── libc v0.2.126
│   │   ├── miniz_oxide v0.5.3 (*)
│   │   ├── object v0.29.0
│   │   │   └── memchr v2.5.0
│   │   └── rustc-demangle v0.1.21
│   │   [build-dependencies]
│   │   └── cc v1.0.73
│   ├── os_type v2.4.0
│   │   └── regex v1.6.0 (*)
│   ├── serde v1.0.138 (*)
│   ├── serde_derive v1.0.138 (proc-macro) (*)
│   ├── termcolor v1.1.3
│   ├── toml v0.5.9 (*)
│   └── uuid v0.8.2
│       └── getrandom v0.2.7 (*)
├── ignore v0.4.18
│   ├── crossbeam-utils v0.8.10 (*)
│   ├── globset v0.4.9
│   │   ├── aho-corasick v0.7.18 (*)
│   │   ├── bstr v0.2.17
│   │   │   └── memchr v2.5.0
│   │   ├── fnv v1.0.7
│   │   ├── log v0.4.17 (*)
│   │   └── regex v1.6.0 (*)
│   ├── lazy_static v1.4.0
│   ├── log v0.4.17 (*)
│   ├── memchr v2.5.0
│   ├── regex v1.6.0 (*)
│   ├── same-file v1.0.6
│   ├── thread_local v1.1.4 (*)
│   └── walkdir v2.3.2
│       └── same-file v1.0.6
├── lddtree v0.2.9
│   ├── fs-err v2.7.0
│   ├── glob v0.3.0
│   └── goblin v0.5.2 (*)
├── minijinja v0.17.0
│   └── serde v1.0.138 (*)
├── multipart v0.18.0
│   ├── log v0.4.17 (*)
│   ├── mime v0.3.16
│   ├── mime_guess v2.0.4
│   │   ├── mime v0.3.16
│   │   └── unicase v2.6.0
│   │       [build-dependencies]
│   │       └── version_check v0.9.4
│   │   [build-dependencies]
│   │   └── unicase v2.6.0 (*)
│   ├── rand v0.8.5 (*)
│   └── tempfile v3.3.0 (*)
├── once_cell v1.13.0
├── platform-info v0.2.0
│   ├── libc v0.2.126
│   └── winapi v0.3.9
├── pretty_env_logger v0.4.0
│   ├── env_logger v0.7.1
│   │   ├── atty v0.2.14 (*)
│   │   ├── humantime v1.3.0
│   │   │   └── quick-error v1.2.3
│   │   ├── log v0.4.17 (*)
│   │   ├── regex v1.6.0 (*)
│   │   └── termcolor v1.1.3
│   └── log v0.4.17 (*)
├── pyproject-toml v0.3.1
│   ├── serde v1.0.138 (*)
│   └── toml v0.5.9 (*)
├── python-pkginfo v0.5.4
│   ├── flate2 v1.0.24 (*)
│   ├── fs-err v2.7.0
│   ├── mailparse v0.13.8
│   │   ├── charset v0.1.3
│   │   │   ├── base64 v0.13.0
│   │   │   └── encoding_rs v0.8.31
│   │   │       └── cfg-if v1.0.0
│   │   ├── data-encoding v2.3.2
│   │   └── quoted_printable v0.4.5
│   ├── rfc2047-decoder v0.1.2
│   │   ├── base64 v0.13.0
│   │   ├── charset v0.1.3 (*)
│   │   └── quoted_printable v0.4.5
│   ├── tar v0.4.38
│   │   ├── filetime v0.2.17
│   │   │   ├── cfg-if v1.0.0
│   │   │   └── libc v0.2.126
│   │   ├── libc v0.2.126
│   │   └── xattr v0.2.3
│   │       └── libc v0.2.126
│   ├── thiserror v1.0.31
│   │   └── thiserror-impl v1.0.31 (proc-macro)
│   │       ├── proc-macro2 v1.0.40 (*)
│   │       ├── quote v1.0.20 (*)
│   │       └── syn v1.0.98 (*)
│   └── zip v0.6.2 (*)
├── regex v1.6.0 (*)
├── rpassword v6.0.1
│   ├── libc v0.2.126
│   ├── serde v1.0.138 (*)
│   └── serde_json v1.0.82 (*)
├── rustc_version v0.4.0 (*)
├── serde v1.0.138 (*)
├── serde_json v1.0.82 (*)
├── sha2 v0.10.2 (*)
├── shlex v1.1.0
├── tar v0.4.38 (*)
├── target-lexicon v0.12.4
├── tempfile v3.3.0 (*)
├── textwrap v0.15.0 (*)
├── thiserror v1.0.31 (*)
├── toml_edit v0.14.4
│   ├── combine v4.6.4
│   │   ├── bytes v1.1.0
│   │   └── memchr v2.5.0
│   ├── indexmap v1.9.1 (*)
│   ├── itertools v0.10.3
│   │   └── either v1.7.0
│   └── serde v1.0.138 (*)
├── tracing v0.1.35 (*)
├── ureq v2.4.0 (*)
└── zip v0.6.2 (*)
[dev-dependencies]
└── indoc v1.0.6 (proc-macro)
```

</details>

Unfortunately, some packages in the tree is written in assembly, and hence not available for some target triples.  For example, [ring](https://github.com/briansmith/ring) blocks my maturin build on [mips-unknown-linux-gnu](https://github.com/briansmith/ring/issues/562), [mipsel-unknown-linux-musl](https://github.com/briansmith/ring/issues/562), [riscv64gc-unknown-linux-musl](https://github.com/briansmith/ring/issues/1182) (which is actually another way to say, all the energy-efficient boxes where my home assistant instances run 24/7 on ;-)

This PR improves #73849, #73874, #73876, and makes `orjson` an optional dependency, so that `mips` and `riscv` targets could upgrade to the latest hass version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request:
  - TODO (upgrade core installation docs to `$ pip3 install "homeassistant[orjson]"`)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
