### PR TITLE
Fix type narrowing in energy integration

### DIFF
--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -54,7 +54,7 @@ class FlowToGridSourceType(TypedDict):
     stat_compensation: str | None
 
     # Used to generate costs if stat_compensation is set to None
-    entity_energy_from: str | None  # entity_id of an energy meter (kWh), entity_id of the energy meter for stat_energy_from
+    entity_energy_to: str | None  # entity_id of an energy meter (kWh), entity_id of the energy meter for stat_energy_to
     entity_energy_price: str | None  # entity_id of an entity providing price ($/kWh)
     number_energy_price: float | None  # Price for energy ($/kWh)
 

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -263,10 +263,10 @@ def _async_validate_auto_generated_cost_entity(
 
 async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
     """Validate the energy configuration."""
-    manager = await data.async_get_manager(hass)
+    manager: data.EnergyManager = await data.async_get_manager(hass)
     statistics_metadata: dict[str, tuple[int, recorder.models.StatisticMetaData]] = {}
     validate_calls = []
-    wanted_statistics_metadata = set()
+    wanted_statistics_metadata: set[str] = set()
 
     result = EnergyPreferencesValidation()
 
@@ -279,6 +279,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
         result.energy_sources.append(source_result)
 
         if source["type"] == "grid":
+            flow: data.FlowFromGridSourceType | data.FlowToGridSourceType
             for flow in source["flow_from"]:
                 wanted_statistics_metadata.add(flow["stat_energy_from"])
                 validate_calls.append(
@@ -294,14 +295,14 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                     )
                 )
 
-                if flow.get("stat_cost") is not None:
-                    wanted_statistics_metadata.add(flow["stat_cost"])
+                if (stat_cost := flow.get("stat_cost")) is not None:
+                    wanted_statistics_metadata.add(stat_cost)
                     validate_calls.append(
                         functools.partial(
                             _async_validate_cost_stat,
                             hass,
                             statistics_metadata,
-                            flow["stat_cost"],
+                            stat_cost,
                             source_result,
                         )
                     )
@@ -345,14 +346,14 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                     )
                 )
 
-                if flow.get("stat_compensation") is not None:
-                    wanted_statistics_metadata.add(flow["stat_compensation"])
+                if (stat_compensation := flow.get("stat_compensation")) is not None:
+                    wanted_statistics_metadata.add(stat_compensation)
                     validate_calls.append(
                         functools.partial(
                             _async_validate_cost_stat,
                             hass,
                             statistics_metadata,
-                            flow["stat_compensation"],
+                            stat_compensation,
                             source_result,
                         )
                     )
@@ -396,14 +397,14 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                 )
             )
 
-            if source.get("stat_cost") is not None:
-                wanted_statistics_metadata.add(source["stat_cost"])
+            if (stat_cost := source.get("stat_cost")) is not None:
+                wanted_statistics_metadata.add(stat_cost)
                 validate_calls.append(
                     functools.partial(
                         _async_validate_cost_stat,
                         hass,
                         statistics_metadata,
-                        source["stat_cost"],
+                        stat_cost,
                         source_result,
                     )
                 )


### PR DESCRIPTION
## Proposed change
Found as part of #75461
Just adding a type declaration for `manager` causes a couple type narrowing issues.
```diff
-manager = await data.async_get_manager(hass)
+manager: data.EnergyManager = await data.async_get_manager(hass)
```
```py
homeassistant/components/energy/validate.py:298: error: Argument 1 to "add" of "set" has incompatible type "Optional[str]"; expected "str"  [arg-type]
homeassistant/components/energy/validate.py:333: error: Incompatible types in assignment (expression has type "FlowToGridSourceType", variable has type "FlowFromGridSourceType")  [assignment]
homeassistant/components/energy/validate.py:334: error: TypedDict "FlowFromGridSourceType" has no key "stat_energy_to"  [typeddict-item]
homeassistant/components/energy/validate.py:334: note: Did you mean "stat_energy_from"?
homeassistant/components/energy/validate.py:340: error: TypedDict "FlowFromGridSourceType" has no key "stat_energy_to"  [typeddict-item]
homeassistant/components/energy/validate.py:340: note: Did you mean "stat_energy_from"?
homeassistant/components/energy/validate.py:349: error: TypedDict "FlowFromGridSourceType" has no key "stat_compensation"  [typeddict-item]
homeassistant/components/energy/validate.py:355: error: TypedDict "FlowFromGridSourceType" has no key "stat_compensation"  [typeddict-item]
homeassistant/components/energy/validate.py:379: error: TypedDict "FlowFromGridSourceType" has no key "entity_energy_to"  [typeddict-item]
homeassistant/components/energy/validate.py:379: note: Did you mean "entity_energy_from" or "entity_energy_price"?
homeassistant/components/energy/validate.py:400: error: Argument 1 to "add" of "set" has incompatible type "Optional[str]"; expected "str"  [arg-type]
```

Turns out the TypedDict `data.FlowToGridSourceType` should have had an attribute `entity_energy_to` instead of `entity_energy_from`. Furthermore, mypy can't narrow `xxx.get(...) is not None` expressions. To work around that, we can assign the value to a temporary variable which can be narrowed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
