### PR TITLE
Add lawn_mower entity

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -26,6 +26,7 @@ base_platforms: &base_platforms
   - homeassistant/components/geo_location/**
   - homeassistant/components/humidifier/**
   - homeassistant/components/image_processing/**
+  - homeassistant/components/lawn_mower/**
   - homeassistant/components/light/**
   - homeassistant/components/lock/**
   - homeassistant/components/media_player/**

--- a/.strict-typing
+++ b/.strict-typing
@@ -144,6 +144,7 @@ homeassistant.components.knx.*
 homeassistant.components.kraken.*
 homeassistant.components.lametric.*
 homeassistant.components.laundrify.*
+homeassistant.components.lawn_mower.*
 homeassistant.components.lcn.*
 homeassistant.components.light.*
 homeassistant.components.local_ip.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -572,6 +572,8 @@ build.json @home-assistant/supervisor
 /tests/components/launch_library/ @ludeeus @DurgNomis-drol
 /homeassistant/components/laundrify/ @xLarry
 /tests/components/laundrify/ @xLarry
+/homeassistant/components/lawn_mower/ @home-assistant/core
+/tests/components/lawn_mower/ @home-assistant/core
 /homeassistant/components/lcn/ @alengwenus
 /tests/components/lcn/ @alengwenus
 /homeassistant/components/lg_netcast/ @Drafteed

--- a/homeassistant/components/lawn_mower/__init__.py
+++ b/homeassistant/components/lawn_mower/__init__.py
@@ -1,0 +1,237 @@
+"""Support for lawn mower robots."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import IntEnum
+from functools import partial
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (  # noqa: F401 # STATE_PAUSED/IDLE are API
+    ATTR_BATTERY_LEVEL,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_IDLE,
+    STATE_ON,
+    STATE_PAUSED,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_validation import (  # noqa: F401
+    PLATFORM_SCHEMA,
+    PLATFORM_SCHEMA_BASE,
+    make_entity_service_schema,
+)
+from homeassistant.helpers.entity import (
+    Entity,
+    EntityDescription,
+    ToggleEntityDescription,
+)
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import bind_hass
+
+# mypy: allow-untyped-defs, no-check-untyped-defs
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "lawn_mower"
+ENTITY_ID_FORMAT = DOMAIN + ".{}"
+SCAN_INTERVAL = timedelta(seconds=20)
+
+ATTR_BATTERY_ICON = "battery_icon"
+ATTR_STATUS = "status"
+
+SERVICE_PAUSE = "pause"
+SERVICE_RETURN_TO_BASE = "return_to_base"
+SERVICE_START_PAUSE = "start_pause"
+SERVICE_START = "start"
+SERVICE_STOP = "stop"
+
+STATE_DOCKED = "docked"
+STATE_ERROR = "error"
+STATE_MOWING = "mowing"
+STATE_RETURNING = "returning"
+
+STATES = [STATE_DOCKED, STATE_ERROR, STATE_MOWING, STATE_RETURNING]
+
+DEFAULT_NAME = "Lawn mower robot"
+
+
+class LawnMowerEntityFeature(IntEnum):
+    """Supported features of the lawn_mower entity."""
+
+    TURN_ON = 1
+    TURN_OFF = 2
+    PAUSE = 4
+    STOP = 8
+    RETURN_HOME = 16
+    BATTERY = 32
+    STATUS = 64
+    STATE = 128
+    START = 256
+
+
+@bind_hass
+def is_on(hass, entity_id):
+    """Return if the lawn mower is on based on the statemachine."""
+    return hass.states.is_state(entity_id, STATE_ON)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the lawn_mower component."""
+    component = hass.data[DOMAIN] = EntityComponent(
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
+    )
+
+    await component.async_setup(config)
+
+    component.async_register_entity_service(SERVICE_TURN_ON, {}, "async_turn_on")
+    component.async_register_entity_service(SERVICE_TURN_OFF, {}, "async_turn_off")
+    component.async_register_entity_service(SERVICE_TOGGLE, {}, "async_toggle")
+    component.async_register_entity_service(
+        SERVICE_START_PAUSE, {}, "async_start_pause"
+    )
+    component.async_register_entity_service(SERVICE_START, {}, "async_start")
+    component.async_register_entity_service(SERVICE_PAUSE, {}, "async_pause")
+    component.async_register_entity_service(
+        SERVICE_RETURN_TO_BASE, {}, "async_return_to_base"
+    )
+    component.async_register_entity_service(SERVICE_STOP, {}, "async_stop")
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    component: EntityComponent = hass.data[DOMAIN]
+    return await component.async_setup_entry(entry)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    component: EntityComponent = hass.data[DOMAIN]
+    return await component.async_unload_entry(entry)
+
+
+class _BaseLawnMower(Entity):
+    """Representation of a base lawn_mower.
+
+    Contains common properties and functions for all lawn mower devices.
+    """
+
+    _attr_battery_icon: str
+    _attr_battery_level: int | None = None
+    _attr_supported_features: int
+
+    @property
+    def supported_features(self) -> int:
+        """Flag lawn mower features that are supported."""
+        return self._attr_supported_features
+
+    @property
+    def battery_level(self) -> int | None:
+        """Return the battery level of the lawn mower."""
+        return self._attr_battery_level
+
+    @property
+    def battery_icon(self) -> str:
+        """Return the battery icon for the lawn mower."""
+        return self._attr_battery_icon
+
+    @property
+    def state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes of the lawn mower."""
+        data: dict[str, Any] = {}
+
+        if self.supported_features & LawnMowerEntityFeature.BATTERY:
+            data[ATTR_BATTERY_LEVEL] = self.battery_level
+            data[ATTR_BATTERY_ICON] = self.battery_icon
+
+        return data
+
+    def stop(self, **kwargs: Any) -> None:
+        """Stop the lawn mower."""
+        raise NotImplementedError()
+
+    async def async_stop(self, **kwargs: Any) -> None:
+        """Stop the lawn mower.
+
+        This method must be run in the event loop.
+        """
+        await self.hass.async_add_executor_job(partial(self.stop, **kwargs))
+
+    def return_to_base(self, **kwargs: Any) -> None:
+        """Set the lawn mower to return to the dock."""
+        raise NotImplementedError()
+
+    async def async_return_to_base(self, **kwargs: Any) -> None:
+        """Set the lawn mower to return to the dock.
+
+        This method must be run in the event loop.
+        """
+        await self.hass.async_add_executor_job(partial(self.return_to_base, **kwargs))
+
+
+@dataclass
+class LawnMowerEntityDescription(ToggleEntityDescription):
+    """A class that describes lawn_mower entities."""
+
+
+@dataclass
+class StateLawnMowerEntityDescription(EntityDescription):
+    """A class that describes lawn_mower entities."""
+
+
+class StateLawnMowerEntity(_BaseLawnMower):
+    """Representation of a lawn mower robot that supports states."""
+
+    entity_description: StateLawnMowerEntityDescription
+
+    @property
+    def state(self) -> str | None:
+        """Return the state of the lawn mower."""
+        return None
+
+    @property
+    def battery_icon(self) -> str:
+        """Return the battery icon for the lawn mower."""
+        charging = bool(self.state == STATE_DOCKED)
+
+        return icon_for_battery_level(
+            battery_level=self.battery_level, charging=charging
+        )
+
+    def start(self) -> None:
+        """Start or resume the mowing task."""
+        raise NotImplementedError()
+
+    async def async_start(self) -> None:
+        """Start or resume the mowing task.
+
+        This method must be run in the event loop.
+        """
+        await self.hass.async_add_executor_job(self.start)
+
+    def pause(self) -> None:
+        """Pause the mowing task."""
+        raise NotImplementedError()
+
+    async def async_pause(self) -> None:
+        """Pause the mowing task.
+
+        This method must be run in the event loop.
+        """
+        await self.hass.async_add_executor_job(self.pause)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Not supported."""
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Not supported."""
+
+    async def async_toggle(self, **kwargs: Any) -> None:
+        """Not supported."""

--- a/homeassistant/components/lawn_mower/device_action.py
+++ b/homeassistant/components/lawn_mower/device_action.py
@@ -1,0 +1,72 @@
+"""Provides device automations for Lawn Mower."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from . import DOMAIN, SERVICE_RETURN_TO_BASE, SERVICE_START
+
+ACTION_TYPES = {"mow", "dock"}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+    }
+)
+
+
+async def async_get_actions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device actions for Lawn Mower devices."""
+    registry = entity_registry.async_get(hass)
+    actions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        base_action = {
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.entity_id,
+        }
+
+        actions.append({**base_action, CONF_TYPE: "mow"})
+        actions.append({**base_action, CONF_TYPE: "dock"})
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant,
+    config: ConfigType,
+    variables: TemplateVarsType,
+    context: Context | None,
+) -> None:
+    """Execute a device action."""
+    config = ACTION_SCHEMA(config)
+
+    service_data = {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]}
+
+    if config[CONF_TYPE] == "mow":
+        service = SERVICE_START
+    elif config[CONF_TYPE] == "dock":
+        service = SERVICE_RETURN_TO_BASE
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, blocking=True, context=context
+    )

--- a/homeassistant/components/lawn_mower/device_condition.py
+++ b/homeassistant/components/lawn_mower/device_condition.py
@@ -1,0 +1,70 @@
+"""Provide the device automations for Lawn Mower."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import condition, config_validation as cv, entity_registry
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from . import DOMAIN, STATE_DOCKED, STATE_MOWING, STATE_RETURNING
+
+CONDITION_TYPES = {"is_mowing", "is_docked"}
+
+CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(CONDITION_TYPES),
+    }
+)
+
+
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device conditions for Lawn Mower devices."""
+    registry = entity_registry.async_get(hass)
+    conditions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        base_condition = {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.entity_id,
+        }
+
+        conditions += [{**base_condition, CONF_TYPE: cond} for cond in CONDITION_TYPES]
+
+    return conditions
+
+
+@callback
+def async_condition_from_config(
+    hass: HomeAssistant, config: ConfigType
+) -> condition.ConditionCheckerType:
+    """Create a function to test a device condition."""
+    if config[CONF_TYPE] == "is_docked":
+        test_states = [STATE_DOCKED]
+    else:
+        test_states = [STATE_MOWING, STATE_RETURNING]
+
+    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if an entity is a certain state."""
+        state = hass.states.get(config[ATTR_ENTITY_ID])
+        return state is not None and state.state in test_states
+
+    return test_is_state

--- a/homeassistant/components/lawn_mower/device_trigger.py
+++ b/homeassistant/components/lawn_mower/device_trigger.py
@@ -1,0 +1,96 @@
+"""Provides device automations for Lawn Mower."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.automation import (
+    AutomationActionType,
+    AutomationTriggerInfo,
+)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import state as state_trigger
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_FOR,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN, STATE_DOCKED, STATE_MOWING
+
+TRIGGER_TYPES = {"mowing", "docked"}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device triggers for Lawn Mower devices."""
+    registry = entity_registry.async_get(hass)
+    triggers = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        triggers += [
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: trigger,
+            }
+            for trigger in TRIGGER_TYPES
+        ]
+
+    return triggers
+
+
+async def async_get_trigger_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, vol.Schema]:
+    """List trigger capabilities."""
+    return {
+        "extra_fields": vol.Schema(
+            {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+        )
+    }
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: AutomationTriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    if config[CONF_TYPE] == "mowing":
+        to_state = STATE_MOWING
+    else:
+        to_state = STATE_DOCKED
+
+    state_config = {
+        CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state_trigger.CONF_TO: to_state,
+    }
+    if CONF_FOR in config:
+        state_config[CONF_FOR] = config[CONF_FOR]
+    state_config = await state_trigger.async_validate_trigger_config(hass, state_config)
+    return await state_trigger.async_attach_trigger(
+        hass, state_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/lawn_mower/group.py
+++ b/homeassistant/components/lawn_mower/group.py
@@ -1,0 +1,18 @@
+"""Describe group states."""
+
+
+from homeassistant.components.group import GroupIntegrationRegistry
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant, callback
+
+from . import STATE_ERROR, STATE_MOWING, STATE_RETURNING
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
+) -> None:
+    """Describe group on off states."""
+    registry.on_off_states(
+        {STATE_MOWING, STATE_ON, STATE_RETURNING, STATE_ERROR}, STATE_OFF
+    )

--- a/homeassistant/components/lawn_mower/manifest.json
+++ b/homeassistant/components/lawn_mower/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "lawn_mower",
+  "name": "Lawn Mower",
+  "documentation": "https://www.home-assistant.io/integrations/lawn_mower",
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/lawn_mower/reproduce_state.py
+++ b/homeassistant/components/lawn_mower/reproduce_state.py
@@ -1,0 +1,99 @@
+"""Reproduce an Lawn Mower state."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+import logging
+from typing import Any
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+)
+from homeassistant.core import Context, HomeAssistant, State
+
+from . import (
+    DOMAIN,
+    SERVICE_PAUSE,
+    SERVICE_RETURN_TO_BASE,
+    SERVICE_START,
+    SERVICE_STOP,
+    STATE_DOCKED,
+    STATE_MOWING,
+    STATE_RETURNING,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_STATES_TOGGLE = {STATE_ON, STATE_OFF}
+VALID_STATES_STATE = {
+    STATE_DOCKED,
+    STATE_IDLE,
+    STATE_MOWING,
+    STATE_RETURNING,
+    STATE_PAUSED,
+}
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistant,
+    state: State,
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
+) -> None:
+    """Reproduce a single state."""
+    if (cur_state := hass.states.get(state.entity_id)) is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if not (state.state in VALID_STATES_TOGGLE or state.state in VALID_STATES_STATE):
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    if cur_state.state != state.state:
+        # Wrong state
+        if state.state == STATE_ON:
+            service = SERVICE_TURN_ON
+        elif state.state == STATE_OFF:
+            service = SERVICE_TURN_OFF
+        elif state.state == STATE_MOWING:
+            service = SERVICE_START
+        elif state.state in [STATE_DOCKED, STATE_RETURNING]:
+            service = SERVICE_RETURN_TO_BASE
+        elif state.state == STATE_IDLE:
+            service = SERVICE_STOP
+        elif state.state == STATE_PAUSED:
+            service = SERVICE_PAUSE
+
+        await hass.services.async_call(
+            DOMAIN, service, service_data, context=context, blocking=True
+        )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistant,
+    states: Iterable[State],
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
+) -> None:
+    """Reproduce Lawn Mower states."""
+    # Reproduce states in parallel.
+    await asyncio.gather(
+        *(
+            _async_reproduce_state(
+                hass, state, context=context, reproduce_options=reproduce_options
+            )
+            for state in states
+        )
+    )

--- a/homeassistant/components/lawn_mower/services.yaml
+++ b/homeassistant/components/lawn_mower/services.yaml
@@ -1,0 +1,50 @@
+# Describes the format for available lawn_mower services
+
+turn_on:
+  name: Turn on
+  description: Start a new mowing task.
+  target:
+    entity:
+      domain: lawn_mower
+
+turn_off:
+  name: Turn off
+  description: Stop the current mowing task and return to home.
+  target:
+    entity:
+      domain: lawn_mower
+
+start:
+  name: Start
+  description: Start or resume the mowing task.
+  target:
+    entity:
+      domain: lawn_mower
+
+start_pause:
+  name: Start/Pause
+  description: Start, pause, or resume the mowing task.
+  target:
+    entity:
+      domain: lawn_mower
+
+pause:
+  name: Pause
+  description: Pause the mowing task.
+  target:
+    entity:
+      domain: lawn_mower
+
+stop:
+  name: Stop
+  description: Stop the current mowing task.
+  target:
+    entity:
+      domain: lawn_mower
+
+return_to_base:
+  name: Return to base
+  description: Tell the lawn mower to return to its dock.
+  target:
+    entity:
+      domain: lawn_mower

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -1,0 +1,29 @@
+{
+  "title": "Lawn Mower",
+  "device_automation": {
+    "condition_type": {
+      "is_docked": "{entity_name} is docked",
+      "is_mowing": "{entity_name} is mowing"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} started mowing",
+      "docked": "{entity_name} docked"
+    },
+    "action_type": {
+      "mow": "Let {entity_name} mow",
+      "dock": "Let {entity_name} return to the dock"
+    }
+  },
+  "state": {
+    "_": {
+      "mowing": "Mowing",
+      "docked": "Docked",
+      "error": "Error",
+      "idle": "[%key:common::state::idle%]",
+      "off": "[%key:common::state::off%]",
+      "on": "[%key:common::state::on%]",
+      "paused": "[%key:common::state::paused%]",
+      "returning": "Returning to dock"
+    }
+  }
+}

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -35,6 +35,7 @@ class Platform(StrEnum):
     GEO_LOCATION = "geo_location"
     HUMIDIFIER = "humidifier"
     IMAGE_PROCESSING = "image_processing"
+    LAWN_MOWER = "lawn_mower"
     LIGHT = "light"
     LOCK = "lock"
     MAILBOX = "mailbox"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1347,6 +1347,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.lawn_mower.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.lcn.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/lawn_mower/__init__.py
+++ b/tests/components/lawn_mower/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for lawn mower platform."""

--- a/tests/components/lawn_mower/test_device_action.py
+++ b/tests/components/lawn_mower/test_device_action.py
@@ -1,0 +1,149 @@
+"""The tests for Lawn Mower device actions."""
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.lawn_mower import DOMAIN
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_get_actions(hass, device_reg, entity_reg):
+    """Test we get the expected actions from a lawn mower."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": "lawn_mower.test_5678",
+            "metadata": {"secondary": False},
+        }
+        for action in ["mow", "dock"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_actions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected actions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_actions = []
+    expected_actions += [
+        {
+            "domain": DOMAIN,
+            "type": action,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for action in ["mow", "dock"]
+    ]
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_action(hass):
+    """Test for turn_on and turn_off actions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_dock"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "lawn_mower.entity",
+                        "type": "dock",
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_mow"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "lawn_mower.entity",
+                        "type": "mow",
+                    },
+                },
+            ]
+        },
+    )
+
+    dock_calls = async_mock_service(hass, "lawn_mower", "return_to_base")
+    mow_calls = async_mock_service(hass, "lawn_mower", "start")
+
+    hass.bus.async_fire("test_event_dock")
+    await hass.async_block_till_done()
+    assert len(dock_calls) == 1
+    assert len(mow_calls) == 0
+
+    hass.bus.async_fire("test_event_mow")
+    await hass.async_block_till_done()
+    assert len(dock_calls) == 1
+    assert len(mow_calls) == 1

--- a/tests/components/lawn_mower/test_device_condition.py
+++ b/tests/components/lawn_mower/test_device_condition.py
@@ -1,0 +1,187 @@
+"""The tests for Lawn Mower device conditions."""
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.lawn_mower import (
+    DOMAIN,
+    STATE_DOCKED,
+    STATE_MOWING,
+    STATE_RETURNING,
+)
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_conditions(hass, device_reg, entity_reg):
+    """Test we get the expected conditions from a lawn mower."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": condition,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
+        }
+        for condition in ["is_mowing", "is_docked"]
+    ]
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
+    assert_lists_same(conditions, expected_conditions)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_conditions_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected conditions from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": condition,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for condition in ["is_mowing", "is_docked"]
+    ]
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
+    assert_lists_same(conditions, expected_conditions)
+
+
+async def test_if_state(hass, calls):
+    """Test for turn_on and turn_off conditions."""
+    hass.states.async_set("lawn_mower.entity", STATE_DOCKED)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "lawn_mower.entity",
+                            "type": "is_mowing",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_mowing - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "lawn_mower.entity",
+                            "type": "is_docked",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_docked - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_docked - event - test_event2"
+
+    hass.states.async_set("lawn_mower.entity", STATE_MOWING)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "is_mowing - event - test_event1"
+
+    # Returning means it's still mowing
+    hass.states.async_set("lawn_mower.entity", STATE_RETURNING)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].data["some"] == "is_mowing - event - test_event1"

--- a/tests/components/lawn_mower/test_device_trigger.py
+++ b/tests/components/lawn_mower/test_device_trigger.py
@@ -1,0 +1,265 @@
+"""The tests for Lawn Mower device triggers."""
+from datetime import timedelta
+
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.lawn_mower import DOMAIN, STATE_DOCKED, STATE_MOWING
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_fire_time_changed,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(hass, device_reg, entity_reg):
+    """Test we get the expected triggers from a lawn mower."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": False},
+        }
+        for trigger in ["mowing", "docked"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "hidden_by,entity_category",
+    (
+        (RegistryEntryHider.INTEGRATION, None),
+        (RegistryEntryHider.USER, None),
+        (None, EntityCategory.CONFIG),
+        (None, EntityCategory.DIAGNOSTIC),
+    ),
+)
+async def test_get_triggers_hidden_auxiliary(
+    hass,
+    device_reg,
+    entity_reg,
+    hidden_by,
+    entity_category,
+):
+    """Test we get the expected triggers from a hidden or auxiliary entity."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "5678",
+        device_id=device_entry.id,
+        entity_category=entity_category,
+        hidden_by=hidden_by,
+    )
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+            "metadata": {"secondary": True},
+        }
+        for trigger in ["mowing", "docked"]
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a lawn mower device."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert len(triggers) == 2
+    for trigger in triggers:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == {
+            "extra_fields": [
+                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            ]
+        }
+
+
+async def test_if_fires_on_state_change(hass, calls):
+    """Test for turn_on and turn_off triggers firing."""
+    hass.states.async_set("lawn_mower.entity", STATE_DOCKED)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "lawn_mower.entity",
+                        "type": "mowing",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "mowing - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "lawn_mower.entity",
+                        "type": "docked",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "docked - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is mowing
+    hass.states.async_set("lawn_mower.entity", STATE_MOWING)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"] == "mowing - device - lawn_mower.entity - docked - mowing"
+    )
+
+    # Fake that the entity is docked
+    hass.states.async_set("lawn_mower.entity", STATE_DOCKED)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert (
+        calls[1].data["some"] == "docked - device - lawn_mower.entity - mowing - docked"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(hass, calls):
+    """Test for triggers firing with delay."""
+    entity_id = f"{DOMAIN}.entity"
+    hass.states.async_set(entity_id, STATE_DOCKED)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entity_id,
+                        "type": "mowing",
+                        "for": {"seconds": 5},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_DOCKED
+    assert len(calls) == 0
+
+    hass.states.async_set(entity_id, STATE_MOWING)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await hass.async_block_till_done()
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entity_id} - docked - mowing - 0:00:05"
+    )

--- a/tests/components/lawn_mower/test_reproduce_state.py
+++ b/tests/components/lawn_mower/test_reproduce_state.py
@@ -1,0 +1,118 @@
+"""Test reproduce state for Lawn Mower."""
+from homeassistant.components.lawn_mower import (
+    SERVICE_PAUSE,
+    SERVICE_RETURN_TO_BASE,
+    SERVICE_START,
+    SERVICE_STOP,
+    STATE_DOCKED,
+    STATE_MOWING,
+    STATE_RETURNING,
+)
+from homeassistant.const import (
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+)
+from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
+
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(hass, caplog):
+    """Test reproducing lawn_mower states."""
+    hass.states.async_set("lawn_mower.entity_off", STATE_OFF, {})
+    hass.states.async_set("lawn_mower.entity_on", STATE_ON, {})
+    hass.states.async_set("lawn_mower.entity_mowing", STATE_MOWING, {})
+    hass.states.async_set("lawn_mower.entity_docked", STATE_DOCKED, {})
+    hass.states.async_set("lawn_mower.entity_idle", STATE_IDLE, {})
+    hass.states.async_set("lawn_mower.entity_returning", STATE_RETURNING, {})
+    hass.states.async_set("lawn_mower.entity_paused", STATE_PAUSED, {})
+
+    turn_on_calls = async_mock_service(hass, "lawn_mower", SERVICE_TURN_ON)
+    turn_off_calls = async_mock_service(hass, "lawn_mower", SERVICE_TURN_OFF)
+    start_calls = async_mock_service(hass, "lawn_mower", SERVICE_START)
+    pause_calls = async_mock_service(hass, "lawn_mower", SERVICE_PAUSE)
+    stop_calls = async_mock_service(hass, "lawn_mower", SERVICE_STOP)
+    return_calls = async_mock_service(hass, "lawn_mower", SERVICE_RETURN_TO_BASE)
+
+    # These calls should do nothing as entities already in desired state
+    await async_reproduce_state(
+        hass,
+        [
+            State("lawn_mower.entity_off", STATE_OFF),
+            State("lawn_mower.entity_on", STATE_ON),
+            State("lawn_mower.entity_mowing", STATE_MOWING),
+            State("lawn_mower.entity_docked", STATE_DOCKED),
+            State("lawn_mower.entity_idle", STATE_IDLE),
+            State("lawn_mower.entity_returning", STATE_RETURNING),
+            State("lawn_mower.entity_paused", STATE_PAUSED),
+        ],
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+    assert len(start_calls) == 0
+    assert len(pause_calls) == 0
+    assert len(stop_calls) == 0
+    assert len(return_calls) == 0
+
+    # Test invalid state is handled
+    await async_reproduce_state(hass, [State("lawn_mower.entity_off", "not_supported")])
+
+    assert "not_supported" in caplog.text
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+    assert len(start_calls) == 0
+    assert len(pause_calls) == 0
+    assert len(stop_calls) == 0
+    assert len(return_calls) == 0
+
+    # Make sure correct services are called
+    await async_reproduce_state(
+        hass,
+        [
+            State("lawn_mower.entity_off", STATE_ON),
+            State("lawn_mower.entity_on", STATE_OFF),
+            State("lawn_mower.entity_mowing", STATE_PAUSED),
+            State("lawn_mower.entity_docked", STATE_MOWING),
+            State("lawn_mower.entity_idle", STATE_DOCKED),
+            State("lawn_mower.entity_returning", STATE_MOWING),
+            State("lawn_mower.entity_paused", STATE_IDLE),
+            # Should not raise
+            State("lawn_mower.non_existing", STATE_ON),
+        ],
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "lawn_mower"
+    assert turn_on_calls[0].data == {"entity_id": "lawn_mower.entity_off"}
+
+    assert len(turn_off_calls) == 1
+    assert turn_off_calls[0].domain == "lawn_mower"
+    assert turn_off_calls[0].data == {"entity_id": "lawn_mower.entity_on"}
+
+    assert len(start_calls) == 2
+    entities = [
+        {"entity_id": "lawn_mower.entity_docked"},
+        {"entity_id": "lawn_mower.entity_returning"},
+    ]
+    for call in start_calls:
+        assert call.domain == "lawn_mower"
+        assert call.data in entities
+        entities.remove(call.data)
+
+    assert len(pause_calls) == 1
+    assert pause_calls[0].domain == "lawn_mower"
+    assert pause_calls[0].data == {"entity_id": "lawn_mower.entity_mowing"}
+
+    assert len(stop_calls) == 1
+    assert stop_calls[0].domain == "lawn_mower"
+    assert stop_calls[0].data == {"entity_id": "lawn_mower.entity_paused"}
+
+    assert len(return_calls) == 1
+    assert return_calls[0].domain == "lawn_mower"
+    assert return_calls[0].data == {"entity_id": "lawn_mower.entity_idle"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a proposal of an implementation of a lawn_mower entity following this architecture discussion: https://github.com/home-assistant/architecture/issues/40
This code is based on the vacuum code and has been modified/simplified to suit a base lawn mower:

States:
- Docked
- Mowing
- Returning
- Error
- Paused
- Idle
- on
- off

Services:
- Turn on
- Turn off
- Start
- Start/Pause
- Pause
- Stop
- Return to base
- Toggle

TODO if this proposal is accepted:
- [ ] Brands
- [ ] User documentation
- [ ] Developper documentation
- [ ] Frontend code (I will need help as I don't know anything about frontend)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/architecture/issues/40
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
