### PR TITLE
Support for encrypted BLE MiBeacon devices

### DIFF
--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -65,7 +65,6 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Enter a legacy bindkey for a v2/v3 MiBeacon device."""
         assert self._discovery_info
-
         errors = {}
 
         if user_input is not None:
@@ -74,7 +73,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             if len(bindkey) != 24:
                 errors["bindkey"] = "expected_24_characters"
             else:
-                device = DeviceData(bindkey=user_input["bindkey"])
+                device = DeviceData(bindkey=bytes.fromhex(bindkey))
 
                 # If we got this far we already know supported will
                 # return true so we don't bother checking that again
@@ -84,7 +83,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
                 if device.bindkey_verified:
                     return self.async_create_entry(
                         title=self.context["title_placeholders"]["name"],
-                        data={"bindkey": user_input["bindkey"]},
+                        data={"bindkey": bindkey},
                     )
 
                 errors["bindkey"] = "decryption_failed"
@@ -110,7 +109,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             if len(bindkey) != 32:
                 errors["bindkey"] = "expected_32_characters"
             else:
-                device = DeviceData(bindkey=user_input["bindkey"])
+                device = DeviceData(bindkey=bytes.fromhex(bindkey))
 
                 # If we got this far we already know supported will
                 # return true so we don't bother checking that again
@@ -120,7 +119,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
                 if device.bindkey_verified:
                     return self.async_create_entry(
                         title=self.context["title_placeholders"]["name"],
-                        data={"bindkey": user_input["bindkey"]},
+                        data={"bindkey": bindkey},
                     )
 
                 errors["bindkey"] = "decryption_failed"
@@ -160,11 +159,13 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
                 self._discovery_info = discovery.discovery_info
                 self._discovered_device = discovery.device
+                self.context["title_placeholders"] = {"name": discovery.title}
                 return await self.async_step_get_encryption_key_legacy()
 
             if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
                 self._discovery_info = discovery.discovery_info
                 self._discovered_device = discovery.device
+                self.context["title_placeholders"] = {"name": discovery.title}
                 return await self.async_step_get_encryption_key_4_5()
 
             return self.async_create_entry(title=discovery.title, data={})

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -54,6 +54,8 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Enter a legacy bindkey for a v2/v3 MiBeacon device."""
+        assert self._discovery_info
+
         errors = {}
 
         if user_input is not None:
@@ -88,6 +90,8 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Enter a bindkey for a v4/v5 MiBeacon device."""
+        assert self._discovery_info
+
         errors = {}
 
         if user_input is not None:

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -162,13 +162,11 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
                 self._discovery_info = discovery.discovery_info
-                self._discovered_device = discovery.device
                 self.context["title_placeholders"] = {"name": discovery.title}
                 return await self.async_step_get_encryption_key_legacy()
 
             if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
                 self._discovery_info = discovery.discovery_info
-                self._discovered_device = discovery.device
                 self.context["title_placeholders"] = {"name": discovery.title}
                 return await self.async_step_get_encryption_key_4_5()
 

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -62,7 +62,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             if len(bindkey) != 24:
                 errors["bindkey"] = "expected_24_characters"
             else:
-                device = DeviceData(user_input["bindkey"])
+                device = DeviceData(bindkey=user_input["bindkey"])
 
                 # If we got this far we already know supported will
                 # return true so we don't bother checking that again
@@ -74,6 +74,8 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
                         title=self.context["title_placeholders"]["name"],
                         data={"bindkey": user_input["bindkey"]},
                     )
+
+                errors["bindkey"] = "decryption_failed"
 
         return self.async_show_form(
             step_id="get_encryption_key_legacy",
@@ -94,7 +96,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             if len(bindkey) != 32:
                 errors["bindkey"] = "expected_32_characters"
             else:
-                device = DeviceData(user_input["bindkey"])
+                device = DeviceData(bindkey=user_input["bindkey"])
 
                 # If we got this far we already know supported will
                 # return true so we don't bother checking that again
@@ -106,6 +108,8 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
                         title=self.context["title_placeholders"]["name"],
                         data={"bindkey": user_input["bindkey"]},
                     )
+
+                errors["bindkey"] = "decryption_failed"
 
         return self.async_show_form(
             step_id="get_encryption_key_4_5",

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -28,6 +28,10 @@ class Discovery:
     device: DeviceData
 
 
+def _title(discovery_info: BluetoothServiceInfo, device: DeviceData) -> str:
+    return device.title or device.get_device_name() or discovery_info.name
+
+
 class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Xiaomi Bluetooth."""
 
@@ -51,7 +55,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_info = discovery_info
         self._discovered_device = device
 
-        title = device.title or device.get_device_name() or discovery_info.name
+        title = _title(discovery_info, device)
         self.context["title_placeholders"] = {"name": title}
 
         if device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
