### PR TITLE
Improve debouncer typing

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -15,6 +15,7 @@ homeassistant.auth.auth_store
 homeassistant.auth.providers.*
 homeassistant.helpers.area_registry
 homeassistant.helpers.condition
+homeassistant.helpers.debounce
 homeassistant.helpers.discovery
 homeassistant.helpers.entity
 homeassistant.helpers.entity_values

--- a/homeassistant/components/flux_led/number.py
+++ b/homeassistant/components/flux_led/number.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Coroutine
 import logging
-from typing import cast
+from typing import Any, cast
 
 from flux_led.protocol import (
     MUSIC_PIXELS_MAX,
@@ -143,7 +144,7 @@ class FluxConfigNumber(
     ) -> None:
         """Initialize the flux number."""
         super().__init__(coordinator, base_unique_id, name, key)
-        self._debouncer: Debouncer | None = None
+        self._debouncer: Debouncer[[], Coroutine[Any, Any, None]] | None = None
         self._pending_value: int | None = None
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/flux_led/number.py
+++ b/homeassistant/components/flux_led/number.py
@@ -144,7 +144,7 @@ class FluxConfigNumber(
     ) -> None:
         """Initialize the flux number."""
         super().__init__(coordinator, base_unique_id, name, key)
-        self._debouncer: Debouncer[[], Coroutine[Any, Any, None]] | None = None
+        self._debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None
         self._pending_value: int | None = None
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -95,14 +95,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.debug("Scanning for GDM clients")
         gdm.scan(scan_for_clients=True)
 
-    debouncer: Debouncer[[], None] = Debouncer(
+    hass.data[PLEX_DOMAIN][GDM_DEBOUNCER] = Debouncer[None](
         hass,
         _LOGGER,
         cooldown=10,
         immediate=True,
         function=gdm_scan,
-    )
-    hass.data[PLEX_DOMAIN][GDM_DEBOUNCER] = debouncer.async_call
+    ).async_call
 
     return True
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -95,7 +95,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.debug("Scanning for GDM clients")
         gdm.scan(scan_for_clients=True)
 
-    hass.data[PLEX_DOMAIN][GDM_DEBOUNCER] = Debouncer(
+    hass.data[PLEX_DOMAIN][GDM_DEBOUNCER] = Debouncer[[], None](
         hass,
         _LOGGER,
         cooldown=10,

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -95,13 +95,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.debug("Scanning for GDM clients")
         gdm.scan(scan_for_clients=True)
 
-    hass.data[PLEX_DOMAIN][GDM_DEBOUNCER] = Debouncer[[], None](
+    debouncer: Debouncer[[], None] = Debouncer(
         hass,
         _LOGGER,
         cooldown=10,
         immediate=True,
         function=gdm_scan,
-    ).async_call
+    )
+    hass.data[PLEX_DOMAIN][GDM_DEBOUNCER] = debouncer.async_call
 
     return True
 

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -1,7 +1,7 @@
 """The Samsung TV integration."""
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Coroutine, Mapping
 from functools import partial
 import socket
 from typing import Any
@@ -131,7 +131,7 @@ class DebouncedEntryReloader:
         self.hass = hass
         self.entry = entry
         self.token = self.entry.data.get(CONF_TOKEN)
-        self._debounced_reload = Debouncer(
+        self._debounced_reload: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -131,7 +131,7 @@ class DebouncedEntryReloader:
         self.hass = hass
         self.entry = entry
         self.token = self.entry.data.get(CONF_TOKEN)
-        self._debounced_reload: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
+        self._debounced_reload: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
 from datetime import timedelta
 from typing import Any, Final, cast
 
@@ -296,7 +297,7 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.entry = entry
         self.device = device
 
-        self._debounced_reload = Debouncer(
+        self._debounced_reload: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,
@@ -636,7 +637,7 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.entry = entry
         self.device = device
 
-        self._debounced_reload = Debouncer(
+        self._debounced_reload: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -297,7 +297,7 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.entry = entry
         self.device = device
 
-        self._debounced_reload: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
+        self._debounced_reload: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,
@@ -637,7 +637,7 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.entry = entry
         self.device = device
 
-        self._debounced_reload: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
+        self._debounced_reload: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,

--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -36,14 +36,13 @@ class SonosHouseholdCoordinator:
     async def _async_setup(self) -> None:
         """Finish setup in async context."""
         self.cache_update_lock = asyncio.Lock()
-        debouncer: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
+        self.async_poll = Debouncer[Coroutine[Any, Any, None]](
             self.hass,
             _LOGGER,
             cooldown=3,
             immediate=False,
             function=self._async_poll,
-        )
-        self.async_poll = debouncer.async_call
+        ).async_call
 
     @property
     def class_type(self) -> str:

--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine
 import logging
+from typing import Any
 
 from soco import SoCo
 
@@ -35,7 +36,7 @@ class SonosHouseholdCoordinator:
     async def _async_setup(self) -> None:
         """Finish setup in async context."""
         self.cache_update_lock = asyncio.Lock()
-        self.async_poll = Debouncer(
+        self.async_poll = Debouncer[[], Coroutine[Any, Any, None]](
             self.hass,
             _LOGGER,
             cooldown=3,

--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -36,13 +36,14 @@ class SonosHouseholdCoordinator:
     async def _async_setup(self) -> None:
         """Finish setup in async context."""
         self.cache_update_lock = asyncio.Lock()
-        self.async_poll = Debouncer[[], Coroutine[Any, Any, None]](
+        debouncer: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
             self.hass,
             _LOGGER,
             cooldown=3,
             immediate=False,
             function=self._async_poll,
-        ).async_call
+        )
+        self.async_poll = debouncer.async_call
 
     @property
     def class_type(self) -> str:

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -1,12 +1,13 @@
 """The USB Discovery integration."""
 from __future__ import annotations
 
+from collections.abc import Coroutine
 import dataclasses
 import fnmatch
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
@@ -109,7 +110,7 @@ class USBDiscovery:
         self.usb = usb
         self.seen: set[tuple[str, ...]] = set()
         self.observer_active = False
-        self._request_debouncer: Debouncer | None = None
+        self._request_debouncer: Debouncer[[], Coroutine[Any, Any, None]] | None = None
 
     async def async_setup(self) -> None:
         """Set up USB Discovery."""

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -110,7 +110,7 @@ class USBDiscovery:
         self.usb = usb
         self.seen: set[tuple[str, ...]] = set()
         self.observer_active = False
-        self._request_debouncer: Debouncer[[], Coroutine[Any, Any, None]] | None = None
+        self._request_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None
 
     async def async_setup(self) -> None:
         """Set up USB Discovery."""

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Coroutine
 import logging
 import time
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -832,7 +833,7 @@ def async_setup_cleanup(hass: HomeAssistant, dev_reg: DeviceRegistry) -> None:
         ent_reg = entity_registry.async_get(hass)
         async_cleanup(hass, dev_reg, ent_reg)
 
-    debounced_cleanup = Debouncer(
+    debounced_cleanup: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
         hass, _LOGGER, cooldown=CLEANUP_DELAY, immediate=False, function=cleanup
     )
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -833,7 +833,7 @@ def async_setup_cleanup(hass: HomeAssistant, dev_reg: DeviceRegistry) -> None:
         ent_reg = entity_registry.async_get(hass)
         async_cleanup(hass, dev_reg, ent_reg)
 
-    debounced_cleanup: Debouncer[[], Coroutine[Any, Any, None]] = Debouncer(
+    debounced_cleanup: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
         hass, _LOGGER, cooldown=CLEANUP_DELAY, immediate=False, function=cleanup
     )
 

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -44,8 +44,7 @@ class DataUpdateCoordinator(Generic[_T]):
         name: str,
         update_interval: timedelta | None = None,
         update_method: Callable[[], Awaitable[_T]] | None = None,
-        request_refresh_debouncer: Debouncer[[], Coroutine[Any, Any, None]]
-        | None = None,
+        request_refresh_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None,
     ) -> None:
         """Initialize global data updater."""
         self.hass = hass

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Coroutine, Generator
 from datetime import datetime, timedelta
 import logging
 from time import monotonic
@@ -44,7 +44,8 @@ class DataUpdateCoordinator(Generic[_T]):
         name: str,
         update_interval: timedelta | None = None,
         update_method: Callable[[], Awaitable[_T]] | None = None,
-        request_refresh_debouncer: Debouncer | None = None,
+        request_refresh_debouncer: Debouncer[[], Coroutine[Any, Any, None]]
+        | None = None,
     ) -> None:
         """Initialize global data updater."""
         self.hass = hass

--- a/mypy.ini
+++ b/mypy.ini
@@ -57,6 +57,9 @@ disallow_any_generics = true
 [mypy-homeassistant.helpers.condition]
 disallow_any_generics = true
 
+[mypy-homeassistant.helpers.debounce]
+disallow_any_generics = true
+
 [mypy-homeassistant.helpers.discovery]
 disallow_any_generics = true
 


### PR DESCRIPTION
## Proposed change
Improve typing for `Debouncer` by adding generics. Previously, `Debouncer.function` was typed as `Callable[..., Awaitable[None]]`. At least in one integration (`plex`), the return type is actually just `None`, not an Awaitable of None. That's perfectly fine as `Debouncer` handles that too.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
