### PR TITLE
Refactor Advantage Air classes for expansion

### DIFF
--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirAcEntity, AdvantageAirZoneEntity
 
 PARALLEL_UPDATES = 0
 
@@ -38,7 +38,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AdvantageAirFilter(AdvantageAirEntity, BinarySensorEntity):
+class AdvantageAirFilter(AdvantageAirAcEntity, BinarySensorEntity):
     """Advantage Air Filter sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
@@ -56,7 +56,7 @@ class AdvantageAirFilter(AdvantageAirEntity, BinarySensorEntity):
         return self._ac["filterCleanStatus"]
 
 
-class AdvantageAirZoneMotion(AdvantageAirEntity, BinarySensorEntity):
+class AdvantageAirZoneMotion(AdvantageAirZoneEntity, BinarySensorEntity):
     """Advantage Air Zone Motion sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.MOTION
@@ -73,7 +73,7 @@ class AdvantageAirZoneMotion(AdvantageAirEntity, BinarySensorEntity):
         return self._zone["motion"] == 20
 
 
-class AdvantageAirZoneMyZone(AdvantageAirEntity, BinarySensorEntity):
+class AdvantageAirZoneMyZone(AdvantageAirZoneEntity, BinarySensorEntity):
     """Advantage Air Zone MyZone sensor."""
 
     _attr_entity_registry_enabled_default = False

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -48,9 +48,7 @@ class AdvantageAirFilter(AdvantageAirEntity, BinarySensorEntity):
     def __init__(self, instance, ac_key):
         """Initialize an Advantage Air Filter sensor."""
         super().__init__(instance, ac_key)
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-filter'
-        )
+        self._attr_unique_id += "-filter"
 
     @property
     def is_on(self):
