### PR TITLE
Set min transition time for Sengled lights in ZHA groups

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -380,7 +380,7 @@ class BaseLight(LogMixin, light.LightEntity):
         # is not none looks odd here but it will override built in bulb transition times if we pass 0 in here
         if transition is not None and supports_level:
             result = await self._level_channel.move_to_level_with_on_off(
-                0, transition * 10
+                0, transition * 10 or self._DEFAULT_MIN_TRANSITION_TIME
             )
         else:
             result = await self._on_off_channel.off()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -74,6 +74,7 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.LIGHT)
 GROUP_MATCH = functools.partial(ZHA_ENTITIES.group_match, Platform.LIGHT)
 PARALLEL_UPDATES = 0
 SIGNAL_LIGHT_GROUP_STATE_CHANGED = "zha_light_group_state_changed"
+DEFAULT_MIN_TRANSITION_MANUFACTURERS = {"Sengled"}
 
 COLOR_MODES_GROUP_LIGHT = {ColorMode.COLOR_TEMP, ColorMode.XY}
 SUPPORT_GROUP_LIGHT = (
@@ -670,10 +671,10 @@ class ForceOnLight(Light):
 @STRICT_MATCH(
     channel_names=CHANNEL_ON_OFF,
     aux_channels={CHANNEL_COLOR, CHANNEL_LEVEL},
-    manufacturers={"Sengled"},
+    manufacturers=DEFAULT_MIN_TRANSITION_MANUFACTURERS,
 )
-class SengledLight(Light):
-    """Representation of a Sengled light which does not react to move_to_color_temp with 0 as a transition."""
+class MinTransitionLight(Light):
+    """Representation of a light which does not react to any "move to" calls with 0 as a transition."""
 
     _DEFAULT_MIN_TRANSITION_TIME = 1
 
@@ -688,6 +689,10 @@ class LightGroup(BaseLight, ZhaGroupEntity):
         """Initialize a light group."""
         super().__init__(entity_ids, unique_id, group_id, zha_device, **kwargs)
         group = self.zha_device.gateway.get_group(self._group_id)
+        self._DEFAULT_MIN_TRANSITION_TIME = any(  # pylint: disable=invalid-name
+            member.device.manufacturer in DEFAULT_MIN_TRANSITION_MANUFACTURERS
+            for member in group.members
+        )
         self._on_off_channel = group.endpoint[OnOff.cluster_id]
         self._level_channel = group.endpoint[LevelControl.cluster_id]
         self._color_channel = group.endpoint[Color.cluster_id]

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1184,7 +1184,7 @@ async def async_test_off_from_hass(hass, cluster, entity_id):
 
 
 async def async_test_level_on_off_from_hass(
-    hass, on_off_cluster, level_cluster, entity_id
+    hass, on_off_cluster, level_cluster, entity_id, expected_default_transition: int = 0
 ):
     """Test on off functionality from hass."""
 
@@ -1259,7 +1259,7 @@ async def async_test_level_on_off_from_hass(
         4,
         level_cluster.commands_by_name["move_to_level_with_on_off"].schema,
         10,
-        0,
+        expected_default_transition,
         expect_reply=True,
         manufacturer=None,
         tries=1,
@@ -1417,7 +1417,11 @@ async def test_zha_group_light_entity(
 
     # test turning the lights on and off from the HA
     await async_test_level_on_off_from_hass(
-        hass, group_cluster_on_off, group_cluster_level, group_entity_id
+        hass,
+        group_cluster_on_off,
+        group_cluster_level,
+        group_entity_id,
+        expected_default_transition=1,  # a Sengled light is in that group and needs a minimum 0.1s transition
     )
 
     # test getting a brightness change from the network


### PR DESCRIPTION
## Proposed change
While working on https://github.com/home-assistant/core/pull/74849, I noticed that two unrelated bug-fixes in that PR weren't in HA yet:
- The "default minimum transition time" for Sengled lights wasn't set when such a light is in a ZHA group.
- The "default minimum transition time" was ignored for a ``light.turn_off`` call with ``transition: 0``

For one, this PR fixes the (possible) issue of Sengled lights not reacting when in ZHA groups and either a default 0 second transition time is used or a 0 second transition time is explictly given in a service call.

The original commit was made by @dmulcahey here: https://github.com/dmulcahey/home-assistant/commit/0755ce6aab27dffd4b6df36e57f1de7b14652771
This PR just updated to the new variable name (``DEFAULT_MIN_TRANSITION_MANUFACTURERS``) and -- like in https://github.com/home-assistant/core/pull/74849 -- changed the ``SengledLight`` to a ``MinTransitionLight`` and also uses the ``DEFAULT_MIN_TRANSITION_MANUFACTURERS`` list there to avoid duplicating manufacturers needing this.

I've also updated the test to expect the correct default min transition time for a ZHA group with a Sengled light but I'm not sure if I've done it in the cleanest/best way.

The second small issue for Sengled light that this PR also fixes:
Calling ``light.turn_off`` with ``transition: 0`` previously ignored the "default min transition time" (not setting to 0.1s for Sengled lights), but now properly respects it.
​

I think this PR shouldn't conflict with https://github.com/home-assistant/core/pull/75599, but I'll rebase this after that one is merged if they conflict.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
