### PR TITLE
Allow account linking to phase out services

### DIFF
--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -38,7 +38,13 @@ async def async_provide_implementation(hass: HomeAssistant, domain: str):
             and CURRENT_VERSION >= service["min_version"]
             and (
                 service.get("accepts_new_authorizations", True)
-                or hass.config_entries.async_entries(domain)
+                or (
+                    (entries := hass.config_entries.async_entries(domain))
+                    and any(
+                        entry.data.get("auth_implementation") == DOMAIN
+                        for entry in entries
+                    )
+                )
             )
         ):
             return [CloudOAuth2Implementation(hass, domain)]

--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -33,7 +33,14 @@ async def async_provide_implementation(hass: HomeAssistant, domain: str):
     services = await _get_services(hass)
 
     for service in services:
-        if service["service"] == domain and CURRENT_VERSION >= service["min_version"]:
+        if (
+            service["service"] == domain
+            and CURRENT_VERSION >= service["min_version"]
+            and (
+                service.get("accepts_new_authorizations", True)
+                or hass.config_entries.async_entries(domain)
+            )
+        ):
             return [CloudOAuth2Implementation(hass, domain)]
 
     return []

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -43,6 +43,12 @@ async def test_setup_provide_implementation(hass):
         version=1,
         data={"auth_implementation": "cloud"},
     )
+    none_cloud_entry = MockConfigEntry(
+        domain="no_cloud",
+        version=1,
+        data={"auth_implementation": "somethingelse"},
+    )
+    none_cloud_entry.add_to_hass(hass)
     legacy_entry.add_to_hass(hass)
     account_link.async_setup(hass)
 
@@ -61,6 +67,11 @@ async def test_setup_provide_implementation(hass):
                 "min_version": "0.1.0",
                 "accepts_new_authorizations": False,
             },
+            {
+                "service": "no_cloud",
+                "min_version": "0.1.0",
+                "accepts_new_authorizations": False,
+            },
         ],
     ):
         assert (
@@ -75,6 +86,10 @@ async def test_setup_provide_implementation(hass):
         )
         assert (
             await config_entry_oauth2_flow.async_get_implementations(hass, "deprecated")
+            == {}
+        )
+        assert (
+            await config_entry_oauth2_flow.async_get_implementations(hass, "no_cloud")
             == {}
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows the cloud account linking service to phase out supported services by marking certain services to no longer accept new authorizations.

In case existing config entries are present for the user, we will continue to load them (making it not hard-breaking).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
