### PR TITLE
Bump AIOAladdinConnect to 0.1.27

### DIFF
--- a/homeassistant/components/aladdin_connect/cover.py
+++ b/homeassistant/components/aladdin_connect/cover.py
@@ -89,6 +89,7 @@ class AladdinDevice(CoverEntity):
         self._device_id = device["device_id"]
         self._number = device["door_number"]
         self._name = device["name"]
+        self._serial = device["serial"]
         self._attr_unique_id = f"{self._device_id}-{self._number}"
         self._attr_has_entity_name = True
 
@@ -108,8 +109,8 @@ class AladdinDevice(CoverEntity):
             """Schedule a state update."""
             self.async_write_ha_state()
 
-        self._acc.register_callback(update_callback, self._number)
-        await self._acc.get_doors(self._number)
+        self._acc.register_callback(update_callback, self._serial)
+        await self._acc.get_doors(self._serial)
 
     async def async_will_remove_from_hass(self) -> None:
         """Close Aladdin Connect before removing."""
@@ -125,7 +126,7 @@ class AladdinDevice(CoverEntity):
 
     async def async_update(self) -> None:
         """Update status of cover."""
-        await self._acc.get_doors(self._number)
+        await self._acc.get_doors(self._serial)
 
     @property
     def is_closed(self) -> bool | None:

--- a/homeassistant/components/aladdin_connect/manifest.json
+++ b/homeassistant/components/aladdin_connect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aladdin_connect",
   "name": "Aladdin Connect",
   "documentation": "https://www.home-assistant.io/integrations/aladdin_connect",
-  "requirements": ["AIOAladdinConnect==0.1.25"],
+  "requirements": ["AIOAladdinConnect==0.1.27"],
   "codeowners": ["@mkmer"],
   "iot_class": "cloud_polling",
   "loggers": ["aladdin_connect"],

--- a/homeassistant/components/aladdin_connect/model.py
+++ b/homeassistant/components/aladdin_connect/model.py
@@ -11,3 +11,4 @@ class DoorDevice(TypedDict):
     door_number: int
     name: str
     status: str
+    serial: str

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.25
+AIOAladdinConnect==0.1.27
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.25
+AIOAladdinConnect==0.1.27
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/tests/components/aladdin_connect/conftest.py
+++ b/tests/components/aladdin_connect/conftest.py
@@ -10,6 +10,7 @@ DEVICE_CONFIG_OPEN = {
     "name": "home",
     "status": "open",
     "link_status": "Connected",
+    "serial": "12345",
 }
 
 

--- a/tests/components/aladdin_connect/test_cover.py
+++ b/tests/components/aladdin_connect/test_cover.py
@@ -33,6 +33,7 @@ DEVICE_CONFIG_OPEN = {
     "name": "home",
     "status": "open",
     "link_status": "Connected",
+    "serial": "12345",
 }
 
 DEVICE_CONFIG_OPENING = {
@@ -41,6 +42,7 @@ DEVICE_CONFIG_OPENING = {
     "name": "home",
     "status": "opening",
     "link_status": "Connected",
+    "serial": "12345",
 }
 
 DEVICE_CONFIG_CLOSED = {
@@ -49,6 +51,7 @@ DEVICE_CONFIG_CLOSED = {
     "name": "home",
     "status": "closed",
     "link_status": "Connected",
+    "serial": "12345",
 }
 
 DEVICE_CONFIG_CLOSING = {
@@ -57,6 +60,7 @@ DEVICE_CONFIG_CLOSING = {
     "name": "home",
     "status": "closing",
     "link_status": "Connected",
+    "serial": "12345",
 }
 
 DEVICE_CONFIG_DISCONNECTED = {
@@ -65,6 +69,7 @@ DEVICE_CONFIG_DISCONNECTED = {
     "name": "home",
     "status": "open",
     "link_status": "Disconnected",
+    "serial": "12345",
 }
 
 DEVICE_CONFIG_BAD = {


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump AIOAladdinConnect to 0.1.27 - https://github.com/mkmer/AIOAladdinConnect/compare/0.1.25...0.1.27
Move to Serial number rather than door number for callback dict - addressing issue with multiple doors not having unique door numbers thus causing websocket callback not to update HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75279 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
