### PR TITLE
Allow templates to pass through service calls

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -237,7 +237,9 @@ def async_prepare_call_from_config(
             continue
         try:
             template.attach(hass, config[conf])
-            render = template.render_complex(config[conf], variables)
+            render = template.render_complex(
+                config[conf], variables, pass_undefined=True
+            )
             if not isinstance(render, dict):
                 raise HomeAssistantError(
                     "Error rendering data template: Result is not a Dictionary"

--- a/tests/components/geo_location/test_trigger.py
+++ b/tests/components/geo_location/test_trigger.py
@@ -285,7 +285,6 @@ async def test_if_fires_on_zone_appear(hass, calls):
                             (
                                 "platform",
                                 "entity_id",
-                                "from_state.state",
                                 "to_state.state",
                                 "zone.name",
                             )
@@ -308,9 +307,7 @@ async def test_if_fires_on_zone_appear(hass, calls):
 
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert (
-        calls[0].data["some"] == "geo_location - geo_location.entity -  - hello - test"
-    )
+    assert calls[0].data["some"] == "geo_location - geo_location.entity - hello - test"
 
 
 async def test_if_fires_on_zone_appear_2(hass, calls):
@@ -400,7 +397,6 @@ async def test_if_fires_on_zone_disappear(hass, calls):
                                 "platform",
                                 "entity_id",
                                 "from_state.state",
-                                "to_state.state",
                                 "zone.name",
                             )
                         )
@@ -415,9 +411,7 @@ async def test_if_fires_on_zone_disappear(hass, calls):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert (
-        calls[0].data["some"] == "geo_location - geo_location.entity - hello -  - test"
-    )
+    assert calls[0].data["some"] == "geo_location - geo_location.entity - hello - test"
 
 
 async def test_zone_undefined(hass, calls, caplog):

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -339,7 +339,27 @@ class TestServiceHelpers(unittest.TestCase):
         assert self.calls[0].data["hello"] == "goodbye"
 
     def test_bad_template(self):
-        """Test passing bad template."""
+        """Test passing bad_template."""
+        config = {
+            "service_template": "{{ unknown_var }}",
+            "entity_id": "hello.world",
+            "data_template": {"hello": " goodbye "},
+        }
+
+        service.call_from_config(
+            self.hass,
+            config,
+            variables={
+                "var_service": "test_domain.test_service",
+                "var_data": "goodbye",
+            },
+        )
+        self.hass.block_till_done()
+
+        assert len(self.calls) == 0
+
+    def test_undefined_template_data(self):
+        """Test passing template with undefined data. The call should go through."""
         config = {
             "service_template": "{{ var_service }}",
             "entity_id": "hello.world",
@@ -356,7 +376,8 @@ class TestServiceHelpers(unittest.TestCase):
         )
         self.hass.block_till_done()
 
-        assert len(self.calls) == 0
+        assert len(self.calls) == 1
+        assert self.calls[0].data["hello"] == "{{ states + unknown_var }}"
 
     def test_split_entity_string(self):
         """Test splitting of entity string."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Templates for service calls from config (including calls from scripts and calls from the frontend developer tools) are rendered in `async_prepare_call_from_config` before the call is sent to the handler. This causes handlers that expect a template to not actually receive one, preventing proper rendering of templates that rely on variables from the service handler.
This PR adds a passthrough option to template rendering and uses it in `async_prepare_call_from_config` to pass through unrendered templates when an UndefinedError occurs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40241
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
