### PR TITLE
Improve availability tracking and coordinator setup in bluetooth

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -167,7 +167,7 @@ def async_register_callback(
 @hass_callback
 def async_track_unavailable(
     hass: HomeAssistant,
-    callback: CALLBACK_TYPE,
+    callback: Callable[[str], None],
     address: str,
 ) -> Callable[[], None]:
     """Register to receive a callback when an address is unavailable.
@@ -250,7 +250,7 @@ class BluetoothManager:
         self.scanner: HaBleakScanner | None = None
         self._cancel_device_detected: CALLBACK_TYPE | None = None
         self._cancel_unavailable_tracking: CALLBACK_TYPE | None = None
-        self._unavailable_callbacks: dict[str, list[CALLBACK_TYPE]] = {}
+        self._unavailable_callbacks: dict[str, list[Callable[[str], None]]] = {}
         self._callbacks: list[
             tuple[BluetoothCallback, BluetoothCallbackMatcher | None]
         ] = []
@@ -300,7 +300,7 @@ class BluetoothManager:
                     continue
                 for callback in callbacks:
                     try:
-                        callback()
+                        callback(address)
                     except Exception:  # pylint: disable=broad-except
                         _LOGGER.exception("Error in unavailable callback")
 
@@ -373,7 +373,7 @@ class BluetoothManager:
 
     @hass_callback
     def async_track_unavailable(
-        self, callback: CALLBACK_TYPE, address: str
+        self, callback: Callable[[str], None], address: str
     ) -> Callable[[], None]:
         """Register a callback."""
         self._unavailable_callbacks.setdefault(address, []).append(callback)

--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -1,11 +1,9 @@
 """The Bluetooth integration."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 import dataclasses
-from datetime import datetime
 import logging
-import time
 from typing import Any, Generic, TypeVar
 
 from home_assistant_bluetooth import BluetoothServiceInfo
@@ -14,18 +12,14 @@ from homeassistant.const import ATTR_IDENTIFIERS, ATTR_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
 
 from . import (
     BluetoothCallbackMatcher,
     BluetoothChange,
-    async_address_present,
     async_register_callback,
+    async_track_unavailable,
 )
 from .const import DOMAIN
-
-UNAVAILABLE_SECONDS = 60 * 5
-NEVER_TIME = -UNAVAILABLE_SECONDS
 
 
 @dataclasses.dataclass(frozen=True)
@@ -49,10 +43,13 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
     """Generic bluetooth data."""
 
     devices: dict[str | None, DeviceInfo] = dataclasses.field(default_factory=dict)
-    entity_descriptions: dict[
+    entity_descriptions: Mapping[
         PassiveBluetoothEntityKey, EntityDescription
     ] = dataclasses.field(default_factory=dict)
-    entity_data: dict[PassiveBluetoothEntityKey, _T] = dataclasses.field(
+    entity_names: Mapping[PassiveBluetoothEntityKey, str | None] = dataclasses.field(
+        default_factory=dict
+    )
+    entity_data: Mapping[PassiveBluetoothEntityKey, _T] = dataclasses.field(
         default_factory=dict
     )
 
@@ -106,6 +103,7 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         ] = {}
         self.update_method = update_method
 
+        self.entity_names: dict[PassiveBluetoothEntityKey, str | None] = {}
         self.entity_data: dict[PassiveBluetoothEntityKey, _T] = {}
         self.entity_descriptions: dict[
             PassiveBluetoothEntityKey, EntityDescription
@@ -113,8 +111,8 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         self.devices: dict[str | None, DeviceInfo] = {}
 
         self.last_update_success = True
-        self._last_callback_time: float = NEVER_TIME
-        self._cancel_track_available: CALLBACK_TYPE | None = None
+        self._cancel_track_unavailable: CALLBACK_TYPE | None = None
+        self._cancel_bluetooth_advertisements: CALLBACK_TYPE | None = None
         self._present = False
 
     @property
@@ -123,44 +121,34 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         return self._present and self.last_update_success
 
     @callback
-    def _async_cancel_available_tracker(self) -> None:
-        """Reset the available tracker."""
-        if self._cancel_track_available:
-            self._cancel_track_available()
-            self._cancel_track_available = None
-
-    @callback
-    def _async_schedule_available_tracker(self, time_remaining: float) -> None:
-        """Schedule the available tracker."""
-        self._cancel_track_available = async_call_later(
-            self.hass, time_remaining, self._async_check_device_present
-        )
-
-    @callback
-    def _async_check_device_present(self, _: datetime) -> None:
-        """Check if the device is present."""
-        time_passed_since_seen = time.monotonic() - self._last_callback_time
-        self._async_cancel_available_tracker()
-        if (
-            not self._present
-            or time_passed_since_seen < UNAVAILABLE_SECONDS
-            or async_address_present(self.hass, self.address)
-        ):
-            self._async_schedule_available_tracker(
-                UNAVAILABLE_SECONDS - time_passed_since_seen
-            )
-            return
+    def _async_handle_unavailable(self) -> None:
+        """Handle the device going unavailable."""
         self._present = False
         self.async_update_listeners(None)
 
     @callback
-    def async_setup(self) -> CALLBACK_TYPE:
-        """Start the callback."""
-        return async_register_callback(
+    def _async_start(self) -> None:
+        """Start the callbacks."""
+        self._cancel_bluetooth_advertisements = async_register_callback(
             self.hass,
             self._async_handle_bluetooth_event,
             BluetoothCallbackMatcher(address=self.address),
         )
+        self._cancel_track_unavailable = async_track_unavailable(
+            self.hass,
+            self._async_handle_unavailable,
+            self.address,
+        )
+
+    @callback
+    def _async_stop(self) -> None:
+        """Stop the callbacks."""
+        if self._cancel_bluetooth_advertisements is not None:
+            self._cancel_bluetooth_advertisements()
+            self._cancel_bluetooth_advertisements = None
+        if self._cancel_track_unavailable is not None:
+            self._cancel_track_unavailable()
+            self._cancel_track_unavailable = None
 
     @callback
     def async_add_entities_listener(
@@ -199,9 +187,21 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         def remove_listener() -> None:
             """Remove update listener."""
             self._listeners.remove(update_callback)
+            self._async_handle_listeners_changed()
 
         self._listeners.append(update_callback)
+        self._async_handle_listeners_changed()
         return remove_listener
+
+    @callback
+    def _async_handle_listeners_changed(self) -> None:
+        """Handle listeners changed."""
+        listener_count = len(self._listeners) + len(self._entity_key_listeners)
+        running = bool(self._cancel_bluetooth_advertisements)
+        if listener_count == 0 and running:
+            self._async_stop()
+        elif not running:
+            self._async_start()
 
     @callback
     def async_add_entity_key_listener(
@@ -217,8 +217,10 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
             self._entity_key_listeners[entity_key].remove(update_callback)
             if not self._entity_key_listeners[entity_key]:
                 del self._entity_key_listeners[entity_key]
+            self._async_handle_listeners_changed()
 
         self._entity_key_listeners.setdefault(entity_key, []).append(update_callback)
+        self._async_handle_listeners_changed()
         return remove_listener
 
     @callback
@@ -243,10 +245,7 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
     ) -> None:
         """Handle a Bluetooth event."""
         self.name = service_info.name
-        self._last_callback_time = time.monotonic()
         self._present = True
-        if not self._cancel_track_available:
-            self._async_schedule_available_tracker(UNAVAILABLE_SECONDS)
         if self.hass.is_stopping:
             return
 
@@ -272,6 +271,7 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         self.devices.update(new_data.devices)
         self.entity_descriptions.update(new_data.entity_descriptions)
         self.entity_data.update(new_data.entity_data)
+        self.entity_names.update(new_data.entity_names)
         self.async_update_listeners(new_data)
 
 
@@ -315,6 +315,7 @@ class PassiveBluetoothCoordinatorEntity(
             self._attr_unique_id = f"{address}-{key}"
         if ATTR_NAME not in self._attr_device_info:
             self._attr_device_info[ATTR_NAME] = self.coordinator.name
+        self._attr_name = coordinator.entity_names.get(entity_key)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -121,7 +121,7 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         return self._present and self.last_update_success
 
     @callback
-    def _async_handle_unavailable(self) -> None:
+    def _async_handle_unavailable(self, _address: str) -> None:
         """Handle the device going unavailable."""
         self._present = False
         self.async_update_listeners(None)

--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -114,18 +114,18 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         self.last_update_success = True
         self._cancel_track_unavailable: CALLBACK_TYPE | None = None
         self._cancel_bluetooth_advertisements: CALLBACK_TYPE | None = None
-        self._present = False
+        self.present = False
         self.last_seen = 0.0
 
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return self._present and self.last_update_success
+        return self.present and self.last_update_success
 
     @callback
     def _async_handle_unavailable(self, _address: str) -> None:
         """Handle the device going unavailable."""
-        self._present = False
+        self.present = False
         self.async_update_listeners(None)
 
     @callback
@@ -248,7 +248,7 @@ class PassiveBluetoothDataUpdateCoordinator(Generic[_T]):
         """Handle a Bluetooth event."""
         self.last_seen = time.monotonic()
         self.name = service_info.name
-        self._present = True
+        self.present = True
         if self.hass.is_stopping:
             return
 

--- a/homeassistant/components/bluetooth/strings.json
+++ b/homeassistant/components/bluetooth/strings.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "description": "Choose a device to setup",
+        "data": {
+          "address": "Device"
+        }
+      },
+      "bluetooth_confirm": {
+        "description": "Do you want to setup {name}?"
+      }
+    }
+  }
+}

--- a/homeassistant/components/bluetooth/translations/en.json
+++ b/homeassistant/components/bluetooth/translations/en.json
@@ -1,0 +1,16 @@
+{
+    "config": {
+        "flow_title": "{name}",
+        "step": {
+            "bluetooth_confirm": {
+                "description": "Do you want to setup {name}?"
+            },
+            "user": {
+                "data": {
+                    "address": "Device"
+                },
+                "description": "Choose a device to setup"
+            }
+        }
+    }
+}

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -252,7 +252,7 @@ async def test_async_discovered_device_api(hass, mock_bleak_scanner_start):
         switchbot_device_went_unavailable = False
 
         @callback
-        def _wrong_device_unavailable_callback(_address: str):
+        def _wrong_device_unavailable_callback(_address: str) -> None:
             """Wrong device unavailable callback."""
             nonlocal wrong_device_went_unavailable
             wrong_device_went_unavailable = True

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Bluetooth integration."""
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from bleak import BleakError
@@ -7,12 +8,18 @@ from bleak.backends.scanner import AdvertisementData, BLEDevice
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
     SOURCE_LOCAL,
+    UNAVAILABLE_TRACK_SECONDS,
     BluetoothChange,
     BluetoothServiceInfo,
+    async_track_unavailable,
     models,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed
 
 
 async def test_setup_and_stop(hass, mock_bleak_scanner_start):
@@ -241,9 +248,55 @@ async def test_async_discovered_device_api(hass, mock_bleak_scanner_start):
         switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
         switchbot_adv = AdvertisementData(local_name="wohand", service_uuids=[])
         models.HA_BLEAK_SCANNER._callback(switchbot_device, switchbot_adv)
+        wrong_device_went_unavailable = False
+        switchbot_device_went_unavailable = False
+
+        @callback
+        def _wrong_device_unavailable_callback():
+            """Wrong device unavailable callback."""
+            nonlocal wrong_device_went_unavailable
+            wrong_device_went_unavailable = True
+            raise ValueError("blow up")
+
+        @callback
+        def _switchbot_device_unavailable_callback():
+            """Switchbot device unavailable callback."""
+            nonlocal switchbot_device_went_unavailable
+            switchbot_device_went_unavailable = True
+
+        wrong_device_unavailable_cancel = async_track_unavailable(
+            hass, _wrong_device_unavailable_callback, wrong_device.address
+        )
+        switchbot_device_unavailable_cancel = async_track_unavailable(
+            hass, _switchbot_device_unavailable_callback, switchbot_device.address
+        )
+
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
+        )
         await hass.async_block_till_done()
 
         service_infos = bluetooth.async_discovered_service_info(hass)
+        assert switchbot_device_went_unavailable is False
+        assert wrong_device_went_unavailable is True
+
+        # See the devices again
+        models.HA_BLEAK_SCANNER._callback(wrong_device, wrong_adv)
+        models.HA_BLEAK_SCANNER._callback(switchbot_device, switchbot_adv)
+        # Cancel the callbacks
+        wrong_device_unavailable_cancel()
+        switchbot_device_unavailable_cancel()
+        wrong_device_went_unavailable = False
+        switchbot_device_went_unavailable = False
+
+        # Verify the cancel is effective
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
+        )
+        await hass.async_block_till_done()
+        assert switchbot_device_went_unavailable is False
+        assert wrong_device_went_unavailable is False
+
         assert len(service_infos) == 1
         # wrong_name should not appear because bleak no longer sees it
         assert service_infos[0].name == "wohand"

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -252,14 +252,14 @@ async def test_async_discovered_device_api(hass, mock_bleak_scanner_start):
         switchbot_device_went_unavailable = False
 
         @callback
-        def _wrong_device_unavailable_callback():
+        def _wrong_device_unavailable_callback(_address: str):
             """Wrong device unavailable callback."""
             nonlocal wrong_device_went_unavailable
             wrong_device_went_unavailable = True
             raise ValueError("blow up")
 
         @callback
-        def _switchbot_device_unavailable_callback():
+        def _switchbot_device_unavailable_callback(_address: str):
             """Switchbot device unavailable callback."""
             nonlocal switchbot_device_went_unavailable
             switchbot_device_went_unavailable = True

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -259,7 +259,7 @@ async def test_async_discovered_device_api(hass, mock_bleak_scanner_start):
             raise ValueError("blow up")
 
         @callback
-        def _switchbot_device_unavailable_callback(_address: str):
+        def _switchbot_device_unavailable_callback(_address: str) -> None:
             """Switchbot device unavailable callback."""
             nonlocal switchbot_device_went_unavailable
             switchbot_device_went_unavailable = True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
From review comments in https://github.com/home-assistant/core/pull/75531

- Availability is now called back from the bluetooth integration into the coordinator to avoid polling in multiple places which solves the performance issue with checking bleak devices

- Names are broken out for the entities since we are now using inline descriptions and there can be many sensors of the same type which means we cannot include the name in the description

- The coordinator no longer needs to have `async_setup` called as it will start/stop its callback subscriptions based on if it has listeners or not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1408

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
