### PR TITLE
Initial xiaomi_ble integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1220,6 +1220,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/xbox_live/ @MartinHjelmare
 /homeassistant/components/xiaomi_aqara/ @danielhiversen @syssi
 /tests/components/xiaomi_aqara/ @danielhiversen @syssi
+/homeassistant/components/xiaomi_ble/ @Jc2k @Ernst79
+/tests/components/xiaomi_ble/ @Jc2k @Ernst79
 /homeassistant/components/xiaomi_miio/ @rytilahti @syssi @starkillerOG @bieniu
 /tests/components/xiaomi_miio/ @rytilahti @syssi @starkillerOG @bieniu
 /homeassistant/components/xiaomi_tv/ @simse

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -1,0 +1,56 @@
+"""The Xiaomi Bluetooth integration."""
+from __future__ import annotations
+
+import logging
+
+from xiaomi_ble import XiaomiBluetoothDeviceData
+
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothDataUpdate,
+    PassiveBluetoothDataUpdateCoordinator,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
+
+from .const import DOMAIN
+from .sensor import sensor_update_to_bluetooth_data_update
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Xiaomi BLE device from a config entry."""
+    address = entry.unique_id
+    assert address is not None
+
+    data = XiaomiBluetoothDeviceData()
+
+    @callback
+    def _async_update_data(
+        service_info: BluetoothServiceInfo,
+    ) -> PassiveBluetoothDataUpdate:
+        """Update data from Xiaomi Bluetooth."""
+        return sensor_update_to_bluetooth_data_update(data.update(service_info))
+
+    hass.data.setdefault(DOMAIN, {})[
+        entry.entry_id
+    ] = PassiveBluetoothDataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        update_method=_async_update_data,
+        address=address,
+    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for xiaomi integration."""
+"""Config flow for Xiaomi Bluetooth integration."""
 from __future__ import annotations
 
 from typing import Any

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -35,7 +35,6 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
         device = DeviceData()
-        print(discovery_info)
         if not device.supported(discovery_info):
             return self.async_abort(reason="not_supported")
         self._discovery_info = discovery_info

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -18,7 +18,7 @@ from .const import DOMAIN
 
 
 class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for xiaomi."""
+    """Handle a config flow for Xiaomi Bluetooth."""
 
     VERSION = 1
 

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -1,0 +1,94 @@
+"""Config flow for xiaomi integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from xiaomi_ble import XiaomiBluetoothDeviceData as DeviceData
+
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfo,
+    async_discovered_service_info,
+)
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+
+class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for xiaomi."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: BluetoothServiceInfo | None = None
+        self._discovered_device: DeviceData | None = None
+        self._discovered_devices: dict[str, str] = {}
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfo
+    ) -> FlowResult:
+        """Handle the bluetooth discovery step."""
+        await self.async_set_unique_id(discovery_info.address)
+        self._abort_if_unique_id_configured()
+        device = DeviceData()
+        print(discovery_info)
+        if not device.supported(discovery_info):
+            return self.async_abort(reason="not_supported")
+        self._discovery_info = discovery_info
+        self._discovered_device = device
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm discovery."""
+        assert self._discovered_device is not None
+        device = self._discovered_device
+        assert self._discovery_info is not None
+        discovery_info = self._discovery_info
+        title = device.title or device.get_device_name() or discovery_info.name
+        if user_input is not None:
+            return self.async_create_entry(title=title, data={})
+
+        self._set_confirm_only()
+        placeholders = {"name": title}
+        self.context["title_placeholders"] = placeholders
+        return self.async_show_form(
+            step_id="bluetooth_confirm", description_placeholders=placeholders
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the user step to pick discovered device."""
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            await self.async_set_unique_id(address, raise_on_progress=False)
+            return self.async_create_entry(
+                title=self._discovered_devices[address], data={}
+            )
+
+        current_addresses = self._async_current_ids()
+        for discovery_info in async_discovered_service_info(self.hass):
+            address = discovery_info.address
+            if address in current_addresses or address in self._discovered_devices:
+                continue
+            device = DeviceData()
+            if device.supported(discovery_info):
+                self._discovered_devices[address] = (
+                    device.title or device.get_device_name() or discovery_info.name
+                )
+
+        if not self._discovered_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_ADDRESS): vol.In(self._discovered_devices)}
+            ),
+        )

