### PR TITLE
Update switchbot bluetooth matchers for sensor devices

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1042,8 +1042,8 @@ build.json @home-assistant/supervisor
 /tests/components/switch/ @home-assistant/core
 /homeassistant/components/switch_as_x/ @home-assistant/core
 /tests/components/switch_as_x/ @home-assistant/core
-/homeassistant/components/switchbot/ @danielhiversen @RenierM26 @murtas
-/tests/components/switchbot/ @danielhiversen @RenierM26 @murtas
+/homeassistant/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas
+/tests/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas
 /homeassistant/components/switcher_kis/ @tomerfi @thecode
 /tests/components/switcher_kis/ @tomerfi @thecode
 /homeassistant/components/switchmate/ @danielhiversen

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -5,7 +5,7 @@
   "requirements": ["PySwitchbot==0.15.0"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
-  "codeowners": ["@danielhiversen", "@RenierM26", "@murtas"],
+  "codeowners": ["@bdraco", "@danielhiversen", "@RenierM26", "@murtas"],
   "bluetooth": [
     {
       "service_data_uuid": "0000fd3d-0000-1000-8000-00805f9b34fb"
@@ -14,6 +14,7 @@
       "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
     }
   ],
+  "bluetooth": [{ "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b" }],
   "iot_class": "local_push",
   "loggers": ["switchbot"]
 }

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -6,7 +6,14 @@
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": ["@danielhiversen", "@RenierM26", "@murtas"],
-  "bluetooth": [{ "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b" }],
+  "bluetooth": [
+    {
+      "service_data_uuid": "0000fd3d-0000-1000-8000-00805f9b34fb"
+    },
+    {
+      "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
+    }
+  ],
   "iot_class": "local_push",
   "loggers": ["switchbot"]
 }

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -14,7 +14,6 @@
       "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
     }
   ],
-  "bluetooth": [{ "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b" }],
   "iot_class": "local_push",
   "loggers": ["switchbot"]
 }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -67,6 +67,10 @@ BLUETOOTH: list[dict[str, str | int | list[int]]] = [
     },
     {
         "domain": "switchbot",
+        "service_data_uuid": "0000fd3d-0000-1000-8000-00805f9b34fb"
+    },
+    {
+        "domain": "switchbot",
         "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
     },
     {


### PR DESCRIPTION
Broken out from https://github.com/home-assistant/core/pull/75687

TODO: 
- [x] run hassfest

Temporarily picking up codeowner for this one for 2022.8 so I can watch/resolve issues

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update switchbot bluetooth matchers for sensor devices
<img width="325" alt="Screen Shot 2022-07-24 at 12 45 46" src="https://user-images.githubusercontent.com/663432/180659535-00b1bcc1-7816-40a5-9c63-d9573f40a538.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
