### PR TITLE
Change manufacturer_data_first_byte to manufacturer_data_start

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -71,7 +71,7 @@ ADDRESS: Final = "address"
 LOCAL_NAME: Final = "local_name"
 SERVICE_UUID: Final = "service_uuid"
 MANUFACTURER_ID: Final = "manufacturer_id"
-MANUFACTURER_DATA_FIRST_BYTE: Final = "manufacturer_data_first_byte"
+MANUFACTURER_DATA_START: Final = "manufacturer_data_start"
 
 
 BluetoothChange = Enum("BluetoothChange", "ADVERTISEMENT")
@@ -157,14 +157,16 @@ def _ble_device_matches(
         return False
 
     if (
-        matcher_manufacturer_data_first_byte := matcher.get(
-            MANUFACTURER_DATA_FIRST_BYTE
+        matcher_manufacturer_data_start := matcher.get(MANUFACTURER_DATA_START)
+    ) is not None:
+        matcher_manufacturer_data_start_bytes = bytearray(
+            matcher_manufacturer_data_start
         )
-    ) is not None and not any(
-        matcher_manufacturer_data_first_byte == manufacturer_data[0]
-        for manufacturer_data in advertisement_data.manufacturer_data.values()
-    ):
-        return False
+        if not any(
+            manufacturer_data.startswith(matcher_manufacturer_data_start_bytes)
+            for manufacturer_data in advertisement_data.manufacturer_data.values()
+        ):
+            return False
 
     return True
 

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "requirements": ["aiohomekit==1.1.4"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
-  "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_first_byte": 6 }],
+  "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_start": [6] }],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],
   "iot_class": "local_push",

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 # fmt: off
 
-BLUETOOTH: list[dict[str, str | int]] = [
+BLUETOOTH: list[dict[str, str | int | list[int]]] = [
     {
         "domain": "homekit_controller",
         "manufacturer_id": 76,
-        "manufacturer_data_first_byte": 6
+        "manufacturer_data_start": [
+            6
+        ]
     },
     {
         "domain": "switchbot",

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -89,7 +89,7 @@ class BluetoothMatcherOptional(TypedDict, total=False):
     local_name: str
     service_uuid: str
     manufacturer_id: int
-    manufacturer_data_first_byte: int
+    manufacturer_data_start: list[int]
 
 
 class BluetoothMatcher(BluetoothMatcherRequired, BluetoothMatcherOptional):

--- a/script/hassfest/bluetooth.py
+++ b/script/hassfest/bluetooth.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 # fmt: off
 
-BLUETOOTH: list[dict[str, str | int]] = {}
+BLUETOOTH: list[dict[str, str | int | list[int]]] = {}
 """.strip()
 
 

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -196,7 +196,7 @@ MANIFEST_SCHEMA = vol.Schema(
                     vol.Optional("service_uuid"): vol.All(str, verify_lowercase),
                     vol.Optional("local_name"): vol.All(str),
                     vol.Optional("manufacturer_id"): int,
-                    vol.Optional("manufacturer_data_first_byte"): int,
+                    vol.Optional("manufacturer_data_start"): [int],
                 }
             )
         ],

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -153,12 +153,12 @@ async def test_discovery_match_by_local_name(hass, mock_bleak_scanner_start):
 async def test_discovery_match_by_manufacturer_id_and_first_byte(
     hass, mock_bleak_scanner_start
 ):
-    """Test bluetooth discovery match by manufacturer_id and manufacturer_data_first_byte."""
+    """Test bluetooth discovery match by manufacturer_id and manufacturer_data_start."""
     mock_bt = [
         {
             "domain": "homekit_controller",
             "manufacturer_id": 76,
-            "manufacturer_data_first_byte": 0x06,
+            "manufacturer_data_start": [0x06, 0x02, 0x03],
         }
     ]
     with patch(
@@ -174,7 +174,9 @@ async def test_discovery_match_by_manufacturer_id_and_first_byte(
 
         hkc_device = BLEDevice("44:44:33:11:23:45", "lock")
         hkc_adv = AdvertisementData(
-            local_name="lock", service_uuids=[], manufacturer_data={76: b"\x06"}
+            local_name="lock",
+            service_uuids=[],
+            manufacturer_data={76: b"\x06\x02\x03\x99"},
         )
 
         models.HA_BLEAK_SCANNER._callback(hkc_device, hkc_adv)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -205,7 +205,7 @@ def test_integration_properties(hass):
                 {"hostname": "tesla_*", "macaddress": "98ED5C*"},
                 {"registered_devices": True},
             ],
-            "bluetooth": [{"manufacturer_id": 76, "manufacturer_data_first_byte": 6}],
+            "bluetooth": [{"manufacturer_id": 76, "manufacturer_data_start": [0x06]}],
             "usb": [
                 {"vid": "10C4", "pid": "EA60"},
                 {"vid": "1CF1", "pid": "0030"},
@@ -244,7 +244,7 @@ def test_integration_properties(hass):
         {"vid": "10C4", "pid": "8A2A"},
     ]
     assert integration.bluetooth == [
-        {"manufacturer_id": 76, "manufacturer_data_first_byte": 6}
+        {"manufacturer_id": 76, "manufacturer_data_start": [0x06]}
     ]
     assert integration.ssdp == [
         {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow matching on the first few bytes instead


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1403

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