--- a/homeassistant/components/xiaomi_ble/const.py
+++ b/homeassistant/components/xiaomi_ble/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Xiaomi Bluetooth integration."""
+
+DOMAIN = "xiaomi_ble"

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -1,0 +1,15 @@
+{
+  "domain": "xiaomi_ble",
+  "name": "Xiaomi BLE",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/xiaomi_ble",
+  "bluetooth": [
+    {
+      "service_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
+    }
+  ],
+  "requirements": ["xiaomi-ble==0.0.3"],
+  "dependencies": ["bluetooth"],
+  "codeowners": ["@Jc2k", "@Ernst79"],
+  "iot_class": "local_push"
+}

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.0.3"],
+  "requirements": ["xiaomi-ble==0.1.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -53,7 +53,7 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
     ),
     (DeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
-        key=f"{DeviceClass.TEMPERATURE}_{Units.PERCENTAGE}",
+        key=f"{DeviceClass.BATTERY}_{Units.PERCENTAGE}",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -1,0 +1,149 @@
+"""Support for xiaomi ble sensors."""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from xiaomi_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
+
+from homeassistant import config_entries
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothCoordinatorEntity,
+    PassiveBluetoothDataUpdate,
+    PassiveBluetoothDataUpdateCoordinator,
+    PassiveBluetoothEntityKey,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    PERCENTAGE,
+    PRESSURE_MBAR,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    TEMP_CELSIUS,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+SENSOR_DESCRIPTIONS = {
+    (DeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
+        key=f"{DeviceClass.TEMPERATURE}_{Units.TEMP_CELSIUS}",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    (DeviceClass.HUMIDITY, Units.PERCENTAGE): SensorEntityDescription(
+        key=f"{DeviceClass.HUMIDITY}_{Units.PERCENTAGE}",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    (DeviceClass.PRESSURE, Units.PRESSURE_MBAR): SensorEntityDescription(
+        key=f"{DeviceClass.PRESSURE}_{Units.PRESSURE_MBAR}",
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement=PRESSURE_MBAR,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    (DeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
+        key=f"{DeviceClass.TEMPERATURE}_{Units.PERCENTAGE}",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    (
+        DeviceClass.SIGNAL_STRENGTH,
+        Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    ): SensorEntityDescription(
+        key=f"{DeviceClass.SIGNAL_STRENGTH}_{Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT}",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+}
+
+
+def _device_key_to_bluetooth_entity_key(
+    device_key: DeviceKey,
+) -> PassiveBluetoothEntityKey:
+    """Convert a device key to an entity key."""
+    return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
+
+
+def _sensor_device_info_to_hass(
+    sensor_device_info: SensorDeviceInfo,
+) -> DeviceInfo:
+    """Convert a sensor device info to a sensor device info."""
+    hass_device_info = DeviceInfo({})
+    if sensor_device_info.name is not None:
+        hass_device_info[ATTR_NAME] = sensor_device_info.name
+    if sensor_device_info.manufacturer is not None:
+        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
+    if sensor_device_info.model is not None:
+        hass_device_info[ATTR_MODEL] = sensor_device_info.model
+    return hass_device_info
+
+
+def sensor_update_to_bluetooth_data_update(
+    sensor_update: SensorUpdate,
+) -> PassiveBluetoothDataUpdate:
+    """Convert a sensor update to a bluetooth data update."""
+    return PassiveBluetoothDataUpdate(
+        devices={
+            device_id: _sensor_device_info_to_hass(device_info)
+            for device_id, device_info in sensor_update.devices.items()
+        },
+        entity_descriptions={
+            _device_key_to_bluetooth_entity_key(device_key): SENSOR_DESCRIPTIONS[
+                (description.device_class, description.native_unit_of_measurement)
+            ]
+            for device_key, description in sensor_update.entity_descriptions.items()
+            if description.device_class and description.native_unit_of_measurement
+        },
+        entity_data={
+            _device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value
+            for device_key, sensor_values in sensor_update.entity_values.items()
+        },
+        entity_names={
+            _device_key_to_bluetooth_entity_key(device_key): sensor_values.name
+            for device_key, sensor_values in sensor_update.entity_values.items()
+        },
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Xiaomi BLE sensors."""
+    coordinator: PassiveBluetoothDataUpdateCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+    entry.async_on_unload(
+        coordinator.async_add_entities_listener(
+            XiaomiBluetoothSensorEntity, async_add_entities
+        )
+    )
+
+
+class XiaomiBluetoothSensorEntity(
+    PassiveBluetoothCoordinatorEntity[
+        PassiveBluetoothDataUpdateCoordinator[Optional[Union[float, int]]]
+    ],
+    SensorEntity,
+):
+    """Representation of a xiaomi ble sensor."""
+
+    @property
+    def native_value(self) -> int | float | None:
+        """Return the native value."""
+        return self.coordinator.entity_data.get(self.entity_key)

