### PR TITLE
Improve deprecation helper typing

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -16,6 +16,7 @@ homeassistant.auth.providers.*
 homeassistant.helpers.area_registry
 homeassistant.helpers.condition
 homeassistant.helpers.debounce
+homeassistant.helpers.deprecation
 homeassistant.helpers.discovery
 homeassistant.helpers.entity
 homeassistant.helpers.entity_values

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -5,12 +5,20 @@ from collections.abc import Callable
 import functools
 import inspect
 import logging
-from typing import Any
+from typing import Any, TypeVar
+
+from typing_extensions import ParamSpec
 
 from ..helpers.frame import MissingIntegrationFrame, get_integration_frame
 
+_ObjectT = TypeVar("_ObjectT", bound=object)
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
-def deprecated_substitute(substitute_name: str) -> Callable[..., Callable]:
+
+def deprecated_substitute(
+    substitute_name: str,
+) -> Callable[[Callable[[_ObjectT], Any]], Callable[[_ObjectT], Any]]:
     """Help migrate properties to new names.
 
     When a property is added to replace an older property, this decorator can
@@ -19,10 +27,10 @@ def deprecated_substitute(substitute_name: str) -> Callable[..., Callable]:
     warning will be issued alerting the user of the impending change.
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[[_ObjectT], Any]) -> Callable[[_ObjectT], Any]:
         """Decorate function as deprecated."""
 
-        def func_wrapper(self: Callable) -> Any:
+        def func_wrapper(self: _ObjectT) -> Any:
             """Wrap for the original function."""
             if hasattr(self, substitute_name):
                 # If this platform is still using the old property, issue
@@ -81,14 +89,16 @@ def get_deprecated(
     return config.get(new_name, default)
 
 
-def deprecated_class(replacement: str) -> Any:
+def deprecated_class(
+    replacement: str,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """Mark class as deprecated and provide a replacement class to be used instead."""
 
-    def deprecated_decorator(cls: Any) -> Any:
+    def deprecated_decorator(cls: Callable[_P, _R]) -> Callable[_P, _R]:
         """Decorate class as deprecated."""
 
         @functools.wraps(cls)
-        def deprecated_cls(*args: Any, **kwargs: Any) -> Any:
+        def deprecated_cls(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             """Wrap for the original class."""
             _print_deprecation_warning(cls, replacement, "class")
             return cls(*args, **kwargs)
@@ -98,14 +108,16 @@ def deprecated_class(replacement: str) -> Any:
     return deprecated_decorator
 
 
-def deprecated_function(replacement: str) -> Callable[..., Callable]:
+def deprecated_function(
+    replacement: str,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """Mark function as deprecated and provide a replacement function to be used instead."""
 
-    def deprecated_decorator(func: Callable) -> Callable:
+    def deprecated_decorator(func: Callable[_P, _R]) -> Callable[_P, _R]:
         """Decorate function as deprecated."""
 
         @functools.wraps(func)
-        def deprecated_func(*args: Any, **kwargs: Any) -> Any:
+        def deprecated_func(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             """Wrap for the original function."""
             _print_deprecation_warning(func, replacement, "function")
             return func(*args, **kwargs)

--- a/mypy.ini
+++ b/mypy.ini
@@ -60,6 +60,9 @@ disallow_any_generics = true
 [mypy-homeassistant.helpers.debounce]
 disallow_any_generics = true
 
+[mypy-homeassistant.helpers.deprecation]
+disallow_any_generics = true
+
 [mypy-homeassistant.helpers.discovery]
 disallow_any_generics = true
 


### PR DESCRIPTION
## Proposed change
Add generic parameter typing to deprecation helper functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
