### PR TITLE
Fix bluetooth service_info typing

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -44,7 +44,7 @@ SOURCE_LOCAL: Final = "local"
 
 
 @dataclass
-class BluetoothServiceInfoBleak(BluetoothServiceInfo):  # type: ignore[misc]
+class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     """BluetoothServiceInfo with bleak data.
 
     Integrations may need BLEDevice and AdvertisementData
@@ -59,7 +59,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):  # type: ignore[misc]
     @classmethod
     def from_advertisement(
         cls, device: BLEDevice, advertisement_data: AdvertisementData, source: str
-    ) -> BluetoothServiceInfo:
+    ) -> BluetoothServiceInfoBleak:
         """Create a BluetoothServiceInfoBleak from an advertisement."""
         return cls(
             name=advertisement_data.local_name or device.name or device.address,
@@ -393,7 +393,7 @@ class BluetoothManager:
         )
 
     @hass_callback
-    def async_discovered_service_info(self) -> list[BluetoothServiceInfo]:
+    def async_discovered_service_info(self) -> list[BluetoothServiceInfoBleak]:
         """Return if the address is present."""
         if models.HA_BLEAK_SCANNER:
             discovered = models.HA_BLEAK_SCANNER.discovered_devices

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -61,7 +61,7 @@ def is_bluetooth_device(device: Device) -> bool:
 def discover_devices(device_id: int) -> list[tuple[str, str]]:
     """Discover Bluetooth devices."""
     try:
-        result = bluetooth.discover_devices(  # type: ignore[attr-defined]
+        result = bluetooth.discover_devices(
             duration=8,
             lookup_names=True,
             flush_cache=True,
@@ -124,7 +124,7 @@ async def get_tracking_devices(hass: HomeAssistant) -> tuple[set[str], set[str]]
 def lookup_name(mac: str) -> str | None:
     """Lookup a Bluetooth device name."""
     _LOGGER.debug("Scanning %s", mac)
-    return bluetooth.lookup_name(mac, timeout=5)  # type: ignore[attr-defined,no-any-return]
+    return bluetooth.lookup_name(mac, timeout=5)  # type: ignore[no-any-return]
 
 
 async def async_setup_scanner(
@@ -180,7 +180,7 @@ async def async_setup_scanner(
             if tasks:
                 await asyncio.wait(tasks)
 
-        except bluetooth.BluetoothError:  # type: ignore[attr-defined]
+        except bluetooth.BluetoothError:
             _LOGGER.exception("Error looking up Bluetooth device")
 
     async def update_bluetooth(now: datetime | None = None) -> None:

--- a/homeassistant/helpers/service_info/__init__.py
+++ b/homeassistant/helpers/service_info/__init__.py
@@ -1,0 +1,1 @@
+"""Service info helpers."""

--- a/homeassistant/helpers/service_info/bluetooth.py
+++ b/homeassistant/helpers/service_info/bluetooth.py
@@ -1,4 +1,6 @@
 """The bluetooth integration service info."""
-from home_assistant_bluetooth import (  # pylint: disable=unused-import # noqa: F401
+from home_assistant_bluetooth import (  # pylint: disable=unused-import
     BluetoothServiceInfo,
 )
+
+__all__ = ["BluetoothServiceInfo"]

--- a/homeassistant/helpers/service_info/bluetooth.py
+++ b/homeassistant/helpers/service_info/bluetooth.py
@@ -1,6 +1,4 @@
 """The bluetooth integration service info."""
-from home_assistant_bluetooth import (  # pylint: disable=unused-import
-    BluetoothServiceInfo,
-)
+from home_assistant_bluetooth import BluetoothServiceInfo
 
 __all__ = ["BluetoothServiceInfo"]


### PR DESCRIPTION
## Proposed change
Add missing `__init__` file in `helpers/service_info` and `__all__` to do an explicit reexport.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
