### PR TITLE
add unique id to device trackers

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -649,6 +649,7 @@ class Device(RestoreEntity):
         self.consider_home = consider_home
 
         # Device ID
+        self._attr_unique_id = dev_id
         self.dev_id = dev_id
         self.mac = mac
 

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -649,7 +649,7 @@ class Device(RestoreEntity):
         self.consider_home = consider_home
 
         # Device ID
-        self._attr_unique_id = dev_id
+        self._attr_unique_id = self.entity_id
         self.dev_id = dev_id
         self.mac = mac
 


### PR DESCRIPTION
## Proposed change
Currently there is no way to attach a device tracker to an area, since it doesn't have a unique id. I couldn't find any way to add such a unique id... So I figured since the device tracker already makes sure the dev_ids are unique, then there is no reason not to set the dev_id to be a unique ids as well

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
