### PR TITLE
Add 1.5 second sleep to motion blinds update

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -65,36 +65,39 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
         self._wait_for_push = coordinator_info[CONF_WAIT_FOR_PUSH]
 
     def update_gateway(self):
-        """Call all updates using one async_add_executor_job."""
-        data = {}
-
+        """Fetch data from gateway."""
         try:
             self._gateway.Update()
         except (timeout, ParseException):
             # let the error be logged and handled by the motionblinds library
-            data[KEY_GATEWAY] = {ATTR_AVAILABLE: False}
-            return data
+            return {ATTR_AVAILABLE: False}
         else:
-            data[KEY_GATEWAY] = {ATTR_AVAILABLE: True}
+            return {ATTR_AVAILABLE: True}
 
-        for blind in self._gateway.device_list.values():
-            try:
-                if self._wait_for_push:
-                    blind.Update()
-                else:
-                    blind.Update_trigger()
-            except (timeout, ParseException):
-                # let the error be logged and handled by the motionblinds library
-                data[blind.mac] = {ATTR_AVAILABLE: False}
+    def update_blind(self, blind):
+        """Fetch data from a blind."""
+        try:
+            if self._wait_for_push:
+                blind.Update()
             else:
-                data[blind.mac] = {ATTR_AVAILABLE: True}
-
-        return data
+                blind.Update_trigger()
+        except (timeout, ParseException):
+            # let the error be logged and handled by the motionblinds library
+            return {ATTR_AVAILABLE: False}
+        else:
+            return {ATTR_AVAILABLE: True}
 
     async def _async_update_data(self):
         """Fetch the latest data from the gateway and blinds."""
+        data = {}
+
         async with self.api_lock:
-            data = await self.hass.async_add_executor_job(self.update_gateway)
+            data[KEY_GATEWAY] = await self.hass.async_add_executor_job(self.update_gateway)
+
+        for blind in self._gateway.device_list.values():
+            await asyncio.sleep(1.5)
+            async with self.api_lock:
+                data[blind.mac] = await self.hass.async_add_executor_job(self.update_blind, blind)
 
         all_available = all(device[ATTR_AVAILABLE] for device in data.values())
         if all_available:

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -92,12 +92,16 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
         data = {}
 
         async with self.api_lock:
-            data[KEY_GATEWAY] = await self.hass.async_add_executor_job(self.update_gateway)
+            data[KEY_GATEWAY] = await self.hass.async_add_executor_job(
+                self.update_gateway
+            )
 
         for blind in self._gateway.device_list.values():
             await asyncio.sleep(1.5)
             async with self.api_lock:
-                data[blind.mac] = await self.hass.async_add_executor_job(self.update_blind, blind)
+                data[blind.mac] = await self.hass.async_add_executor_job(
+                    self.update_blind, blind
+                )
 
         all_available = all(device[ATTR_AVAILABLE] for device in data.values())
         if all_available:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
At a request of the manufacturere I added a 1.5 second delay between two sebsequent querys of the gateway.
They have seen problems with gateways losing there configuration due to problems with writing to the EEPROM chips in the gateway.
The manufacturer believes this might be due to too many request stacking up in the que of the gateway (internal que for communication with the actual blinds over 433MHz radio, not the WiFi que, the response of the gateway after a UDP request is awaited before sending the next one, ensured with a async.lock).

The update frequency for the coordinator is 10 minutes, so the 1.5 second delays of max 30 blinds = 45 seconds schould not cause problems for HomeAssistant.

The delay has been implemented as a asyncio.sleep to not have a thread-worker of HomeAssistant blocked for 45 seconds.

More information about the gateway issues see: https://github.com/starkillerOG/motion-blinds/issues/25

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/starkillerOG/motion-blinds/issues/25
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
