### PR TITLE
Add IPv6 sensor to fritz component

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -670,6 +670,10 @@ class AvmWrapper(FritzBoxTools):
             partial(self.get_wan_link_properties)
         )
 
+    async def async_ipv6_active(self) -> bool:
+        """Call WANIPConn service."""
+        return await self.hass.async_add_executor_job(partial(self.ipv6_active))
+
     async def async_get_connection_info(self) -> ConnectionInfo:
         """Return ConnectionInfo data."""
 
@@ -678,6 +682,7 @@ class AvmWrapper(FritzBoxTools):
             connection=link_properties.get("NewWANAccessType", "").lower(),
             mesh_role=self.mesh_role,
             wan_enabled=self.device_is_router,
+            ipv6_active=await self.async_ipv6_active(),
         )
         _LOGGER.debug(
             "ConnectionInfo for FritzBox %s: %s",
@@ -793,6 +798,15 @@ class AvmWrapper(FritzBoxTools):
 
         return self._service_call_action(
             "WANCommonInterfaceConfig", "1", "GetCommonLinkProperties"
+        )
+
+    def ipv6_active(self) -> bool:
+        """Call WANIPConn service."""
+
+        return bool(
+            self._service_call_action(
+                "WANIPConn", "1", "X_AVM_DE_GetExternalIPv6Address"
+            )["NewExternalIPv6Address"]
         )
 
     def set_wlan_configuration(self, index: int, turn_on: bool) -> dict[str, Any]:
@@ -1023,3 +1037,4 @@ class ConnectionInfo:
     connection: str
     mesh_role: MeshRoles
     wan_enabled: bool
+    ipv6_active: bool

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -671,8 +671,12 @@ class AvmWrapper(FritzBoxTools):
         )
 
     async def async_ipv6_active(self) -> bool:
-        """Call WANIPConn service."""
-        return await self.hass.async_add_executor_job(partial(self.ipv6_active))
+        """Check ip an ipv6 is active on the WAn interface."""
+
+        def wrap_external_ipv6() -> str:
+            return str(self.fritz_status.external_ipv6)
+
+        return bool(await self.hass.async_add_executor_job(wrap_external_ipv6))
 
     async def async_get_connection_info(self) -> ConnectionInfo:
         """Return ConnectionInfo data."""
@@ -798,15 +802,6 @@ class AvmWrapper(FritzBoxTools):
 
         return self._service_call_action(
             "WANCommonInterfaceConfig", "1", "GetCommonLinkProperties"
-        )
-
-    def ipv6_active(self) -> bool:
-        """Call WANIPConn service."""
-
-        return bool(
-            self._service_call_action(
-                "WANIPConn", "1", "X_AVM_DE_GetExternalIPv6Address"
-            )["NewExternalIPv6Address"]
         )
 
     def set_wlan_configuration(self, index: int, turn_on: bool) -> dict[str, Any]:

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -165,6 +165,7 @@ SENSOR_TYPES: tuple[FritzSensorEntityDescription, ...] = (
         name="External IPv6",
         icon="mdi:earth",
         value_fn=_retrieve_external_ipv6_state,
+        is_suitable=lambda info: info.ipv6_active,
     ),
     FritzSensorEntityDescription(
         key="device_uptime",

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any, cast
+from typing import Any
 
 from fritzconnection.core.exceptions import FritzConnectionException
 from fritzconnection.lib.fritzstatus import FritzStatus
@@ -68,7 +68,7 @@ def _retrieve_external_ip_state(status: FritzStatus, last_value: str) -> str:
 
 def _retrieve_external_ipv6_state(status: FritzStatus, last_value: str) -> str:
     """Return external ipv6 from device."""
-    return cast(str, status.external_ipv6)
+    return str(status.external_ipv6)
 
 
 def _retrieve_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fritzconnection.core.exceptions import FritzConnectionException
 from fritzconnection.lib.fritzstatus import FritzStatus
@@ -68,7 +68,7 @@ def _retrieve_external_ip_state(status: FritzStatus, last_value: str) -> str:
 
 def _retrieve_external_ipv6_state(status: FritzStatus, last_value: str) -> str:
     """Return external ipv6 from device."""
-    return status.external_ipv6  # type: ignore[no-any-return]
+    return cast(str, status.external_ipv6)
 
 
 def _retrieve_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -66,6 +66,11 @@ def _retrieve_external_ip_state(status: FritzStatus, last_value: str) -> str:
     return status.external_ip  # type: ignore[no-any-return]
 
 
+def _retrieve_external_ipv6_state(status: FritzStatus, last_value: str) -> str:
+    """Return external ipv6 from device."""
+    return status.external_ipv6  # type: ignore[no-any-return]
+
+
 def _retrieve_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:
     """Return upload transmission rate."""
     return round(status.transmission_rate[0] / 1000, 1)  # type: ignore[no-any-return]
@@ -154,6 +159,12 @@ SENSOR_TYPES: tuple[FritzSensorEntityDescription, ...] = (
         name="External IP",
         icon="mdi:earth",
         value_fn=_retrieve_external_ip_state,
+    ),
+    FritzSensorEntityDescription(
+        key="external_ipv6",
+        name="External IPv6",
+        icon="mdi:earth",
+        value_fn=_retrieve_external_ipv6_state,
     ),
     FritzSensorEntityDescription(
         key="device_uptime",

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -138,6 +138,7 @@ MOCK_FB_SERVICES: dict[str, dict] = {
             "NewUptime": 35307,
         },
         "GetExternalIPAddress": {"NewExternalIPAddress": "1.2.3.4"},
+        "X_AVM_DE_GetExternalIPv6Address": {"NewExternalIPv6Address": "fec0::1"},
     },
     "WANPPPConnection1": {
         "GetInfo": {

--- a/tests/components/fritz/test_sensor.py
+++ b/tests/components/fritz/test_sensor.py
@@ -36,6 +36,10 @@ SENSOR_STATES: dict[str, dict[str, Any]] = {
         ATTR_STATE: "1.2.3.4",
         ATTR_ICON: "mdi:earth",
     },
+    "sensor.mock_title_external_ipv6": {
+        ATTR_STATE: "fec0::1",
+        ATTR_ICON: "mdi:earth",
+    },
     "sensor.mock_title_device_uptime": {
         # ATTR_STATE: "2022-02-05T17:46:04+00:00",
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The change just adds the external IPv6 address of the fritz box as a sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Resolves Feature request [394532 [AVM FRITZ!Box Tools - External IP Sensor show IPv6](https://community.home-assistant.io/t/avm-fritz-box-tools-external-ip-sensor-show-ipv6/394532)](https://community.home-assistant.io/t/avm-fritz-box-tools-external-ip-sensor-show-ipv6/394532)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
