### PR TITLE
Add bluetooth discovery to HomeKit Controller

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -527,8 +527,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     @callback
     def _async_step_pair_show_form(self, errors=None):
-        placeholders = {"name": self.name}
-        self.context["title_placeholders"] = {
+        placeholders = self.context["title_placeholders"] = {
             "name": self.name,
             "category": formatted_category(self.category),
         }

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -367,7 +367,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except ValueError:
             return self.async_abort(reason="ignored_model")
 
-        if ~device.status_flags & StatusFlags.UNPAIRED:
+        if not (device.status_flags & StatusFlags.UNPAIRED):
             return self.async_abort(reason="already_paired")
 
         if self.controller is None:

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -69,6 +69,11 @@ def normalize_hkid(hkid: str) -> str:
     return hkid.lower()
 
 
+def formatted_category(category: Categories) -> str:
+    """Return a human readable category name."""
+    return str(category.name).replace("_", " ").title()
+
+
 @callback
 def find_existing_host(hass, serial: str) -> config_entries.ConfigEntry | None:
     """Return a set of the configured hosts."""
@@ -148,7 +153,14 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             errors=errors,
             data_schema=vol.Schema(
-                {vol.Required("device"): vol.In(self.devices.keys())}
+                {
+                    vol.Required("device"): vol.In(
+                        {
+                            key: f"{key} ({formatted_category(discovery.description.category)})"
+                            for key, discovery in self.devices.items()
+                        }
+                    )
+                }
             ),
         )
 
@@ -518,7 +530,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         placeholders = {"name": self.name}
         self.context["title_placeholders"] = {
             "name": self.name,
-            "category": str(self.category.name).replace("_", " ").title(),
+            "category": formatted_category(self.category),
         }
 
         schema = {vol.Required("pairing_code"): vol.All(str, vol.Strip)}

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -43,6 +43,8 @@ PIN_FORMAT = re.compile(r"^(\d{3})-{0,1}(\d{2})-{0,1}(\d{3})$")
 _LOGGER = logging.getLogger(__name__)
 
 
