### PR TITLE
Fix diagnostics export for generic camera

### DIFF
--- a/homeassistant/components/generic/diagnostics.py
+++ b/homeassistant/components/generic/diagnostics.py
@@ -21,12 +21,12 @@ TO_REDACT = {
 # A very similar redact function is in components.sql.  Possible to be made common.
 def redact_url(data: str) -> str:
     """Redact credentials from string url."""
-    url_in = yarl.URL(data)
+    url = url_in = yarl.URL(data)
     if url_in.user:
-        url = url_in.with_user("****")
+        url = url.with_user("****")
     if url_in.password:
         url = url.with_password("****")
-    if url_in.path:
+    if url_in.path != "/":
         url = url.with_path("****")
     if url_in.query_string:
         url = url.with_query("****=****")

--- a/tests/components/generic/test_diagnostics.py
+++ b/tests/components/generic/test_diagnostics.py
@@ -1,5 +1,8 @@
 """Test generic (IP camera) diagnostics."""
+import pytest
+
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.components.generic.diagnostics import redact_url
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
@@ -22,3 +25,34 @@ async def test_entry_diagnostics(hass, hass_client, setup_entry):
             "content_type": "image/jpeg",
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("url_in", "url_out_expected"),
+    [
+        (
+            "http://www.example.com",
+            "http://www.example.com",
+        ),
+        (
+            "http://fred:letmein1@www.example.com/image.php?key=secret2",
+            "http://****:****@www.example.com/****?****=****",
+        ),
+        (
+            "http://fred@www.example.com/image.php?key=secret2",
+            "http://****@www.example.com/****?****=****",
+        ),
+        (
+            "http://fred@www.example.com/image.php",
+            "http://****@www.example.com/****",
+        ),
+        (
+            "http://:letmein1@www.example.com",
+            "http://:****@www.example.com",
+        ),
+    ],
+)
+def test_redact_url(url_in, url_out_expected):
+    """Test url redaction."""
+    url_out = redact_url(url_in)
+    assert url_out == url_out_expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There was a problem #75252 when trying to download diagnostics for the generic camera integration.  Certain URLs tripped up the redaction function which is there to mask credentials.  This caused the diagnostic export to fail.

This PR fixes the problem and adds test cases for the scenarios that previously failed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75252
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
