### PR TITLE
Update PySwitchbot to improve connection reliability

### DIFF
--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -17,14 +17,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
-from .const import (
-    CONF_RETRY_COUNT,
-    CONF_RETRY_TIMEOUT,
-    DEFAULT_RETRY_COUNT,
-    DEFAULT_RETRY_TIMEOUT,
-    DOMAIN,
-    SUPPORTED_MODEL_TYPES,
-)
+from .const import CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT, DOMAIN, SUPPORTED_MODEL_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,11 +133,6 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
         """Manage Switchbot options."""
         if user_input is not None:
             # Update common entity options for all other entities.
-            for entry in self.hass.config_entries.async_entries(DOMAIN):
-                if entry.unique_id != self.config_entry.unique_id:
-                    self.hass.config_entries.async_update_entry(
-                        entry, options=user_input
-                    )
             return self.async_create_entry(title="", data=user_input)
 
         options = {
@@ -153,13 +141,7 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
                 default=self.config_entry.options.get(
                     CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT
                 ),
-            ): int,
-            vol.Optional(
-                CONF_RETRY_TIMEOUT,
-                default=self.config_entry.options.get(
-                    CONF_RETRY_TIMEOUT, DEFAULT_RETRY_TIMEOUT
-                ),
-            ): int,
+            ): int
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -15,15 +15,11 @@ SUPPORTED_MODEL_TYPES = {
 
 # Config Defaults
 DEFAULT_RETRY_COUNT = 3
-DEFAULT_RETRY_TIMEOUT = 5
 
 # Config Options
 CONF_RETRY_COUNT = "retry_count"
-CONF_SCAN_TIMEOUT = "scan_timeout"
 
 # Deprecated config Entry Options to be removed in 2023.4
 CONF_TIME_BETWEEN_UPDATE_COMMAND = "update_time"
 CONF_RETRY_TIMEOUT = "retry_timeout"
-
-# Data
-COMMON_OPTIONS = "common_options"
+CONF_SCAN_TIMEOUT = "scan_timeout"

--- a/homeassistant/components/switchbot/coordinator.py
+++ b/homeassistant/components/switchbot/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
 import logging
 from typing import Any, cast
 
@@ -15,8 +14,6 @@ from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothDataUpdateCoordinator,
 )
 from homeassistant.core import HomeAssistant, callback
-
-from .const import CONF_RETRY_COUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,20 +35,13 @@ class SwitchbotDataUpdateCoordinator(PassiveBluetoothDataUpdateCoordinator):
         logger: logging.Logger,
         ble_device: BLEDevice,
         device: switchbot.SwitchbotDevice,
-        common_options: Mapping[str, int],
     ) -> None:
         """Initialize global switchbot data updater."""
         super().__init__(hass, logger, ble_device.address)
         self.ble_device = ble_device
         self.device = device
-        self.common_options = common_options
         self.data: dict[str, Any] = {}
         self._ready_event = asyncio.Event()
-
-    @property
-    def retry_count(self) -> int:
-        """Return retry count."""
-        return self.common_options[CONF_RETRY_COUNT]
 
     @callback
     def _async_handle_bluetooth_event(

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.15.0"],
+  "requirements": ["PySwitchbot==0.15.1"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": ["@danielhiversen", "@RenierM26", "@murtas"],

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -24,8 +24,7 @@
     "step": {
       "init": {
         "data": {
-          "retry_count": "Retry count",
-          "retry_timeout": "Timeout between retries"
+          "retry_count": "Retry count"
         }
       }
     }

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -24,8 +24,7 @@
         "step": {
             "init": {
                 "data": {
-                    "retry_count": "Retry count",
-                    "retry_timeout": "Timeout between retries"
+                    "retry_count": "Retry count"
                 }
             }
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -37,7 +37,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.15.0
+PySwitchbot==0.15.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -33,7 +33,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.15.0
+PySwitchbot==0.15.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -2,10 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.switchbot.const import (
-    CONF_RETRY_COUNT,
-    CONF_RETRY_TIMEOUT,
-)
+from homeassistant.components.switchbot.const import CONF_RETRY_COUNT
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PASSWORD, CONF_SENSOR_TYPE
 from homeassistant.data_entry_flow import FlowResultType
@@ -276,7 +273,6 @@ async def test_options_flow(hass):
         },
         options={
             CONF_RETRY_COUNT: 10,
-            CONF_RETRY_TIMEOUT: 10,
         },
         unique_id="aabbccddeeff",
     )
@@ -294,7 +290,6 @@ async def test_options_flow(hass):
             result["flow_id"],
             user_input={
                 CONF_RETRY_COUNT: 3,
-                CONF_RETRY_TIMEOUT: 5,
             },
         )
         await hass.async_block_till_done()
@@ -318,7 +313,6 @@ async def test_options_flow(hass):
             result["flow_id"],
             user_input={
                 CONF_RETRY_COUNT: 6,
-                CONF_RETRY_TIMEOUT: 6,
             },
         )
         await hass.async_block_till_done()

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -301,7 +301,6 @@ async def test_options_flow(hass):
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_RETRY_COUNT] == 3
-    assert result["data"][CONF_RETRY_TIMEOUT] == 5
 
     assert len(mock_setup_entry.mock_calls) == 2
 
@@ -326,9 +325,7 @@ async def test_options_flow(hass):
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_RETRY_COUNT] == 6
-    assert result["data"][CONF_RETRY_TIMEOUT] == 6
 
     assert len(mock_setup_entry.mock_calls) == 1
 
     assert entry.options[CONF_RETRY_COUNT] == 6
-    assert entry.options[CONF_RETRY_TIMEOUT] == 6


### PR DESCRIPTION
~~Docs changed blocked by https://github.com/home-assistant/home-assistant.io/pull/23495~~

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Removes the retry timeout option as it is now automatic
- Removes the common options as they are no longer shared between instances

Changelog: https://github.com/Danielhiversen/pySwitchbot/compare/0.15.0...0.15.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Fixes #66629 Fixes #70262 Fixes #71966
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23512

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