@@ -178,9 +182,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             device = DeviceData()
             if device.supported(discovery_info):
                 self._discovered_devices[address] = Discovery(
-                    title=device.title
-                    or device.get_device_name()
-                    or discovery_info.name,
+                    title=_title(discovery_info, device),
                     discovery_info=discovery_info,
                     device=device,
                 )

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.2.0"],
+  "requirements": ["xiaomi-ble==0.5.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.5.0"],
+  "requirements": ["xiaomi-ble==0.5.1"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -158,7 +158,10 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    data = XiaomiBluetoothDeviceData(bindkey=entry.data.get("bindkey"))
+    kwargs = {}
+    if bindkey := entry.data.get("bindkey"):
+        kwargs["bindkey"] = bytes.fromhex(bindkey)
+    data = XiaomiBluetoothDeviceData(**kwargs)
     processor = PassiveBluetoothDataProcessor(
         lambda service_info: sensor_update_to_bluetooth_data_update(
             data.update(service_info)

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -158,7 +158,7 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    data = XiaomiBluetoothDeviceData()
+    data = XiaomiBluetoothDeviceData(bindkey=entry.data.get("bindkey"))
     processor = PassiveBluetoothDataProcessor(
         lambda service_info: sensor_update_to_bluetooth_data_update(
             data.update(service_info)

--- a/homeassistant/components/xiaomi_ble/strings.json
+++ b/homeassistant/components/xiaomi_ble/strings.json
@@ -10,12 +10,27 @@
       },
       "bluetooth_confirm": {
         "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
+      },
+      "get_encryption_key_legacy": {
+        "description": "The sensor data broadcast by the sensor is encrypted. In order to decrypt it we need a 24 character hexadecimal bindkey.",
+        "data": {
+          "bindkey": "Bindkey"
+        }
+      },
+      "get_encryption_key_4_5": {
+        "description": "The sensor data broadcast by the sensor is encrypted. In order to decrypt it we need a 24 character hexadecimal bindkey.",
+        "data": {
+          "bindkey": "Bindkey"
+        }
       }
     },
     "abort": {
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "decryption_failed": "The provided bindkey did not work, sensor data could not be decrypted. Please check it and try again.",
+      "expected_24_characters": "Expected a 24 character hexadecimal bindkey.",
+      "expected_32_characters": "Expected a 32 character hexadecimal bindkey."
     }
   }
 }

--- a/homeassistant/components/xiaomi_ble/strings.json
+++ b/homeassistant/components/xiaomi_ble/strings.json
@@ -18,7 +18,7 @@
         }
       },
       "get_encryption_key_4_5": {
-        "description": "The sensor data broadcast by the sensor is encrypted. In order to decrypt it we need a 24 character hexadecimal bindkey.",
+        "description": "The sensor data broadcast by the sensor is encrypted. In order to decrypt it we need a 32 character hexadecimal bindkey.",
         "data": {
           "bindkey": "Bindkey"
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2477,7 +2477,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.5.0
+xiaomi-ble==0.5.1
 
 # homeassistant.components.knx
 xknx==0.21.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2477,7 +2477,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.2.0
+xiaomi-ble==0.5.0
 
 # homeassistant.components.knx
 xknx==0.21.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1662,7 +1662,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.5.0
+xiaomi-ble==0.5.1
 
 # homeassistant.components.knx
 xknx==0.21.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1662,7 +1662,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.2.0
+xiaomi-ble==0.5.0
 
 # homeassistant.components.knx
 xknx==0.21.5

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -37,6 +37,30 @@ MMC_T201_1_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+JTYJGD03MI_SERVICE_INFO = BluetoothServiceInfo(
+    name="JTYJGD03MI",
+    address="54:EF:44:E3:9C:BC",
+    rssi=-56,
+    manufacturer_data={},
+    service_data={
+        "0000fe95-0000-1000-8000-00805f9b34fb": b'XY\x97\td\xbc\x9c\xe3D\xefT" `\x88\xfd\x00\x00\x00\x00:\x14\x8f\xb3'
+    },
+    service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)
+
+YLKG07YL_SERVICE_INFO = BluetoothServiceInfo(
+    name="YLKG07YL",
+    address="F8:24:41:C5:98:8B",
+    rssi=-56,
+    manufacturer_data={},
+    service_data={
+        "0000fe95-0000-1000-8000-00805f9b34fb": b"X0\xb6\x03\xd2\x8b\x98\xc5A$\xf8\xc3I\x14vu~\x00\x00\x00\x99",
+    },
+    service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)
+
 
 def make_advertisement(address: str, payload: bytes) -> BluetoothServiceInfo:
     """Make a dummy advertisement."""

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -7,9 +7,11 @@ from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
+    JTYJGD03MI_SERVICE_INFO,
     LYWSDCGQ_SERVICE_INFO,
     MMC_T201_1_SERVICE_INFO,
     NOT_SENSOR_PUSH_SERVICE_INFO,
+    YLKG07YL_SERVICE_INFO,
 )
 
 from tests.common import MockConfigEntry
@@ -34,6 +36,53 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["title"] == "MMC_T201_1"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "00:81:F9:DD:6F:C1"
+
+
+async def test_async_step_bluetooth_valid_device_legacy_encryption(hass):
+    """Test discovery via bluetooth with a valid device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=YLKG07YL_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "get_encryption_key_legacy"
+
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "b853075158487ca39a5b5ea9"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "YLKG07YL"
+    assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
+    assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
+
+
+async def test_async_step_bluetooth_valid_device_v4_encryption(hass):
+    """Test discovery via bluetooth with a valid device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=JTYJGD03MI_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "get_encryption_key_4_5"
+
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "JTYJGD03MI"
+    assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
+    assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
 async def test_async_step_bluetooth_not_xiaomi(hass):
@@ -80,6 +129,73 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["title"] == "LYWSDCGQ"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "58:2D:34:35:93:21"
+
+
+async def test_async_step_user_with_found_devices_v4_encryption(hass):
+    """Test setup from service info cache with devices found."""
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[JTYJGD03MI_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result1 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"address": "54:EF:44:E3:9C:BC"},
+    )
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "get_encryption_key_4_5"
+
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "JTYJGD03MI"
+    assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
+    assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
+
+
+async def test_async_step_user_with_found_devices_legacy_encryption(hass):
+    """Test setup from service info cache with devices found."""
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[YLKG07YL_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result1 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"address": "F8:24:41:C5:98:8B"},
+    )
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "get_encryption_key_legacy"
+
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "b853075158487ca39a5b5ea9"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "YLKG07YL"
+    assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
+    assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
 
 async def test_async_step_user_with_found_devices_already_setup(hass):

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_async_step_bluetooth_valid_device(hass):
 
 
 async def test_async_step_bluetooth_valid_device_legacy_encryption(hass):