@@ -67,9 +65,7 @@ class AdvantageAirZoneMotion(AdvantageAirEntity, BinarySensorEntity):
         """Initialize an Advantage Air Zone Motion sensor."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = f'{self._zone["name"]} motion'
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}-motion'
-        )
+        self._attr_unique_id += "-motion"
 
     @property
     def is_on(self):
@@ -87,9 +83,7 @@ class AdvantageAirZoneMyZone(AdvantageAirEntity, BinarySensorEntity):
         """Initialize an Advantage Air Zone MyZone sensor."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = f'{self._zone["name"]} myZone'
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}-myzone'
-        )
+        self._attr_unique_id += "-myzone"
 
     @property
     def is_on(self):

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -25,7 +25,7 @@ from .const import (
     ADVANTAGE_AIR_STATE_OPEN,
     DOMAIN as ADVANTAGE_AIR_DOMAIN,
 )
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirAcEntity, AdvantageAirZoneEntity
 
 ADVANTAGE_AIR_HVAC_MODES = {
     "heat": HVACMode.HEAT,
@@ -45,7 +45,7 @@ AC_HVAC_MODES = [
 ]
 
 ADVANTAGE_AIR_FAN_MODES = {
-    "auto": FAN_AUTO,
+    "autoAA": FAN_AUTO,
     "low": FAN_LOW,
     "medium": FAN_MEDIUM,
     "high": FAN_HIGH,
@@ -87,18 +87,13 @@ async def async_setup_entry(
     )
 
 
-class AdvantageAirClimateEntity(AdvantageAirEntity, ClimateEntity):
-    """AdvantageAir Climate class."""
+class AdvantageAirAC(AdvantageAirAcEntity, ClimateEntity):
+    """AdvantageAir AC unit."""
 
     _attr_temperature_unit = TEMP_CELSIUS
     _attr_target_temperature_step = PRECISION_WHOLE
     _attr_max_temp = 32
     _attr_min_temp = 16
-
-
-class AdvantageAirAC(AdvantageAirClimateEntity):
-    """AdvantageAir AC unit."""
-
     _attr_fan_modes = [FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH]
     _attr_hvac_modes = AC_HVAC_MODES
     _attr_supported_features = (
@@ -158,9 +153,13 @@ class AdvantageAirAC(AdvantageAirClimateEntity):
         await self.async_change({self.ac_key: {"info": {"setTemp": temp}}})
 
 
-class AdvantageAirZone(AdvantageAirClimateEntity):
+class AdvantageAirZone(AdvantageAirZoneEntity, ClimateEntity):
     """AdvantageAir Zone control."""
 
+    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_target_temperature_step = PRECISION_WHOLE
+    _attr_max_temp = 32
+    _attr_min_temp = 16
     _attr_hvac_modes = ZONE_HVAC_MODES
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 
@@ -168,6 +167,9 @@ class AdvantageAirZone(AdvantageAirClimateEntity):
         """Initialize an AdvantageAir Zone control."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = self._zone["name"]
+        self._attr_unique_id = (
+            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}'
+        )
 
     @property
     def hvac_mode(self):

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -45,7 +45,7 @@ AC_HVAC_MODES = [
 ]
 
 ADVANTAGE_AIR_FAN_MODES = {
-    "autoAA": FAN_AUTO,
+    "auto": FAN_AUTO,
     "low": FAN_LOW,
     "medium": FAN_MEDIUM,
     "high": FAN_HIGH,

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -108,7 +108,6 @@ class AdvantageAirAC(AdvantageAirClimateEntity):
     def __init__(self, instance, ac_key):
         """Initialize an AdvantageAir AC unit."""
         super().__init__(instance, ac_key)
-        self._attr_unique_id = f'{self.coordinator.data["system"]["rid"]}-{ac_key}'
         if self._ac.get("myAutoModeEnabled"):
             self._attr_hvac_modes = AC_HVAC_MODES + [HVACMode.AUTO]
 
@@ -169,9 +168,6 @@ class AdvantageAirZone(AdvantageAirClimateEntity):
         """Initialize an AdvantageAir Zone control."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = self._zone["name"]
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}'
-        )
 
     @property
     def hvac_mode(self):

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -53,9 +53,6 @@ class AdvantageAirZoneVent(AdvantageAirEntity, CoverEntity):
         """Initialize an Advantage Air Zone Vent."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = self._zone["name"]
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}'
-        )
 
     @property
     def is_closed(self) -> bool:

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -16,7 +16,7 @@ from .const import (
     ADVANTAGE_AIR_STATE_OPEN,
     DOMAIN as ADVANTAGE_AIR_DOMAIN,
 )
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirZoneEntity
 
 PARALLEL_UPDATES = 0
 
@@ -39,7 +39,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AdvantageAirZoneVent(AdvantageAirEntity, CoverEntity):
+class AdvantageAirZoneVent(AdvantageAirZoneEntity, CoverEntity):
     """Advantage Air Zone Vent."""
 
     _attr_device_class = CoverDeviceClass.DAMPER

--- a/homeassistant/components/advantage_air/entity.py
+++ b/homeassistant/components/advantage_air/entity.py
@@ -11,27 +11,43 @@ class AdvantageAirEntity(CoordinatorEntity):
 
     _attr_has_entity_name = True
 
-    def __init__(self, instance, ac_key, zone_key=None):
-        """Initialize common aspects of an Advantage Air sensor."""
+    def __init__(self, instance):
+        """Initialize common aspects of an Advantage Air entity."""
         super().__init__(instance["coordinator"])
+        self._attr_unique_id = self.coordinator.data["system"]["rid"]
+
+
+class AdvantageAirAcEntity(AdvantageAirEntity):
+    """Parent class for Advantage Air AC Entities."""
+
+    def __init__(self, instance, ac_key):
+        """Initialize common aspects of an Advantage Air ac entity."""
+        super().__init__(instance)
         self.async_change = instance["async_change"]
         self.ac_key = ac_key
-        self.zone_key = zone_key
-        self._attr_unique_id = f'{self.coordinator.data["system"]["rid"]}-{ac_key}'
+        self._attr_unique_id += f"-{ac_key}"
 
         self._attr_device_info = DeviceInfo(
             via_device=(DOMAIN, self.coordinator.data["system"]["rid"]),
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Advantage Air",
             model=self.coordinator.data["system"]["sysType"],
-            name=self._ac["name"],
+            name=self.coordinator.data["aircons"][self.ac_key]["info"]["name"],
         )
-        if zone_key:
-            self._attr_unique_id += f"-{zone_key}"
 
     @property
     def _ac(self):
         return self.coordinator.data["aircons"][self.ac_key]["info"]
+
+
+class AdvantageAirZoneEntity(AdvantageAirAcEntity):
+    """Parent class for Advantage Air Zone Entities."""
+
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize common aspects of an Advantage Air zone entity."""
+        super().__init__(instance, ac_key)
+        self.zone_key = zone_key
+        self._attr_unique_id += f"-{zone_key}"
 
     @property
     def _zone(self):

--- a/homeassistant/components/advantage_air/entity.py
+++ b/homeassistant/components/advantage_air/entity.py
@@ -17,15 +17,17 @@ class AdvantageAirEntity(CoordinatorEntity):
         self.async_change = instance["async_change"]
         self.ac_key = ac_key
         self.zone_key = zone_key
+        self._attr_unique_id = f'{self.coordinator.data["system"]["rid"]}-{ac_key}'
+
         self._attr_device_info = DeviceInfo(
             via_device=(DOMAIN, self.coordinator.data["system"]["rid"]),
-            identifiers={
-                (DOMAIN, f"{self.coordinator.data['system']['rid']}_{ac_key}")
-            },
+            identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Advantage Air",
             model=self.coordinator.data["system"]["sysType"],
             name=self._ac["name"],
         )
+        if zone_key:
+            self._attr_unique_id += f"-{zone_key}"
 
     @property
     def _ac(self):

--- a/homeassistant/components/advantage_air/select.py
+++ b/homeassistant/components/advantage_air/select.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirAcEntity
 
 ADVANTAGE_AIR_INACTIVE = "Inactive"
 
@@ -25,7 +25,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AdvantageAirMyZone(AdvantageAirEntity, SelectEntity):
+class AdvantageAirMyZone(AdvantageAirAcEntity, SelectEntity):
     """Representation of Advantage Air MyZone control."""
 
     _attr_icon = "mdi:home-thermometer"

--- a/homeassistant/components/advantage_air/select.py
+++ b/homeassistant/components/advantage_air/select.py
@@ -37,9 +37,7 @@ class AdvantageAirMyZone(AdvantageAirEntity, SelectEntity):
     def __init__(self, instance, ac_key):
         """Initialize an Advantage Air MyZone control."""
         super().__init__(instance, ac_key)
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-myzone'
-        )
+        self._attr_unique_id += "-myzone"
 
         for zone in instance["coordinator"].data["aircons"][ac_key]["zones"].values():
             if zone["type"] > 0:

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -68,9 +68,7 @@ class AdvantageAirTimeTo(AdvantageAirEntity, SensorEntity):
         self.action = action
         self._time_key = f"countDownTo{action}"
         self._attr_name = f"Time to {action}"
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{self.ac_key}-timeto{action}'
-        )
+        self._attr_unique_id += f"-timeto{action}"
 
     @property
     def native_value(self):
