### PR TITLE
Update awair SensorDeviceClass to specify icon

### DIFF
--- a/homeassistant/components/awair/const.py
+++ b/homeassistant/components/awair/const.py
@@ -86,7 +86,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
     ),
     AwairSensorEntityDescription(
         key=API_VOC,
-        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+        icon="mdi:molecule",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
         name="Volatile organic compounds",
         unique_id_tag="VOC",  # matches legacy format

--- a/homeassistant/components/awair/const.py
+++ b/homeassistant/components/awair/const.py
@@ -86,7 +86,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
     ),
     AwairSensorEntityDescription(
         key=API_VOC,
-        icon="mdi:cloud",
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
         name="Volatile organic compounds",
         unique_id_tag="VOC",  # matches legacy format
@@ -101,7 +101,6 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
     AwairSensorEntityDescription(
         key=API_CO2,
         device_class=SensorDeviceClass.CO2,
-        icon="mdi:cloud",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         name="Carbon dioxide",
         unique_id_tag="CO2",  # matches legacy format
@@ -111,14 +110,14 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
 SENSOR_TYPES_DUST: tuple[AwairSensorEntityDescription, ...] = (
     AwairSensorEntityDescription(
         key=API_PM25,
-        icon="mdi:blur",
+        device_class=SensorDeviceClass.PM25,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         name="PM2.5",
         unique_id_tag="PM25",  # matches legacy format
     ),
     AwairSensorEntityDescription(
         key=API_PM10,
-        icon="mdi:blur",
+        device_class=SensorDeviceClass.PM10,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         name="PM10",
         unique_id_tag="PM10",  # matches legacy format

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -87,6 +87,7 @@ async def test_awair_gen1_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
+        {},
     )
 
     assert_expected_properties(
@@ -178,6 +179,7 @@ async def test_awair_gen2_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "97",
+        {},
     )
 
     assert_expected_properties(
@@ -210,6 +212,7 @@ async def test_awair_mint_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "98",
+        {},
     )
 
     assert_expected_properties(
@@ -250,6 +253,7 @@ async def test_awair_glow_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "93",
+        {},
     )
 
     # The glow does not have a particle sensor
@@ -269,6 +273,7 @@ async def test_awair_omni_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "99",
+        {},
     )
 
     assert_expected_properties(
@@ -277,6 +282,7 @@ async def test_awair_omni_sensors(hass):
         "sensor.living_room_sound_level",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SPL_A].unique_id_tag}",
         "47.0",
+        {ATTR_UNIT_OF_MEASUREMENT: "dBa"},
     )
 
     assert_expected_properties(
@@ -320,6 +326,7 @@ async def test_awair_unavailable(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
+        {},
     )
 
     with patch("python_awair.AwairClient.query", side_effect=OFFLINE_FIXTURE):
@@ -330,4 +337,5 @@ async def test_awair_unavailable(hass):
             "sensor.living_room_awair_score",
             f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
             STATE_UNAVAILABLE,
+            {},
         )

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.awair.const import (
     SENSOR_TYPES_DUST,
 )
 from homeassistant.const import (
-    ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
@@ -88,7 +87,6 @@ async def test_awair_gen1_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
-        {ATTR_ICON: "mdi:blur"},
     )
 
     assert_expected_properties(
@@ -116,7 +114,6 @@ async def test_awair_gen1_sensors(hass):
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_CO2].unique_id_tag}",
         "654.0",
         {
-            ATTR_ICON: "mdi:cloud",
             ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_PARTS_PER_MILLION,
             "awair_index": 0.0,
         },
@@ -129,7 +126,6 @@ async def test_awair_gen1_sensors(hass):
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_VOC].unique_id_tag}",
         "366",
         {
-            ATTR_ICON: "mdi:cloud",
             ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_PARTS_PER_BILLION,
             "awair_index": 1.0,
         },
@@ -143,7 +139,6 @@ async def test_awair_gen1_sensors(hass):
         f"{AWAIR_UUID}_DUST",
         "14.3",
         {
-            ATTR_ICON: "mdi:blur",
             ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             "awair_index": 1.0,
         },
@@ -156,7 +151,6 @@ async def test_awair_gen1_sensors(hass):
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_PM10].unique_id_tag}",
         "14.3",
         {
-            ATTR_ICON: "mdi:blur",
             ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             "awair_index": 1.0,
         },
@@ -184,7 +178,6 @@ async def test_awair_gen2_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "97",
-        {ATTR_ICON: "mdi:blur"},
     )
 
     assert_expected_properties(
@@ -194,7 +187,6 @@ async def test_awair_gen2_sensors(hass):
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_PM25].unique_id_tag}",
         "2.0",
         {
-            ATTR_ICON: "mdi:blur",
             ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             "awair_index": 0.0,
         },
@@ -218,7 +210,6 @@ async def test_awair_mint_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "98",
-        {ATTR_ICON: "mdi:blur"},
     )
 
     assert_expected_properties(
@@ -228,7 +219,6 @@ async def test_awair_mint_sensors(hass):
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_PM25].unique_id_tag}",
         "1.0",
         {
-            ATTR_ICON: "mdi:blur",
             ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             "awair_index": 0.0,
         },
@@ -260,7 +250,6 @@ async def test_awair_glow_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "93",
-        {ATTR_ICON: "mdi:blur"},
     )
 
     # The glow does not have a particle sensor
@@ -280,7 +269,6 @@ async def test_awair_omni_sensors(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "99",
-        {ATTR_ICON: "mdi:blur"},
     )
 
     assert_expected_properties(
@@ -289,7 +277,6 @@ async def test_awair_omni_sensors(hass):
         "sensor.living_room_sound_level",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SPL_A].unique_id_tag}",
         "47.0",
-        {ATTR_ICON: "mdi:ear-hearing", ATTR_UNIT_OF_MEASUREMENT: "dBa"},
     )
 
     assert_expected_properties(
@@ -333,7 +320,6 @@ async def test_awair_unavailable(hass):
         "sensor.living_room_awair_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
-        {ATTR_ICON: "mdi:blur"},
     )
 
     with patch("python_awair.AwairClient.query", side_effect=OFFLINE_FIXTURE):
@@ -344,5 +330,4 @@ async def test_awair_unavailable(hass):
             "sensor.living_room_awair_score",
             f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
             STATE_UNAVAILABLE,
-            {ATTR_ICON: "mdi:blur"},
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

* Update the `awair` integration to use the appropriate `SensorDeviceClass` for VOC, PM2.5, and PM10 sensors, and remove the icon override for these sensors so the `SensorDeviceClass`'s default icon is used.  
* Remove the icon override so the CO2 sensor's `SensorDeviceClass`'s default icon is used.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue:  N/A
- Link to documentation pull request:  N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
