### PR TITLE
Add Insteon lock and load controller devices

### DIFF
--- a/homeassistant/components/insteon/const.py
+++ b/homeassistant/components/insteon/const.py
@@ -44,6 +44,7 @@ INSTEON_PLATFORMS = [
     Platform.COVER,
     Platform.FAN,
     Platform.LIGHT,
+    Platform.LOCK,
     Platform.SWITCH,
 ]
 

--- a/homeassistant/components/insteon/ipdb.py
+++ b/homeassistant/components/insteon/ipdb.py
@@ -1,5 +1,6 @@
 """Utility methods for the Insteon platform."""
 from pyinsteon.device_types import (
+    AccessControl_Morningstar,
     ClimateControl_Thermostat,
     ClimateControl_WirelessThermostat,
     DimmableLightingControl,
@@ -12,6 +13,7 @@ from pyinsteon.device_types import (
     DimmableLightingControl_OutletLinc,
     DimmableLightingControl_SwitchLinc,
     DimmableLightingControl_ToggleLinc,
+    EnergyManagement_LoadController,
     GeneralController_ControlLinc,
     GeneralController_MiniRemote_4,
     GeneralController_MiniRemote_8,
@@ -44,11 +46,13 @@ from homeassistant.components.climate import DOMAIN as CLIMATE
 from homeassistant.components.cover import DOMAIN as COVER
 from homeassistant.components.fan import DOMAIN as FAN
 from homeassistant.components.light import DOMAIN as LIGHT
+from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.switch import DOMAIN as SWITCH
 
 from .const import ON_OFF_EVENTS
 
 DEVICE_PLATFORM = {
+    AccessControl_Morningstar: {LOCK: [1]},
     DimmableLightingControl: {LIGHT: [1], ON_OFF_EVENTS: [1]},
     DimmableLightingControl_DinRail: {LIGHT: [1], ON_OFF_EVENTS: [1]},
     DimmableLightingControl_FanLinc: {LIGHT: [1], FAN: [2], ON_OFF_EVENTS: [1, 2]},
@@ -67,6 +71,7 @@ DEVICE_PLATFORM = {
     DimmableLightingControl_OutletLinc: {LIGHT: [1], ON_OFF_EVENTS: [1]},
     DimmableLightingControl_SwitchLinc: {LIGHT: [1], ON_OFF_EVENTS: [1]},
     DimmableLightingControl_ToggleLinc: {LIGHT: [1], ON_OFF_EVENTS: [1]},
+    EnergyManagement_LoadController: {SWITCH: [1], BINARY_SENSOR: [2]},
     GeneralController_ControlLinc: {ON_OFF_EVENTS: [1]},
     GeneralController_MiniRemote_4: {ON_OFF_EVENTS: range(1, 5)},
     GeneralController_MiniRemote_8: {ON_OFF_EVENTS: range(1, 9)},

--- a/homeassistant/components/insteon/lock.py
+++ b/homeassistant/components/insteon/lock.py
@@ -1,0 +1,49 @@
+"""Support for INSTEON locks."""
+
+from typing import Any
+
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import SIGNAL_ADD_ENTITIES
+from .insteon_entity import InsteonEntity
+from .utils import async_add_insteon_entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Insteon locks from a config entry."""
+
+    @callback
+    def async_add_insteon_lock_entities(discovery_info=None):
+        """Add the Insteon entities for the platform."""
+        async_add_insteon_entities(
+            hass, LOCK_DOMAIN, InsteonLockEntity, async_add_entities, discovery_info
+        )
+
+    signal = f"{SIGNAL_ADD_ENTITIES}_{LOCK_DOMAIN}"
+    async_dispatcher_connect(hass, signal, async_add_insteon_lock_entities)
+    async_add_insteon_lock_entities()
+
+
+class InsteonLockEntity(InsteonEntity, LockEntity):
+    """A Class for an Insteon lock entity."""
+
+    @property
+    def is_locked(self) -> bool:
+        """Return the boolean response if the node is on."""
+        return bool(self._insteon_device_group.value)
+
+    async def async_lock(self, **kwargs: Any) -> None:
+        """Lock the device."""
+        await self._insteon_device.async_lock()
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        """Unlock the device."""
+        await self._insteon_device.async_unlock()

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/insteon",
   "dependencies": ["http", "websocket_api"],
   "requirements": [
-    "pyinsteon==1.1.3",
+    "pyinsteon==1.2.0",
     "insteon-frontend-home-assistant==0.2.0"
   ],
   "codeowners": ["@teharris1"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1570,7 +1570,7 @@ pyialarm==2.2.0
 pyicloud==1.0.0
 
 # homeassistant.components.insteon
-pyinsteon==1.1.3
+pyinsteon==1.2.0
 
 # homeassistant.components.intesishome
 pyintesishome==1.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1070,7 +1070,7 @@ pyialarm==2.2.0
 pyicloud==1.0.0
 
 # homeassistant.components.insteon
-pyinsteon==1.1.3
+pyinsteon==1.2.0
 
 # homeassistant.components.ipma
 pyipma==2.0.5

--- a/tests/components/insteon/mock_devices.py
+++ b/tests/components/insteon/mock_devices.py
@@ -60,7 +60,7 @@ class MockDevices:
 
     async def async_load(self, *args, **kwargs):
         """Load the mock devices."""
-        if self._connected:
+        if self._connected and not self._devices:
             addr0 = Address("AA.AA.AA")
             addr1 = Address("11.11.11")
             addr2 = Address("22.22.22")
@@ -104,7 +104,9 @@ class MockDevices:
                     return_value=ResponseStatus.SUCCESS
                 )
 
-            for device in [self._devices[addr] for addr in [addr2, addr3, addr4]]:
+            for device in [
+                self._devices[addr] for addr in [addr2, addr3, addr4, addr5]
+            ]:
                 device.async_status = AsyncMock()
             self._devices[addr1].async_status = AsyncMock(side_effect=AttributeError)
             self._devices[addr0].aldb.async_load = AsyncMock()
@@ -121,13 +123,13 @@ class MockDevices:
             self._devices[addr2].async_write_ext_properties = AsyncMock(
                 return_value=ResponseStatus.FAILURE
             )
+
             self._devices[addr5].async_lock = AsyncMock(
                 return_value=ResponseStatus.SUCCESS
             )
             self._devices[addr5].async_unlock = AsyncMock(
                 return_value=ResponseStatus.SUCCESS
             )
-
             self.modem = self._devices[addr0]
             self.modem.async_read_config = AsyncMock()
 

--- a/tests/components/insteon/mock_devices.py
+++ b/tests/components/insteon/mock_devices.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pyinsteon.address import Address
 from pyinsteon.constants import ALDBStatus, ResponseStatus
 from pyinsteon.device_types import (
+    AccessControl_Morningstar,
     DimmableLightingControl_KeypadLinc_8,
     GeneralController_RemoteLinc,
     Hub,
@@ -65,6 +66,7 @@ class MockDevices:
             addr2 = Address("22.22.22")
             addr3 = Address("33.33.33")
             addr4 = Address("44.44.44")
+            addr5 = Address("55.55.55")
             self._devices[addr0] = Hub(addr0, 0x03, 0x00, 0x00, "Hub AA.AA.AA", "0")
             self._devices[addr1] = MockSwitchLinc(
                 addr1, 0x02, 0x00, 0x00, "Device 11.11.11", "1"
@@ -78,9 +80,12 @@ class MockDevices:
             self._devices[addr4] = SensorsActuators_IOLink(
                 addr4, 0x07, 0x00, 0x00, "Device 44.44.44", "4"
             )
+            self._devices[addr5] = AccessControl_Morningstar(
+                addr5, 0x0F, 0x0A, 0x00, "Device 55.55.55", "5"
+            )
 
             for device in [
-                self._devices[addr] for addr in [addr1, addr2, addr3, addr4]
+                self._devices[addr] for addr in [addr1, addr2, addr3, addr4, addr5]
             ]:
                 device.async_read_config = AsyncMock()
                 device.aldb.async_write = AsyncMock()
@@ -115,6 +120,12 @@ class MockDevices:
             )
             self._devices[addr2].async_write_ext_properties = AsyncMock(
                 return_value=ResponseStatus.FAILURE
+            )
+            self._devices[addr5].async_lock = AsyncMock(
+                return_value=ResponseStatus.SUCCESS
+            )
+            self._devices[addr5].async_unlock = AsyncMock(
+                return_value=ResponseStatus.SUCCESS
             )
 
             self.modem = self._devices[addr0]
@@ -155,6 +166,6 @@ class MockDevices:
             yield address
         await asyncio.sleep(0.01)
 
-    def subscribe(self, listener):
+    def subscribe(self, listener, force_strong_ref=False):
         """Mock the subscribe function."""
         subscribe_topic(listener, DEVICE_LIST_CHANGED)

--- a/tests/components/insteon/test_lock.py
+++ b/tests/components/insteon/test_lock.py
@@ -1,0 +1,109 @@
+"""Tests for the Insteon lock."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import insteon
+from homeassistant.components.insteon import (
+    DOMAIN,
+    insteon_entity,
+    utils as insteon_utils,
+)
+from homeassistant.components.lock import (  # SERVICE_LOCK,; SERVICE_UNLOCK,
+    DOMAIN as LOCK_DOMAIN,
+)
+from homeassistant.const import (  # ATTR_ENTITY_ID,;
+    EVENT_HOMEASSISTANT_STOP,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+    Platform,
+)
+from homeassistant.helpers import entity_registry as er
+
+from .const import MOCK_USER_INPUT_PLM
+from .mock_devices import MockDevices
+
+from tests.common import MockConfigEntry
+
+devices = MockDevices()
+
+
+@pytest.fixture(autouse=True)
+def lock_platform_only():
+    """Only setup the lock and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.insteon.INSTEON_PLATFORMS",
+        (Platform.LOCK,),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_setup_and_devices():
+    """Patch the Insteon setup process and devices."""
+    with patch.object(insteon, "async_connect", new=mock_connection), patch.object(
+        insteon, "async_close"
+    ), patch.object(insteon, "devices", devices), patch.object(
+        insteon_utils, "devices", devices
+    ), patch.object(
+        insteon_entity, "devices", devices
+    ):
+        yield
+
+
+async def mock_connection(*args, **kwargs):
+    """Return a successful connection."""
+    return True
+
+
+async def test_lock_lock(hass):
+    """Test locking an Insteon lock device."""
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
+    config_entry.add_to_hass(hass)
+    registry_entity = er.async_get(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    try:
+        lock = registry_entity.async_get("lock.device_55_55_55_55_55_55")
+        state = hass.states.get(lock.entity_id)
+        assert state.state is STATE_UNLOCKED
+
+        # lock via UI
+        await hass.services.async_call(
+            LOCK_DOMAIN, "lock", {"entity_id": lock.entity_id}, blocking=True
+        )
+        assert devices["55.55.55"].async_lock.call_count == 1
+    finally:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+
+async def test_lock_unlock(hass):
+    """Test locking an Insteon lock device."""
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
+    config_entry.add_to_hass(hass)
+    registry_entity = er.async_get(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    devices["55.55.55"].groups[1].set_value(255)
+
+    try:
+        lock = registry_entity.async_get("lock.device_55_55_55_55_55_55")
+        state = hass.states.get(lock.entity_id)
+
+        assert state.state is STATE_LOCKED
+
+        # lock via UI
+        await hass.services.async_call(
+            LOCK_DOMAIN, "unlock", {"entity_id": lock.entity_id}, blocking=True
+        )
+        assert devices["55.55.55"].async_unlock.call_count == 1
+    finally:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for the following Insteon devices:
- Morningstar lock
- Load controller

Changelog: https://github.com/pyinsteon/pyinsteon/compare/1.1.3...1.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
