### PR TITLE
Add guards to ZHA light groups when using hs color mode

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -129,6 +129,7 @@ CONF_DATABASE = "database_path"
 CONF_DEFAULT_LIGHT_TRANSITION = "default_light_transition"
 CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_ENHANCED_LIGHT_TRANSITION = "enhanced_light_transition"
+CONF_ALWAYS_PREFER_XY_COLOR_MODE = "always_prefer_xy_color_mode"
 CONF_ENABLE_IDENTIFY_ON_JOIN = "enable_identify_on_join"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_FLOWCONTROL = "flow_control"
@@ -145,6 +146,7 @@ CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
         vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=False): cv.boolean,
+        vol.Required(CONF_ALWAYS_PREFER_XY_COLOR_MODE, default=True): cv.boolean,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
         vol.Optional(
             CONF_CONSIDER_UNAVAILABLE_MAINS,

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -279,7 +279,10 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_hs_color = None
 
         if hs_color is not None:
-            if self._color_channel.enhanced_hue_supported:
+            if (
+                not isinstance(self, LightGroup)
+                and self._color_channel.enhanced_hue_supported
+            ):
                 result = await self._color_channel.enhanced_move_to_hue_and_saturation(
                     int(hs_color[0] * 65535 / 360),
                     int(hs_color[1] * 2.54),

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -636,7 +636,7 @@ class Light(BaseLight, ZhaEntity):
                         self._attr_xy_color = None
                         self._attr_color_temp = None
                 else:
-                    self._attr_color_mode = Color.ColorMode.X_and_Y
+                    self._attr_color_mode = ColorMode.XY
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -792,6 +792,12 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             if ColorMode.BRIGHTNESS in color_mode_count:
                 color_mode_count[ColorMode.BRIGHTNESS] = 0
             self._attr_color_mode = color_mode_count.most_common(1)[0][0]
+            if self._attr_color_mode == ColorMode.HS and color_mode_count[
+                ColorMode.HS
+            ] != len(
+                self._group.members
+            ):  # switch to XY if all members do not support HS
+                self._attr_color_mode = ColorMode.XY
 
         self._attr_supported_color_modes = None
         all_supported_color_modes = list(

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -40,6 +40,7 @@ from .core.const import (
     CHANNEL_COLOR,
     CHANNEL_LEVEL,
     CHANNEL_ON_OFF,
+    CONF_ALWAYS_PREFER_XY_COLOR_MODE,
     CONF_DEFAULT_LIGHT_TRANSITION,
     CONF_ENABLE_ENHANCED_LIGHT_TRANSITION,
     DATA_ZHA,
@@ -119,6 +120,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._off_brightness: int | None = None
         self._zha_config_transition = self._DEFAULT_MIN_TRANSITION_TIME
         self._zha_config_enhanced_light_transition: bool = False
+        self._zha_config_always_prefer_xy_color_mode: bool = True
         self._on_off_channel = None
         self._level_channel = None
         self._color_channel = None
@@ -420,6 +422,13 @@ class Light(BaseLight, ZhaEntity):
         self._cancel_refresh_handle = None
         effect_list = []
 
+        self._zha_config_always_prefer_xy_color_mode = async_get_zha_config_value(
+            zha_device.gateway.config_entry,
+            ZHA_OPTIONS,
+            CONF_ALWAYS_PREFER_XY_COLOR_MODE,
+            True,
+        )
+
         self._attr_supported_color_modes = {ColorMode.ONOFF}
         if self._level_channel:
             self._attr_supported_color_modes.add(ColorMode.BRIGHTNESS)
@@ -431,9 +440,9 @@ class Light(BaseLight, ZhaEntity):
                 self._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
                 self._attr_color_temp = self._color_channel.color_temperature
 
-            if (
-                self._color_channel.xy_supported
-                and not self._color_channel.hs_supported
+            if self._color_channel.xy_supported and (
+                self._zha_config_always_prefer_xy_color_mode
+                or not self._color_channel.hs_supported
             ):
                 self._attr_supported_color_modes.add(ColorMode.XY)
                 curr_x = self._color_channel.current_x
@@ -443,7 +452,10 @@ class Light(BaseLight, ZhaEntity):
                 else:
                     self._attr_xy_color = (0, 0)
 
-            if self._color_channel.hs_supported:
+            if (
+                self._color_channel.hs_supported
+                and not self._zha_config_always_prefer_xy_color_mode
+            ):
                 self._attr_supported_color_modes.add(ColorMode.HS)
                 if self._color_channel.enhanced_hue_supported:
                     curr_hue = self._color_channel.enhanced_current_hue * 65535 / 360
@@ -574,12 +586,16 @@ class Light(BaseLight, ZhaEntity):
                 "current_x",
                 "current_y",
             ]
-            if self._color_channel.enhanced_hue_supported:
+            if (
+                not self._zha_config_always_prefer_xy_color_mode
+                and self._color_channel.enhanced_hue_supported
+            ):
                 attributes.append("enhanced_current_hue")
                 attributes.append("current_saturation")
             if (
                 self._color_channel.hs_supported
                 and not self._color_channel.enhanced_hue_supported
+                and not self._zha_config_always_prefer_xy_color_mode
             ):
                 attributes.append("current_hue")
                 attributes.append("current_saturation")
@@ -600,7 +616,10 @@ class Light(BaseLight, ZhaEntity):
                         self._attr_color_temp = color_temp
                         self._attr_xy_color = None
                         self._attr_hs_color = None
-                elif color_mode == Color.ColorMode.Hue_and_saturation:
+                elif (
+                    color_mode == Color.ColorMode.Hue_and_saturation
+                    and not self._zha_config_always_prefer_xy_color_mode
+                ):
                     self._attr_color_mode = ColorMode.HS
                     if self._color_channel.enhanced_hue_supported:
                         current_hue = results.get("enhanced_current_hue")
@@ -702,6 +721,12 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             CONF_DEFAULT_LIGHT_TRANSITION,
             0,
         )
+        self._zha_config_always_prefer_xy_color_mode = async_get_zha_config_value(
+            zha_device.gateway.config_entry,
+            ZHA_OPTIONS,
+            CONF_ALWAYS_PREFER_XY_COLOR_MODE,
+            True,
+        )
         self._zha_config_enhanced_light_transition = False
         self._attr_color_mode = None
 
@@ -751,9 +776,10 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             on_states, light.ATTR_XY_COLOR, reduce=helpers.mean_tuple
         )
 
-        self._attr_hs_color = helpers.reduce_attribute(
-            on_states, light.ATTR_HS_COLOR, reduce=helpers.mean_tuple
-        )
+        if not self._zha_config_always_prefer_xy_color_mode:
+            self._attr_hs_color = helpers.reduce_attribute(
+                on_states, light.ATTR_HS_COLOR, reduce=helpers.mean_tuple
+            )
 
         self._attr_color_temp = helpers.reduce_attribute(
             on_states, light.ATTR_COLOR_TEMP
@@ -792,10 +818,9 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             if ColorMode.BRIGHTNESS in color_mode_count:
                 color_mode_count[ColorMode.BRIGHTNESS] = 0
             self._attr_color_mode = color_mode_count.most_common(1)[0][0]
-            if self._attr_color_mode == ColorMode.HS and color_mode_count[
-                ColorMode.HS
-            ] != len(
-                self._group.members
+            if self._attr_color_mode == ColorMode.HS and (
+                color_mode_count[ColorMode.HS] != len(self._group.members)
+                or self._zha_config_always_prefer_xy_color_mode
             ):  # switch to XY if all members do not support HS
                 self._attr_color_mode = ColorMode.XY
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -609,7 +609,7 @@ class Light(BaseLight, ZhaEntity):
                             int(current_hue * 360 / 65535)
                             if self._color_channel.enhanced_hue_supported
                             else int(current_hue * 360 / 254),
-                            int(current_saturation / 254),
+                            int(current_saturation / 2.54),
                         )
                         self._attr_xy_color = None
                         self._attr_color_temp = None

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -38,6 +38,7 @@
     "zha_options": {
       "title": "Global Options",
       "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
+      "always_prefer_xy_color_mode": "Always prefer XY color mode.",
       "enable_identify_on_join": "Enable identify effect when devices join the network",
       "default_light_transition": "Default light transition time (seconds)",
       "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -38,7 +38,7 @@
     "zha_options": {
       "title": "Global Options",
       "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
-      "always_prefer_xy_color_mode": "Always prefer XY color mode.",
+      "always_prefer_xy_color_mode": "Always prefer XY color mode",
       "enable_identify_on_join": "Enable identify effect when devices join the network",
       "default_light_transition": "Default light transition time (seconds)",
       "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -51,7 +51,7 @@
             "default_light_transition": "Default light transition time (seconds)",
             "enable_identify_on_join": "Enable identify effect when devices join the network",
             "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
-            "always_prefer_xy_color_mode": "Always prefer XY color mode.",
+            "always_prefer_xy_color_mode": "Always prefer XY color mode",
             "title": "Global Options"
         }
     },

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -51,6 +51,7 @@
             "default_light_transition": "Default light transition time (seconds)",
             "enable_identify_on_join": "Enable identify effect when devices join the network",
             "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
+            "always_prefer_xy_color_mode": "Always prefer XY color mode.",
             "title": "Global Options"
         }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds some slight tweaks to the ZHA light entities after adding support for HS color modes. 

Also **HUGE thanks to @TheJulianJES** for a ton of help and a lot of testing with all of the light entity changes. Here is some info from his testing:

https://github.com/home-assistant/core/pull/75573 added support for using the HS color mode (instead of only XY) for supporting Zigbee lights.

As it turns out, the official Philips Hue app, the Hue integration in HA and Zigbee2MQTT (through HA) all only use XY colors when talking to Zigbee lights. This is possibly the case because some colors (especially blue) are way off when using HS commands. As always enabling HS colors might "break" a lot of existing installations (but HS color mode might still be nice for some use-cases).

---

### Color comparison of clicking blue in the color slider (so ``RGB: 0, 0, 255``):

XY color (actually blue):
<img src="https://user-images.githubusercontent.com/6409465/180500575-261ea17e-d8d7-460f-9941-87b77d9430b1.png" width="100">

HS color (looks like cyan, way too much green):
<img src="https://user-images.githubusercontent.com/6409465/180500585-a0c0408c-a615-4445-8ed0-a98dc04fefad.png" width="100">

Other colors (like red) are completely fine with both HS and XY though, so it's not a total hue shift.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
