### PR TITLE
Do not access hass.data in unifi test

### DIFF
--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -5,7 +5,6 @@ from aiounifi.controller import MESSAGE_DEVICE
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 from yarl import URL
 
-from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -24,7 +23,12 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 
-from .test_controller import DESCRIPTION, setup_unifi_integration
+from .test_controller import (
+    DEFAULT_HOST,
+    DEFAULT_SITE,
+    DESCRIPTION,
+    setup_unifi_integration,
+)
 
 DEVICE_1 = {
     "board_rev": 3,
@@ -158,16 +162,13 @@ async def test_not_admin(hass, aioclient_mock):
 
 async def test_install(hass, aioclient_mock):
     """Test the device update install call."""
-    config_entry = await setup_unifi_integration(
-        hass, aioclient_mock, devices_response=[DEVICE_1]
-    )
+    await setup_unifi_integration(hass, aioclient_mock, devices_response=[DEVICE_1])
 
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
     device_state = hass.states.get("update.device_1")
     assert device_state.state == STATE_ON
 
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-    url = f"https://{controller.host}:1234/api/s/{controller.site}/cmd/devmgr"
+    url = f"https://{DEFAULT_HOST}:1234/api/s/{DEFAULT_SITE}/cmd/devmgr"
     aioclient_mock.clear_requests()
     aioclient_mock.post(url)
 

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -5,6 +5,7 @@ from aiounifi.controller import MESSAGE_DEVICE
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 from yarl import URL
 
+from homeassistant.components.unifi.const import CONF_SITE_ID
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -18,17 +19,13 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
+    CONF_HOST,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
 
-from .test_controller import (
-    DEFAULT_HOST,
-    DEFAULT_SITE,
-    DESCRIPTION,
-    setup_unifi_integration,
-)
+from .test_controller import DESCRIPTION, setup_unifi_integration
 
 DEVICE_1 = {
     "board_rev": 3,
@@ -162,13 +159,15 @@ async def test_not_admin(hass, aioclient_mock):
 
 async def test_install(hass, aioclient_mock):
     """Test the device update install call."""
-    await setup_unifi_integration(hass, aioclient_mock, devices_response=[DEVICE_1])
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, devices_response=[DEVICE_1]
+    )
 
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
     device_state = hass.states.get("update.device_1")
     assert device_state.state == STATE_ON
 
-    url = f"https://{DEFAULT_HOST}:1234/api/s/{DEFAULT_SITE}/cmd/devmgr"
+    url = f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr"
     aioclient_mock.clear_requests()
     aioclient_mock.post(url)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Process review feedback by @MartinHjelmare at https://github.com/home-assistant/core/pull/75302#discussion_r922709587: Do not access `hass.data` in the test introduced in #75302.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
