### PR TITLE
ZHA light entity cleanup 

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -32,6 +32,7 @@ class ColorChannel(ZigbeeChannel):
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_hue", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="enhanced_current_hue", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_saturation", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
     )
@@ -43,7 +44,6 @@ class ColorChannel(ZigbeeChannel):
         "color_temp_physical_max": True,
         "color_capabilities": True,
         "color_loop_active": False,
-        "enhanced_current_hue": True,
     }
 
     @property

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -55,7 +55,10 @@ class ColorChannel(ZigbeeChannel):
     @property
     def zcl_color_capabilities(self) -> lighting.Color.ColorCapabilities:
         """Return ZCL color capabilities of the light."""
-        return self.cluster.get("color_capabilities")
+        color_capabilities = self.cluster.get("color_capabilities")
+        if color_capabilities is None:
+            return lighting.Color.ColorCapabilities(self.CAPABILITIES_COLOR_XY)
+        return lighting.Color.ColorCapabilities(color_capabilities)
 
     @property
     def color_mode(self) -> int | None:

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -30,7 +30,7 @@ class ColorChannel(ZigbeeChannel):
     UNSUPPORTED_ATTRIBUTE = 0x86
     REPORT_CONFIG = (
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
-        AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_hue", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_saturation", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -53,6 +53,11 @@ class ColorChannel(ZigbeeChannel):
         return self.CAPABILITIES_COLOR_XY
 
     @property
+    def zcl_color_capabilities(self) -> lighting.Color.ColorCapabilities:
+        """Return ZCL color capabilities of the light."""
+        return self.cluster.get("color_capabilities")
+
+    @property
     def color_mode(self) -> int | None:
         """Return cached value of the color_mode attribute."""
         return self.cluster.get("color_mode")
@@ -78,6 +83,16 @@ class ColorChannel(ZigbeeChannel):
         return self.cluster.get("current_y")
 
     @property
+    def current_hue(self) -> int | None:
+        """Return cached value of the current_hue attribute."""
+        return self.cluster.get("current_hue")
+
+    @property
+    def current_saturation(self) -> int | None:
+        """Return cached value of the current_saturation attribute."""
+        return self.cluster.get("current_saturation")
+
+    @property
     def min_mireds(self) -> int:
         """Return the coldest color_temp that this channel supports."""
         return self.cluster.get("color_temp_physical_min", self.MIN_MIREDS)
@@ -86,3 +101,39 @@ class ColorChannel(ZigbeeChannel):
     def max_mireds(self) -> int:
         """Return the warmest color_temp that this channel supports."""
         return self.cluster.get("color_temp_physical_max", self.MAX_MIREDS)
+
+    @property
+    def hs_supported(self) -> bool:
+        """Return if the channel supports hue and saturation."""
+        return (
+            self.zcl_color_capabilities is not None
+            and lighting.Color.ColorCapabilities.Hue_and_saturation
+            in self.zcl_color_capabilities
+        )
+
+    @property
+    def xy_supported(self) -> bool:
+        """Return if the channel supports xy."""
+        return (
+            self.zcl_color_capabilities is not None
+            and lighting.Color.ColorCapabilities.XY_attributes
+            in self.zcl_color_capabilities
+        )
+
+    @property
+    def color_temp_supported(self) -> bool:
+        """Return if the channel supports color temperature."""
+        return (
+            self.zcl_color_capabilities is not None
+            and lighting.Color.ColorCapabilities.Color_temperature
+            in self.zcl_color_capabilities
+        )
+
+    @property
+    def color_loop_supported(self) -> bool:
+        """Return if the channel supports color loop."""
+        return (
+            self.zcl_color_capabilities is not None
+            and lighting.Color.ColorCapabilities.Color_loop
+            in self.zcl_color_capabilities
+        )

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -30,7 +30,10 @@ class ColorChannel(ZigbeeChannel):
     UNSUPPORTED_ATTRIBUTE = 0x86
     REPORT_CONFIG = (
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
-        AttrReportConfig(attr="current_y", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="current_hue", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="current_saturation", config=REPORT_CONFIG_DEFAULT),
+        AttrReportConfig(attr="enhanced_current_hue", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
     )
     MAX_MIREDS: int = 500
@@ -91,6 +94,11 @@ class ColorChannel(ZigbeeChannel):
         return self.cluster.get("current_hue")
 
     @property
+    def enhanced_current_hue(self) -> int | None:
+        """Return cached value of the enhanced_current_hue attribute."""
+        return self.cluster.get("enhanced_current_hue")
+
+    @property
     def current_saturation(self) -> int | None:
         """Return cached value of the current_saturation attribute."""
         return self.cluster.get("current_saturation")
@@ -107,7 +115,7 @@ class ColorChannel(ZigbeeChannel):
 
     @property
     def hs_supported(self) -> bool:
-        """Return if the channel supports hue and saturation."""
+        """Return True if the channel supports hue and saturation."""
         return (
             self.zcl_color_capabilities is not None
             and lighting.Color.ColorCapabilities.Hue_and_saturation
@@ -115,8 +123,17 @@ class ColorChannel(ZigbeeChannel):
         )
 
     @property
+    def enhanced_hue_supported(self) -> bool:
+        """Return True if the channel supports enhanced hue and saturation."""
+        return (
+            self.zcl_color_capabilities is not None
+            and lighting.Color.ColorCapabilities.Enhanced_hue
+            in self.zcl_color_capabilities
+        )
+
+    @property
     def xy_supported(self) -> bool:
-        """Return if the channel supports xy."""
+        """Return True if the channel supports xy."""
         return (
             self.zcl_color_capabilities is not None
             and lighting.Color.ColorCapabilities.XY_attributes
@@ -125,7 +142,7 @@ class ColorChannel(ZigbeeChannel):
 
     @property
     def color_temp_supported(self) -> bool:
-        """Return if the channel supports color temperature."""
+        """Return True if the channel supports color temperature."""
         return (
             self.zcl_color_capabilities is not None
             and lighting.Color.ColorCapabilities.Color_temperature
@@ -134,7 +151,7 @@ class ColorChannel(ZigbeeChannel):
 
     @property
     def color_loop_supported(self) -> bool:
-        """Return if the channel supports color loop."""
+        """Return True if the channel supports color loop."""
         return (
             self.zcl_color_capabilities is not None
             and lighting.Color.ColorCapabilities.Color_loop

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -33,7 +33,6 @@ class ColorChannel(ZigbeeChannel):
         AttrReportConfig(attr="current_x", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_hue", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="current_saturation", config=REPORT_CONFIG_DEFAULT),
-        AttrReportConfig(attr="enhanced_current_hue", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="color_temperature", config=REPORT_CONFIG_DEFAULT),
     )
     MAX_MIREDS: int = 500
@@ -44,6 +43,7 @@ class ColorChannel(ZigbeeChannel):
         "color_temp_physical_max": True,
         "color_capabilities": True,
         "color_loop_active": False,
+        "enhanced_current_hue": True,
     }
 
     @property

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -274,6 +274,7 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_color_mode = ColorMode.COLOR_TEMP
             self._attr_color_temp = temperature
             self._attr_xy_color = None
+            self._attr_hs_color = None
 
         if hs_color is not None:
             if self._color_channel.enhanced_hue_supported:
@@ -298,9 +299,9 @@ class BaseLight(LogMixin, light.LightEntity):
                 self.debug("turned on: %s", t_log)
                 return
             self._attr_color_mode = ColorMode.HS
+            self._attr_hs_color = hs_color
             self._attr_xy_color = None
             self._attr_color_temp = None
-            self._attr_hs_color = hs_color
             xy_color = None  # don't set xy_color if it is also present
 
         if xy_color is not None:
@@ -318,6 +319,7 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_color_mode = ColorMode.XY
             self._attr_xy_color = xy_color
             self._attr_color_temp = None
+            self._attr_hs_color = None
 
         if new_color_provided_while_off:
             # The light is has the correct color, so we can now transition it to the correct brightness level.
@@ -586,6 +588,7 @@ class Light(BaseLight, ZhaEntity):
                     if color_temp is not None and color_mode:
                         self._attr_color_temp = color_temp
                         self._attr_xy_color = None
+                        self._attr_hs_color = None
                 elif color_mode == Color.ColorMode.Hue_and_saturation:
                     self._attr_color_mode = ColorMode.HS
                     if self._color_channel.enhanced_hue_supported:
@@ -603,7 +606,7 @@ class Light(BaseLight, ZhaEntity):
                         self._attr_xy_color = None
                         self._attr_color_temp = None
                 else:
-                    self._attr_color_mode = ColorMode.XY
+                    self._attr_color_mode = Color.ColorMode.X_and_Y
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -283,7 +283,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 if new_color_provided_while_off
                 else duration,
             )
-            t_log["move_to_color"] = result
+            t_log["move_to_hue_and_saturation"] = result
             if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)
                 return
@@ -291,7 +291,7 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_xy_color = None
             self._attr_color_temp = None
             self._attr_hs_color = hs_color
-            xy_color = None
+            xy_color = None  # don't set xy_color if it is also present
 
         if xy_color is not None:
             result = await self._color_channel.move_to_color(
@@ -707,6 +707,10 @@ class LightGroup(BaseLight, ZhaGroupEntity):
 
         self._attr_xy_color = helpers.reduce_attribute(
             on_states, light.ATTR_XY_COLOR, reduce=helpers.mean_tuple
+        )
+
+        self._attr_hs_color = helpers.reduce_attribute(
+            on_states, light.ATTR_HS_COLOR, reduce=helpers.mean_tuple
         )
 
         self._attr_color_temp = helpers.reduce_attribute(

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -295,8 +295,8 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if xy_color is not None:
             result = await self._color_channel.move_to_color(
-                int(xy_color[0] * 65535),
-                int(xy_color[1] * 65535),
+                int(xy_color[0] * 65536),
+                int(xy_color[1] * 65536),
                 self._DEFAULT_MIN_TRANSITION_TIME
                 if new_color_provided_while_off
                 else duration,
@@ -422,7 +422,7 @@ class Light(BaseLight, ZhaEntity):
                 curr_x = self._color_channel.current_x
                 curr_y = self._color_channel.current_y
                 if curr_x is not None and curr_y is not None:
-                    self._attr_xy_color = (curr_x / 65535, curr_y / 65535)
+                    self._attr_xy_color = (curr_x / 65536, curr_y / 65536)
                 else:
                     self._attr_xy_color = (0, 0)
 
@@ -580,7 +580,7 @@ class Light(BaseLight, ZhaEntity):
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
-                        self._attr_xy_color = (color_x / 65535, color_y / 65535)
+                        self._attr_xy_color = (color_x / 65536, color_y / 65536)
                         self._attr_color_temp = None
                         self._attr_hs_color = None
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -586,7 +586,7 @@ class Light(BaseLight, ZhaEntity):
                     if color_temp is not None and color_mode:
                         self._attr_color_temp = color_temp
                         self._attr_xy_color = None
-                elif color_mode == Color.ColorMode.HS:
+                elif color_mode == Color.ColorMode.Hue_and_saturation:
                     self._attr_color_mode = ColorMode.HS
                     if self._color_channel.enhanced_hue_supported:
                         current_hue = results.get("enhanced_current_hue")

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -159,6 +159,7 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
                 "current_y",
                 "color_temperature",
                 "current_hue",
+                "enhanced_current_hue",
                 "current_saturation",
             },
         ),

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -151,7 +151,17 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
             },
         ),
         (0x0202, 1, {"fan_mode"}),
-        (0x0300, 1, {"current_x", "current_y", "color_temperature"}),
+        (
+            0x0300,
+            1,
+            {
+                "current_x",
+                "current_y",
+                "color_temperature",
+                "current_hue",
+                "current_saturation",
+            },
+        ),
         (0x0400, 1, {"measured_value"}),
         (0x0401, 1, {"level_status"}),
         (0x0402, 1, {"measured_value"}),

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -301,7 +301,7 @@ async def test_light_refresh(hass, zigpy_device_mock, zha_device_joined_restored
 )
 @pytest.mark.parametrize(
     "device, reporting",
-    [(LIGHT_ON_OFF, (1, 0, 0)), (LIGHT_LEVEL, (1, 1, 0)), (LIGHT_COLOR, (1, 1, 3))],
+    [(LIGHT_ON_OFF, (1, 0, 0)), (LIGHT_LEVEL, (1, 1, 0)), (LIGHT_COLOR, (1, 1, 6))],
 )
 async def test_light(
     hass, zigpy_device_mock, zha_device_joined_restored, device, reporting

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1400,7 +1400,7 @@ async def test_zha_group_light_entity(
     assert group_state.state == STATE_OFF
     assert group_state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
-        ColorMode.HS,
+        ColorMode.XY,
     ]
     # Light which is off has no color mode
     assert "color_mode" not in group_state.attributes
@@ -1431,9 +1431,9 @@ async def test_zha_group_light_entity(
     assert group_state.state == STATE_ON
     assert group_state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
-        ColorMode.HS,
+        ColorMode.XY,
     ]
-    assert group_state.attributes["color_mode"] == ColorMode.HS
+    assert group_state.attributes["color_mode"] == ColorMode.XY
 
     # test long flashing the lights from the HA
     await async_test_flash_from_hass(

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -15,11 +15,7 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.components.zha.core.group import GroupMember
-from homeassistant.components.zha.light import (
-    CAPABILITIES_COLOR_TEMP,
-    CAPABILITIES_COLOR_XY,
-    FLASH_EFFECTS,
-)
+from homeassistant.components.zha.light import FLASH_EFFECTS
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 import homeassistant.util.dt as dt_util
 
@@ -148,7 +144,8 @@ async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
     )
     color_cluster = zigpy_device.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
-        "color_capabilities": CAPABILITIES_COLOR_TEMP | CAPABILITIES_COLOR_XY
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature
+        | lighting.Color.ColorCapabilities.XY_attributes
     }
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
@@ -180,7 +177,8 @@ async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
     )
     color_cluster = zigpy_device.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
-        "color_capabilities": CAPABILITIES_COLOR_TEMP | CAPABILITIES_COLOR_XY
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature
+        | lighting.Color.ColorCapabilities.XY_attributes
     }
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
@@ -239,7 +237,8 @@ async def eWeLink_light(hass, zigpy_device_mock, zha_device_joined):
     )
     color_cluster = zigpy_device.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
-        "color_capabilities": CAPABILITIES_COLOR_TEMP | CAPABILITIES_COLOR_XY
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature
+        | lighting.Color.ColorCapabilities.XY_attributes
     }
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the ZHA light entity classes and adds support for the Zigbee HS color mode / commands. There will be an additional PR after this one to add some Zigbee 3.0 specific enhancements. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