-    """Test discovery via bluetooth with a valid device."""
+    """Test discovery via bluetooth with a valid device, with legacy encryption."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
@@ -61,8 +61,74 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption(hass):
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
 
+async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key(hass):
+    """Test discovery via bluetooth with a valid device, with legacy encryption and invalid key."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=YLKG07YL_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "get_encryption_key_legacy"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "aaaaaaaaaaaaaaaaaaaaaaaa"},
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_legacy"
+    assert result2["errors"]["bindkey"] == "decryption_failed"
+
+    # Test can finish flow
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "b853075158487ca39a5b5ea9"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "YLKG07YL"
+    assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
+    assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
+
+
+async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key_length(
+    hass,
+):
+    """Test discovery via bluetooth with a valid device, with legacy encryption and wrong key length."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=YLKG07YL_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "get_encryption_key_legacy"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "aaaaaaaaaaaaaaaaaaaaaaa"},
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_legacy"
+    assert result2["errors"]["bindkey"] == "expected_24_characters"
+
+    # Test can finish flow
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "b853075158487ca39a5b5ea9"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "YLKG07YL"
+    assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
+    assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
+
+
 async def test_async_step_bluetooth_valid_device_v4_encryption(hass):
-    """Test discovery via bluetooth with a valid device."""
+    """Test discovery via bluetooth with a valid device, with v4 encryption."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
@@ -71,6 +137,74 @@ async def test_async_step_bluetooth_valid_device_v4_encryption(hass):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "get_encryption_key_4_5"
 
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "JTYJGD03MI"
+    assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
+    assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
+
+
+async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key(hass):
+    """Test discovery via bluetooth with a valid device, with v4 encryption and wrong key."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=JTYJGD03MI_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "get_encryption_key_4_5"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_4_5"
+    assert result2["errors"]["bindkey"] == "decryption_failed"
+
+    # Test can finish flow
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "JTYJGD03MI"
+    assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
+    assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
+
+
+async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key_length(hass):
+    """Test discovery via bluetooth with a valid device, with v4 encryption and wrong key length."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=JTYJGD03MI_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "get_encryption_key_4_5"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "5b51a7c91cde6707c9ef18fda143a58"},
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_4_5"
+    assert result2["errors"]["bindkey"] == "expected_32_characters"
+
+    # Test can finish flow
     with patch(
         "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
     ):
@@ -132,7 +266,7 @@ async def test_async_step_user_with_found_devices(hass):
 
 
 async def test_async_step_user_with_found_devices_v4_encryption(hass):
