### PR TITLE
Remove websocket_api send_big_result

### DIFF
--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -37,10 +37,7 @@ def _handle_errors(func):
             connection.send_error(msg["id"], *error)
             return
 
-        if msg is not None:
-            connection.send_big_result(msg["id"], result)
-        else:
-            connection.send_result(msg["id"], result)
+        connection.send_result(msg["id"], result)
 
     return send_with_error_handling
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1129,12 +1129,6 @@ class MediaPlayerImageView(HomeAssistantView):
 
 @websocket_api.websocket_command(
     {
-        vol.Required("type"): "media_player_thumbnail",
-        vol.Required("entity_id"): cv.entity_id,
-    }
-)
-@websocket_api.websocket_command(
-    {
         vol.Required("type"): "media_player/browse_media",
         vol.Required("entity_id"): cv.entity_id,
         vol.Inclusive(

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import collections
 from collections.abc import Callable
 from contextlib import suppress
@@ -27,7 +26,6 @@ from homeassistant.backports.enum import StrEnum
 from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
 from homeassistant.components.websocket_api.const import (
-    ERR_NOT_FOUND,
     ERR_NOT_SUPPORTED,
     ERR_UNKNOWN_ERROR,
 )
@@ -254,7 +252,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL
     )
 
-    websocket_api.async_register_command(hass, websocket_handle_thumbnail)
     websocket_api.async_register_command(hass, websocket_browse_media)
     hass.http.register_view(MediaPlayerImageView(component))
 
@@ -1136,43 +1133,6 @@ class MediaPlayerImageView(HomeAssistantView):
         vol.Required("entity_id"): cv.entity_id,
     }
 )
-@websocket_api.async_response
-async def websocket_handle_thumbnail(hass, connection, msg):
-    """Handle get media player cover command.
-
-    Async friendly.
-    """
-    component = hass.data[DOMAIN]
-
-    if (player := component.get_entity(msg["entity_id"])) is None:
-        connection.send_message(
-            websocket_api.error_message(msg["id"], ERR_NOT_FOUND, "Entity not found")
-        )
-        return
-
-    _LOGGER.warning(
-        "The websocket command media_player_thumbnail is deprecated. Use /api/media_player_proxy instead"
-    )
-
-    data, content_type = await player.async_get_media_image()
-
-    if data is None:
-        connection.send_message(
-            websocket_api.error_message(
-                msg["id"], "thumbnail_fetch_failed", "Failed to fetch thumbnail"
-            )
-        )
-        return
-
-    connection.send_big_result(
-        msg["id"],
-        {
-            "content_type": content_type,
-            "content": base64.b64encode(data).decode("utf-8"),
-        },
-    )
-
-
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "media_player/browse_media",

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant.auth.models import RefreshToken, User
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
-from homeassistant.helpers.json import JSON_DUMP
 
 from . import const, messages
 
@@ -53,10 +52,6 @@ class ActiveConnection:
     def send_result(self, msg_id: int, result: Any | None = None) -> None:
         """Send a result message."""
         self.send_message(messages.result_message(msg_id, result))
-
-    def send_big_result(self, msg_id: int, result: Any) -> None:
-        """Send a result message that would be expensive to JSON serialize."""
-        self.send_message(JSON_DUMP(messages.result_message(msg_id, result)))
 
     @callback
     def send_error(self, msg_id: int, code: str, message: str) -> None:

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the camera component."""
 import asyncio
-import base64
 from http import HTTPStatus
 import io
 from unittest.mock import AsyncMock, Mock, PropertyMock, mock_open, patch
@@ -233,24 +232,6 @@ async def test_snapshot_service(hass, mock_camera):
 
         assert len(mock_write.mock_calls) == 1
         assert mock_write.mock_calls[0][1][0] == b"Test"
-
-
-async def test_websocket_camera_thumbnail(hass, hass_ws_client, mock_camera):
-    """Test camera_thumbnail websocket command."""
-    await async_setup_component(hass, "camera", {})
-
-    client = await hass_ws_client(hass)
-    await client.send_json(
-        {"id": 5, "type": "camera_thumbnail", "entity_id": "camera.demo_camera"}
-    )
-
-    msg = await client.receive_json()
-
-    assert msg["id"] == 5
-    assert msg["type"] == TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"]["content_type"] == "image/jpg"
-    assert msg["result"]["content"] == base64.b64encode(b"Test").decode("utf-8")
 
 
 async def test_websocket_stream_no_source(

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -1,6 +1,5 @@
 """Test the base functions of the media player."""
 import asyncio
-import base64
 from http import HTTPStatus
 from unittest.mock import patch
 
@@ -12,39 +11,6 @@ from homeassistant.components.media_player.browse_media import BrowseMedia
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
 from homeassistant.setup import async_setup_component
-
-
-async def test_get_image(hass, hass_ws_client, caplog):
-    """Test get image via WS command."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
-    await hass.async_block_till_done()
-
-    client = await hass_ws_client(hass)
-
-    with patch(
-        "homeassistant.components.media_player.MediaPlayerEntity."
-        "async_get_media_image",
-        return_value=(b"image", "image/jpeg"),
-    ):
-        await client.send_json(
-            {
-                "id": 5,
-                "type": "media_player_thumbnail",
-                "entity_id": "media_player.bedroom",
-            }
-        )
-
-        msg = await client.receive_json()
-
-    assert msg["id"] == 5
-    assert msg["type"] == TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"]["content_type"] == "image/jpeg"
-    assert msg["result"]["content"] == base64.b64encode(b"image").decode("utf-8")
-
-    assert "media_player_thumbnail is deprecated" in caplog.text
 
 
 async def test_get_image_http(hass, hass_client_no_auth):

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -7,28 +7,8 @@ import voluptuous as vol
 
 from homeassistant import exceptions
 from homeassistant.components import websocket_api
-from homeassistant.components.websocket_api import const
 
 from tests.common import MockUser
-
-
-async def test_send_big_result(hass, websocket_client):
-    """Test sending big results over the WS."""
-
-    @websocket_api.websocket_command({"type": "big_result"})
-    @websocket_api.async_response
-    def send_big_result(hass, connection, msg):
-        connection.send_big_result(msg["id"], {"big": "result"})
-
-    websocket_api.async_register_command(hass, send_big_result)
-
-    await websocket_client.send_json({"id": 5, "type": "big_result"})
-
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 5
-    assert msg["type"] == const.TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"] == {"big": "result"}
 
 
 async def test_exception_handling():


### PR DESCRIPTION
Remove deprecated websocket command camera_thumbnail
Remove deprecated websocket command media_player_thumbnail

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The websocket commands camera_thumbnail and media_player_thumbnail are removed in this PR. They were both deprecated in March 2020 in #32473 and #32471.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is a follow on to #75427. `send_big_result` is no longer needed as it is now essentially the same as `send_result`. Of the three callers, two were deprecated over two years ago and are now removed. The remaining usage in `lovelace` is updated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
