### PR TITLE
Modify Ridwell to store a single dataclass in `hass.data`

### DIFF
--- a/homeassistant/components/ridwell/__init__.py
+++ b/homeassistant/components/ridwell/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
@@ -21,17 +22,19 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import (
-    DATA_ACCOUNT,
-    DATA_COORDINATOR,
-    DOMAIN,
-    LOGGER,
-    SENSOR_TYPE_NEXT_PICKUP,
-)
+from .const import DOMAIN, LOGGER, SENSOR_TYPE_NEXT_PICKUP
 
 DEFAULT_UPDATE_INTERVAL = timedelta(hours=1)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH]
+
+
+@dataclass
+class RidwellData:
+    """Define an object to be stored in `hass.data`."""
+
+    accounts: dict[str, RidwellAccount]
+    coordinator: DataUpdateCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -77,10 +80,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_ACCOUNT: accounts,
-        DATA_COORDINATOR: coordinator,
-    }
+    hass.data[DOMAIN][entry.entry_id] = RidwellData(
+        accounts=accounts, coordinator=coordinator
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/ridwell/const.py
+++ b/homeassistant/components/ridwell/const.py
@@ -5,7 +5,4 @@ DOMAIN = "ridwell"
 
 LOGGER = logging.getLogger(__package__)
 
-DATA_ACCOUNT = "account"
-DATA_COORDINATOR = "coordinator"
-
 SENSOR_TYPE_NEXT_PICKUP = "next_pickup"

--- a/homeassistant/components/ridwell/diagnostics.py
+++ b/homeassistant/components/ridwell/diagnostics.py
@@ -6,19 +6,17 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DATA_COORDINATOR, DOMAIN
+from . import RidwellData
+from .const import DOMAIN
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        DATA_COORDINATOR
-    ]
+    data: RidwellData = hass.data[DOMAIN][entry.entry_id]
 
     return {
-        "data": [dataclasses.asdict(event) for event in coordinator.data.values()],
+        "data": [dataclasses.asdict(event) for event in data.coordinator.data.values()]
     }

--- a/homeassistant/components/ridwell/sensor.py
+++ b/homeassistant/components/ridwell/sensor.py
@@ -18,8 +18,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import RidwellEntity
-from .const import DATA_ACCOUNT, DATA_COORDINATOR, DOMAIN, SENSOR_TYPE_NEXT_PICKUP
+from . import RidwellData, RidwellEntity
+from .const import DOMAIN, SENSOR_TYPE_NEXT_PICKUP
 
 ATTR_CATEGORY = "category"
 ATTR_PICKUP_STATE = "pickup_state"
@@ -37,13 +37,12 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Ridwell sensors based on a config entry."""
-    accounts = hass.data[DOMAIN][entry.entry_id][DATA_ACCOUNT]
-    coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+    data: RidwellData = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         [
-            RidwellSensor(coordinator, account, SENSOR_DESCRIPTION)
-            for account in accounts.values()
+            RidwellSensor(data.coordinator, account, SENSOR_DESCRIPTION)
+            for account in data.accounts.values()
         ]
     )
 

--- a/homeassistant/components/ridwell/switch.py
+++ b/homeassistant/components/ridwell/switch.py
@@ -12,8 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import RidwellEntity
-from .const import DATA_ACCOUNT, DATA_COORDINATOR, DOMAIN
+from . import RidwellData, RidwellEntity
+from .const import DOMAIN
 
 SWITCH_TYPE_OPT_IN = "opt_in"
 
@@ -28,13 +28,12 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Ridwell sensors based on a config entry."""
-    accounts = hass.data[DOMAIN][entry.entry_id][DATA_ACCOUNT]
-    coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+    data: RidwellData = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         [
-            RidwellSwitch(coordinator, account, SWITCH_DESCRIPTION)
-            for account in accounts.values()
+            RidwellSwitch(data.coordinator, account, SWITCH_DESCRIPTION)
+            for account in data.accounts.values()
         ]
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes how the Ridwell integration stores data in `hass.data` (from a loose, nested dict to a dataclass). This will help catch issues by strongly typing the data object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
