### PR TITLE
Modify Guardian to store a single dataclass in `hass.data`

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -173,7 +173,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     await paired_sensor_manager.async_initialize()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = GuardianData(
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = GuardianData(
         entry=entry,
         client=client,
         valve_controller_coordinators=valve_controller_coordinators,

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -18,10 +18,9 @@ from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_PORT,
     CONF_URL,
-    EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -343,13 +342,7 @@ class PairedSensorManager:
         cancel_process_task = self._sensor_pair_dump_coordinator.async_add_listener(
             async_create_process_task
         )
-
-        @callback
-        def async_teardown(_: Event) -> None:
-            """Tear the manager down."""
-            cancel_process_task()
-
-        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_teardown)
+        self._entry.async_on_unload(cancel_process_task)
 
     async def async_pair_sensor(self, uid: str) -> None:
         """Add a new paired sensor coordinator."""

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
+    GuardianData,
     PairedSensorEntity,
     ValveControllerEntity,
     ValveControllerEntityDescription,
@@ -23,8 +24,6 @@ from .const import (
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
     API_WIFI_STATUS,
     CONF_UID,
-    DATA_COORDINATOR,
-    DATA_COORDINATOR_PAIRED_SENSOR,
     DOMAIN,
     SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED,
 )
@@ -79,16 +78,14 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Guardian switches based on a config entry."""
-    entry_data = hass.data[DOMAIN][entry.entry_id]
-    paired_sensor_coordinators = entry_data[DATA_COORDINATOR_PAIRED_SENSOR]
-    valve_controller_coordinators = entry_data[DATA_COORDINATOR]
+    data: GuardianData = hass.data[DOMAIN][entry.entry_id]
 
     @callback
     def add_new_paired_sensor(uid: str) -> None:
         """Add a new paired sensor."""
         async_add_entities(
             PairedSensorBinarySensor(
-                entry, paired_sensor_coordinators[uid], description
+                entry, data.paired_sensor_manager.coordinators[uid], description
             )
             for description in PAIRED_SENSOR_DESCRIPTIONS
         )
@@ -104,7 +101,9 @@ async def async_setup_entry(
 
     # Add all valve controller-specific binary sensors:
     sensors: list[PairedSensorBinarySensor | ValveControllerBinarySensor] = [
-        ValveControllerBinarySensor(entry, valve_controller_coordinators, description)
+        ValveControllerBinarySensor(
+            entry, data.valve_controller_coordinators, description
+        )
         for description in VALVE_CONTROLLER_DESCRIPTIONS
     ]
 
@@ -112,7 +111,7 @@ async def async_setup_entry(
     sensors.extend(
         [
             PairedSensorBinarySensor(entry, coordinator, description)
-            for coordinator in paired_sensor_coordinators.values()
+            for coordinator in data.paired_sensor_manager.coordinators.values()
             for description in PAIRED_SENSOR_DESCRIPTIONS
         ]
     )

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -14,8 +14,4 @@ API_WIFI_STATUS = "wifi_status"
 
 CONF_UID = "uid"
 
-DATA_CLIENT = "client"
-DATA_COORDINATOR = "coordinator"
-DATA_COORDINATOR_PAIRED_SENSOR = "coordinator_paired_sensor"
-
 SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED = "guardian_paired_sensor_coordinator_added_{0}"

--- a/homeassistant/components/guardian/diagnostics.py
+++ b/homeassistant/components/guardian/diagnostics.py
@@ -7,8 +7,8 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_UID, DATA_COORDINATOR, DATA_COORDINATOR_PAIRED_SENSOR, DOMAIN
-from .util import GuardianDataUpdateCoordinator
+from . import GuardianData
+from .const import CONF_UID, DOMAIN
 
 CONF_BSSID = "bssid"
 CONF_PAIRED_UIDS = "paired_uids"
@@ -26,12 +26,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
-
-    coordinators: dict[str, GuardianDataUpdateCoordinator] = data[DATA_COORDINATOR]
-    paired_sensor_coordinators: dict[str, GuardianDataUpdateCoordinator] = data[
-        DATA_COORDINATOR_PAIRED_SENSOR
-    ]
+    data: GuardianData = hass.data[DOMAIN][entry.entry_id]
 
     return {
         "entry": {
@@ -41,11 +36,11 @@ async def async_get_config_entry_diagnostics(
         "data": {
             "valve_controller": {
                 api_category: async_redact_data(coordinator.data, TO_REDACT)
-                for api_category, coordinator in coordinators.items()
+                for api_category, coordinator in data.valve_controller_coordinators.items()
             },
             "paired_sensors": [
                 async_redact_data(coordinator.data, TO_REDACT)
-                for coordinator in paired_sensor_coordinators.values()
+                for coordinator in data.paired_sensor_manager.coordinators.values()
             ],
         },
     }

--- a/tests/components/guardian/test_diagnostics.py
+++ b/tests/components/guardian/test_diagnostics.py
@@ -1,22 +1,16 @@
 """Test Guardian diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
-from homeassistant.components.guardian import (
-    DATA_PAIRED_SENSOR_MANAGER,
-    DOMAIN,
-    PairedSensorManager,
-)
+from homeassistant.components.guardian import DOMAIN, GuardianData
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
 async def test_entry_diagnostics(hass, config_entry, hass_client, setup_guardian):
     """Test config entry diagnostics."""
-    paired_sensor_manager: PairedSensorManager = hass.data[DOMAIN][
-        config_entry.entry_id
-    ][DATA_PAIRED_SENSOR_MANAGER]
+    data: GuardianData = hass.data[DOMAIN][config_entry.entry_id]
 
     # Simulate the pairing of a paired sensor:
-    await paired_sensor_manager.async_pair_sensor("AABBCCDDEEFF")
+    await data.paired_sensor_manager.async_pair_sensor("AABBCCDDEEFF")
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes how the Guardian integration stores data in `hass.data` (from a loose, nested dict to a dataclass). This will help catch issues by strongly typing the data object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
