### PR TITLE
Add ZHA config option for optional HS color support

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -129,6 +129,7 @@ CONF_DATABASE = "database_path"
 CONF_DEFAULT_LIGHT_TRANSITION = "default_light_transition"
 CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_ENHANCED_LIGHT_TRANSITION = "enhanced_light_transition"
+CONF_ENABLE_HS_LIGHT_SUPPORT = "enable_hs_light_support"
 CONF_ENABLE_IDENTIFY_ON_JOIN = "enable_identify_on_join"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_FLOWCONTROL = "flow_control"
@@ -145,6 +146,7 @@ CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
         vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=False): cv.boolean,
+        vol.Required(CONF_ENABLE_HS_LIGHT_SUPPORT, default=False): cv.boolean,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
         vol.Optional(
             CONF_CONSIDER_UNAVAILABLE_MAINS,

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -279,7 +279,10 @@ class BaseLight(LogMixin, light.LightEntity):
             self._attr_hs_color = None
 
         if hs_color is not None:
-            if self._color_channel.enhanced_hue_supported:
+            if (
+                not isinstance(self, LightGroup)
+                and self._color_channel.enhanced_hue_supported
+            ):
                 result = await self._color_channel.enhanced_move_to_hue_and_saturation(
                     int(hs_color[0] * 65535 / 360),
                     int(hs_color[1] * 2.54),

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -792,6 +792,12 @@ class LightGroup(BaseLight, ZhaGroupEntity):
             if ColorMode.BRIGHTNESS in color_mode_count:
                 color_mode_count[ColorMode.BRIGHTNESS] = 0
             self._attr_color_mode = color_mode_count.most_common(1)[0][0]
+            if self._attr_color_mode == ColorMode.HS and color_mode_count[
+                ColorMode.HS
+            ] != len(
+                self._group.members
+            ):  # switch to XY if all members do not support HS
+                self._attr_color_mode = ColorMode.XY
 
         self._attr_supported_color_modes = None
         all_supported_color_modes = list(

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -609,7 +609,7 @@ class Light(BaseLight, ZhaEntity):
                             int(current_hue * 360 / 65535)
                             if self._color_channel.enhanced_hue_supported
                             else int(current_hue * 360 / 254),
-                            int(current_saturation / 254),
+                            int(current_saturation / 2.54),
                         )
                         self._attr_xy_color = None
                         self._attr_color_temp = None

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -38,6 +38,7 @@
     "zha_options": {
       "title": "Global Options",
       "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
+      "enable_hs_light_support": "Enable HS color light support",
       "enable_identify_on_join": "Enable identify effect when devices join the network",
       "default_light_transition": "Default light transition time (seconds)",
       "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -49,6 +49,7 @@
             "consider_unavailable_battery": "Consider battery powered devices unavailable after (seconds)",
             "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",
             "default_light_transition": "Default light transition time (seconds)",
+            "enable_hs_light_support": "Enable HS color light support",
             "enable_identify_on_join": "Enable identify effect when devices join the network",
             "enhanced_light_transition": "Enable enhanced light color/temperature transition from an off-state",
             "title": "Global Options"


### PR DESCRIPTION
## Proposed change
!**Needs to be rebased once https://github.com/home-assistant/core/pull/75599 gets merged**!
Actual diff is only this at the moment: https://github.com/TheJulianJES/core/commit/6452678325f2c5272661e27e1ea63793086b0c9a​

https://github.com/home-assistant/core/pull/75573 added support for using the HS color mode (instead of only XY) for supporting Zigbee lights.

As it turns out, the official Philips Hue app, the Hue integration in HA and Zigbee2MQTT (through HA) all only use XY colors when talking to Zigbee lights. This is possibly the case because some colors (especially blue) are way off when using HS commands. As always enabling HS colors might "break" a lot of existing installations (but HS color mode might still be nice for some use-cases), this PR proposes an opt-in config option for enabling the new HS behavior.

_Note: Another option (instead of adding a config option) would be to drop the HS color support again_.

The config option allows users to opt-in to using HS support for supporting Zigbee lights (and keeps XY color by default):
<img src="https://user-images.githubusercontent.com/6409465/180499447-8717eb59-4369-4489-ac4a-c213edf97f86.png" width="400">

I'm not sure if "Enable HS support" is the best possible name for such a config option, I also thought of "Always prefer XY color" or "Use HS color if possible". (Maybe other ideas?)

---

### Color comparison of clicking blue in the color slider (so ``RGB: 0, 0, 255``):

XY color (actually blue):
<img src="https://user-images.githubusercontent.com/6409465/180500575-261ea17e-d8d7-460f-9941-87b77d9430b1.png" width="100">

HS color (looks like cyan, way too much green):
<img src="https://user-images.githubusercontent.com/6409465/180500585-a0c0408c-a615-4445-8ed0-a98dc04fefad.png" width="100">

Other colors (like red) are completely fine with both HS and XY though, so it's not a total hue shift.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
This PR is related to PRs:
- https://github.com/home-assistant/core/pull/75599
- https://github.com/home-assistant/core/pull/75573

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