+BLE_DEFAULT_NAME = "Bluetooth device"
+
 INSECURE_CODES = {
     "00000000",
     "11111111",
@@ -115,9 +117,9 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             key = user_input["device"]
             self.hkid = self.devices[key].description.id
             self.model = getattr(
-                self.devices[key].description, "model", "Bluetooth device"
+                self.devices[key].description, "model", BLE_DEFAULT_NAME
             )
-            self.name = self.devices[key].description.name or "Bluetooth device"
+            self.name = self.devices[key].description.name or BLE_DEFAULT_NAME
 
             await self.async_set_unique_id(
                 normalize_hkid(self.hkid), raise_on_progress=False
@@ -380,7 +382,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_paired")
 
         self.name = discovery.description.name
-        self.model = "Bluetooth device"
+        self.model = BLE_DEFAULT_NAME
         self.hkid = discovery.description.id
 
         return self._async_step_pair_show_form()

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -1,14 +1,16 @@
 """Config flow to configure homekit_controller."""
 from __future__ import annotations
 
+from collections.abc import Awaitable
 import logging
 import re
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohomekit
-from aiohomekit import const as aiohomekit_const
-from aiohomekit.controller.abstract import AbstractPairing
+from aiohomekit import Controller, const as aiohomekit_const
+from aiohomekit.controller.abstract import AbstractDiscovery, AbstractPairing
 from aiohomekit.exceptions import AuthenticationError
+from aiohomekit.model.categories import Categories
 from aiohomekit.model.status_flags import StatusFlags
 from aiohomekit.utils import domain_supported, domain_to_name
 import voluptuous as vol
@@ -97,14 +99,15 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the homekit_controller flow."""
-        self.model = None
-        self.hkid = None
-        self.name = None
-        self.devices = {}
-        self.controller = None
-        self.finish_pairing = None
+        self.model: str | None = None
+        self.hkid: str | None = None
+        self.name: str | None = None
+        self.category: Categories | None = None
+        self.devices: dict[str, AbstractDiscovery] = {}
+        self.controller: Controller | None = None
+        self.finish_pairing: Awaitable[AbstractPairing] | None = None
 
     async def _async_setup_controller(self):
         """Create the controller."""
@@ -116,11 +119,11 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             key = user_input["device"]
-            self.hkid = self.devices[key].description.id
-            self.model = getattr(
-                self.devices[key].description, "model", BLE_DEFAULT_NAME
-            )
-            self.name = self.devices[key].description.name or BLE_DEFAULT_NAME
+            discovery = self.devices[key]
+            self.category = discovery.description.category
+            self.hkid = discovery.description.id
+            self.model = getattr(discovery.description, "model", BLE_DEFAULT_NAME)
+            self.name = discovery.description.name or BLE_DEFAULT_NAME
 
             await self.async_set_unique_id(
                 normalize_hkid(self.hkid), raise_on_progress=False
@@ -158,13 +161,14 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self._async_setup_controller()
 
         try:
-            device = await self.controller.async_find(unique_id)
+            discovery = await self.controller.async_find(unique_id)
         except aiohomekit.AccessoryNotFoundError:
             return self.async_abort(reason="accessory_not_found_error")
 
-        self.name = device.description.name
-        self.model = device.description.model
-        self.hkid = device.description.id
+        self.name = discovery.description.name
+        self.model = discovery.description.model
+        self.category = discovery.description.category
+        self.hkid = discovery.description.id
 
         return self._async_step_pair_show_form()
 
@@ -220,6 +224,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         model = properties["md"]
         name = domain_to_name(discovery_info.name)
         status_flags = int(properties["sf"])
+        category = Categories(int(properties.get("ci", 0)))
         paired = not status_flags & 0x01
 
         # The configuration number increases every time the characteristic map
@@ -333,6 +338,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.name = name
         self.model = model
+        self.category = category
         self.hkid = hkid
 
         # We want to show the pairing form - but don't call async_step_pair
@@ -384,6 +390,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.name = discovery.description.name
         self.model = BLE_DEFAULT_NAME
+        self.category = discovery.description.category
         self.hkid = discovery.description.id
 
         return self._async_step_pair_show_form()
@@ -509,7 +516,10 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def _async_step_pair_show_form(self, errors=None):
         placeholders = {"name": self.name}
-        self.context["title_placeholders"] = {"name": self.name}
+        self.context["title_placeholders"] = {
+            "name": self.name,
+            "category": str(self.category.name).replace("_", " ").title(),
+        }
 
         schema = {vol.Required("pairing_code"): vol.All(str, vol.Strip)}
         if errors and errors.get("pairing_code") == "insecure_setup_code":

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.1.2"],
+  "requirements": ["aiohomekit==1.1.3"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_first_byte": 6 }],
   "after_dependencies": ["zeroconf", "bluetooth"],

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "requirements": ["aiohomekit==1.1.1"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
-  "bluetooth": [{ "manufacturer_id": 76 }],
+  "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_first_byte": 6 }],
   "after_dependencies": ["zeroconf", "bluetooth"],
   "codeowners": ["@Jc2k", "@bdraco"],
   "iot_class": "local_push",

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.1.3"],
+  "requirements": ["aiohomekit==1.1.4"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_first_byte": 6 }],
   "after_dependencies": ["zeroconf", "bluetooth"],

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -5,7 +5,8 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "requirements": ["aiohomekit==1.1.1"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
-  "after_dependencies": ["zeroconf"],
+  "bluetooth": [{ "manufacturer_id": 76 }],
+  "after_dependencies": ["zeroconf", "bluetooth"],
   "codeowners": ["@Jc2k", "@bdraco"],
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"]

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.1.1"],
+  "requirements": ["aiohomekit==1.1.2"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_first_byte": 6 }],
   "after_dependencies": ["zeroconf", "bluetooth"],

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -6,7 +6,7 @@
   "requirements": ["aiohomekit==1.1.4"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_first_byte": 6 }],
-  "after_dependencies": ["zeroconf", "bluetooth"],
+  "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"]

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -12,7 +12,7 @@
       },
       "pair": {
         "title": "Pair with a device via HomeKit Accessory Protocol",
-        "description": "HomeKit Controller communicates with {name} over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",
+        "description": "HomeKit Controller communicates with {name} ({category}) over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",
         "data": {
           "pairing_code": "Pairing Code",
           "allow_insecure_setup_codes": "Allow pairing with insecure setup codes."

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -1,7 +1,7 @@
 {
   "title": "HomeKit Controller",
   "config": {
-    "flow_title": "{name}",
+    "flow_title": "{name} ({category})",
     "step": {
       "user": {
         "title": "Device selection",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -18,7 +18,7 @@
             "unable_to_pair": "Unable to pair, please try again.",
             "unknown_error": "Device reported an unknown error. Pairing failed."
         },
-        "flow_title": "{name}",
+        "flow_title": "{name} ({category})",
         "step": {
             "busy_error": {
                 "description": "Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -33,7 +33,7 @@
                     "allow_insecure_setup_codes": "Allow pairing with insecure setup codes.",
                     "pairing_code": "Pairing Code"
                 },
-                "description": "HomeKit Controller communicates with {name} over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",
+                "description": "HomeKit Controller communicates with {name} ({category}) over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",
                 "title": "Pair with a device via HomeKit Accessory Protocol"
             },
             "protocol_error": {

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 BLUETOOTH: list[dict[str, str | int]] = [
     {
+        "domain": "homekit_controller",
+        "manufacturer_id": 76
+    },
+    {
         "domain": "switchbot",
         "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
     }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 BLUETOOTH: list[dict[str, str | int]] = [
     {
         "domain": "homekit_controller",
-        "manufacturer_id": 76
+        "manufacturer_id": 76,
+        "manufacturer_data_first_byte": 6
     },
     {
         "domain": "switchbot",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.03.2
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.1.3
+aiohomekit==1.1.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.03.2
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.1.1
+aiohomekit==1.1.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.03.2
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.1.2
+aiohomekit==1.1.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.03.2
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.1.2
+aiohomekit==1.1.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.03.2
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.1.3
+aiohomekit==1.1.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.03.2
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.1.1
+aiohomekit==1.1.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1069,9 +1069,8 @@ async def test_bluetooth_valid_device_discovery_paired(hass, controller):
 
 
 async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
-    """Test bluetooth discovery  with a homekit device and discovery works."""
-    device = setup_mock_accessory(controller)
-
+    """Test bluetooth discovery with a homekit device and discovery works."""
+    setup_mock_accessory(controller)
     with patch(
         "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
         True,
@@ -1091,23 +1090,11 @@ async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
         "title_placeholders": {"name": "TestDevice", "category": "Other"},
     }
 
-    original_async_start_pairing = device.async_start_pairing
-
-    async def _async_start_pairing(*args, **kwargs):
-        finish_pairing = await original_async_start_pairing(*args, **kwargs)
-
-        async def _finish_pairing(*args, **kwargs):
-            return await finish_pairing(*args, **kwargs)
-
-        return _finish_pairing
-
-    with patch.object(device, "async_start_pairing", _async_start_pairing):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
-
-    assert result["type"] == RESULT_TYPE_FORM
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"pairing_code": "111-22-333"}
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result2["type"] == RESULT_TYPE_FORM
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], user_input={"pairing_code": "111-22-333"}
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Koogeek-LS1-20833F"
-    assert result["data"] == {}
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "Koogeek-LS1-20833F"
+    assert result3["data"] == {}

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -187,7 +187,7 @@ def get_device_discovery_info(
             "c#": device.description.config_num,
             "s#": device.description.state_num,
             "ff": "0",
-            "ci": "0",
+            "ci": "7",
             "sf": "0" if paired else "1",
             "sh": "",
         },
@@ -244,7 +244,7 @@ async def test_discovery_works(hass, controller, upper_case_props, missing_cshar
     assert result["step_id"] == "pair"
     assert get_flow_context(hass, result) == {
         "source": config_entries.SOURCE_ZEROCONF,
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
     }
 
@@ -628,7 +628,7 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
     )
 
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -643,7 +643,7 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
     assert result["errors"]["pairing_code"] == expected
 
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -676,7 +676,7 @@ async def test_pair_abort_errors_on_finish(hass, controller, exception, expected
     )
 
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -689,7 +689,7 @@ async def test_pair_abort_errors_on_finish(hass, controller, exception, expected
 
     assert result["type"] == "form"
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -716,7 +716,7 @@ async def test_pair_form_errors_on_finish(hass, controller, exception, expected)
     )
 
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -729,7 +729,7 @@ async def test_pair_form_errors_on_finish(hass, controller, exception, expected)
 
     assert result["type"] == "form"
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -742,7 +742,7 @@ async def test_pair_form_errors_on_finish(hass, controller, exception, expected)
     assert result["errors"]["pairing_code"] == expected
 
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
         "pairing": True,
@@ -773,7 +773,7 @@ async def test_user_works(hass, controller):
     assert get_flow_context(hass, result) == {
         "source": config_entries.SOURCE_USER,
         "unique_id": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Other"},
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -808,7 +808,7 @@ async def test_user_pairing_with_insecure_setup_code(hass, controller):
     assert get_flow_context(hass, result) == {
         "source": config_entries.SOURCE_USER,
         "unique_id": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Other"},
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -865,7 +865,7 @@ async def test_unignore_works(hass, controller):
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Other"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_UNIGNORE,
     }
@@ -953,7 +953,7 @@ async def test_mdns_update_to_paired_during_pairing(hass, controller):
     )
 
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -978,7 +978,7 @@ async def test_mdns_update_to_paired_during_pairing(hass, controller):
 
     assert result["type"] == "form"
     assert get_flow_context(hass, result) == {
-        "title_placeholders": {"name": "TestDevice"},
+        "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
     }
@@ -1084,3 +1084,9 @@ async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
 
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "pair"
+
+    assert get_flow_context(hass, result) == {
+        "source": config_entries.SOURCE_BLUETOOTH,
+        "unique_id": "AA:BB:CC:DD:EE:FF",
+        "title_placeholders": {"name": "TestDevice", "category": "Other"},
+    }

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -111,7 +111,7 @@ HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_UNPAIRED = BluetoothServiceInfo(
     rssi=-81,
     # ID is '00:00:00:00:00:00', pairing flag is byte 3
     manufacturer_data={
-        76: b"\x061\x00\x01\x00\x00\x00\x00\x00\x07\x00\x06\x00\x02\x02X\x19\xb1Q"
+        76: b"\x061\x01\x00\x00\x00\x00\x00\x00\x07\x00\x06\x00\x02\x02X\x19\xb1Q"
     },
     service_data={},
     service_uuids=[],

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,6 +1,5 @@
 """Tests for homekit_controller config flow."""
 import asyncio
-from unittest import mock
 import unittest.mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,8 +14,13 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_FORM,
+    FlowResultType,
+)
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from tests.common import MockConfigEntry, mock_device_registry
 
@@ -78,23 +82,55 @@ VALID_PAIRING_CODES = [
     "   98765432  ",
 ]
 
+NOT_HK_BLUETOOTH_SERVICE_INFO = BluetoothServiceInfo(
+    name="FakeAccessory",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-81,
+    manufacturer_data={12: b"\x06\x12\x34"},
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
 
-def _setup_flow_handler(hass, pairing=None):
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
-    flow.context = {}
+HK_BLUETOOTH_SERVICE_INFO_NOT_DISCOVERED = BluetoothServiceInfo(
+    name="Eve Energy Not Found",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-81,
+    # ID is '9b:86:af:01:af:db'
+    manufacturer_data={
+        76: b"\x061\x01\x9b\x86\xaf\x01\xaf\xdb\x07\x00\x06\x00\x02\x02X\x19\xb1Q"
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
 
-    finish_pairing = unittest.mock.AsyncMock(return_value=pairing)
+HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_UNPAIRED = BluetoothServiceInfo(
+    name="Eve Energy Found Unpaired",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-81,
+    # ID is '00:00:00:00:00:00', pairing flag is byte 3
+    manufacturer_data={
+        76: b"\x061\x00\x01\x00\x00\x00\x00\x00\x07\x00\x06\x00\x02\x02X\x19\xb1Q"
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
 
-    discovery = mock.Mock()
-    discovery.description.id = "00:00:00:00:00:00"
-    discovery.async_start_pairing = unittest.mock.AsyncMock(return_value=finish_pairing)
 
-    flow.controller = mock.Mock()
-    flow.controller.pairings = {}
-    flow.controller.async_find = unittest.mock.AsyncMock(return_value=discovery)
-
-    return flow
+HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_PAIRED = BluetoothServiceInfo(
+    name="Eve Energy Found Paired",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-81,
+    # ID is '00:00:00:00:00:00', pairing flag is byte 3
+    manufacturer_data={
+        76: b"\x061\x00\x00\x00\x00\x00\x00\x00\x07\x00\x06\x00\x02\x02X\x19\xb1Q"
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
 
 
 @pytest.mark.parametrize("pairing_code", INVALID_PAIRING_CODES)
@@ -967,3 +1003,84 @@ async def test_mdns_update_to_paired_during_pairing(hass, controller):
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Koogeek-LS1-20833F"
     assert result["data"] == {}
+
+
+async def test_discovery_no_bluetooth_support(hass, controller):
+    """Test discovery with bluetooth support not available."""
+    with patch(
+        "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
+        False,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            "homekit_controller",
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=HK_BLUETOOTH_SERVICE_INFO_NOT_DISCOVERED,
+        )
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "ignored_model"
+
+
+async def test_bluetooth_not_homekit(hass, controller):
+    """Test bluetooth discovery with a non-homekit device."""
+    with patch(
+        "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
+        True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            "homekit_controller",
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=NOT_HK_BLUETOOTH_SERVICE_INFO,
+        )
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "ignored_model"
+
+
+async def test_bluetooth_valid_device_no_discovery(hass, controller):
+    """Test bluetooth discovery  with a homekit device and discovery fails."""
+    with patch(
+        "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
+        True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            "homekit_controller",
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=HK_BLUETOOTH_SERVICE_INFO_NOT_DISCOVERED,
+        )
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "accessory_not_found_error"
+
+
+async def test_bluetooth_valid_device_discovery_paired(hass, controller):
+    """Test bluetooth discovery  with a homekit device and discovery works."""
+    setup_mock_accessory(controller)
+
+    with patch(
+        "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
+        True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            "homekit_controller",
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_PAIRED,
+        )
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_paired"
+
+
+async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
+    """Test bluetooth discovery  with a homekit device and discovery works."""
+    setup_mock_accessory(controller)
+
+    with patch(
+        "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
+        True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            "homekit_controller",
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_UNPAIRED,
+        )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pair"


### PR DESCRIPTION
## Proposed change

Add bluetooth discovery to HKC

Changelog: https://github.com/Jc2k/aiohomekit/compare/1.1.1...1.1.4

<img width="264" alt="Screen Shot 2022-07-16 at 10 06 02 PM" src="https://user-images.githubusercontent.com/663432/179382106-b0035bd6-848e-43f5-ba39-d4d37719a64e.png">
<img width="268" alt="Screen Shot 2022-07-16 at 10 05 48 PM" src="https://user-images.githubusercontent.com/663432/179382107-8376f1f8-5d1b-43ce-b5b1-70474d55cbc5.png">
<img width="261" alt="Screen Shot 2022-07-16 at 10 05 45 PM" src="https://user-images.githubusercontent.com/663432/179382108-6214bbea-4f18-4c1e-ad99-de01791623a1.png">
<img width="254" alt="Screen Shot 2022-07-16 at 10 05 36 PM" src="https://user-images.githubusercontent.com/663432/179382109-80ed567f-0774-45f3-926c-04e88b3b0021.png">


<img width="327" alt="Screen Shot 2022-07-16 at 19 27 51" src="https://user-images.githubusercontent.com/663432/179377447-a1c51717-c878-422f-9182-7be1bb3efaae.png">
<img width="319" alt="Screen Shot 2022-07-16 at 19 27 48" src="https://user-images.githubusercontent.com/663432/179377453-6a04a4cc-b2f0-4cfc-860a-ace7d7a4e593.png">
<img width="322" alt="Screen Shot 2022-07-16 at 19 27 46" src="https://user-images.githubusercontent.com/663432/179377458-a6705382-c2e1-478b-aa18-0387b32c8d92.png">
<img width="326" alt="Screen Shot 2022-07-16 at 19 27 44" src="https://user-images.githubusercontent.com/663432/179377463-3ddcc44d-179e-4ba2-8648-16ebffe07d32.png">
<img width="328" alt="Screen Shot 2022-07-16 at 19 27 39" src="https://user-images.githubusercontent.com/663432/179377469-f30bf327-5c97-4d1e-91ba-77d7597c2971.png">
<img width="323" alt="Screen Shot 2022-07-16 at 19 27 35" src="https://user-images.githubusercontent.com/663432/179377471-2dede367-fb8b-4fb9-85b4-e4e10b394d86.png">
<img width="583" alt="Screen Shot 2022-07-16 at 10 17 27 PM" src="https://user-images.githubusercontent.com/663432/179382373-1ee2fbab-7c76-49a7-aa5d-451c9d8a5527.png">


- [x] Tests
- [x] Docs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23417

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
