### PR TITLE
Improve http decorator typing

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -257,7 +257,7 @@ class LoginFlowResourceView(LoginFlowBaseView):
 
     @RequestDataValidator(vol.Schema({"client_id": str}, extra=vol.ALLOW_EXTRA))
     @log_invalid_auth
-    async def post(self, request, flow_id, data):
+    async def post(self, request, data, flow_id):
         """Handle progressing a login flow request."""
         client_id = data.pop("client_id")
 

--- a/homeassistant/components/http/data_validator.py
+++ b/homeassistant/components/http/data_validator.py
@@ -1,16 +1,20 @@
 """Decorator for view methods to help with data validation."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, TypeVar
 
 from aiohttp import web
+from typing_extensions import Concatenate, ParamSpec
 import voluptuous as vol
 
 from .view import HomeAssistantView
+
+_HassViewT = TypeVar("_HassViewT", bound=HomeAssistantView)
+_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,33 +37,40 @@ class RequestDataValidator:
         self._allow_empty = allow_empty
 
     def __call__(
-        self, method: Callable[..., Awaitable[web.StreamResponse]]
-    ) -> Callable:
+        self,
+        method: Callable[
+            Concatenate[_HassViewT, web.Request, dict[str, Any], _P],
+            Awaitable[web.Response],
+        ],
+    ) -> Callable[
+        Concatenate[_HassViewT, web.Request, _P],
+        Coroutine[Any, Any, web.Response],
+    ]:
         """Decorate a function."""
 
         @wraps(method)
         async def wrapper(
-            view: HomeAssistantView, request: web.Request, *args: Any, **kwargs: Any
-        ) -> web.StreamResponse:
+            view: _HassViewT, request: web.Request, *args: _P.args, **kwargs: _P.kwargs
+        ) -> web.Response:
             """Wrap a request handler with data validation."""
-            data = None
+            raw_data = None
             try:
-                data = await request.json()
+                raw_data = await request.json()
             except ValueError:
                 if not self._allow_empty or (await request.content.read()) != b"":
                     _LOGGER.error("Invalid JSON received")
                     return view.json_message("Invalid JSON.", HTTPStatus.BAD_REQUEST)
-                data = {}
+                raw_data = {}
 
             try:
-                kwargs["data"] = self._schema(data)
+                data: dict[str, Any] = self._schema(raw_data)
             except vol.Invalid as err:
                 _LOGGER.error("Data does not match schema: %s", err)
                 return view.json_message(
                     f"Message format incorrect: {err}", HTTPStatus.BAD_REQUEST
                 )
 
-            result = await method(view, request, *args, **kwargs)
+            result = await method(view, request, data, *args, **kwargs)
             return result
 
         return wrapper

--- a/homeassistant/components/repairs/websocket_api.py
+++ b/homeassistant/components/repairs/websocket_api.py
@@ -112,7 +112,7 @@ class RepairsFlowIndexView(FlowManagerIndexView):
 
         result = self._prepare_result_json(result)
 
-        return self.json(result)  # pylint: disable=arguments-differ
+        return self.json(result)
 
 
 class RepairsFlowResourceView(FlowManagerResourceView):
@@ -135,4 +135,4 @@ class RepairsFlowResourceView(FlowManagerResourceView):
             raise Unauthorized(permission=POLICY_EDIT)
 
         # pylint: disable=no-value-for-parameter
-        return await super().post(request, flow_id)  # type: ignore[no-any-return]
+        return await super().post(request, flow_id)

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -102,7 +102,7 @@ class FlowManagerResourceView(_BaseFlowManagerView):
 
     @RequestDataValidator(vol.Schema(dict), allow_empty=True)
     async def post(
-        self, request: web.Request, flow_id: str, data: dict[str, Any]
+        self, request: web.Request, data: dict[str, Any], flow_id: str
     ) -> web.Response:
         """Handle a POST request."""
         try:


### PR DESCRIPTION
## Proposed change
Use ParamSpec, Concatenate, and TypeVars to better type the `log_invalid_auth` and `RequestDataValidator` decorators.

To be able to use `Concatenate` for `RequestDataValidator`, `data` needs to be separated from `kwargs` and passed as dedicated argument.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