@@ -101,9 +99,7 @@ class AdvantageAirZoneVent(AdvantageAirEntity, SensorEntity):
         """Initialize an Advantage Air Zone Vent Sensor."""
         super().__init__(instance, ac_key, zone_key=zone_key)
         self._attr_name = f'{self._zone["name"]} vent'
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}-vent'
-        )
+        self._attr_unique_id += "-vent"
 
     @property
     def native_value(self):
@@ -131,9 +127,7 @@ class AdvantageAirZoneSignal(AdvantageAirEntity, SensorEntity):
         """Initialize an Advantage Air Zone wireless signal sensor."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = f'{self._zone["name"]} signal'
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}-signal'
-        )
+        self._attr_unique_id += "-signal"
 
     @property
     def native_value(self):
@@ -167,9 +161,7 @@ class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
         """Initialize an Advantage Air Zone Temp Sensor."""
         super().__init__(instance, ac_key, zone_key)
         self._attr_name = f'{self._zone["name"]} temperature'
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-{zone_key}-temp'
-        )
+        self._attr_unique_id += "-temp"
 
     @property
     def native_value(self):

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ADVANTAGE_AIR_STATE_OPEN, DOMAIN as ADVANTAGE_AIR_DOMAIN
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirAcEntity, AdvantageAirZoneEntity
 
 ADVANTAGE_AIR_SET_COUNTDOWN_VALUE = "minutes"
 ADVANTAGE_AIR_SET_COUNTDOWN_UNIT = "min"
@@ -56,7 +56,7 @@ async def async_setup_entry(
     )
 
 
-class AdvantageAirTimeTo(AdvantageAirEntity, SensorEntity):
+class AdvantageAirTimeTo(AdvantageAirAcEntity, SensorEntity):
     """Representation of Advantage Air timer control."""
 
     _attr_native_unit_of_measurement = ADVANTAGE_AIR_SET_COUNTDOWN_UNIT
@@ -88,7 +88,7 @@ class AdvantageAirTimeTo(AdvantageAirEntity, SensorEntity):
         await self.async_change({self.ac_key: {"info": {self._time_key: value}}})
 
 
-class AdvantageAirZoneVent(AdvantageAirEntity, SensorEntity):
+class AdvantageAirZoneVent(AdvantageAirZoneEntity, SensorEntity):
     """Representation of Advantage Air Zone Vent Sensor."""
 
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -116,7 +116,7 @@ class AdvantageAirZoneVent(AdvantageAirEntity, SensorEntity):
         return "mdi:fan-off"
 
 
-class AdvantageAirZoneSignal(AdvantageAirEntity, SensorEntity):
+class AdvantageAirZoneSignal(AdvantageAirZoneEntity, SensorEntity):
     """Representation of Advantage Air Zone wireless signal sensor."""
 
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -148,7 +148,7 @@ class AdvantageAirZoneSignal(AdvantageAirEntity, SensorEntity):
         return "mdi:wifi-strength-outline"
 
 
-class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
+class AdvantageAirZoneTemp(AdvantageAirZoneEntity, SensorEntity):
     """Representation of Advantage Air Zone temperature sensor."""
 
     _attr_native_unit_of_measurement = TEMP_CELSIUS

--- a/homeassistant/components/advantage_air/switch.py
+++ b/homeassistant/components/advantage_air/switch.py
@@ -9,7 +9,7 @@ from .const import (
     ADVANTAGE_AIR_STATE_ON,
     DOMAIN as ADVANTAGE_AIR_DOMAIN,
 )
-from .entity import AdvantageAirEntity
+from .entity import AdvantageAirAcEntity
 
 
 async def async_setup_entry(
@@ -28,7 +28,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AdvantageAirFreshAir(AdvantageAirEntity, SwitchEntity):
+class AdvantageAirFreshAir(AdvantageAirAcEntity, SwitchEntity):
     """Representation of Advantage Air fresh air control."""
 
     _attr_icon = "mdi:air-filter"

--- a/homeassistant/components/advantage_air/switch.py
+++ b/homeassistant/components/advantage_air/switch.py
@@ -37,9 +37,7 @@ class AdvantageAirFreshAir(AdvantageAirEntity, SwitchEntity):
     def __init__(self, instance, ac_key):
         """Initialize an Advantage Air fresh air control."""
         super().__init__(instance, ac_key)
-        self._attr_unique_id = (
-            f'{self.coordinator.data["system"]["rid"]}-{ac_key}-freshair'
-        )
+        self._attr_unique_id += "-freshair"
 
     @property
     def is_on(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I am adding two new platforms and multiple entities to the existing platforms, so this change refactors the parent classes to enable more entity types and reduce repetitive code. This change also moved _attr_unique_id to the parent classes to simply the child classes. This also standardises my device ids to match the entitiy unique ids, as this was changed very recently in https://github.com/home-assistant/core/pull/75395

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
