### PR TITLE
Add unique id for todoist calendar entity

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -296,7 +296,7 @@ class TodoistProjectEntity(CalendarEntity):
         )
         self._cal_data = {}
         self._name = data[CONF_NAME]
-        self._attr_unique_id = data[ID]
+        self._attr_unique_id = data[CONF_ID]
 
     @property
     def event(self) -> CalendarEvent:

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -296,6 +296,7 @@ class TodoistProjectEntity(CalendarEntity):
         )
         self._cal_data = {}
         self._name = data[CONF_NAME]
+        self._attr_unique_id = data[ID]
 
     @property
     def event(self) -> CalendarEvent:

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -296,7 +296,7 @@ class TodoistProjectEntity(CalendarEntity):
         )
         self._cal_data = {}
         self._name = data[CONF_NAME]
-        self._attr_unique_id = data[CONF_ID]
+        self._attr_unique_id = data.get(CONF_ID)
 
     @property
     def event(self) -> CalendarEvent:

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -104,3 +104,6 @@ async def test_calendar_custom_project_unique_id(todoist_api, hass, state):
     registry = entity_registry.async_get(hass)
     entity = registry.async_get("calendar.all_projects")
     assert entity is None
+
+    state = hass.states.get("calendar.all_projects")
+    assert "off" == state.state

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -73,7 +73,6 @@ async def test_calendar_entity_unique_id(todoist_api, hass, state):
             "calendar": {
                 "platform": DOMAIN,
                 CONF_TOKEN: "token",
-                "custom_projects": [{"name": "custom"}],
             }
         },
     )

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -81,3 +81,26 @@ async def test_calendar_entity_unique_id(todoist_api, hass, state):
     registry = entity_registry.async_get(hass)
     entity = registry.async_get("calendar.name")
     assert 12345 == entity.unique_id
+
+
+@patch("homeassistant.components.todoist.calendar.TodoistAPI")
+async def test_calendar_custom_project_unique_id(todoist_api, hass, state):
+    """Test unique id is None for any custom projects."""
+    api = Mock(state=state)
+    todoist_api.return_value = api
+    assert await setup.async_setup_component(
+        hass,
+        "calendar",
+        {
+            "calendar": {
+                "platform": DOMAIN,
+                CONF_TOKEN: "token",
+                "custom_projects": [{"name": "All projects"}],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    registry = entity_registry.async_get(hass)
+    entity = registry.async_get("calendar.all_projects")
+    assert entity is None

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -1,7 +1,11 @@
 """Unit tests for the Todoist calendar platform."""
 from datetime import datetime
+from unittest.mock import Mock
 
-from homeassistant.components.todoist.calendar import _parse_due_date
+from homeassistant.components.todoist.calendar import (
+    TodoistProjectEntity,
+    _parse_due_date,
+)
 from homeassistant.components.todoist.types import DueDate
 from homeassistant.util import dt
 
@@ -42,3 +46,14 @@ def test_parse_due_date_without_timezone_uses_offset():
     }
     actual = _parse_due_date(data, timezone_offset=-8)
     assert datetime(2022, 2, 2, 22, 0, 0, tzinfo=dt.UTC) == actual
+
+
+def test_calendar_entity_unique_id():
+    """Test unique id is set to project id."""
+    entity = TodoistProjectEntity(
+        hass=Mock(),
+        data={"id": 12345, "name": "My project"},
+        labels=[],
+        token=Mock(),
+    )
+    assert 12345 == entity.unique_id

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -106,4 +106,4 @@ async def test_calendar_custom_project_unique_id(todoist_api, hass, state):
     assert entity is None
 
     state = hass.states.get("calendar.all_projects")
-    assert "off" == state.state
+    assert state.state == "off"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This ticket addresses #75509 and adds a unique id for todoist calendar entities so that they can be managed from the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75509 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