-    """Test setup from service info cache with devices found."""
+    """Test setup from service info cache with devices found, with v4 encryption."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
         return_value=[JTYJGD03MI_SERVICE_INFO],
@@ -165,8 +299,102 @@ async def test_async_step_user_with_found_devices_v4_encryption(hass):
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
+async def test_async_step_user_with_found_devices_v4_encryption_wrong_key(hass):
+    """Test setup from service info cache with devices found, with v4 encryption and wrong key."""
+    # Get a list of devices
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[JTYJGD03MI_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Pick a device
+    result1 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"address": "54:EF:44:E3:9C:BC"},
+    )
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "get_encryption_key_4_5"
+
+    # Try an incorrect key
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_4_5"
+    assert result2["errors"]["bindkey"] == "decryption_failed"
+
+    # Check can still finish flow
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "JTYJGD03MI"
+    assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
+    assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
+
+
+async def test_async_step_user_with_found_devices_v4_encryption_wrong_key_length(hass):
+    """Test setup from service info cache with devices found, with v4 encryption and wrong key length."""
+    # Get a list of devices
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[JTYJGD03MI_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Select a single device
+    result1 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"address": "54:EF:44:E3:9C:BC"},
+    )
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "get_encryption_key_4_5"
+
+    # Try an incorrect key
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "5b51a7c91cde6707c9ef1dfda143a58"},
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_4_5"
+    assert result2["errors"]["bindkey"] == "expected_32_characters"
+
+    # Check can still finish flow
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "JTYJGD03MI"
+    assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
+    assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
+
+
 async def test_async_step_user_with_found_devices_legacy_encryption(hass):
-    """Test setup from service info cache with devices found."""
+    """Test setup from service info cache with devices found, with legacy encryption."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
         return_value=[YLKG07YL_SERVICE_INFO],
@@ -185,6 +413,96 @@ async def test_async_step_user_with_found_devices_legacy_encryption(hass):
     assert result1["type"] == FlowResultType.FORM
     assert result1["step_id"] == "get_encryption_key_legacy"
 
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "b853075158487ca39a5b5ea9"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "YLKG07YL"
+    assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
+    assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
+
+
+async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key(
+    hass,
+):
+    """Test setup from service info cache with devices found, with legacy encryption and wrong key."""
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[YLKG07YL_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result1 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"address": "F8:24:41:C5:98:8B"},
+    )
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "get_encryption_key_legacy"
+
+    # Enter an incorrect code
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "aaaaaaaaaaaaaaaaaaaaaaaa"},
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_legacy"
+    assert result2["errors"]["bindkey"] == "decryption_failed"
+
+    # Check you can finish the flow
+    with patch(
+        "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bindkey": "b853075158487ca39a5b5ea9"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "YLKG07YL"
+    assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
+    assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
+
+
+async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key_length(
+    hass,
+):
+    """Test setup from service info cache with devices found, with legacy encryption and wrong key length."""
+    with patch(
+        "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
+        return_value=[YLKG07YL_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result1 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"address": "F8:24:41:C5:98:8B"},
+    )
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "get_encryption_key_legacy"
+
+    # Enter an incorrect code
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"bindkey": "b85307518487ca39a5b5ea9"},
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "get_encryption_key_legacy"
+    assert result2["errors"]["bindkey"] == "expected_24_characters"
+
+    # Check you can finish the flow
     with patch(
         "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
     ):

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -149,7 +149,7 @@ async def test_xiaomi_CGDK2(hass):
         return lambda: None
 
     with patch(
-        "homeassistant.components.bluetooth.passive_update_coordinator.async_register_callback",
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
         _async_register_callback,
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -130,3 +130,48 @@ async def test_xiaomi_HHCCJCY01(hass):
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_xiaomi_CGDK2(hass):
+    """This device has encrypion so we need to retrieve its bindkey from the configentry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="58:2D:34:12:20:89",
+        data={"bindkey": "a3bfe9853dd85a620debe3620caaa351"},
+    )
+    entry.add_to_hass(hass)
+
+    saved_callback = None
+
+    def _async_register_callback(_hass, _callback, _matcher):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.passive_update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    saved_callback(
+        make_advertisement(
+            "58:2D:34:12:20:89",
+            b"XXo\x06\x07\x89 \x124-X_\x17m\xd5O\x02\x00\x00/\xa4S\xfa",
+        ),
+        BluetoothChange.ADVERTISEMENT,
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 1
+
+    temp_sensor = hass.states.get("sensor.test_device_temperature")
+    temp_sensor_attribtes = temp_sensor.attributes
+    assert temp_sensor.state == "22.6"
+    assert temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Temperature"
+    assert temp_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
+    assert temp_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
Adjust the config flow to allow entering a legacy or v4/5 bindkey when setting up an encrypted MiBeacon

This is still WIP. Todo:

* [x] Get the sensor to use the bindkey from the config entry
* [x] Adjust step_user to prompt for encrypt keys
* [x] Tests
* [x] Add new strings

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
