### PR TITLE
Address NextDNS late review

### DIFF
--- a/homeassistant/components/nextdns/config_flow.py
+++ b/homeassistant/components/nextdns/config_flow.py
@@ -24,8 +24,8 @@ class NextDnsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self.nextdns: NextDns
-        self.api_key: str
+        self.nextdns: NextDns | None = None
+        self.api_key: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -62,6 +62,8 @@ class NextDnsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the profiles step."""
         errors: dict[str, str] = {}
+
+        assert self.nextdns is not None
 
         if user_input is not None:
             profile_name = user_input[CONF_PROFILE_NAME]

--- a/tests/components/nextdns/__init__.py
+++ b/tests/components/nextdns/__init__.py
@@ -53,9 +53,7 @@ SETTINGS = Settings(
 )
 
 
-async def init_integration(
-    hass: HomeAssistant, add_to_hass: bool = True
-) -> MockConfigEntry:
+async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the NextDNS integration in Home Assistant."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -63,9 +61,6 @@ async def init_integration(
         unique_id="xyz12",
         data={CONF_API_KEY: "fake_api_key", CONF_PROFILE_ID: "xyz12"},
     )
-
-    if not add_to_hass:
-        return entry
 
     with patch(
         "homeassistant.components.nextdns.NextDns.get_profiles", return_value=PROFILES

--- a/tests/components/nextdns/test_button.py
+++ b/tests/components/nextdns/test_button.py
@@ -3,13 +3,14 @@ from unittest.mock import patch
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import init_integration
 
 
-async def test_button(hass):
+async def test_button(hass: HomeAssistant) -> None:
     """Test states of the button."""
     registry = er.async_get(hass)
 
@@ -24,7 +25,7 @@ async def test_button(hass):
     assert entry.unique_id == "xyz12_clear_logs"
 
 
-async def test_button_press(hass):
+async def test_button_press(hass: HomeAssistant) -> None:
     """Test button press."""
     await init_integration(hass)
 

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -13,11 +13,12 @@ from homeassistant.components.nextdns.const import (
 )
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
 
 from . import PROFILES, init_integration
 
 
-async def test_form_create_entry(hass):
+async def test_form_create_entry(hass: HomeAssistant) -> None:
     """Test that the user step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -60,7 +61,7 @@ async def test_form_create_entry(hass):
         (ValueError, "unknown"),
     ],
 )
