### PR TITLE
Disable Aladdin Connect battery_level by default

### DIFF
--- a/homeassistant/components/aladdin_connect/sensor.py
+++ b/homeassistant/components/aladdin_connect/sensor.py
@@ -42,6 +42,7 @@ SENSORS: tuple[AccSensorEntityDescription, ...] = (
         key="battery_level",
         name="Battery level",
         device_class=SensorDeviceClass.BATTERY,
+        entity_registry_enabled_default=False,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=AladdinConnectClient.get_battery_status,

--- a/tests/components/aladdin_connect/test_init.py
+++ b/tests/components/aladdin_connect/test_init.py
@@ -9,14 +9,14 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import AsyncMock, MockConfigEntry
 
-YAML_CONFIG = {"username": "test-user", "password": "test-password"}
+CONFIG = {"username": "test-user", "password": "test-password"}
 
 
 async def test_setup_get_doors_errors(hass: HomeAssistant) -> None:
     """Test component setup Get Doors Errors."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=YAML_CONFIG,
+        data=CONFIG,
         unique_id="test-id",
     )
     config_entry.add_to_hass(hass)
@@ -38,7 +38,7 @@ async def test_setup_login_error(
     """Test component setup Login Errors."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=YAML_CONFIG,
+        data=CONFIG,
         unique_id="test-id",
     )
     config_entry.add_to_hass(hass)
@@ -57,7 +57,7 @@ async def test_setup_connection_error(
     """Test component setup Login Errors."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=YAML_CONFIG,
+        data=CONFIG,
         unique_id="test-id",
     )
     config_entry.add_to_hass(hass)
@@ -74,7 +74,7 @@ async def test_setup_component_no_error(hass: HomeAssistant) -> None:
     """Test component setup No Error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=YAML_CONFIG,
+        data=CONFIG,
         unique_id="test-id",
     )
     config_entry.add_to_hass(hass)
@@ -116,7 +116,7 @@ async def test_load_and_unload(
     """Test loading and unloading Aladdin Connect entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=YAML_CONFIG,
+        data=CONFIG,
         unique_id="test-id",
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/aladdin_connect/test_sensor.py
+++ b/tests/components/aladdin_connect/test_sensor.py
@@ -6,12 +6,11 @@ from homeassistant.components.aladdin_connect.const import DOMAIN
 from homeassistant.components.aladdin_connect.cover import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
-from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-YAML_CONFIG = {"username": "test-user", "password": "test-password"}
+CONFIG = {"username": "test-user", "password": "test-password"}
 RELOAD_AFTER_UPDATE_DELAY = timedelta(seconds=31)
 
 
@@ -22,12 +21,11 @@ async def test_sensors(
     """Test Sensors for AladdinConnect."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=YAML_CONFIG,
+        data=CONFIG,
         unique_id="test-id",
     )
     config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
 
     with patch(
@@ -48,6 +46,9 @@ async def test_sensors(
         await hass.async_block_till_done()
         assert update_entry != entry
         assert update_entry.disabled is False
+        state = hass.states.get("sensor.home_battery_level")
+        assert state is None
+
         async_fire_time_changed(
             hass,
             utcnow() + SCAN_INTERVAL,
@@ -67,6 +68,8 @@ async def test_sensors(
         await hass.async_block_till_done()
         assert update_entry != entry
         assert update_entry.disabled is False
+        state = hass.states.get("sensor.home_wi_fi_rssi")
+        assert state is None
 
         update_entry = registry.async_update_entity(
             entry.entity_id, **{"disabled_by": None}

--- a/tests/components/aladdin_connect/test_sensor.py
+++ b/tests/components/aladdin_connect/test_sensor.py
@@ -1,0 +1,82 @@
+"""Test the Aladdin Connect Sensors."""
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.aladdin_connect.const import DOMAIN
+from homeassistant.components.aladdin_connect.cover import SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
+from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+YAML_CONFIG = {"username": "test-user", "password": "test-password"}
+RELOAD_AFTER_UPDATE_DELAY = timedelta(seconds=31)
+
+
+async def test_sensors(
+    hass: HomeAssistant,
+    mock_aladdinconnect_api: MagicMock,
+) -> None:
+    """Test Sensors for AladdinConnect."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=YAML_CONFIG,
+        unique_id="test-id",
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.aladdin_connect.AladdinConnectClient",
+        return_value=mock_aladdinconnect_api,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        registry = entity_registry.async_get(hass)
+        entry = registry.async_get("sensor.home_battery_level")
+        assert entry
+        assert entry.disabled
+        assert entry.disabled_by is entity_registry.RegistryEntryDisabler.INTEGRATION
+        update_entry = registry.async_update_entity(
+            entry.entity_id, **{"disabled_by": None}
+        )
+        await hass.async_block_till_done()
+        assert update_entry != entry
+        assert update_entry.disabled is False
+        async_fire_time_changed(
+            hass,
+            utcnow() + SCAN_INTERVAL,
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get("sensor.home_battery_level")
+        assert state
+
+        entry = registry.async_get("sensor.home_wi_fi_rssi")
+        await hass.async_block_till_done()
+        assert entry
+        assert entry.disabled
+        assert entry.disabled_by is entity_registry.RegistryEntryDisabler.INTEGRATION
+        update_entry = registry.async_update_entity(
+            entry.entity_id, **{"disabled_by": None}
+        )
+        await hass.async_block_till_done()
+        assert update_entry != entry
+        assert update_entry.disabled is False
+
+        update_entry = registry.async_update_entity(
+            entry.entity_id, **{"disabled_by": None}
+        )
+        await hass.async_block_till_done()
+        async_fire_time_changed(
+            hass,
+            utcnow() + SCAN_INTERVAL,
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.home_wi_fi_rssi")
+        assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Disabled battery_level sensor by default - found that most users do not have battery in openers.  This should go along with the next release that includes the Aladdin Connect sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Disabled battery_level by default
Added sensor tests to reach 100% code coverage

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