--- a/homeassistant/components/xiaomi_ble/strings.json
+++ b/homeassistant/components/xiaomi_ble/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "flow_title": "[%key:component::bluetooth::config::flow_title%]",
+    "step": {
+      "user": {
+        "description": "[%key:component::bluetooth::config::step::user::description%]",
+        "data": {
+          "address": "[%key:component::bluetooth::config::step::user::data::address%]"
+        }
+      },
+      "bluetooth_confirm": {
+        "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
+      }
+    },
+    "abort": {
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/xiaomi_ble/translations/en.json
+++ b/homeassistant/components/xiaomi_ble/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured",
+            "already_in_progress": "Configuration flow is already in progress",
+            "no_devices_found": "No devices found on the network"
+        },
+        "flow_title": "{name}",
+        "step": {
+            "bluetooth_confirm": {
+                "description": "Do you want to setup {name}?"
+            },
+            "user": {
+                "data": {
+                    "address": "Device"
+                },
+                "description": "Choose a device to setup"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -37,5 +37,9 @@ BLUETOOTH: list[dict[str, str | int | list[int]]] = [
     {
         "domain": "switchbot",
         "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
+    },
+    {
+        "domain": "xiaomi_ble",
+        "service_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
 ]

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -419,6 +419,7 @@ FLOWS = {
         "ws66i",
         "xbox",
         "xiaomi_aqara",
+        "xiaomi_ble",
         "xiaomi_miio",
         "yale_smart_alarm",
         "yamaha_musiccast",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2467,6 +2467,9 @@ xbox-webapi==2.0.11
 # homeassistant.components.xbox_live
 xboxapi==2.0.1
 
+# homeassistant.components.xiaomi_ble
+xiaomi-ble==0.0.3
+
 # homeassistant.components.knx
 xknx==0.21.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2468,7 +2468,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.0.3
+xiaomi-ble==0.1.0
 
 # homeassistant.components.knx
 xknx==0.21.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1652,6 +1652,9 @@ wolf_smartset==0.1.11
 # homeassistant.components.xbox
 xbox-webapi==2.0.11
 
+# homeassistant.components.xiaomi_ble
+xiaomi-ble==0.0.3
+
 # homeassistant.components.knx
 xknx==0.21.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1653,7 +1653,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.0.3
+xiaomi-ble==0.1.0
 
 # homeassistant.components.knx
 xknx==0.21.5

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -15,7 +15,7 @@ NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfo(
 
 LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
     name="LYWSDCGQ",
-    address="00:00:00:00:00:01",
+    address="58:2D:34:35:93:21",
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -27,7 +27,7 @@ LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
 
 MMC_T201_1_SERVICE_INFO = BluetoothServiceInfo(
     name="MMC_T201_1",
-    address="00:00:00:00:00:02",
+    address="00:81:F9:DD:6F:C1",
     rssi=-56,
     manufacturer_data={},
     service_data={

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfo(
     name="Not it",
-    address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    address="00:00:00:00:00:00",
     rssi=-63,
     manufacturer_data={3234: b"\x00\x01"},
     service_data={},
@@ -15,7 +15,7 @@ NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfo(
 
 LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
     name="LYWSDCGQ",
-    address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    address="00:00:00:00:00:01",
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -27,7 +27,7 @@ LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
 
 MMC_T201_1_SERVICE_INFO = BluetoothServiceInfo(
     name="MMC_T201_1",
-    address="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
+    address="00:00:00:00:00:02",
     rssi=-56,
     manufacturer_data={},
     service_data={

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -1,0 +1,38 @@
+"""Tests for the SensorPush integration."""
+
+
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
+
+NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfo(
+    name="Not it",
+    address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    rssi=-63,
+    manufacturer_data={3234: b"\x00\x01"},
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
+HTW_SERVICE_INFO = BluetoothServiceInfo(
+    name="LYWSDCGQ",
+    address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    rssi=-63,
+    manufacturer_data={},
+    service_data={
+        "0000fe95-0000-1000-8000-00805f9b34fb": b"P \xaa\x01\xda!\x9354-X\r\x10\x04\xfe\x00H\x02"
+    },
+    service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)
+
+HTPWX_SERVICE_INFO = BluetoothServiceInfo(
+    name="MMC_T201_1",
+    address="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
+    rssi=-56,
+    manufacturer_data={},
+    service_data={
+        "0000fe95-0000-1000-8000-00805f9b34fb": b'p"\xdb\x00o\xc1o\xdd\xf9\x81\x00\t\x00 \x05\xc6\rc\rQ'
+    },
+    service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -13,7 +13,7 @@ NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-HTW_SERVICE_INFO = BluetoothServiceInfo(
+LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
     name="LYWSDCGQ",
     address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
     rssi=-63,
@@ -25,7 +25,7 @@ HTW_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-HTPWX_SERVICE_INFO = BluetoothServiceInfo(
+MMC_T201_1_SERVICE_INFO = BluetoothServiceInfo(
     name="MMC_T201_1",
     address="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
     rssi=-56,

--- a/tests/components/xiaomi_ble/conftest.py
+++ b/tests/components/xiaomi_ble/conftest.py
@@ -1,8 +1,8 @@
-"""SensorPush session fixtures."""
+"""Session fixtures."""
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def auto_mock_bleak_scanner_start(mock_bleak_scanner_start):
-    """Auto mock bleak scanner start."""
+def mock_bluetooth(enable_bluetooth):
+    """Auto mock bluetooth."""

--- a/tests/components/xiaomi_ble/conftest.py
+++ b/tests/components/xiaomi_ble/conftest.py
@@ -1,0 +1,8 @@
+"""SensorPush session fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_mock_bleak_scanner_start(mock_bleak_scanner_start):
+    """Auto mock bleak scanner start."""

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -1,0 +1,94 @@
+"""Test the Xiaomi config flow."""
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.xiaomi_ble.const import DOMAIN
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import HTPWX_SERVICE_INFO, HTW_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
+
+from tests.common import MockConfigEntry
+
+
+async def test_async_step_bluetooth_valid_device(hass):
+    """Test discovery via bluetooth with a valid device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=HTPWX_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    with patch("homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "MMC_T201_1"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "4125DDBA-2774-4851-9889-6AADDD4CAC3D"
+
+
+async def test_async_step_bluetooth_not_xiaomi(hass):
+    """Test discovery via bluetooth not xiaomi."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=NOT_SENSOR_PUSH_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_supported"
+
+
+async def test_async_step_user_no_devices_found(hass):
+    """Test setup from service info cache with no devices found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_async_step_user_with_found_devices(hass):
+    """Test setup from service info cache with devices found."""
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[HTW_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    with patch("homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": "61DE521B-F0BF-9F44-64D4-75BBE1738105"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "LYWSDCGQ"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "61DE521B-F0BF-9F44-64D4-75BBE1738105"
+
+
+async def test_async_step_user_with_found_devices_already_setup(hass):
+    """Test setup from service info cache with devices found."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[HTW_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -100,3 +100,39 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
         )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
+
+
+async def test_async_step_bluetooth_devices_already_setup(hass):
+    """Test we can't start a flow if there is already a config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="00:81:F9:DD:6F:C1",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=MMC_T201_1_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_async_step_bluetooth_already_in_progress(hass):
+    """Test we can't start a flow for the same device twice."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=MMC_T201_1_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=MMC_T201_1_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import HTPWX_SERVICE_INFO, HTW_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
+from . import MMC_T201_1_SERVICE_INFO, LYWSDCGQ_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 
@@ -16,7 +16,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=HTPWX_SERVICE_INFO,
+        data=MMC_T201_1_SERVICE_INFO,
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
@@ -57,7 +57,7 @@ async def test_async_step_user_with_found_devices(hass):
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
-        return_value=[HTW_SERVICE_INFO],
+        return_value=[LYWSDCGQ_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -88,7 +88,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
 
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
-        return_value=[HTW_SERVICE_INFO],
+        return_value=[LYWSDCGQ_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -33,7 +33,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "MMC_T201_1"
     assert result2["data"] == {}
-    assert result2["result"].unique_id == "4125DDBA-2774-4851-9889-6AADDD4CAC3D"
+    assert result2["result"].unique_id == "00:00:00:00:00:02"
 
 
 async def test_async_step_bluetooth_not_xiaomi(hass):
@@ -74,19 +74,19 @@ async def test_async_step_user_with_found_devices(hass):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": "61DE521B-F0BF-9F44-64D4-75BBE1738105"},
+            user_input={"address": "00:00:00:00:00:01"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "LYWSDCGQ"
     assert result2["data"] == {}
-    assert result2["result"].unique_id == "61DE521B-F0BF-9F44-64D4-75BBE1738105"
+    assert result2["result"].unique_id == "00:00:00:00:00:01"
 
 
 async def test_async_step_user_with_found_devices_already_setup(hass):
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        unique_id="00:00:00:00:00:01",
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -6,7 +6,11 @@ from homeassistant import config_entries
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import LYWSDCGQ_SERVICE_INFO, MMC_T201_1_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
+from . import (
+    LYWSDCGQ_SERVICE_INFO,
+    MMC_T201_1_SERVICE_INFO,
+    NOT_SENSOR_PUSH_SERVICE_INFO,
+)
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -33,7 +33,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "MMC_T201_1"
     assert result2["data"] == {}
-    assert result2["result"].unique_id == "00:00:00:00:00:02"
+    assert result2["result"].unique_id == "00:81:F9:DD:6F:C1"
 
 
 async def test_async_step_bluetooth_not_xiaomi(hass):
@@ -74,19 +74,19 @@ async def test_async_step_user_with_found_devices(hass):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": "00:00:00:00:00:01"},
+            user_input={"address": "58:2D:34:35:93:21"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "LYWSDCGQ"
     assert result2["data"] == {}
-    assert result2["result"].unique_id == "00:00:00:00:00:01"
+    assert result2["result"].unique_id == "58:2D:34:35:93:21"
 
 
 async def test_async_step_user_with_found_devices_already_setup(hass):
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="00:00:00:00:00:01",
+        unique_id="58:2D:34:35:93:21",
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -149,12 +149,26 @@ async def test_async_step_user_takes_precedence_over_discovery(hass):
     assert result["step_id"] == "bluetooth_confirm"
 
     with patch(
-        "homeassistant.components.sensorpush.async_setup_entry", return_value=True
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[MMC_T201_1_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"address": "00:81:F9:DD:6F:C1"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "MMC_T201_1"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "00:81:F9:DD:6F:C1"
+
+    # Verify the original one was aborted
+    assert not hass.config_entries.flow.async_progress(DOMAIN)

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import MMC_T201_1_SERVICE_INFO, LYWSDCGQ_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
+from . import LYWSDCGQ_SERVICE_INFO, MMC_T201_1_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -20,7 +20,9 @@ async def test_async_step_bluetooth_valid_device(hass):
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
-    with patch("homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True):
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
@@ -63,7 +65,9 @@ async def test_async_step_user_with_found_devices(hass):
         )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
-    with patch("homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True):
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"address": "61DE521B-F0BF-9F44-64D4-75BBE1738105"},

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 
-from . import HTPWX_SERVICE_INFO
+from . import MMC_T201_1_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 
@@ -35,7 +35,7 @@ async def test_sensors(hass):
         await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(HTPWX_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    saved_callback(MMC_T201_1_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
 

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -1,0 +1,50 @@
+"""Test the Xiaomi config flow."""
+
+from unittest.mock import patch
+
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.components.sensor import ATTR_STATE_CLASS
+from homeassistant.components.xiaomi_ble.const import DOMAIN
+from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+
+from . import HTPWX_SERVICE_INFO
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensors(hass):
+    """Test setting up creates the sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    )
+    entry.add_to_hass(hass)
+
+    saved_callback = None
+
+    def _async_register_callback(_hass, _callback, _matcher):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.passive_update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    saved_callback(HTPWX_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 2
+
+    temp_sensor = hass.states.get("sensor.mmc_t201_1_temperature")
+    temp_sensor_attribtes = temp_sensor.attributes
+    assert temp_sensor.state == "36.8719980616822"
+    assert temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "MMC_T201_1 Temperature"
+    assert temp_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
+    assert temp_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -16,7 +16,7 @@ async def test_sensors(hass):
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        unique_id="00:81:F9:DD:6F:C1",
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Proposed change

Based on @bdraco's work on bluetooth and HA, this adds support for the Xiaomi BLE devices as found in (ble_monitor)[https://github.com/custom-components/ble_monitor].

This uses sensorpush as a template - see https://github.com/home-assistant/core/pull/75531 for the discussion around the design.

Note that the migration for python 3.10 has broken integrations that rely on bluepy. This includes MiFlora (https://github.com/home-assistant/core/issues/74585). This integration has basic support for MiFlora, so my hope is to deprecate/remove that integration too.

![Screenshot 2022-07-22 at 11 27 47](https://user-images.githubusercontent.com/11544/180420433-cff32882-50c2-4aa4-a8d6-fc86b465da96.png)

@Ernst79 interest.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23491

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