-async def test_form_errors(hass, error):
+async def test_form_errors(hass: HomeAssistant, error: tuple[Exception, str]) -> None:
     """Test we handle errors."""
     exc, base_error = error
     with patch(
@@ -75,7 +76,7 @@ async def test_form_errors(hass, error):
     assert result["errors"] == {"base": base_error}
 
 
-async def test_form_already_configured(hass):
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test that errors are shown when duplicates are added."""
     await init_integration(hass)
 

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -53,7 +53,7 @@ async def test_form_create_entry(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error",
+    "exc,base_error",
     [
         (ApiError("API Error"), "cannot_connect"),
         (InvalidApiKeyError, "invalid_api_key"),
@@ -61,9 +61,10 @@ async def test_form_create_entry(hass: HomeAssistant) -> None:
         (ValueError, "unknown"),
     ],
 )
-async def test_form_errors(hass: HomeAssistant, error: tuple[Exception, str]) -> None:
+async def test_form_errors(
+    hass: HomeAssistant, exc: Exception, base_error: str
+) -> None:
     """Test we handle errors."""
-    exc, base_error = error
     with patch(
         "homeassistant.components.nextdns.NextDns.get_profiles", side_effect=exc
     ):

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -77,8 +77,7 @@ async def test_form_errors(hass, error):
 
 async def test_form_already_configured(hass):
     """Test that errors are shown when duplicates are added."""
-    entry = await init_integration(hass)
-    entry.add_to_hass(hass)
+    await init_integration(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/nextdns/test_diagnostics.py
+++ b/tests/components/nextdns/test_diagnostics.py
@@ -1,11 +1,18 @@
 """Test NextDNS diagnostics."""
+from collections.abc import Awaitable, Callable
+
+from aiohttp import ClientSession
+
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.components.nextdns import init_integration
 
 
-async def test_entry_diagnostics(hass, hass_client):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: Callable[..., Awaitable[ClientSession]]
+) -> None:
     """Test config entry diagnostics."""
     entry = await init_integration(hass)
 

--- a/tests/components/nextdns/test_init.py
+++ b/tests/components/nextdns/test_init.py
@@ -3,11 +3,13 @@ from unittest.mock import patch
 
 from nextdns import ApiError
 
-from homeassistant.components.nextdns.const import DOMAIN
+from homeassistant.components.nextdns.const import CONF_PROFILE_ID, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import CONF_API_KEY, STATE_UNAVAILABLE
 
 from . import init_integration
+
+from tests.common import MockConfigEntry
 
 
 async def test_async_setup_entry(hass):
@@ -22,7 +24,12 @@ async def test_async_setup_entry(hass):
 
 async def test_config_not_ready(hass):
     """Test for setup failure if the connection to the service fails."""
-    entry = await init_integration(hass, add_to_hass=False)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Fake Profile",
+        unique_id="xyz12",
+        data={CONF_API_KEY: "fake_api_key", CONF_PROFILE_ID: "xyz12"},
+    )
 
     with patch(
         "homeassistant.components.nextdns.NextDns.get_profiles",

--- a/tests/components/nextdns/test_init.py
+++ b/tests/components/nextdns/test_init.py
@@ -6,13 +6,14 @@ from nextdns import ApiError
 from homeassistant.components.nextdns.const import CONF_PROFILE_ID, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_API_KEY, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
 from tests.common import MockConfigEntry
 
 
-async def test_async_setup_entry(hass):
+async def test_async_setup_entry(hass: HomeAssistant) -> None:
     """Test a successful setup entry."""
     await init_integration(hass)
 
@@ -22,7 +23,7 @@ async def test_async_setup_entry(hass):
     assert state.state == "20.0"
 
 
-async def test_config_not_ready(hass):
+async def test_config_not_ready(hass: HomeAssistant) -> None:
     """Test for setup failure if the connection to the service fails."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -40,7 +41,7 @@ async def test_config_not_ready(hass):
         assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 

--- a/tests/components/nextdns/test_sensor.py
+++ b/tests/components/nextdns/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -19,7 +20,7 @@ from . import DNSSEC, ENCRYPTION, IP_VERSIONS, PROTOCOLS, STATUS, init_integrati
 from tests.common import async_fire_time_changed
 
 
-async def test_sensor(hass):
+async def test_sensor(hass: HomeAssistant) -> None:
     """Test states of sensors."""
     registry = er.async_get(hass)
 
@@ -356,7 +357,7 @@ async def test_sensor(hass):
     assert entry.unique_id == "xyz12_udp_queries_ratio"
 
 
-async def test_availability(hass):
+async def test_availability(hass: HomeAssistant) -> None:
     """Ensure that we mark the entities unavailable correctly when service causes an error."""
     registry = er.async_get(hass)
 

--- a/tests/components/nextdns/test_system_health.py
+++ b/tests/components/nextdns/test_system_health.py
@@ -5,12 +5,16 @@ from aiohttp import ClientError
 from nextdns.const import API_ENDPOINT
 
 from homeassistant.components.nextdns.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_nextdns_system_health(hass, aioclient_mock):
+async def test_nextdns_system_health(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test NextDNS system health."""
     aioclient_mock.get(API_ENDPOINT, text="")
     hass.config.components.add(DOMAIN)
@@ -25,7 +29,9 @@ async def test_nextdns_system_health(hass, aioclient_mock):
     assert info == {"can_reach_server": "ok"}
 
 
-async def test_nextdns_system_health_fail(hass, aioclient_mock):
+async def test_nextdns_system_health_fail(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test NextDNS system health."""
     aioclient_mock.get(API_ENDPOINT, exc=ClientError)
     hass.config.components.add(DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR addresses [late review](https://github.com/home-assistant/core/pull/74150#discussion_r918379974)  and improve typing in tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
